### PR TITLE
fix: modified CLI command options for clarity, changing `-vv` to `-d`

### DIFF
--- a/packages/jsdoc-open-api/README.md
+++ b/packages/jsdoc-open-api/README.md
@@ -36,12 +36,12 @@
 
 ## Features
 
--   **Automatic Generation:** Creates OpenAPI specs from JSDoc comments.
--   **Multiple Syntaxes:** Supports standard OpenAPI YAML/JSON within comments and a concise short syntax.
--   **CLI Tool:** Provides a command-line interface for easy generation.
--   **Programmatic API:** Offers a JavaScript API for integration into build processes.
--   **Framework Integration:** Includes helpers like a Webpack plugin (useful for Next.js).
--   **Performance:** Focused on speed and low overhead.
+- **Automatic Generation:** Creates OpenAPI specs from JSDoc comments.
+- **Multiple Syntaxes:** Supports standard OpenAPI YAML/JSON within comments and a concise short syntax.
+- **CLI Tool:** Provides a command-line interface for easy generation.
+- **Programmatic API:** Offers a JavaScript API for integration into build processes.
+- **Framework Integration:** Includes helpers like a Webpack plugin (useful for Next.js).
+- **Performance:** Focused on speed and low overhead.
 
 ## Installation
 
@@ -75,9 +75,31 @@ Choose the syntax you prefer for defining OpenAPI details within your JSDoc comm
 
 The Command Line Interface (CLI) provides a straightforward way to generate your OpenAPI specification.
 
+### Running via Package Managers
+
+Instead of installing the CLI globally or relying on optional dependencies, you can run the installed binary directly using your package manager:
+
+```bash
+# With npx (comes with npm)
+npx jsdoc-open-api generate src/
+# Or explicitly using the package name:
+npx @visulima/jsdoc-open-api generate src/
+
+# With pnpm
+pnpm exec jsdoc-open-api generate src/
+
+# With Yarn 1.x
+yarn run jsdoc-open-api generate src/
+
+# With Yarn Berry (2+)
+yarn jsdoc-open-api generate src/
+```
+
+This is often the recommended way to use package binaries within a project.
+
 ### Optional Dependencies
 
-The CLI relies on `commander` and `cli-progress`. These are listed as `optionalDependencies`. Depending on your package manager (npm/yarn/pnpm) and configuration, you *might* need to install them manually if they weren't installed automatically:
+The CLI relies on `commander` and `cli-progress`. These are listed as `optionalDependencies`. Depending on your package manager (npm/yarn/pnpm) and configuration, you _might_ need to install them manually if they weren't installed automatically:
 
 ```sh
 # If needed:
@@ -125,11 +147,11 @@ jsdoc-open-api generate -d src/
 jsdoc-open-api generate [options] [path ...]
 ```
 
--   `[path ...]` : Paths to files or directories to parse (optional, uses configuration if not provided).
--   `-c, --config [.openapirc.js]` : Specify the configuration file path. Defaults to `.openapirc.js`.
--   `-o, --output [swaggerSpec.json]` : Specify the output file for the OpenAPI specification. Defaults to `swaggerSpec.json`.
--   `-v, --verbose` : Enable verbose output during generation.
--   `-d, --very-verbose` : Enable *very* verbose output for detailed debugging.
+- `[path ...]` : Paths to files or directories to parse (optional, uses configuration if not provided).
+- `-c, --config [.openapirc.js]` : Specify the configuration file path. Defaults to `.openapirc.js`.
+- `-o, --output [swaggerSpec.json]` : Specify the output file for the OpenAPI specification. Defaults to `swaggerSpec.json`.
+- `-v, --verbose` : Enable verbose output during generation.
+- `-d, --very-verbose` : Enable _very_ verbose output for detailed debugging.
 
 ---
 
@@ -138,44 +160,43 @@ jsdoc-open-api generate [options] [path ...]
 You can integrate the generation process directly into your Node.js scripts.
 
 ```javascript
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import jsdocOpenApi from '@visulima/jsdoc-open-api'; // Adjust import based on your module system (require vs import)
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jsdocOpenApi from "@visulima/jsdoc-open-api"; // Adjust import based on your module system (require vs import)
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const options = {
-  definition: {
-    openapi: '3.0.0',
-    info: {
-      title: 'My Programmatic API',
-      version: '1.0.0',
-      description: 'API documentation generated programmatically',
+    definition: {
+        openapi: "3.0.0",
+        info: {
+            title: "My Programmatic API",
+            version: "1.0.0",
+            description: "API documentation generated programmatically",
+        },
+        // Add other base OpenAPI definition properties here
     },
-    // Add other base OpenAPI definition properties here
-  },
-  // Glob patterns pointing to your source files with JSDoc comments
-  sources: [path.join(__dirname, 'src/routes/**/*.js')],
-  // Optional: Specify output path (defaults to 'swaggerSpec.json' in current dir)
-  // output: path.join(__dirname, 'public/api-docs.json'),
-  // Optional: Enable verbose logging
-  // verbose: true,
+    // Glob patterns pointing to your source files with JSDoc comments
+    sources: [path.join(__dirname, "src/routes/**/*.js")],
+    // Optional: Specify output path (defaults to 'swaggerSpec.json' in current dir)
+    // output: path.join(__dirname, 'public/api-docs.json'),
+    // Optional: Enable verbose logging
+    // verbose: true,
 };
 
 async function generateDocs() {
-  try {
-    const specification = await jsdocOpenApi(options);
-    console.log('OpenAPI specification generated successfully:');
-    // The specification object is returned, and also written to the output file if specified.
-    // console.log(JSON.stringify(specification, null, 2));
-  } catch (error) {
-    console.error('Error generating OpenAPI specification:', error);
-  }
+    try {
+        const specification = await jsdocOpenApi(options);
+        console.log("OpenAPI specification generated successfully:");
+        // The specification object is returned, and also written to the output file if specified.
+        // console.log(JSON.stringify(specification, null, 2));
+    } catch (error) {
+        console.error("Error generating OpenAPI specification:", error);
+    }
 }
 
 generateDocs();
-
 ```
 
 ---
@@ -229,14 +250,7 @@ const withOpenApi =
 
                 // Add the SwaggerCompilerPlugin to webpack plugins
                 config.plugins = config.plugins || [];
-                config.plugins.push(
-                    new SwaggerCompilerPlugin(
-                        absoluteOutputPath,
-                        absoluteSourcePaths,
-                        definition,
-                        { verbose },
-                    ),
-                );
+                config.plugins.push(new SwaggerCompilerPlugin(absoluteOutputPath, absoluteSourcePaths, definition, { verbose }));
 
                 // Call the original webpack config function if it exists
                 if (typeof nextConfig.webpack === "function") {
@@ -295,18 +309,18 @@ When using the CLI `generate` command without specifying paths or using the `ini
 ```javascript
 // .openapirc.js
 module.exports = {
-  definition: {
-    openapi: '3.0.0',
-    info: {
-      title: 'API from Config',
-      version: '2.0.0',
+    definition: {
+        openapi: "3.0.0",
+        info: {
+            title: "API from Config",
+            version: "2.0.0",
+        },
+        // ... other base definition properties
     },
-    // ... other base definition properties
-  },
-  // Array of glob patterns for your source files
-  sources: ['src/**/*.js', 'routes/**/*.js'],
-  output: 'docs/swagger.json', // Default output file path
-  verbose: false, // Default verbosity
+    // Array of glob patterns for your source files
+    sources: ["src/**/*.js", "routes/**/*.js"],
+    output: "docs/swagger.json", // Default output file path
+    verbose: false, // Default verbosity
 };
 ```
 
@@ -373,7 +387,7 @@ Embed standard OpenAPI 3.0 YAML or JSON directly within `@openapi` or `@swagger`
  *         description: User not found.
  */
 function getUserById(userId) {
-  // Implementation...
+    // Implementation...
 }
 ```
 
@@ -394,9 +408,9 @@ Define the HTTP method and path, followed by tags like `@summary`, `@description
  * @response 200 - A JSON array of user names
  * @responseContent {string[]} 200.application/json
  */
- function listUsers() {
-  // Implementation...
- }
+function listUsers() {
+    // Implementation...
+}
 ```
 
 #### Parameters
@@ -413,9 +427,9 @@ Use `@pathParam`, `@queryParam`, `@headerParam`, `@cookieParam` to define parame
  * @response 200 - OK
  * @responseContent {User} 200.application/json - A user object (assuming 'User' schema is defined elsewhere).
  */
- function getUser(userId, role) {
-  // Implementation...
- }
+function getUser(userId, role) {
+    // Implementation...
+}
 ```
 
 #### Request Body
@@ -432,9 +446,9 @@ Use `@bodyContent` to describe the request body and `@bodyRequired` if it's mand
  * @response 201 - User created successfully.
  * @responseContent {User} 201.application/json - The created user object.
  */
- function createUser(userData) {
-  // Implementation...
- }
+function createUser(userData) {
+    // Implementation...
+}
 ```
 
 #### Responses
@@ -452,9 +466,9 @@ Define responses using `@response` for the status code and description, and `@re
  * @response 404 - Product not found.
  * @response default - Unexpected error.
  */
- function getProduct(productId) {
-  // Implementation...
- }
+function getProduct(productId) {
+    // Implementation...
+}
 ```
 
 #### Input and Output Models (Schema References)
@@ -475,9 +489,9 @@ Reference schemas defined globally (usually using the standard `@openapi` syntax
  * @responseContent {User} 200.application/json
  * @response 404 - User not found.
  */
- function updateUser(userId, userData) {
-  // Implementation...
- }
+function updateUser(userId, userData) {
+    // Implementation...
+}
 ```
 
 #### Authentication
@@ -494,12 +508,13 @@ Reference `securitySchemes` defined globally (using standard `@openapi` syntax) 
  * @security BasicAuth
  * @response 200 - Admin settings object.
  */
- function getAdminSettings() {
-  // Implementation...
- }
+function getAdminSettings() {
+    // Implementation...
+}
 ```
 
 For detailed information on the short syntax tags and possibilities, please refer to the documentation (link to be added if available).
+
 <!-- Add link to short syntax docs here if they exist -->
 
 ---

--- a/packages/jsdoc-open-api/README.md
+++ b/packages/jsdoc-open-api/README.md
@@ -1,9 +1,16 @@
 <div align="center">
   <h3>Visulima jsdoc-open-api</h3>
   <p>
-
-Visulima jsdoc-open-api parser and generator is a forked version of [openapi-comment-parser](https://github.com/bee-travels/openapi-comment-parser) and [swagger-jsdoc](https://github.com/Surnet/swagger-jsdoc) its built on top of [swagger](https://swagger.io/) and [JSDoc](https://jsdoc.app/), for speed and minimal runtime overhead.
-
+    Generate OpenAPI (Swagger) specifications automatically from your JSDoc comments.
+    <br />
+    This package parses your existing code comments to create comprehensive API documentation, saving you time and effort.
+    <br />
+    It is designed for speed and minimal runtime overhead, building upon the foundations of JSDoc and Swagger standards.
+  </p>
+  <p>
+    <small>
+      <i>Note: This package originated as a fork of <a href="https://github.com/bee-travels/openapi-comment-parser" target="_blank" rel="noopener noreferrer">openapi-comment-parser</a> and <a href="https://github.com/Surnet/swagger-jsdoc" target="_blank" rel="noopener noreferrer">swagger-jsdoc</a>.</i>
+    </small>
   </p>
 </div>
 
@@ -27,6 +34,15 @@ Visulima jsdoc-open-api parser and generator is a forked version of [openapi-com
 
 ---
 
+## Features
+
+-   **Automatic Generation:** Creates OpenAPI specs from JSDoc comments.
+-   **Multiple Syntaxes:** Supports standard OpenAPI YAML/JSON within comments and a concise short syntax.
+-   **CLI Tool:** Provides a command-line interface for easy generation.
+-   **Programmatic API:** Offers a JavaScript API for integration into build processes.
+-   **Framework Integration:** Includes helpers like a Webpack plugin (useful for Next.js).
+-   **Performance:** Focused on speed and low overhead.
+
 ## Installation
 
 ```sh
@@ -41,95 +57,188 @@ yarn add @visulima/jsdoc-open-api
 pnpm add @visulima/jsdoc-open-api
 ```
 
-## Usage
+## Usage Overview
 
-Choose the syntax you want to use for your OpenAPI definitions:
+You can use `@visulima/jsdoc-open-api` in several ways:
+
+1.  **Via Command Line (CLI):** Quick generation for simple use cases or manual runs.
+2.  **Programmatically:** Integrate generation into your custom scripts or build tools.
+3.  **With Webpack (e.g., Next.js):** Automate generation during your build process.
+
+Choose the syntax you prefer for defining OpenAPI details within your JSDoc comments:
 
 ![choose the syntax](./__assets__/swagger-difference.png)
 
-### CLI:
+---
 
-#### To use the CLI, you need to install this missing packages:
+## Usage with CLI
 
-```sh
-npm install cli-progress commander
-```
+The Command Line Interface (CLI) provides a straightforward way to generate your OpenAPI specification.
 
-```sh
-yarn add cli-progress commander
-```
+### Optional Dependencies
+
+The CLI relies on `commander` and `cli-progress`. These are listed as `optionalDependencies`. Depending on your package manager (npm/yarn/pnpm) and configuration, you *might* need to install them manually if they weren't installed automatically:
 
 ```sh
-pnpm add cli-progress commander
+# If needed:
+npm install commander cli-progress
+# or
+yarn add commander cli-progress
+# or
+pnpm add commander cli-progress
 ```
 
-#### Than you can use the CLI like this:
+### Commands
+
+#### `init`
+
+Initializes the project by creating a `.openapirc.js` configuration file. This is typically run once per project.
 
 ```bash
-# This generate the .openapirc.js config file, this command is only needed on the first run
 jsdoc-open-api init
-
-# This will generate the swagger.json file
-jsdoc-open-api generate src/
 ```
 
-### As Next.js webpack plugin:
+#### `generate`
 
-#### with-open-api.js
+Parses your source files based on the configuration (or command-line arguments) and generates the OpenAPI specification file.
+
+```bash
+# Generate using defaults defined in .openapirc.js (if it exists)
+jsdoc-open-api generate
+
+# Specify input path(s) directly
+jsdoc-open-api generate src/routes/**/*.js src/controllers/
+
+# Specify output file
+jsdoc-open-api generate -o ./public/swagger.json src/
+
+# Use verbose output
+jsdoc-open-api generate -v src/
+
+# Use very verbose output for debugging
+jsdoc-open-api generate -d src/
+```
+
+### `generate` Command Options:
+
+```bash
+jsdoc-open-api generate [options] [path ...]
+```
+
+-   `[path ...]` : Paths to files or directories to parse (optional, uses configuration if not provided).
+-   `-c, --config [.openapirc.js]` : Specify the configuration file path. Defaults to `.openapirc.js`.
+-   `-o, --output [swaggerSpec.json]` : Specify the output file for the OpenAPI specification. Defaults to `swaggerSpec.json`.
+-   `-v, --verbose` : Enable verbose output during generation.
+-   `-d, --very-verbose` : Enable *very* verbose output for detailed debugging.
+
+---
+
+## Programmatic Usage
+
+You can integrate the generation process directly into your Node.js scripts.
+
+```javascript
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import jsdocOpenApi from '@visulima/jsdoc-open-api'; // Adjust import based on your module system (require vs import)
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'My Programmatic API',
+      version: '1.0.0',
+      description: 'API documentation generated programmatically',
+    },
+    // Add other base OpenAPI definition properties here
+  },
+  // Glob patterns pointing to your source files with JSDoc comments
+  sources: [path.join(__dirname, 'src/routes/**/*.js')],
+  // Optional: Specify output path (defaults to 'swaggerSpec.json' in current dir)
+  // output: path.join(__dirname, 'public/api-docs.json'),
+  // Optional: Enable verbose logging
+  // verbose: true,
+};
+
+async function generateDocs() {
+  try {
+    const specification = await jsdocOpenApi(options);
+    console.log('OpenAPI specification generated successfully:');
+    // The specification object is returned, and also written to the output file if specified.
+    // console.log(JSON.stringify(specification, null, 2));
+  } catch (error) {
+    console.error('Error generating OpenAPI specification:', error);
+  }
+}
+
+generateDocs();
+
+```
+
+---
+
+## Usage with Next.js (via Webpack Plugin)
+
+The package includes a Webpack plugin for seamless integration with frameworks like Next.js.
+
+### `with-open-api.js` Helper
+
+Create a helper file (e.g., `with-open-api.js`) in your project root:
 
 ```js
 const path = require("node:path");
 const fs = require("node:fs");
+// Adjust the import path based on your project structure if needed
 const { SwaggerCompilerPlugin } = require("@visulima/jsdoc-open-api");
 
 /**
- * @param definition {import('@visulima/jsdoc-open-api').SwaggerDefinition}
- * @param sources {string[]}
- * @param verbose {boolean}
- * @param output {string}
+ * @param {object} options
+ * @param {import('@visulima/jsdoc-open-api').SwaggerDefinition} options.definition - Base OpenAPI definition.
+ * @param {string[]} options.sources - Glob patterns for source files relative to project root.
+ * @param {boolean} [options.verbose=false] - Enable verbose logging.
+ * @param {string} [options.output='swagger/swagger.json'] - Output path relative to project root.
  *
- * @returns {function(*): *&{webpack: function(Configuration, *): (Configuration)}}
+ * @returns {function(import('next').NextConfig): import('next').NextConfig & {webpack: function(import('webpack').Configuration, object): import('webpack').Configuration}}
  */
 const withOpenApi =
     ({ definition, sources, verbose, output = "swagger/swagger.json" }) =>
-    (nextConfig) => {
+    (nextConfig = {}) => {
         return {
             ...nextConfig,
             webpack: (config, options) => {
+                // Run generation only on the server build in Next.js
                 if (!options.isServer) {
                     return config;
                 }
 
-                if (output.startsWith("/")) {
-                    output = output.slice(1);
+                let outputPath = output;
+                if (outputPath.startsWith("/")) {
+                    outputPath = outputPath.slice(1);
                 }
 
-                if (!output.endsWith(".json")) {
+                if (!outputPath.endsWith(".json")) {
+                    // Consider allowing YAML output as well?
                     throw new Error("The output path must end with .json");
                 }
 
-                // eslint-disable-next-line no-param-reassign
-                config = {
-                    ...config,
-                    plugins: [
-                        // @ts-ignore
-                        ...config.plugins,
-                        new SwaggerCompilerPlugin(
-                            `${options.dir}/${output}`,
-                            sources.map((source) => {
-                                const combinedPath = path.join(options.dir, source.replace("./", ""));
+                const absoluteOutputPath = path.join(options.dir, outputPath);
+                const absoluteSourcePaths = sources.map((source) => path.join(options.dir, source.replace(/^\.\//, ""))); // Normalize paths
 
-                                // Check if the path is a directory
-                                fs.lstatSync(combinedPath).isDirectory();
+                // Add the SwaggerCompilerPlugin to webpack plugins
+                config.plugins = config.plugins || [];
+                config.plugins.push(
+                    new SwaggerCompilerPlugin(
+                        absoluteOutputPath,
+                        absoluteSourcePaths,
+                        definition,
+                        { verbose },
+                    ),
+                );
 
-                                return combinedPath;
-                            }),
-                            definition,
-                            { verbose },
-                        ),
-                    ],
-                };
-
+                // Call the original webpack config function if it exists
                 if (typeof nextConfig.webpack === "function") {
                     return nextConfig.webpack(config, options);
                 }
@@ -142,204 +251,273 @@ const withOpenApi =
 module.exports = withOpenApi;
 ```
 
-#### Next.config.js
+### `next.config.js`
+
+Wrap your Next.js configuration with the helper:
 
 ```js
-const withOpenApi = require("./with-open-api");
+const withOpenApi = require("./with-open-api"); // Adjust path if necessary
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
     swcMinify: true,
     env: {
-        NEXT_PUBLIC_APP_ORIGIN: process.env.VERCEL_URL || "http://localhost:3001",
+        NEXT_PUBLIC_APP_ORIGIN: process.env.VERCEL_URL || "http://localhost:3000", // Default to 3000?
     },
+    // ... other Next.js config
 };
 
 module.exports = withOpenApi({
     definition: {
         openapi: "3.0.0",
         info: {
-            title: "My API",
+            title: "My Next.js API",
             version: "1.0.0",
         },
+        // servers: [{ url: '/api' }], // Optional: Define servers
     },
-    sources: ["pages/api"],
-    verbose: false, // default is false
+    // Paths relative to your project root
+    sources: ["pages/api/**/*.js", "src/controllers/**/*.js"],
+    output: "public/swagger.json", // Output to the public folder
+    verbose: false,
 })(nextConfig);
 ```
 
-## OpenApi YAML syntax
+Now, the OpenAPI specification (`public/swagger.json`) will be generated automatically during your Next.js build.
 
-The library will take the contents of @openapi (or @swagger):
+---
 
-```ts
-/**
- * @openapi
- * /:
- *   get:
- *     description: Welcome to swagger-jsdoc!
- *     responses:
- *       200:
- *         description: Returns a mysterious string.
- */
+## Configuration (`.openapirc.js`)
+
+When using the CLI `generate` command without specifying paths or using the `init` command, `@visulima/jsdoc-open-api` looks for a `.openapirc.js` file in your project root. This file should export an options object similar to the one used in Programmatic Usage:
+
+```javascript
+// .openapirc.js
+module.exports = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'API from Config',
+      version: '2.0.0',
+    },
+    // ... other base definition properties
+  },
+  // Array of glob patterns for your source files
+  sources: ['src/**/*.js', 'routes/**/*.js'],
+  output: 'docs/swagger.json', // Default output file path
+  verbose: false, // Default verbosity
+};
 ```
 
-## OpenApi short syntax
+---
 
-### Basic structure
+## Defining OpenAPI Specs in JSDoc
 
-You can write OpenAPI definitions in JSDoc comments or YAML files.
-In this guide, we use only JSDoc comments examples. However, YAML files work equally as well.
+You have two main ways to define your API specifications within JSDoc comments:
 
-Each comment defines individual endpoints (paths) in your API, and the HTTP methods (operations) supported by these endpoints.
-For example, `GET /users` can be described as:
+### 1. Standard OpenAPI (YAML/JSON) Syntax
 
-```js
+Embed standard OpenAPI 3.0 YAML or JSON directly within `@openapi` or `@swagger` blocks. The library extracts and merges these definitions.
+
+```javascript
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     User:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           format: int64
+ *           example: 10
+ *         username:
+ *           type: string
+ *           example: 'theUser'
+ *         firstName:
+ *           type: string
+ *           example: 'John'
+ *         lastName:
+ *           type: string
+ *           example: 'Doe'
+ *       required:
+ *         - id
+ *         - username
+ */
+
+/**
+ * @openapi
+ * /users/{userId}:
+ *   get:
+ *     summary: Get user by ID
+ *     description: Retrieve detailed information about a specific user.
+ *     tags:
+ *       - Users
+ *     parameters:
+ *       - name: userId
+ *         in: path
+ *         required: true
+ *         description: ID of the user to retrieve.
+ *         schema:
+ *           type: integer
+ *           format: int64
+ *     responses:
+ *       '200':
+ *         description: Successful response with user data.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User' # Reference the schema defined above
+ *       '404':
+ *         description: User not found.
+ */
+function getUserById(userId) {
+  // Implementation...
+}
+```
+
+### 2. OpenApi Short Syntax
+
+Use custom JSDoc tags for a more concise way to define paths, operations, parameters, and responses.
+
+#### Basic Structure
+
+Define the HTTP method and path, followed by tags like `@summary`, `@description`, `@response`, etc.
+
+```javascript
 /**
  * GET /users
  * @summary Returns a list of users.
  * @description Optional extended description in CommonMark or HTML.
+ * @tags Users
  * @response 200 - A JSON array of user names
  * @responseContent {string[]} 200.application/json
  */
+ function listUsers() {
+  // Implementation...
+ }
 ```
 
 #### Parameters
 
-Operations can have parameters passed via URL path (`/users/{userId}`), query string (`/users?role=admin`),
-headers (`X-CustomHeader: Value`) or cookies (`Cookie: debug=0`).
-You can define the parameter data types, format, whether they are required or optional, and other details:
+Use `@pathParam`, `@queryParam`, `@headerParam`, `@cookieParam` to define parameters.
 
-```js
+```javascript
 /**
  * GET /users/{userId}
  * @summary Returns a user by ID.
- * @pathParam {int64} userId - Parameter description in CommonMark or HTML.
+ * @tags Users
+ * @pathParam {integer | int64} userId - The ID of the user to retrieve. {required}
+ * @queryParam {string} [role] - Filter users by role (optional). Possible values: 'admin', 'member'.
  * @response 200 - OK
+ * @responseContent {User} 200.application/json - A user object (assuming 'User' schema is defined elsewhere).
  */
+ function getUser(userId, role) {
+  // Implementation...
+ }
 ```
 
-For more information, see [Describing Parameters](/docs/short/describing-parameters.md).
+#### Request Body
 
-#### Request body
+Use `@bodyContent` to describe the request body and `@bodyRequired` if it's mandatory.
 
-If an operation sends a request body, use the `bodyContent` keyword to describe the body content and media type.
-Use `bodyRequired` to indicate that a request body is required.
-
-```js
-/**
- * POST /users
- * @summary Creates a user.
- * @bodyContent {User} application/json
- * @bodyRequired
- * @response 201 - Created
- */
-```
-
-For more information, see [Describing Request Body](/docs/short/describing-request-body.md).
-
-#### Responses
-
-For each operation, you can define possible status codes, such as 200 OK or 404 Not Found, and the response body content.
-You can also provide example responses for different content types:
-
-```js
-/**
- * GET /users/{userId}
- * @summary Returns a user by ID.
- * @pathParam {int64} userId - The ID of the user to return.
- * @response 200 - A user object.
- * @responseContent {User} 200.application/json
- * @response 400 - The specified user ID is invalid (not a number).
- * @response 404 - A user with the specified ID was not found.
- * @response default - Unexpected error
- */
-```
-
-For more information, see [Describing Responses](/docs/short/describing-responses.md).
-
-#### Input and output models
-
-You can create global `components/schemas` section lets you define common data structures used in your API.
-They can be referenced by name whenever a schema is required – in parameters, request bodies, and response bodies.
-For example, this JSON object:
-
-```json
-{
-    "id": 4,
-    "name": "Arthur Dent"
-}
-```
-
-Can be represented as:
-
-```yaml
-components:
-    schemas:
-        User:
-            properties:
-                id:
-                    type: integer
-                name:
-                    type: string
-            # Both properties are required
-            required:
-                - id
-                - name
-```
-
-And then referenced in the request body schema and response body schema as follows:
-
-```js
-/**
- * GET /users/{userId}
- * @summary Returns a user by ID.
- * @pathParam {integer} userId
- * @response 200 - OK
- * @responseContent {User} 200.application/json
- */
-
+```javascript
 /**
  * POST /users
  * @summary Creates a new user.
- * @bodyContent {User} application/json
+ * @tags Users
+ * @bodyContent {User} application/json - User object to create.
  * @bodyRequired
- * @response 201 - Created
+ * @response 201 - User created successfully.
+ * @responseContent {User} 201.application/json - The created user object.
  */
+ function createUser(userData) {
+  // Implementation...
+ }
+```
+
+#### Responses
+
+Define responses using `@response` for the status code and description, and `@responseContent` for the body schema.
+
+```javascript
+/**
+ * GET /products/{productId}
+ * @summary Get product details.
+ * @tags Products
+ * @pathParam {string} productId - ID of the product.
+ * @response 200 - Product details.
+ * @responseContent {ProductSchema} 200.application/json
+ * @response 404 - Product not found.
+ * @response default - Unexpected error.
+ */
+ function getProduct(productId) {
+  // Implementation...
+ }
+```
+
+#### Input and Output Models (Schema References)
+
+Reference schemas defined globally (usually using the standard `@openapi` syntax in a central file or comment block) within your short syntax using type definitions like `{User}` or `{ProductSchema}`.
+
+```javascript
+// Assuming 'User' schema is defined in components/schemas
+
+/**
+ * PUT /users/{userId}
+ * @summary Update an existing user.
+ * @tags Users
+ * @pathParam {integer} userId - ID of the user to update.
+ * @bodyContent {User} application/json - Updated user data.
+ * @bodyRequired
+ * @response 200 - User updated successfully.
+ * @responseContent {User} 200.application/json
+ * @response 404 - User not found.
+ */
+ function updateUser(userId, userData) {
+  // Implementation...
+ }
 ```
 
 #### Authentication
 
-The `securitySchemes` and `security` keywords are used to describe the authentication methods used in your API.
+Reference `securitySchemes` defined globally (using standard `@openapi` syntax) with the `@security` tag.
 
-```yaml
-components:
-    securitySchemes:
-        BasicAuth:
-            type: http
-            scheme: basic
-```
+```javascript
+// Assuming 'BasicAuth' is defined in components/securitySchemes
 
-```js
 /**
- * GET /users
+ * GET /admin/settings
+ * @summary Get administrative settings (requires auth).
+ * @tags Admin
  * @security BasicAuth
+ * @response 200 - Admin settings object.
  */
+ function getAdminSettings() {
+  // Implementation...
+ }
 ```
 
-Supported authentication methods are:
+For detailed information on the short syntax tags and possibilities, please refer to the documentation (link to be added if available).
+<!-- Add link to short syntax docs here if they exist -->
 
-- HTTP authentication: Basic, Bearer, and so on.
-- API key as a header or query parameter or in cookies
-- OAuth 2
-- OpenID Connect Discovery
+---
 
-For more information, see [Authentication](/docs/short/authentication.md).
+## Contributing
+
+Contributions are welcome! Please refer to the [Contribution Guidelines](../../../.github/CONTRIBUTING.md) for details on how to submit pull requests, report issues, and suggest improvements.
+
+---
+
+## License
+
+This project is licensed under the **MIT License**. See the [LICENSE.md](LICENSE.md) file for details.
+
+---
 
 [typescript-image]: https://img.shields.io/badge/Typescript-294E80.svg?style=for-the-badge&logo=typescript
-
-[typescript-url]: https://www.typescriptlang.org/ "TypeScript" "typescript"
+[typescript-url]: https://www.typescriptlang.org/ "TypeScript"
 [license-image]: https://img.shields.io/npm/l/@visulima/jsdoc-open-api?color=blueviolet&style=for-the-badge
 [license-url]: LICENSE.md "license"
 [npm-image]: https://img.shields.io/npm/v/@visulima/jsdoc-open-api/latest.svg?style=for-the-badge&logo=npm

--- a/packages/jsdoc-open-api/package.json
+++ b/packages/jsdoc-open-api/package.json
@@ -108,22 +108,22 @@
         "comment-parser": "^1.4.1",
         "lodash.mergewith": "^4.6.2",
         "read-pkg-up": "^7.0.1",
-        "yaml": "^2.7.0"
+        "yaml": "^2.7.1"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "^15.0.3",
         "@anolilab/prettier-config": "^5.0.14",
         "@anolilab/semantic-release-pnpm": "^1.1.10",
         "@anolilab/semantic-release-preset": "^10.0.3",
-        "@babel/core": "^7.26.10",
+        "@babel/core": "^7.27.1",
         "@rushstack/eslint-plugin-security": "^0.10.0",
         "@types/cli-progress": "^3.11.6",
         "@types/http-errors": "^2.0.4",
         "@types/lodash.mergewith": "^4.6.9",
         "@types/node": "18.19.71",
         "@types/webpack": "^5.28.5",
-        "@vitest/coverage-v8": "^3.0.8",
-        "@vitest/ui": "^3.0.8",
+        "@vitest/coverage-v8": "^3.1.2",
+        "@vitest/ui": "^3.1.2",
         "cli-progress": "^3.12.0",
         "commander": "^13.1.0",
         "conventional-changelog-conventionalcommits": "8.0.0",
@@ -132,7 +132,7 @@
         "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-etc": "^2.0.3",
         "eslint-plugin-import": "npm:eslint-plugin-i@^2.29.1",
-        "eslint-plugin-mdx": "^3.2.0",
+        "eslint-plugin-mdx": "^3.4.1",
         "eslint-plugin-vitest": "0.4.1",
         "eslint-plugin-vitest-globals": "^1.5.0",
         "openapi-types": "^12.1.3",
@@ -140,14 +140,14 @@
         "rimraf": "6.0.1",
         "semantic-release": "24.2.3",
         "tsup": "^8.4.0",
-        "typescript": "5.8.2",
-        "vitest": "^3.0.8",
-        "webpack": "^5.98.0"
+        "typescript": "5.8.3",
+        "vitest": "^3.1.2",
+        "webpack": "^5.99.7"
     },
     "optionalDependencies": {
         "cli-progress": "^3.12.0",
         "commander": "^13.1.0",
-        "webpack": "^5.98.0"
+        "webpack": "^5.99.7"
     },
     "engines": {
         "node": ">=18.0.0 <=23.x"

--- a/packages/jsdoc-open-api/src/cli/command/generate-command.ts
+++ b/packages/jsdoc-open-api/src/cli/command/generate-command.ts
@@ -70,7 +70,7 @@ const generateCommand = async (
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         const realDirectory = await realpath(dir);
 
-        const files = await collect(realDirectory, {
+        const files: string[] = await collect(realDirectory, {
             extensions: openapiConfig.extensions ?? [".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".yaml", ".yml"],
             followSymlinks: openapiConfig.followSymlinks ?? false,
             match: openapiConfig.include,
@@ -79,7 +79,7 @@ const generateCommand = async (
 
         if (options.verbose ?? options.veryVerbose) {
             // eslint-disable-next-line no-console
-            console.log(`\nFound ${files.length} files in ${realDirectory}`);
+            console.log(`\nFound ${String(files.length)} files in ${realDirectory}`);
         }
 
         if (options.veryVerbose) {

--- a/packages/jsdoc-open-api/src/cli/command/init-command.ts
+++ b/packages/jsdoc-open-api/src/cli/command/init-command.ts
@@ -20,7 +20,7 @@ const initCommand = (configName: string, packageJsonPath = process.cwd()): void 
         const { packageJson: package_, path: packagePath } = foundPackageJson;
 
         // eslint-disable-next-line no-console
-        console.info(`Found package.json at "${packagePath}"`);
+        console.info(`Found package.json at "${packagePath as string}"`);
 
         if (package_.type === "module") {
             // eslint-disable-next-line no-console

--- a/packages/jsdoc-open-api/src/cli/commander/command/generate-command.ts
+++ b/packages/jsdoc-open-api/src/cli/commander/command/generate-command.ts
@@ -13,7 +13,7 @@ const generateCommand = (program: Command, commandName = "generate", configName 
         .option("-c, --config [.openapirc.js]", "@visulima/jsdoc-open-api config file path.")
         .option("-o, --output [swaggerSpec.json]", "Output swagger specification.")
         .option("-v, --verbose", "Verbose output.")
-        .option("-vv, --very-verbose", "Very verbose output.")
+        .option("-d, --very-verbose", "Very verbose output.")
 
         .action(async (paths, options) => {
             try {

--- a/packages/jsdoc-open-api/src/jsdoc/comments-to-open-api.ts
+++ b/packages/jsdoc-open-api/src/jsdoc/comments-to-open-api.ts
@@ -75,7 +75,7 @@ const parseDescription = (tag: Spec): { description: string | undefined; name: s
             type: formatMap[parsedType],
         };
     } else {
-        rootType = { $ref: `#/components/schemas/${parsedType}` };
+        rootType = { $ref: `#/components/schemas/${parsedType as string}` };
     }
 
     let schema: object | undefined = isArray
@@ -379,7 +379,7 @@ const commentsToOpenApi = (fileContents: string, verbose?: boolean): { loc: numb
             // Line count, number of tags + 1 for description.
             // - Don't count line-breaking due to long descriptions
             // - Don't count empty lines
-            const loc = comment.tags.length + 1;
+            const loc = (comment.tags.length as number) + 1;
 
             const result = mergeWith({}, ...tagsToObjects(comment.tags, verbose), customizer);
 

--- a/packages/jsdoc-open-api/src/swagger-jsdoc/comments-to-open-api.ts
+++ b/packages/jsdoc-open-api/src/swagger-jsdoc/comments-to-open-api.ts
@@ -16,7 +16,7 @@ const specificationTemplate = {
     v4: ["components", "channels"],
 };
 
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,perfectionist/sort-intersection-types
 type ExtendedYAMLError = YAMLError & { annotation?: string };
 
 const tagsToObjects = (specs: Spec[], verbose?: boolean) =>
@@ -36,13 +36,12 @@ const tagsToObjects = (specs: Spec[], verbose?: boolean) =>
 
                 let errorString = "Error parsing YAML in @openapi spec:";
 
-                errorString += verbose
+                errorString += (verbose
                     ? (parsed.errors as ExtendedYAMLError[])
-
-                          .map((error) => `${error.toString()}\nImbedded within:\n\`\`\`\n  ${error.annotation?.replace(/\n/gu, "\n  ")}\n\`\`\``)
+                          .map((error) => `${(error as ExtendedYAMLError).toString() as string}\nImbedded within:\n\`\`\`\n  ${(error as ExtendedYAMLError).annotation?.replace(/\n/gu, "\n  ") as string}\n\`\`\``)
                           .join("\n")
                     : // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                      parsed.errors.map((error) => error.toString()).join("\n");
+                      parsed.errors.map((error) => error.toString()).join("\n")) as string;
 
                 throw new Error(errorString);
             }
@@ -74,7 +73,7 @@ const commentsToOpenApi = (fileContents: string, verbose?: boolean): { loc: numb
         // Line count, number of tags + 1 for description.
         // - Don't count line-breaking due to long descriptions
         // - Don't count empty lines
-        const loc = comment.tags.length + 1;
+        const loc = (comment.tags.length as number) + 1;
         const result = mergeWith({}, ...tagsToObjects(comment.tags, verbose), customizer);
 
         ["definitions", "responses", "parameters", "securityDefinitions", "components", "tags"].forEach((property) => {

--- a/packages/jsdoc-open-api/src/webpack/swagger-compiler-plugin.ts
+++ b/packages/jsdoc-open-api/src/webpack/swagger-compiler-plugin.ts
@@ -60,7 +60,7 @@ class SwaggerCompilerPlugin {
 
             // eslint-disable-next-line no-restricted-syntax,unicorn/prevent-abbreviations,no-loops/no-loops
             for await (const dir of this.sources) {
-                const files = await collect(dir, {
+                const files: string[] = await collect(dir, {
                     extensions: [".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".yaml", ".yml"],
                     includeDirs: false,
                     skip: [...skip],
@@ -68,7 +68,7 @@ class SwaggerCompilerPlugin {
 
                 if (this.verbose) {
                     // eslint-disable-next-line no-console
-                    console.log(`Found ${files.length} files in ${dir}`);
+                    console.log(`Found ${String(files.length)} files in ${dir}`);
                     // eslint-disable-next-line no-console
                     console.log(files);
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 5.0.3(@commitlint/cli@19.8.0(@types/node@18.19.71)(typescript@5.8.2))(@types/node@18.19.71)(typescript@5.8.2)
       '@anolilab/lint-staged-config':
         specifier: ^2.1.7
-        version: 2.1.7(eslint@8.57.1)(husky@9.1.7)(jest@29.7.0(@types/node@18.19.71))(lint-staged@15.5.0)(prettier@3.5.3)(secretlint@9.2.0)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+        version: 2.1.7(eslint@8.57.1)(husky@9.1.7)(jest@29.7.0(@types/node@18.19.71))(lint-staged@15.5.0)(prettier@3.5.3)(secretlint@9.2.0)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@anolilab/multi-semantic-release':
         specifier: ^1.1.10
         version: 1.1.10(semantic-release@24.2.3(typescript@5.8.2))(typescript@5.8.2)
@@ -158,13 +158,13 @@ importers:
         version: 14.5.0
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.1)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   apps/docs:
     dependencies:
@@ -348,7 +348,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   apps/storybook:
     dependencies:
@@ -400,13 +400,13 @@ importers:
         version: 8.6.4(react@19.0.0)(storybook@8.6.4(prettier@3.5.3))
       '@storybook/addon-styling':
         specifier: ^1.3.7
-        version: 1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(postcss@8.5.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+        version: 1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(postcss@8.5.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
       '@storybook/addon-themes':
         specifier: ^8.6.4
         version: 8.6.4(storybook@8.6.4(prettier@3.5.3))
       '@storybook/builder-vite':
         specifier: ~8.6.4
-        version: 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+        version: 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@storybook/core-server':
         specifier: ~8.6.4
         version: 8.6.4(storybook@8.6.4(prettier@3.5.3))
@@ -415,7 +415,7 @@ importers:
         version: 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)
       '@storybook/react-vite':
         specifier: ^8.6.4
-        version: 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.9)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+        version: 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.9)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@storybook/test-runner':
         specifier: ^0.22.0
         version: 0.22.0(@swc/helpers@0.5.15)(@types/node@18.19.71)(storybook@8.6.4(prettier@3.5.3))
@@ -436,7 +436,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.3.4(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -508,10 +508,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: '>=6.2.6'
-        version: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+        version: 5.1.4(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
 
   examples/api-platform/express:
     dependencies:
@@ -636,10 +636,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -663,7 +663,7 @@ importers:
         version: 1.4.21
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -729,7 +729,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/ansi/__fixtures__/package/cjs:
     dependencies:
@@ -1024,10 +1024,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1045,7 +1045,7 @@ importers:
         version: 1.4.21
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -1108,7 +1108,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       wrap-ansi:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1135,7 +1135,7 @@ importers:
         version: 1.4.21
       '@visulima/find-cache-dir':
         specifier: 1.0.28
-        version: 1.0.28(yaml@2.7.0)
+        version: 1.0.28(yaml@2.7.1)
       '@visulima/pail':
         specifier: 2.1.22
         version: 2.1.22(rotating-file-stream@3.2.6)
@@ -1157,10 +1157,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1199,7 +1199,7 @@ importers:
         version: 4.0.26(csstype@3.1.3)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.2.16(acorn@8.14.1)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(zod@3.24.2)
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -1250,7 +1250,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/cerebro/__fixtures__/package/cjs:
     dependencies:
@@ -1278,10 +1278,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@babel/core':
         specifier: ^7.26.10
         version: 7.26.10
@@ -1299,7 +1299,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -1365,7 +1365,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/colorize/__bench__:
     dependencies:
@@ -1444,10 +1444,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1468,7 +1468,7 @@ importers:
         version: 4.0.26(csstype@3.1.3)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.2.16(acorn@8.14.1)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(zod@3.24.2)
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -1531,7 +1531,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -1559,10 +1559,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arthurgeron/eslint-plugin-react-usememo':
         specifier: ^2.4.4
         version: 2.4.4
@@ -1673,28 +1673,28 @@ importers:
         version: 24.2.3(typescript@5.8.2)
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.1)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/deep-clone:
     devDependencies:
       '@anolilab/eslint-config':
         specifier: ^15.0.3
-        version: 15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.26.10)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-tsdoc@0.4.0)(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.2)
+        version: 15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.27.1)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-tsdoc@0.4.0)(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.2)
       '@anolilab/prettier-config':
         specifier: ^5.0.14
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1718,7 +1718,7 @@ importers:
         version: 1.3.0
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -1805,7 +1805,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/error:
     devDependencies:
@@ -1817,10 +1817,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1859,7 +1859,7 @@ importers:
         version: 4.0.26(csstype@3.1.3)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.2.16(acorn@8.14.1)(next@15.3.1(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(zod@3.24.2)
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -1913,13 +1913,13 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/find-cache-dir:
     dependencies:
       '@visulima/fs':
         specifier: 3.1.2
-        version: 3.1.2(yaml@2.7.0)
+        version: 3.1.2(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -1932,10 +1932,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1956,7 +1956,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2013,7 +2013,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/fmt:
     devDependencies:
@@ -2025,10 +2025,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2043,7 +2043,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2097,7 +2097,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/fs:
     dependencies:
@@ -2134,7 +2134,7 @@ importers:
         version: 4.4.16
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2251,10 +2251,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2275,7 +2275,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2359,7 +2359,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
       next:
         specifier: '>=15.2.3'
@@ -2375,10 +2375,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2399,7 +2399,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -2462,7 +2462,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/humanizer/__fixtures__/package/cjs:
     dependencies:
@@ -2486,10 +2486,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2513,10 +2513,10 @@ importers:
         version: 1.4.21
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/browser':
         specifier: ^3.0.8
-        version: 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)
+        version: 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2576,7 +2576,7 @@ importers:
         version: 1.1.1(typescript@5.8.2)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       webdriverio:
         specifier: ^9.12.0
         version: 9.12.0
@@ -2601,7 +2601,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/is-ansi-color-supported:
     devDependencies:
@@ -2613,10 +2613,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2634,7 +2634,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2688,7 +2688,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/jsdoc-open-api:
     dependencies:
@@ -2697,7 +2697,7 @@ importers:
         version: 10.1.1(openapi-types@12.1.3)
       '@visulima/fs':
         specifier: 3.1.2
-        version: 3.1.2(yaml@2.7.0)
+        version: 3.1.2(yaml@2.7.1)
       comment-parser:
         specifier: ^1.4.1
         version: 1.4.1
@@ -2708,27 +2708,27 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       yaml:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.7.1
+        version: 2.7.1
     devDependencies:
       '@anolilab/eslint-config':
         specifier: ^15.0.3
-        version: 15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.26.10)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-storybook@0.11.4(eslint@8.57.0)(typescript@5.8.2))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-testing-library@7.1.1(eslint@8.57.0)(typescript@5.8.2))(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.2)
+        version: 15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.27.1)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.3)
       '@anolilab/prettier-config':
         specifier: ^5.0.14
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.3)))(semantic-release@24.2.3(typescript@5.8.3))(yaml@2.7.1)
       '@babel/core':
-        specifier: ^7.26.10
-        version: 7.26.10
+        specifier: ^7.27.1
+        version: 7.27.1
       '@rushstack/eslint-plugin-security':
         specifier: ^0.10.0
-        version: 0.10.0(eslint@8.57.0)(typescript@5.8.2)
+        version: 0.10.0(eslint@8.57.0)(typescript@5.8.3)
       '@types/cli-progress':
         specifier: ^3.11.6
         version: 3.11.6
@@ -2745,11 +2745,11 @@ importers:
         specifier: ^5.28.5
         version: 5.28.5(@swc/core@1.6.7(@swc/helpers@0.5.15))
       '@vitest/coverage-v8':
-        specifier: ^3.0.8
-        version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
+        specifier: ^3.1.2
+        version: 3.1.2(@vitest/browser@3.0.8)(vitest@3.1.2)
       '@vitest/ui':
-        specifier: ^3.0.8
-        version: 3.0.8(vitest@3.0.8)
+        specifier: ^3.1.2
+        version: 3.1.2(vitest@3.1.2)
       conventional-changelog-conventionalcommits:
         specifier: 8.0.0
         version: 8.0.0
@@ -2761,19 +2761,19 @@ importers:
         version: 8.57.0
       eslint-plugin-deprecation:
         specifier: ^3.0.0
-        version: 3.0.0(eslint@8.57.0)(typescript@5.8.2)
+        version: 3.0.0(eslint@8.57.0)(typescript@5.8.3)
       eslint-plugin-etc:
         specifier: ^2.0.3
-        version: 2.0.3(eslint@8.57.0)(typescript@5.8.2)
+        version: 2.0.3(eslint@8.57.0)(typescript@5.8.3)
       eslint-plugin-import:
         specifier: npm:eslint-plugin-i@^2.29.1
         version: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-mdx:
-        specifier: ^3.2.0
-        version: 3.2.0(eslint@8.57.0)
+        specifier: ^3.4.1
+        version: 3.4.1(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: 0.4.1
-        version: 0.4.1(eslint@8.57.0)(typescript@5.8.2)(vitest@3.0.8)
+        version: 0.4.1(eslint@8.57.0)(typescript@5.8.3)(vitest@3.1.2)
       eslint-plugin-vitest-globals:
         specifier: ^1.5.0
         version: 1.5.0
@@ -2788,16 +2788,16 @@ importers:
         version: 6.0.1
       semantic-release:
         specifier: 24.2.3
-        version: 24.2.3(typescript@5.8.2)
+        version: 24.2.3(typescript@5.8.3)
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+        version: 8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       typescript:
-        specifier: 5.8.2
-        version: 5.8.2
+        specifier: 5.8.3
+        version: 5.8.3
       vitest:
-        specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.1.2)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
       cli-progress:
         specifier: ^3.12.0
@@ -2806,8 +2806,8 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       webpack:
-        specifier: ^5.98.0
-        version: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+        specifier: ^5.99.7
+        version: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
 
   packages/object:
     devDependencies:
@@ -2819,10 +2819,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2843,7 +2843,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: ^1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -2912,7 +2912,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/package:
     dependencies:
@@ -2924,7 +2924,7 @@ importers:
         version: 5.1.7(@types/node@18.19.71)
       '@visulima/fs':
         specifier: 3.1.2
-        version: 3.1.2(yaml@2.7.0)
+        version: 3.1.2(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -2940,10 +2940,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -2973,7 +2973,7 @@ importers:
         version: 2.4.4
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3042,7 +3042,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       yarn:
         specifier: ^1.22.22
         version: 1.22.22
@@ -3069,10 +3069,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3087,7 +3087,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3144,7 +3144,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/pail:
     dependencies:
@@ -3172,10 +3172,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3196,7 +3196,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@visulima/redact':
         specifier: 1.0.14
         version: 1.0.14
@@ -3265,7 +3265,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       wrap-ansi:
         specifier: ^9.0.0
         version: 9.0.0
@@ -3299,7 +3299,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/pail/__fixtures__/package/cjs:
     dependencies:
@@ -3323,10 +3323,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@22.13.9)(yaml@2.7.0)
+        version: 1.1.10(@types/node@22.13.9)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3344,7 +3344,7 @@ importers:
         version: 22.13.9
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@22.13.9)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@22.13.9)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3401,7 +3401,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       zeptomatch:
         specifier: ^2.0.1
         version: 2.0.1
@@ -3432,10 +3432,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3462,7 +3462,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: 3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3519,7 +3519,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/redact:
     dependencies:
@@ -3535,10 +3535,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: ^1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3556,7 +3556,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3613,7 +3613,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/redact/__bench__:
     dependencies:
@@ -3638,7 +3638,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/redact/__fixtures__/package/cjs:
     dependencies:
@@ -3669,10 +3669,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3693,7 +3693,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -3747,7 +3747,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/string:
     devDependencies:
@@ -3759,10 +3759,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: 10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arcanis/slice-ansi':
         specifier: 2.0.1
         version: 2.0.1
@@ -3792,7 +3792,7 @@ importers:
         version: 1.4.21
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.1)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.1)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: 3.0.9
         version: 3.0.9(@vitest/browser@3.0.8)(vitest@3.0.9)
@@ -3882,7 +3882,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 3.0.9
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       wrap-ansi:
         specifier: 9.0.0
         version: 9.0.0
@@ -3891,7 +3891,7 @@ importers:
     dependencies:
       '@visulima/fs':
         specifier: 3.1.2
-        version: 3.1.2(yaml@2.7.0)
+        version: 3.1.2(yaml@2.7.1)
       '@visulima/path':
         specifier: 1.3.5
         version: 1.3.5
@@ -3910,10 +3910,10 @@ importers:
         version: 5.0.14(prettier@3.5.3)
       '@anolilab/semantic-release-pnpm':
         specifier: 1.1.10
-        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.0)
+        version: 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
       '@anolilab/semantic-release-preset':
         specifier: ^10.0.3
-        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)
+        version: 10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -3934,7 +3934,7 @@ importers:
         version: 18.19.71
       '@visulima/packem':
         specifier: 1.19.1
-        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)
+        version: 1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)
       '@vitest/coverage-v8':
         specifier: ^3.0.8
         version: 3.0.8(@vitest/browser@3.0.8)(vitest@3.0.8)
@@ -4006,7 +4006,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   packages/tsconfig/__fixtures__/package/cjs:
     dependencies:
@@ -4287,12 +4287,24 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.26.8':
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.27.1':
+    resolution: {integrity: sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.26.10':
     resolution: {integrity: sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.27.1':
+    resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/eslint-parser@7.26.10':
@@ -4306,6 +4318,10 @@ packages:
     resolution: {integrity: sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.27.1':
+    resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.24.7':
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
@@ -4316,6 +4332,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.26.5':
     resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.1':
+    resolution: {integrity: sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.24.7':
@@ -4355,8 +4375,18 @@ packages:
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.26.0':
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.27.1':
+    resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -4397,12 +4427,24 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.25.9':
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.24.7':
@@ -4413,6 +4455,10 @@ packages:
     resolution: {integrity: sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@7.27.1':
+    resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.26.10':
     resolution: {integrity: sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==}
     engines: {node: '>=6.0.0'}
@@ -4420,6 +4466,11 @@ packages:
 
   '@babel/parser@7.26.9':
     resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.27.1':
+    resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4940,12 +4991,24 @@ packages:
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.27.1':
+    resolution: {integrity: sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.26.10':
     resolution: {integrity: sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.27.1':
+    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.26.10':
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -6626,6 +6689,10 @@ packages:
 
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@pkgr/core@0.2.4':
+    resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
@@ -9366,6 +9433,15 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/coverage-v8@3.1.2':
+    resolution: {integrity: sha512-XDdaDOeaTMAMYW7N63AqoK32sYUWbXnTkC6tEbVcu3RlU1bB9of32T+PGf8KZvxqLNqeXhafDFqCkwpf2+dyaQ==}
+    peerDependencies:
+      '@vitest/browser': 3.1.2
+      vitest: 3.1.2
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
@@ -9374,6 +9450,9 @@ packages:
 
   '@vitest/expect@3.0.9':
     resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
+
+  '@vitest/expect@3.1.2':
+    resolution: {integrity: sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==}
 
   '@vitest/mocker@3.0.8':
     resolution: {integrity: sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==}
@@ -9397,6 +9476,17 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@3.1.2':
+    resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: '>=6.2.6'
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
@@ -9409,17 +9499,26 @@ packages:
   '@vitest/pretty-format@3.0.9':
     resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
 
+  '@vitest/pretty-format@3.1.2':
+    resolution: {integrity: sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==}
+
   '@vitest/runner@3.0.8':
     resolution: {integrity: sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==}
 
   '@vitest/runner@3.0.9':
     resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
 
+  '@vitest/runner@3.1.2':
+    resolution: {integrity: sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==}
+
   '@vitest/snapshot@3.0.8':
     resolution: {integrity: sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==}
 
   '@vitest/snapshot@3.0.9':
     resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
+
+  '@vitest/snapshot@3.1.2':
+    resolution: {integrity: sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==}
 
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
@@ -9430,6 +9529,9 @@ packages:
   '@vitest/spy@3.0.9':
     resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
 
+  '@vitest/spy@3.1.2':
+    resolution: {integrity: sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==}
+
   '@vitest/ui@3.0.8':
     resolution: {integrity: sha512-MfTjaLU+Gw/lYorgwFZ06Cym+Mj9hPfZh/Q91d4JxyAHiicAakPTvS7zYCSHF+5cErwu2PVBe1alSjuh6L/UiA==}
     peerDependencies:
@@ -9439,6 +9541,11 @@ packages:
     resolution: {integrity: sha512-FpZD4aIv/qNpwkV3XbLV6xldWFHMgoNWAJEgg5GmpObmAOLAErpYjew9dDwXdYdKOS3iZRKdwI+P3JOJcYeUBg==}
     peerDependencies:
       vitest: 3.0.9
+
+  '@vitest/ui@3.1.2':
+    resolution: {integrity: sha512-+YPgKiLpFEyBVJNHDkRcSDcLrrnr20lyU4HQoI9Jtq1MdvoX8usql9h38mQw82MBU1Zo5BPC6sw+sXZ6NS18CQ==}
+    peerDependencies:
+      vitest: 3.1.2
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
@@ -9451,6 +9558,9 @@ packages:
 
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
+
+  '@vitest/utils@3.1.2':
+    resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
   '@wdio/config@9.11.0':
     resolution: {integrity: sha512-lBcmd7r+3nHJwIWDZ/cLIXcIL9rCmQmMvMWQ+Ykcrlc2khePX92VZyd0igptrZATJGD3tQ7VySR5Bozz6uMzyA==}
@@ -11749,6 +11859,16 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
+  eslint-mdx@3.4.1:
+    resolution: {integrity: sha512-/Pt9D5TIAZwAUnCJA24i+uE9NuqulmLI58a1oU1eRb5jeUNOR23FpIt4xuBE9CFR50nd4FkLnuyox7dSNSZ5Tg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+      remark-lint-file-extension: '*'
+    peerDependenciesMeta:
+      remark-lint-file-extension:
+        optional: true
+
   eslint-module-utils@2.12.0:
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
@@ -11860,6 +11980,12 @@ packages:
 
   eslint-plugin-mdx@3.2.0:
     resolution: {integrity: sha512-zMD6DoFf5tj86dF1M0g90IxeBzrckyhYwksvalO1vfOBPPzhpR2wAbILBHZnubNuQALVgiqYQbPQ922GpviuGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+
+  eslint-plugin-mdx@3.4.1:
+    resolution: {integrity: sha512-dfQ7LthK/Kmfw2d5XrR4CS1ScmFOa1S9vPjBUxtKgCEl6mNnYVfA/yg50xLyab0pI/GEfGEmvlajs2biDHJBsA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       eslint: '>=8.0.0'
@@ -12221,6 +12347,10 @@ packages:
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
@@ -17562,6 +17692,10 @@ packages:
     resolution: {integrity: sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==}
     engines: {node: '>= 10.13.0'}
 
+  schema-utils@4.3.2:
+    resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
+    engines: {node: '>= 10.13.0'}
+
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
@@ -17962,6 +18096,9 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
@@ -18252,6 +18389,10 @@ packages:
 
   synchronous-promise@2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
+
+  synckit@0.11.4:
+    resolution: {integrity: sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   synckit@0.6.2:
     resolution: {integrity: sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==}
@@ -18891,6 +19032,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typical@7.3.0:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
@@ -19309,6 +19455,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-node@3.1.2:
+    resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
@@ -19395,6 +19546,34 @@ packages:
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       '@vitest/browser': 3.0.9
       '@vitest/ui': 3.0.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.1.2:
+    resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.2
+      '@vitest/ui': 3.1.2
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -19510,6 +19689,16 @@ packages:
 
   webpack@5.98.0:
     resolution: {integrity: sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
+  webpack@5.99.7:
+    resolution: {integrity: sha512-CNqKBRMQjwcmKR0idID5va1qlhrqVUKpovi+Ec79ksW8ux7iS1+A6VqzfZXgVYCFRKl7XL5ap3ZoMpwBJxcg0w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -19707,6 +19896,11 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yaml@2.7.1:
+    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -19891,74 +20085,6 @@ snapshots:
       - svelte-eslint-parser
       - vue-eslint-parser
 
-  '@anolilab/eslint-config@15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.26.10)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-tsdoc@0.4.0)(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.2)':
-    dependencies:
-      '@anolilab/package-json-utils': 3.0.9
-      '@babel/core': 7.26.10
-      '@babel/eslint-parser': 7.26.10(@babel/core@7.26.10)(eslint@8.57.0)
-      '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.26.10)
-      '@eslint/js': 8.57.0
-      '@html-eslint/eslint-plugin': 0.20.0
-      '@html-eslint/parser': 0.20.0
-      '@jsenv/eslint-import-resolver': 8.1.2
-      '@rushstack/eslint-patch': 1.10.3
-      '@rushstack/eslint-plugin-security': 0.7.1(eslint@8.57.0)(typescript@5.8.2)
-      '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.2)
-      confusing-browser-globals: 1.0.11
-      eslint: 8.57.0
-      eslint-define-config: 1.24.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-antfu: 1.0.13(eslint@8.57.0)
-      eslint-plugin-compat: 4.2.0(eslint@8.57.0)
-      eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
-      eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-html: 7.1.0
-      eslint-plugin-i: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jsonc: 2.16.0(eslint@8.57.0)
-      eslint-plugin-markdown: 3.0.1(eslint@8.57.0)
-      eslint-plugin-mdx: 2.3.4(eslint@8.57.0)
-      eslint-plugin-n: 16.6.2(eslint@8.57.0)
-      eslint-plugin-no-loops: 0.3.0(eslint@8.57.0)
-      eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-no-secrets: 0.8.9(eslint@8.57.0)
-      eslint-plugin-no-use-extend-native: 0.5.0
-      eslint-plugin-perfectionist: 2.11.0(eslint@8.57.0)(typescript@5.8.2)
-      eslint-plugin-promise: 6.4.0(eslint@8.57.0)
-      eslint-plugin-regexp: 2.6.0(eslint@8.57.0)
-      eslint-plugin-security: 1.7.1
-      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.57.0)
-      eslint-plugin-sonarjs: 0.22.0(eslint@8.57.0)
-      eslint-plugin-toml: 0.6.1(eslint@8.57.0)
-      eslint-plugin-unicorn: 49.0.0(eslint@8.57.0)
-      eslint-plugin-yml: 1.14.0(eslint@8.57.0)
-      find-up: 5.0.0
-      globals: 13.24.0
-      jsonc-eslint-parser: 2.4.0
-      read-pkg-up: 7.0.1
-      semver: 7.7.1
-      toml-eslint-parser: 0.6.1
-      yaml-eslint-parser: 1.2.3
-    optionalDependencies:
-      '@arthurgeron/eslint-plugin-react-usememo': 2.4.4
-      eslint-plugin-editorconfig: 4.0.3
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
-      eslint-plugin-react: 7.37.4(eslint@8.57.0)
-      eslint-plugin-ssr-friendly: 1.3.0(eslint@8.57.0)
-      eslint-plugin-tailwindcss: 3.18.0(tailwindcss@4.0.13)
-      eslint-plugin-tsdoc: 0.4.0
-      eslint-plugin-validate-jsx-nesting: 0.1.1(eslint@8.57.0)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - astro-eslint-parser
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import
-      - supports-color
-      - svelte
-      - svelte-eslint-parser
-      - vue-eslint-parser
-
   '@anolilab/eslint-config@15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.26.10)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.1))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.1))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@anolilab/package-json-utils': 3.0.9
@@ -20026,7 +20152,142 @@ snapshots:
       - svelte-eslint-parser
       - vue-eslint-parser
 
-  '@anolilab/lint-staged-config@2.1.7(eslint@8.57.1)(husky@9.1.7)(jest@29.7.0(@types/node@18.19.71))(lint-staged@15.5.0)(prettier@3.5.3)(secretlint@9.2.0)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@anolilab/eslint-config@15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.27.1)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-tsdoc@0.4.0)(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.2)':
+    dependencies:
+      '@anolilab/package-json-utils': 3.0.9
+      '@babel/core': 7.27.1
+      '@babel/eslint-parser': 7.26.10(@babel/core@7.27.1)(eslint@8.57.0)
+      '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.27.1)
+      '@eslint/js': 8.57.0
+      '@html-eslint/eslint-plugin': 0.20.0
+      '@html-eslint/parser': 0.20.0
+      '@jsenv/eslint-import-resolver': 8.1.2
+      '@rushstack/eslint-patch': 1.10.3
+      '@rushstack/eslint-plugin-security': 0.7.1(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.2)
+      confusing-browser-globals: 1.0.11
+      eslint: 8.57.0
+      eslint-define-config: 1.24.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-antfu: 1.0.13(eslint@8.57.0)
+      eslint-plugin-compat: 4.2.0(eslint@8.57.0)
+      eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
+      eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-i: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-jsonc: 2.16.0(eslint@8.57.0)
+      eslint-plugin-markdown: 3.0.1(eslint@8.57.0)
+      eslint-plugin-mdx: 2.3.4(eslint@8.57.0)
+      eslint-plugin-n: 16.6.2(eslint@8.57.0)
+      eslint-plugin-no-loops: 0.3.0(eslint@8.57.0)
+      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-no-secrets: 0.8.9(eslint@8.57.0)
+      eslint-plugin-no-use-extend-native: 0.5.0
+      eslint-plugin-perfectionist: 2.11.0(eslint@8.57.0)(typescript@5.8.2)
+      eslint-plugin-promise: 6.4.0(eslint@8.57.0)
+      eslint-plugin-regexp: 2.6.0(eslint@8.57.0)
+      eslint-plugin-security: 1.7.1
+      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.57.0)
+      eslint-plugin-sonarjs: 0.22.0(eslint@8.57.0)
+      eslint-plugin-toml: 0.6.1(eslint@8.57.0)
+      eslint-plugin-unicorn: 49.0.0(eslint@8.57.0)
+      eslint-plugin-yml: 1.14.0(eslint@8.57.0)
+      find-up: 5.0.0
+      globals: 13.24.0
+      jsonc-eslint-parser: 2.4.0
+      read-pkg-up: 7.0.1
+      semver: 7.7.1
+      toml-eslint-parser: 0.6.1
+      yaml-eslint-parser: 1.2.3
+    optionalDependencies:
+      '@arthurgeron/eslint-plugin-react-usememo': 2.4.4
+      eslint-plugin-editorconfig: 4.0.3
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
+      eslint-plugin-react: 7.37.4(eslint@8.57.0)
+      eslint-plugin-ssr-friendly: 1.3.0(eslint@8.57.0)
+      eslint-plugin-tailwindcss: 3.18.0(tailwindcss@4.0.13)
+      eslint-plugin-tsdoc: 0.4.0
+      eslint-plugin-validate-jsx-nesting: 0.1.1(eslint@8.57.0)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - astro-eslint-parser
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import
+      - supports-color
+      - svelte
+      - svelte-eslint-parser
+      - vue-eslint-parser
+
+  '@anolilab/eslint-config@15.0.3(@arthurgeron/eslint-plugin-react-usememo@2.4.4)(@babel/core@7.27.1)(eslint-plugin-editorconfig@4.0.3)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0))(eslint-plugin-react@7.37.4(eslint@8.57.0))(eslint-plugin-ssr-friendly@1.3.0(eslint@8.57.0))(eslint-plugin-tailwindcss@3.18.0(tailwindcss@4.0.13))(eslint-plugin-validate-jsx-nesting@0.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@anolilab/package-json-utils': 3.0.9
+      '@babel/core': 7.27.1
+      '@babel/eslint-parser': 7.26.10(@babel/core@7.27.1)(eslint@8.57.0)
+      '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.27.1)
+      '@eslint/js': 8.57.0
+      '@html-eslint/eslint-plugin': 0.20.0
+      '@html-eslint/parser': 0.20.0
+      '@jsenv/eslint-import-resolver': 8.1.2
+      '@rushstack/eslint-patch': 1.10.3
+      '@rushstack/eslint-plugin-security': 0.7.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      confusing-browser-globals: 1.0.11
+      eslint: 8.57.0
+      eslint-define-config: 1.24.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-antfu: 1.0.13(eslint@8.57.0)
+      eslint-plugin-compat: 4.2.0(eslint@8.57.0)
+      eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
+      eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-i: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-jsonc: 2.16.0(eslint@8.57.0)
+      eslint-plugin-markdown: 3.0.1(eslint@8.57.0)
+      eslint-plugin-mdx: 2.3.4(eslint@8.57.0)
+      eslint-plugin-n: 16.6.2(eslint@8.57.0)
+      eslint-plugin-no-loops: 0.3.0(eslint@8.57.0)
+      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-no-secrets: 0.8.9(eslint@8.57.0)
+      eslint-plugin-no-use-extend-native: 0.5.0
+      eslint-plugin-perfectionist: 2.11.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint-plugin-promise: 6.4.0(eslint@8.57.0)
+      eslint-plugin-regexp: 2.6.0(eslint@8.57.0)
+      eslint-plugin-security: 1.7.1
+      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.57.0)
+      eslint-plugin-sonarjs: 0.22.0(eslint@8.57.0)
+      eslint-plugin-toml: 0.6.1(eslint@8.57.0)
+      eslint-plugin-unicorn: 49.0.0(eslint@8.57.0)
+      eslint-plugin-yml: 1.14.0(eslint@8.57.0)
+      find-up: 5.0.0
+      globals: 13.24.0
+      jsonc-eslint-parser: 2.4.0
+      read-pkg-up: 7.0.1
+      semver: 7.7.1
+      toml-eslint-parser: 0.6.1
+      yaml-eslint-parser: 1.2.3
+    optionalDependencies:
+      '@arthurgeron/eslint-plugin-react-usememo': 2.4.4
+      eslint-plugin-editorconfig: 4.0.3
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
+      eslint-plugin-react: 7.37.4(eslint@8.57.0)
+      eslint-plugin-ssr-friendly: 1.3.0(eslint@8.57.0)
+      eslint-plugin-tailwindcss: 3.18.0(tailwindcss@4.0.13)
+      eslint-plugin-validate-jsx-nesting: 0.1.1(eslint@8.57.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - astro-eslint-parser
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import
+      - supports-color
+      - svelte
+      - svelte-eslint-parser
+      - vue-eslint-parser
+
+  '@anolilab/lint-staged-config@2.1.7(eslint@8.57.1)(husky@9.1.7)(jest@29.7.0(@types/node@18.19.71))(lint-staged@15.5.0)(prettier@3.5.3)(secretlint@9.2.0)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@anolilab/package-json-utils': 3.0.9
       find-up: 5.0.0
@@ -20038,7 +20299,7 @@ snapshots:
       jest: 29.7.0(@types/node@18.19.71)
       prettier: 3.5.3
       secretlint: 9.2.0
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   '@anolilab/multi-semantic-release@1.1.10(semantic-release@24.2.3(typescript@5.8.2))(typescript@5.8.2)':
     dependencies:
@@ -20080,10 +20341,27 @@ snapshots:
     transitivePeerDependencies:
       - yaml
 
+  '@anolilab/rc@1.1.6(yaml@2.7.1)':
+    dependencies:
+      '@visulima/fs': 3.1.2(yaml@2.7.1)
+      '@visulima/path': 1.3.5
+      ini: 5.0.0
+      ts-deepmerge: 7.0.2
+    transitivePeerDependencies:
+      - yaml
+
   '@anolilab/semantic-release-clean-package-json@2.0.1(yaml@2.7.0)':
     dependencies:
       '@semantic-release/error': 4.0.0
       '@visulima/fs': 3.1.2(yaml@2.7.0)
+      '@visulima/path': 1.3.5
+    transitivePeerDependencies:
+      - yaml
+
+  '@anolilab/semantic-release-clean-package-json@2.0.1(yaml@2.7.1)':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      '@visulima/fs': 3.1.2(yaml@2.7.1)
       '@visulima/path': 1.3.5
     transitivePeerDependencies:
       - yaml
@@ -20104,12 +20382,28 @@ snapshots:
       - '@types/node'
       - yaml
 
-  '@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.0)':
+  '@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1)':
     dependencies:
-      '@anolilab/rc': 1.1.6(yaml@2.7.0)
+      '@anolilab/rc': 1.1.6(yaml@2.7.1)
       '@semantic-release/error': 4.0.0
-      '@visulima/fs': 3.1.2(yaml@2.7.0)
-      '@visulima/package': 3.5.2(@types/node@22.13.9)(yaml@2.7.0)
+      '@visulima/fs': 3.1.2(yaml@2.7.1)
+      '@visulima/package': 3.5.2(@types/node@18.19.71)(yaml@2.7.1)
+      '@visulima/path': 1.3.5
+      execa: 9.5.2
+      ini: 5.0.0
+      normalize-url: 8.0.1
+      registry-auth-token: 5.1.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - yaml
+
+  '@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.1)':
+    dependencies:
+      '@anolilab/rc': 1.1.6(yaml@2.7.1)
+      '@semantic-release/error': 4.0.0
+      '@visulima/fs': 3.1.2(yaml@2.7.1)
+      '@visulima/package': 3.5.2(@types/node@22.13.9)(yaml@2.7.1)
       '@visulima/path': 1.3.5
       execa: 9.5.2
       ini: 5.0.0
@@ -20138,9 +20432,9 @@ snapshots:
       - supports-color
       - yaml
 
-  '@anolilab/semantic-release-preset@10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.0))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.0)':
+  '@anolilab/semantic-release-preset@10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)':
     dependencies:
-      '@anolilab/semantic-release-clean-package-json': 2.0.1(yaml@2.7.0)
+      '@anolilab/semantic-release-clean-package-json': 2.0.1(yaml@2.7.1)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.3(typescript@5.8.2))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.3(typescript@5.8.2))
       '@semantic-release/exec': 7.0.3(semantic-release@24.2.3(typescript@5.8.2))
@@ -20150,7 +20444,43 @@ snapshots:
       conventional-changelog-conventionalcommits: 8.0.0
       semantic-release: 24.2.3(typescript@5.8.2)
     optionalDependencies:
-      '@anolilab/semantic-release-pnpm': 1.1.10(@types/node@22.13.9)(yaml@2.7.0)
+      '@anolilab/semantic-release-pnpm': 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
+      '@semantic-release/npm': 12.0.1(semantic-release@24.2.3(typescript@5.8.2))
+    transitivePeerDependencies:
+      - supports-color
+      - yaml
+
+  '@anolilab/semantic-release-preset@10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@18.19.71)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.3)))(semantic-release@24.2.3(typescript@5.8.3))(yaml@2.7.1)':
+    dependencies:
+      '@anolilab/semantic-release-clean-package-json': 2.0.1(yaml@2.7.1)
+      '@semantic-release/changelog': 6.0.3(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/exec': 7.0.3(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/git': 10.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/github': 11.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.3(typescript@5.8.3))
+      conventional-changelog-conventionalcommits: 8.0.0
+      semantic-release: 24.2.3(typescript@5.8.3)
+    optionalDependencies:
+      '@anolilab/semantic-release-pnpm': 1.1.10(@types/node@18.19.71)(yaml@2.7.1)
+      '@semantic-release/npm': 12.0.1(semantic-release@24.2.3(typescript@5.8.3))
+    transitivePeerDependencies:
+      - supports-color
+      - yaml
+
+  '@anolilab/semantic-release-preset@10.0.3(@anolilab/semantic-release-pnpm@1.1.10(@types/node@22.13.9)(yaml@2.7.1))(@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2)))(semantic-release@24.2.3(typescript@5.8.2))(yaml@2.7.1)':
+    dependencies:
+      '@anolilab/semantic-release-clean-package-json': 2.0.1(yaml@2.7.1)
+      '@semantic-release/changelog': 6.0.3(semantic-release@24.2.3(typescript@5.8.2))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.3(typescript@5.8.2))
+      '@semantic-release/exec': 7.0.3(semantic-release@24.2.3(typescript@5.8.2))
+      '@semantic-release/git': 10.0.1(semantic-release@24.2.3(typescript@5.8.2))
+      '@semantic-release/github': 11.0.1(semantic-release@24.2.3(typescript@5.8.2))
+      '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.3(typescript@5.8.2))
+      conventional-changelog-conventionalcommits: 8.0.0
+      semantic-release: 24.2.3(typescript@5.8.2)
+    optionalDependencies:
+      '@anolilab/semantic-release-pnpm': 1.1.10(@types/node@22.13.9)(yaml@2.7.1)
       '@semantic-release/npm': 12.0.1(semantic-release@24.2.3(typescript@5.8.2))
     transitivePeerDependencies:
       - supports-color
@@ -20278,7 +20608,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.26.8': {}
+
+  '@babel/compat-data@7.27.1': {}
 
   '@babel/core@7.26.10':
     dependencies:
@@ -20292,6 +20630,26 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.10
       '@babel/types': 7.26.10
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.27.1':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/helper-compilation-targets': 7.27.1
+      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
+      '@babel/helpers': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -20316,10 +20674,26 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
+  '@babel/eslint-parser@7.26.10(@babel/core@7.27.1)(eslint@8.57.0)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 8.57.0
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
+
   '@babel/generator@7.26.10':
     dependencies:
       '@babel/parser': 7.26.10
       '@babel/types': 7.26.10
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
+  '@babel/generator@7.27.1':
+    dependencies:
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
@@ -20339,6 +20713,14 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.26.8
       '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-compilation-targets@7.27.1':
+    dependencies:
+      '@babel/compat-data': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.4
       lru-cache: 5.1.1
       semver: 6.3.1
@@ -20403,12 +20785,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
       '@babel/traverse': 7.26.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -20456,9 +20854,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
 
+  '@babel/helper-validator-identifier@7.27.1': {}
+
   '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-wrap-function@7.24.7':
     dependencies:
@@ -20474,6 +20878,11 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/types': 7.26.10
 
+  '@babel/helpers@7.27.1':
+    dependencies:
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
+
   '@babel/parser@7.26.10':
     dependencies:
       '@babel/types': 7.26.10
@@ -20481,6 +20890,10 @@ snapshots:
   '@babel/parser@7.26.9':
     dependencies:
       '@babel/types': 7.26.10
+
+  '@babel/parser@7.27.1':
+    dependencies:
+      '@babel/types': 7.27.1
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.26.10)':
     dependencies:
@@ -20517,14 +20930,24 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.10)':
@@ -20547,6 +20970,11 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -20557,9 +20985,19 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.26.10)':
@@ -20567,9 +21005,19 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.10)':
@@ -20577,9 +21025,19 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.10)':
@@ -20587,14 +21045,29 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.10)':
@@ -20607,9 +21080,19 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
@@ -21129,6 +21612,12 @@ snapshots:
       '@babel/parser': 7.26.10
       '@babel/types': 7.26.10
 
+  '@babel/template@7.27.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
+
   '@babel/traverse@7.26.10':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -21141,10 +21630,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.27.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.26.10':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -22313,7 +22819,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -22340,12 +22846,12 @@ snapshots:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.8.2)
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
       typescript: 5.8.2
 
@@ -22917,10 +23423,17 @@ snapshots:
       esquery: 1.5.0
       typescript: 5.8.2
 
+  '@phenomnomnominal/tsquery@5.0.1(typescript@5.8.3)':
+    dependencies:
+      esquery: 1.5.0
+      typescript: 5.8.3
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@pkgr/core@0.2.4': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -23768,6 +24281,15 @@ snapshots:
       - supports-color
       - typescript
 
+  '@rushstack/eslint-plugin-security@0.10.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 8.26.1(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@rushstack/eslint-plugin-security@0.10.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
@@ -23781,6 +24303,15 @@ snapshots:
     dependencies:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.57.0)(typescript@5.8.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@rushstack/eslint-plugin-security@0.7.1(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.1
+      '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -23879,6 +24410,14 @@ snapshots:
       lodash: 4.17.21
       semantic-release: 24.2.3(typescript@5.8.2)
 
+  '@semantic-release/changelog@6.0.3(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      '@semantic-release/error': 3.0.0
+      aggregate-error: 3.1.0
+      fs-extra: 11.3.0
+      lodash: 4.17.21
+      semantic-release: 24.2.3(typescript@5.8.3)
+
   '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.3(typescript@5.8.2))':
     dependencies:
       conventional-changelog-angular: 8.0.0
@@ -23890,6 +24429,20 @@ snapshots:
       lodash-es: 4.17.21
       micromatch: 4.0.8
       semantic-release: 24.2.3(typescript@5.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      conventional-changelog-angular: 8.0.0
+      conventional-changelog-writer: 8.0.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.0.0
+      debug: 4.4.0
+      import-from-esm: 2.0.0
+      lodash-es: 4.17.21
+      micromatch: 4.0.8
+      semantic-release: 24.2.3(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -23909,6 +24462,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@semantic-release/exec@7.0.3(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.0
+      execa: 9.5.2
+      lodash-es: 4.17.21
+      parse-json: 8.1.0
+      semantic-release: 24.2.3(typescript@5.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@semantic-release/git@10.0.1(semantic-release@24.2.3(typescript@5.8.2))':
     dependencies:
       '@semantic-release/error': 3.0.0
@@ -23920,6 +24485,20 @@ snapshots:
       micromatch: 4.0.8
       p-reduce: 2.1.0
       semantic-release: 24.2.3(typescript@5.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/git@10.0.1(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      '@semantic-release/error': 3.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.0
+      dir-glob: 3.0.1
+      execa: 5.1.1
+      lodash: 4.17.21
+      micromatch: 4.0.8
+      p-reduce: 2.1.0
+      semantic-release: 24.2.3(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -23945,6 +24524,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@semantic-release/github@11.0.1(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      '@octokit/core': 6.1.4
+      '@octokit/plugin-paginate-rest': 11.4.3(@octokit/core@6.1.4)
+      '@octokit/plugin-retry': 7.1.1(@octokit/core@6.1.4)
+      '@octokit/plugin-throttling': 9.3.0(@octokit/core@6.1.4)
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      debug: 4.4.0
+      dir-glob: 3.0.1
+      globby: 14.1.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      issue-parser: 7.0.1
+      lodash-es: 4.17.21
+      mime: 4.0.3
+      p-filter: 4.1.0
+      semantic-release: 24.2.3(typescript@5.8.3)
+      url-join: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.2))':
     dependencies:
       '@semantic-release/error': 4.0.0
@@ -23962,6 +24563,23 @@ snapshots:
       semver: 7.7.1
       tempy: 3.1.0
 
+  '@semantic-release/npm@12.0.1(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      execa: 9.5.2
+      fs-extra: 11.3.0
+      lodash-es: 4.17.21
+      nerf-dart: 1.0.0
+      normalize-url: 8.0.1
+      npm: 10.9.2
+      rc: 1.2.8
+      read-pkg: 9.0.1
+      registry-auth-token: 5.1.0
+      semantic-release: 24.2.3(typescript@5.8.3)
+      semver: 7.7.1
+      tempy: 3.1.0
+
   '@semantic-release/release-notes-generator@14.0.3(semantic-release@24.2.3(typescript@5.8.2))':
     dependencies:
       conventional-changelog-angular: 8.0.0
@@ -23975,6 +24593,22 @@ snapshots:
       lodash-es: 4.17.21
       read-package-up: 11.0.0
       semantic-release: 24.2.3(typescript@5.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/release-notes-generator@14.0.3(semantic-release@24.2.3(typescript@5.8.3))':
+    dependencies:
+      conventional-changelog-angular: 8.0.0
+      conventional-changelog-writer: 8.0.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.0.0
+      debug: 4.4.0
+      get-stream: 7.0.1
+      import-from-esm: 2.0.0
+      into-stream: 7.0.0
+      lodash-es: 4.17.21
+      read-package-up: 11.0.0
+      semantic-release: 24.2.3(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -24168,7 +24802,7 @@ snapshots:
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-styling@1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(postcss@8.5.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))':
+  '@storybook/addon-styling@1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(postcss@8.5.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))':
     dependencies:
       '@babel/template': 7.26.9
       '@babel/types': 7.26.10
@@ -24181,18 +24815,18 @@ snapshots:
       '@storybook/preview-api': 7.6.20
       '@storybook/theming': 7.6.20(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/types': 7.6.20
-      css-loader: 6.11.0(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
-      less-loader: 11.1.4(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
-      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      css-loader: 6.11.0(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      less-loader: 11.1.4(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.8.2)(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
       prettier: 2.8.8
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
-      style-loader: 3.3.4(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      sass-loader: 13.3.3(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      style-loader: 3.3.4(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
     optionalDependencies:
       postcss: 8.5.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@types/react'
@@ -24236,13 +24870,13 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/builder-vite@8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@storybook/builder-vite@8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.4(storybook@8.6.4(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   '@storybook/channels@7.6.17':
     dependencies:
@@ -24449,11 +25083,11 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       storybook: 8.6.4(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.9)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@storybook/react-vite@8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.9)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
-      '@storybook/builder-vite': 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+      '@storybook/builder-vite': 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@storybook/react': 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -24463,7 +25097,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.6.4(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
       '@storybook/test': 8.6.4(storybook@8.6.4(prettier@3.5.3))
     transitivePeerDependencies:
@@ -24582,54 +25216,54 @@ snapshots:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.26.10)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.26.10)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.10
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.26.10)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.26.10)
+      '@babel/core': 7.27.1
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.27.1)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.27.1)
 
   '@svgr/core@8.1.0(typescript@5.8.2)':
     dependencies:
-      '@babel/core': 7.26.10
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10)
+      '@babel/core': 7.27.1
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.27.1)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.8.2)
       snake-case: 3.0.4
@@ -24644,8 +25278,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.2))':
     dependencies:
-      '@babel/core': 7.26.10
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10)
+      '@babel/core': 7.27.1
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.27.1)
       '@svgr/core': 8.1.0(typescript@5.8.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -26067,6 +26701,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 7.15.0
+      '@typescript-eslint/type-utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 7.15.0
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -26111,6 +26763,14 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/experimental-utils@5.59.11(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/utils': 5.59.11(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/experimental-utils@5.59.11(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/utils': 5.59.11(eslint@8.57.1)(typescript@5.8.2)
@@ -26122,6 +26782,14 @@ snapshots:
   '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.8.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -26145,6 +26813,19 @@ snapshots:
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.0
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26211,6 +26892,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@7.15.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
+      debug: 4.4.0
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@7.15.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.8.2)
@@ -26259,6 +26952,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@5.59.11(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 5.59.11
+      '@typescript-eslint/visitor-keys': 5.59.11
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.1
+      tsutils: 3.21.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -26270,6 +26977,20 @@ snapshots:
       tsutils: 3.21.0(typescript@5.8.2)
     optionalDependencies:
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.1
+      tsutils: 3.21.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26288,6 +27009,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.1
+      ts-api-utils: 1.3.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@7.15.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 7.15.0
@@ -26300,6 +27036,21 @@ snapshots:
       ts-api-utils: 1.3.0(typescript@5.8.2)
     optionalDependencies:
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.15.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 7.15.0
+      '@typescript-eslint/visitor-keys': 7.15.0
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 1.3.0(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26317,6 +27068,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.26.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/visitor-keys': 8.26.1
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.0.1(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@5.59.11(eslint@8.57.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -26325,6 +27090,21 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.59.11
       '@typescript-eslint/types': 5.59.11
       '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.8.2)
+      eslint: 8.57.0
+      eslint-scope: 5.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@5.59.11(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.59.11
+      '@typescript-eslint/types': 5.59.11
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.8.3)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -26362,6 +27142,21 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
+      eslint: 8.57.0
+      eslint-scope: 5.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
@@ -26383,6 +27178,17 @@ snapshots:
       '@typescript-eslint/scope-manager': 7.15.0
       '@typescript-eslint/types': 7.15.0
       '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.8.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.15.0(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 7.15.0
+      '@typescript-eslint/types': 7.15.0
+      '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.8.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -26418,6 +27224,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
       eslint: 8.57.0
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.26.1(eslint@8.57.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.3)
+      eslint: 8.57.0
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26476,7 +27293,22 @@ snapshots:
 
   '@visulima/boxen@1.0.30': {}
 
-  '@visulima/cerebro@1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.0)':
+  '@visulima/cerebro@1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.1)':
+    dependencies:
+      '@visulima/boxen': 1.0.29
+      '@visulima/colorize': 1.4.20
+      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.1)
+      '@visulima/pail': 2.1.21(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)
+      cli-table3: 0.6.5
+      command-line-args: 6.0.1
+      fastest-levenshtein: 1.0.16
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@visulima/redact'
+      - rotating-file-stream
+      - yaml
+
+  '@visulima/cerebro@1.1.39(rotating-file-stream@3.2.6)(yaml@2.7.0)':
     dependencies:
       '@visulima/boxen': 1.0.29
       '@visulima/colorize': 1.4.20
@@ -26526,9 +27358,16 @@ snapshots:
     transitivePeerDependencies:
       - yaml
 
-  '@visulima/find-cache-dir@1.0.28(yaml@2.7.0)':
+  '@visulima/find-cache-dir@1.0.27(yaml@2.7.1)':
     dependencies:
-      '@visulima/fs': 3.1.2(yaml@2.7.0)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
+      '@visulima/path': 1.3.4
+    transitivePeerDependencies:
+      - yaml
+
+  '@visulima/find-cache-dir@1.0.28(yaml@2.7.1)':
+    dependencies:
+      '@visulima/fs': 3.1.2(yaml@2.7.1)
       '@visulima/path': 1.3.5
     transitivePeerDependencies:
       - yaml
@@ -26543,11 +27382,23 @@ snapshots:
     optionalDependencies:
       yaml: 2.7.0
 
+  '@visulima/fs@3.1.1(yaml@2.7.1)':
+    dependencies:
+      '@visulima/path': 1.3.4
+    optionalDependencies:
+      yaml: 2.7.1
+
   '@visulima/fs@3.1.2(yaml@2.7.0)':
     dependencies:
       '@visulima/path': 1.3.5
     optionalDependencies:
       yaml: 2.7.0
+
+  '@visulima/fs@3.1.2(yaml@2.7.1)':
+    dependencies:
+      '@visulima/path': 1.3.5
+    optionalDependencies:
+      yaml: 2.7.1
 
   '@visulima/humanizer@1.1.1': {}
 
@@ -26620,18 +27471,29 @@ snapshots:
       - '@types/node'
       - yaml
 
-  '@visulima/package@3.5.2(@types/node@22.13.9)(yaml@2.7.0)':
+  '@visulima/package@3.5.2(@types/node@18.19.71)(yaml@2.7.1)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
-      '@inquirer/confirm': 5.1.7(@types/node@22.13.9)
-      '@visulima/fs': 3.1.1(yaml@2.7.0)
+      '@inquirer/confirm': 5.1.7(@types/node@18.19.71)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
       '@visulima/path': 1.3.4
       normalize-package-data: 7.0.0
     transitivePeerDependencies:
       - '@types/node'
       - yaml
 
-  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)':
+  '@visulima/package@3.5.2(@types/node@22.13.9)(yaml@2.7.1)':
+    dependencies:
+      '@antfu/install-pkg': 1.0.0
+      '@inquirer/confirm': 5.1.7(@types/node@22.13.9)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
+      '@visulima/path': 1.3.4
+      normalize-package-data: 7.0.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - yaml
+
+  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(@visulima/redact@1.0.14)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
       '@babel/parser': 7.26.9
@@ -26648,7 +27510,80 @@ snapshots:
       '@rollup/plugin-replace': 6.0.2(rollup@4.34.9)
       '@rollup/plugin-wasm': 6.2.2(rollup@4.34.9)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
-      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.0)
+      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.1)
+      '@visulima/colorize': 1.4.20
+      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.1)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
+      '@visulima/humanizer': 1.1.1
+      '@visulima/package': 3.5.2(@types/node@18.19.71)(yaml@2.7.1)
+      '@visulima/pail': 2.1.21(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)
+      '@visulima/path': 1.3.4
+      '@visulima/source-map': 1.0.17
+      '@visulima/tsconfig': 1.1.15(yaml@2.7.1)
+      browserslist: 4.24.4
+      defu: 6.1.4
+      es-module-lexer: 1.6.0
+      fastest-levenshtein: 1.0.16
+      glob-parent: 6.0.2
+      hookable: 5.5.3
+      jiti: 2.4.2
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      oxc-parser: 0.54.0
+      oxc-resolver: 4.2.0
+      picomatch: 4.0.2
+      rollup: 4.34.9
+      rollup-plugin-dts: 6.1.1(rollup@4.34.9)(typescript@5.8.2)
+      rollup-plugin-license: 3.6.0(picomatch@4.0.2)(rollup@4.34.9)
+      rollup-plugin-polyfill-node: 0.13.0(rollup@4.34.9)
+      rollup-plugin-visualizer: 5.14.0(rollup@4.34.9)
+      semver: 7.7.1
+      source-map-js: 1.2.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.12
+    optionalDependencies:
+      '@swc/core': 1.6.7(@swc/helpers@0.5.15)
+      esbuild: 0.25.0
+      icss-utils: 5.1.0(postcss@8.5.3)
+      lightningcss: 1.25.1
+      postcss: 8.5.3
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.3)
+      postcss-modules-scope: 3.2.0(postcss@8.5.3)
+      postcss-modules-values: 4.0.0(postcss@8.5.3)
+      postcss-value-parser: 4.2.0
+      sucrase: 3.35.0
+      typedoc: 0.27.9(typescript@5.8.2)
+      typedoc-plugin-markdown: 4.4.2(typedoc@0.27.9(typescript@5.8.2))
+      typedoc-plugin-rename-defaults: 0.7.2(typedoc@0.27.9(typescript@5.8.2))
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@types/node'
+      - '@visulima/redact'
+      - rolldown
+      - rotating-file-stream
+      - yaml
+
+  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)':
+    dependencies:
+      '@antfu/install-pkg': 1.0.0
+      '@babel/parser': 7.26.9
+      '@clack/prompts': 0.10.0
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-slow-plugins': 2.0.0(postcss@8.5.3)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.34.9)
+      '@rollup/plugin-commonjs': 28.0.2(rollup@4.34.9)
+      '@rollup/plugin-dynamic-import-vars': 2.1.5(rollup@4.34.9)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.34.9)
+      '@rollup/plugin-json': 6.1.0(rollup@4.34.9)
+      '@rollup/plugin-node-resolve': 16.0.0(rollup@4.34.9)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.34.9)
+      '@rollup/plugin-wasm': 6.2.2(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
+      '@visulima/cerebro': 1.1.39(rotating-file-stream@3.2.6)(yaml@2.7.0)
       '@visulima/colorize': 1.4.20
       '@visulima/find-cache-dir': 1.0.27(yaml@2.7.0)
       '@visulima/fs': 3.1.1(yaml@2.7.0)
@@ -26704,7 +27639,7 @@ snapshots:
       - rotating-file-stream
       - yaml
 
-  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.1)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)':
+  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@18.19.71)(esbuild@0.25.1)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
       '@babel/parser': 7.26.9
@@ -26721,16 +27656,16 @@ snapshots:
       '@rollup/plugin-replace': 6.0.2(rollup@4.34.9)
       '@rollup/plugin-wasm': 6.2.2(rollup@4.34.9)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
-      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.0)
+      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.1)
       '@visulima/colorize': 1.4.20
-      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.0)
-      '@visulima/fs': 3.1.1(yaml@2.7.0)
+      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.1)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
       '@visulima/humanizer': 1.1.1
-      '@visulima/package': 3.5.2(@types/node@18.19.71)(yaml@2.7.0)
+      '@visulima/package': 3.5.2(@types/node@18.19.71)(yaml@2.7.1)
       '@visulima/pail': 2.1.21(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)
       '@visulima/path': 1.3.4
       '@visulima/source-map': 1.0.17
-      '@visulima/tsconfig': 1.1.15(yaml@2.7.0)
+      '@visulima/tsconfig': 1.1.15(yaml@2.7.1)
       browserslist: 4.24.4
       defu: 6.1.4
       es-module-lexer: 1.6.0
@@ -26758,7 +27693,7 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.5.3)
       lightningcss: 1.25.1
       postcss: 8.5.3
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1)
       postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
       postcss-modules-local-by-default: 4.0.5(postcss@8.5.3)
       postcss-modules-scope: 3.2.0(postcss@8.5.3)
@@ -26777,7 +27712,7 @@ snapshots:
       - rotating-file-stream
       - yaml
 
-  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@22.13.9)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.0)':
+  '@visulima/packem@1.19.1(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@22.13.9)(esbuild@0.25.0)(icss-utils@5.1.0(postcss@8.5.3))(lightningcss@1.25.1)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1))(postcss-modules-extract-imports@3.1.0(postcss@8.5.3))(postcss-modules-local-by-default@4.0.5(postcss@8.5.3))(postcss-modules-scope@3.2.0(postcss@8.5.3))(postcss-modules-values@4.0.0(postcss@8.5.3))(postcss-value-parser@4.2.0)(postcss@8.5.3)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc-plugin-rename-defaults@0.7.2(typedoc@0.27.9(typescript@5.8.2)))(typedoc@0.27.9(typescript@5.8.2))(typescript@5.8.2)(yaml@2.7.1)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
       '@babel/parser': 7.26.9
@@ -26794,16 +27729,16 @@ snapshots:
       '@rollup/plugin-replace': 6.0.2(rollup@4.34.9)
       '@rollup/plugin-wasm': 6.2.2(rollup@4.34.9)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
-      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.0)
+      '@visulima/cerebro': 1.1.39(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)(yaml@2.7.1)
       '@visulima/colorize': 1.4.20
-      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.0)
-      '@visulima/fs': 3.1.1(yaml@2.7.0)
+      '@visulima/find-cache-dir': 1.0.27(yaml@2.7.1)
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
       '@visulima/humanizer': 1.1.1
-      '@visulima/package': 3.5.2(@types/node@22.13.9)(yaml@2.7.0)
+      '@visulima/package': 3.5.2(@types/node@22.13.9)(yaml@2.7.1)
       '@visulima/pail': 2.1.21(@visulima/redact@1.0.14)(rotating-file-stream@3.2.6)
       '@visulima/path': 1.3.4
       '@visulima/source-map': 1.0.17
-      '@visulima/tsconfig': 1.1.15(yaml@2.7.0)
+      '@visulima/tsconfig': 1.1.15(yaml@2.7.1)
       browserslist: 4.24.4
       defu: 6.1.4
       es-module-lexer: 1.6.0
@@ -26831,7 +27766,7 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.5.3)
       lightningcss: 1.25.1
       postcss: 8.5.3
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1)
       postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
       postcss-modules-local-by-default: 4.0.5(postcss@8.5.3)
       postcss-modules-scope: 3.2.0(postcss@8.5.3)
@@ -26901,14 +27836,23 @@ snapshots:
     transitivePeerDependencies:
       - yaml
 
-  '@vitejs/plugin-react@4.3.4(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@visulima/tsconfig@1.1.15(yaml@2.7.1)':
+    dependencies:
+      '@visulima/fs': 3.1.1(yaml@2.7.1)
+      '@visulima/path': 1.3.4
+      jsonc-parser: 3.3.1
+      resolve-pkg-maps: 1.0.0
+    transitivePeerDependencies:
+      - yaml
+
+  '@vitejs/plugin-react@4.3.4(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26933,17 +27877,40 @@ snapshots:
       - typescript
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser@3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.9)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)':
+  '@vitest/browser@3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)':
     dependencies:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
+      '@vitest/utils': 3.0.8
+      magic-string: 0.30.17
+      msw: 2.7.3(@types/node@18.19.71)(typescript@5.8.2)
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.51.0
+      webdriverio: 9.12.0
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.9)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)':
+    dependencies:
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@vitest/utils': 3.0.8
       magic-string: 0.30.17
       msw: 2.7.3(@types/node@22.13.9)(typescript@5.8.2)
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       ws: 8.18.1
     optionalDependencies:
       playwright: 1.51.0
@@ -26971,9 +27938,9 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
-      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -26991,9 +27958,29 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     optionalDependencies:
-      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.1.2(@vitest/browser@3.0.8)(vitest@3.1.2)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.1.2)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+    optionalDependencies:
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27018,6 +28005,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.1.2':
+    dependencies:
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.8
@@ -27027,23 +28021,41 @@ snapshots:
       msw: 2.7.3(@types/node@18.19.71)(typescript@5.8.2)
       vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.0.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.3(@types/node@18.19.71)(typescript@5.8.2)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+
+  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.3(@types/node@22.13.9)(typescript@5.8.2)
-      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
-  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.3(@types/node@18.19.71)(typescript@5.8.2)
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+
+  '@vitest/mocker@3.1.2(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.3(@types/node@18.19.71)(typescript@5.8.3)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -27061,6 +28073,10 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.1.2':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@3.0.8':
     dependencies:
       '@vitest/utils': 3.0.8
@@ -27069,6 +28085,11 @@ snapshots:
   '@vitest/runner@3.0.9':
     dependencies:
       '@vitest/utils': 3.0.9
+      pathe: 2.0.3
+
+  '@vitest/runner@3.1.2':
+    dependencies:
+      '@vitest/utils': 3.1.2
       pathe: 2.0.3
 
   '@vitest/snapshot@3.0.8':
@@ -27080,6 +28101,12 @@ snapshots:
   '@vitest/snapshot@3.0.9':
     dependencies:
       '@vitest/pretty-format': 3.0.9
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.1.2':
+    dependencies:
+      '@vitest/pretty-format': 3.1.2
       magic-string: 0.30.17
       pathe: 2.0.3
 
@@ -27095,6 +28122,10 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
+  '@vitest/spy@3.1.2':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/ui@3.0.8(vitest@3.0.8)':
     dependencies:
       '@vitest/utils': 3.0.8
@@ -27104,7 +28135,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   '@vitest/ui@3.0.9(vitest@3.0.9)':
     dependencies:
@@ -27115,7 +28146,18 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+
+  '@vitest/ui@3.1.2(vitest@3.1.2)':
+    dependencies:
+      '@vitest/utils': 3.1.2
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.13
+      tinyrainbow: 2.0.0
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.1.2)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -27139,6 +28181,12 @@ snapshots:
   '@vitest/utils@3.0.9':
     dependencies:
       '@vitest/pretty-format': 3.0.9
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.1.2':
+    dependencies:
+      '@vitest/pretty-format': 3.1.2
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -27705,13 +28753,13 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-jest@29.7.0(@babel/core@7.26.10):
+  babel-jest@29.7.0(@babel/core@7.27.1):
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.26.10)
+      babel-preset-jest: 29.6.3(@babel/core@7.27.1)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -27759,27 +28807,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.26.10):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.27.1):
     dependencies:
-      '@babel/core': 7.26.10
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.10)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.10)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.10)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.10)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.10)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.10)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
+      '@babel/core': 7.27.1
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.27.1)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.27.1)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.27.1)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.27.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.27.1)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.27.1)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.27.1)
 
-  babel-preset-jest@29.6.3(@babel/core@7.26.10):
+  babel-preset-jest@29.6.3(@babel/core@7.27.1):
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.26.10)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.27.1)
 
   bail@1.0.5: {}
 
@@ -28664,6 +29712,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
+  cosmiconfig@9.0.0(typescript@5.8.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.8.3
+
   crc-32@1.2.2: {}
 
   crc32-stream@6.0.0:
@@ -28716,7 +29773,7 @@ snapshots:
 
   css-gradient-parser@0.0.16: {}
 
-  css-loader@6.11.0(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+  css-loader@6.11.0(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -28727,7 +29784,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
 
   css-select@5.1.0:
     dependencies:
@@ -29724,6 +30781,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-etc@5.2.1(eslint@8.57.0)(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+      tsutils: 3.21.0(typescript@5.8.3)
+      tsutils-etc: 1.4.2(tsutils@3.21.0(typescript@5.8.3))(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-etc@5.2.1(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
@@ -29748,6 +30815,23 @@ snapshots:
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      fast-glob: 3.3.3
+      get-tsconfig: 4.7.5
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0):
+    dependencies:
+      debug: 4.4.0
+      enhanced-resolve: 5.17.1
+      eslint: 8.57.0
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.7.5
@@ -29873,6 +30957,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-mdx@3.4.1(eslint@8.57.0):
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint: 8.57.0
+      espree: 10.3.0
+      estree-util-visit: 2.0.0
+      remark-mdx: 3.1.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      synckit: 0.11.4
+      tslib: 2.8.1
+      unified: 11.0.5
+      unified-engine: 11.2.2
+      unist-util-visit: 5.0.0
+      uvu: 0.5.6
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
@@ -29881,6 +30985,17 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29943,6 +31058,16 @@ snapshots:
       ts-api-utils: 1.3.0(typescript@5.8.2)
       tslib: 2.8.1
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-deprecation@3.0.0(eslint@8.57.0)(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.8.3)
+      tslib: 2.8.1
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -30009,6 +31134,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-etc@2.0.3(eslint@8.57.0)(typescript@5.8.3):
+    dependencies:
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+      eslint-etc: 5.2.1(eslint@8.57.0)(typescript@5.8.3)
+      requireindex: 1.2.0
+      tslib: 2.8.1
+      tsutils: 3.21.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-etc@2.0.3(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.2)
@@ -30033,6 +31171,23 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      get-tsconfig: 4.7.5
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+    dependencies:
+      debug: 4.4.0
+      doctrine: 3.0.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.7.5
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -30268,6 +31423,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-mdx@3.4.1(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
+      eslint-mdx: 3.4.1(eslint@8.57.0)
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+      remark-mdx: 3.1.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      synckit: 0.11.4
+      tslib: 2.8.1
+      unified: 11.0.5
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - remark-lint-file-extension
+      - supports-color
+
   eslint-plugin-n@15.7.0(eslint@8.57.0):
     dependencies:
       builtins: 5.1.0
@@ -30338,6 +31511,16 @@ snapshots:
   eslint-plugin-perfectionist@2.11.0(eslint@8.57.0)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.2)
+      eslint: 8.57.0
+      minimatch: 9.0.5
+      natural-compare-lite: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-perfectionist@2.11.0(eslint@8.57.0)(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
@@ -30595,7 +31778,17 @@ snapshots:
       '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.2)
       eslint: 8.57.0
     optionalDependencies:
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-vitest@0.4.1(eslint@8.57.0)(typescript@5.8.3)(vitest@3.1.2):
+    dependencies:
+      '@typescript-eslint/utils': 7.15.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint: 8.57.0
+    optionalDependencies:
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.1.2)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -30605,7 +31798,7 @@ snapshots:
       '@typescript-eslint/utils': 7.15.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
     optionalDependencies:
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -30973,6 +32166,8 @@ snapshots:
   expect-playwright@0.8.0: {}
 
   expect-type@1.1.0: {}
+
+  expect-type@1.2.1: {}
 
   expect@29.7.0:
     dependencies:
@@ -32694,7 +33889,7 @@ snapshots:
 
   istanbul-lib-instrument@4.0.3:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -32703,7 +33898,7 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@babel/parser': 7.26.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -32713,7 +33908,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@babel/parser': 7.26.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -32845,10 +34040,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@18.19.71):
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
+      babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -32875,10 +34070,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.13.9):
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
+      babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -33102,15 +34297,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@babel/generator': 7.26.10
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.26.10)
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.26.10)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.27.1)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.27.1)
       '@babel/types': 7.26.10
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.26.10)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.27.1)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -33423,9 +34618,9 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@11.1.4(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+  less-loader@11.1.4(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
     dependencies:
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
 
   leven@3.1.0: {}
 
@@ -33526,7 +34721,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.7.0
+      yaml: 2.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35174,6 +36369,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.7(@types/node@18.19.71)
+      '@mswjs/interceptors': 0.37.1
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.9.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.37.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
@@ -35629,7 +36850,7 @@ snapshots:
       tmp: 0.2.3
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      yaml: 2.7.0
+      yaml: 2.7.1
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -36412,7 +37633,7 @@ snapshots:
 
   pnpm-workspace-yaml@0.1.2:
     dependencies:
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   points-on-curve@0.2.0: {}
 
@@ -36461,7 +37682,7 @@ snapshots:
   postcss-load-config@5.1.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3):
     dependencies:
       lilconfig: 3.1.3
-      yaml: 2.7.0
+      yaml: 2.7.1
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.5.3
@@ -36476,13 +37697,22 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.3
+      tsx: 4.19.3
+      yaml: 2.7.1
+
+  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.8.2)(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.8.2)
       jiti: 1.21.6
       postcss: 8.5.3
       semver: 7.7.1
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - typescript
 
@@ -36800,7 +38030,7 @@ snapshots:
 
   react-docgen@7.0.3:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.27.1
       '@babel/traverse': 7.26.10
       '@babel/types': 7.26.10
       '@types/babel__core': 7.20.5
@@ -37796,10 +39026,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+  sass-loader@13.3.3(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
 
   satori@0.12.1:
     dependencies:
@@ -37824,6 +39054,13 @@ snapshots:
   schema-dts@1.1.5: {}
 
   schema-utils@4.3.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.17.1
+      ajv-formats: 2.1.1
+      ajv-keywords: 5.1.0(ajv@8.17.1)
+
+  schema-utils@4.3.2:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
@@ -37871,6 +39108,41 @@ snapshots:
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.3(typescript@5.8.2))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.8.2)
+      debug: 4.4.0
+      env-ci: 11.0.0
+      execa: 9.5.2
+      figures: 6.1.0
+      find-versions: 6.0.0
+      get-stream: 6.0.1
+      git-log-parser: 1.2.1
+      hook-std: 3.0.0
+      hosted-git-info: 8.0.0
+      import-from-esm: 2.0.0
+      lodash-es: 4.17.21
+      marked: 12.0.2
+      marked-terminal: 7.1.0(marked@12.0.2)
+      micromatch: 4.0.8
+      p-each-series: 3.0.0
+      p-reduce: 3.0.0
+      read-package-up: 11.0.0
+      resolve-from: 5.0.0
+      semver: 7.7.1
+      semver-diff: 4.0.0
+      signale: 1.4.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  semantic-release@24.2.3(typescript@5.8.3):
+    dependencies:
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/error': 4.0.0
+      '@semantic-release/github': 11.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/npm': 12.0.1(semantic-release@24.2.3(typescript@5.8.3))
+      '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.3(typescript@5.8.3))
+      aggregate-error: 5.0.0
+      cosmiconfig: 9.0.0(typescript@5.8.3)
       debug: 4.4.0
       env-ci: 11.0.0
       execa: 9.5.2
@@ -38389,6 +39661,8 @@ snapshots:
 
   std-env@3.8.0: {}
 
+  std-env@3.9.0: {}
+
   stdin-discarder@0.2.2: {}
 
   stickyfill@1.1.1: {}
@@ -38604,9 +39878,9 @@ snapshots:
     dependencies:
       boundary: 2.0.0
 
-  style-loader@3.3.4(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+  style-loader@3.3.4(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
     dependencies:
-      webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
 
   style-to-object@1.0.8:
     dependencies:
@@ -38784,6 +40058,11 @@ snapshots:
 
   synchronous-promise@2.0.17: {}
 
+  synckit@0.11.4:
+    dependencies:
+      '@pkgr/core': 0.2.4
+      tslib: 2.8.1
+
   synckit@0.6.2:
     dependencies:
       tslib: 2.8.1
@@ -38854,7 +40133,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.12
       unconfig: 7.3.1
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   telejson@7.2.0:
     dependencies:
@@ -38884,6 +40163,17 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.31.1
       webpack: 5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15))
+    optionalDependencies:
+      '@swc/core': 1.6.7(@swc/helpers@0.5.15)
+
+  terser-webpack-plugin@5.3.12(@swc/core@1.6.7(@swc/helpers@0.5.15))(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.31.1
+      webpack: 5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15))
     optionalDependencies:
       '@swc/core': 1.6.7(@swc/helpers@0.5.15)
 
@@ -39248,9 +40538,17 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-api-utils@1.3.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-api-utils@2.0.1(typescript@5.8.2):
     dependencies:
       typescript: 5.8.2
+
+  ts-api-utils@2.0.1(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
 
   ts-dedent@2.2.0: {}
 
@@ -39319,6 +40617,62 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.0)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.0
+      debug: 4.4.0
+      esbuild: 0.25.0
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1)
+      resolve-from: 5.0.0
+      rollup: 4.34.9
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.12
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.6.7(@swc/helpers@0.5.15)
+      postcss: 8.5.3
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.4.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.0)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.0
+      debug: 4.4.0
+      esbuild: 0.25.0
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.1)
+      resolve-from: 5.0.0
+      rollup: 4.34.9
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.12
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.6.7(@swc/helpers@0.5.15)
+      postcss: 8.5.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsutils-etc@1.4.2(tsutils@3.21.0(typescript@5.8.2))(typescript@5.8.2):
     dependencies:
       '@types/yargs': 17.0.32
@@ -39326,10 +40680,22 @@ snapshots:
       typescript: 5.8.2
       yargs: 17.7.2
 
+  tsutils-etc@1.4.2(tsutils@3.21.0(typescript@5.8.3))(typescript@5.8.3):
+    dependencies:
+      '@types/yargs': 17.0.32
+      tsutils: 3.21.0(typescript@5.8.3)
+      typescript: 5.8.3
+      yargs: 17.7.2
+
   tsutils@3.21.0(typescript@5.8.2):
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.2
+
+  tsutils@3.21.0(typescript@5.8.3):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.8.3
 
   tsx@4.19.3:
     dependencies:
@@ -39484,6 +40850,8 @@ snapshots:
 
   typescript@5.8.2: {}
 
+  typescript@5.8.3: {}
+
   typical@7.3.0: {}
 
   uc.micro@2.1.0: {}
@@ -39574,7 +40942,7 @@ snapshots:
       vfile-message: 3.1.4
       vfile-reporter: 7.0.5
       vfile-statistics: 2.0.1
-      yaml: 2.7.0
+      yaml: 2.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -39600,7 +40968,7 @@ snapshots:
       vfile-message: 4.0.2
       vfile-reporter: 8.1.1
       vfile-statistics: 3.0.0
-      yaml: 2.7.0
+      yaml: 2.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -40065,13 +41433,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.8(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
+  vite-node@3.0.8(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -40086,13 +41454,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.9(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
+  vite-node@3.0.8(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -40107,13 +41475,55 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)):
+  vite-node@3.0.9(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.1.2(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.1(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -40135,7 +41545,24 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
+  vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.1
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.34.9
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 18.19.71
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.25.1
+      terser: 5.31.1
+      tsx: 4.19.3
+      yaml: 2.7.1
+
+  vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.1
       fdir: 6.4.4(picomatch@4.0.2)
@@ -40150,7 +41577,7 @@ snapshots:
       lightningcss: 1.25.1
       terser: 5.31.1
       tsx: 4.19.3
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   vitest@3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
@@ -40194,10 +41621,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
+  vitest@3.0.8(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -40213,13 +41640,13 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 3.0.8(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite-node: 3.0.8(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.13.9
-      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.9)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@types/node': 18.19.71
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
       '@vitest/ui': 3.0.8(vitest@3.0.8)
       jsdom: 26.0.0
     transitivePeerDependencies:
@@ -40236,10 +41663,52 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0):
+  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.8)(@vitest/ui@3.0.8)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.0.8
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.0.8
+      '@vitest/runner': 3.0.8
+      '@vitest/snapshot': 3.0.8
+      '@vitest/spy': 3.0.8
+      '@vitest/utils': 3.0.8
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite-node: 3.0.8(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.13.9
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.9)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@vitest/ui': 3.0.8(vitest@3.0.8)
+      jsdom: 26.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.2))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -40255,14 +41724,57 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 3.0.9(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite-node: 3.0.9(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.71
-      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
       '@vitest/ui': 3.0.9(vitest@3.0.9)
+      jsdom: 26.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.1.2(@types/debug@4.1.12)(@types/node@18.19.71)(@vitest/browser@3.0.8)(@vitest/ui@3.1.2)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.25.1)(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.1.2
+      '@vitest/mocker': 3.1.2(msw@2.7.3(@types/node@18.19.71)(typescript@5.8.3))(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.2
+      '@vitest/runner': 3.1.2
+      '@vitest/snapshot': 3.1.2
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      vite-node: 3.1.2(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 18.19.71
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@18.19.71)(playwright@1.51.0)(typescript@5.8.2)(vite@6.3.3(@types/node@18.19.71)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.31.1)(tsx@4.19.3)(yaml@2.7.1))(vitest@3.0.8)(webdriverio@9.12.0)
+      '@vitest/ui': 3.1.2(vitest@3.1.2)
       jsdom: 26.0.0
     transitivePeerDependencies:
       - jiti
@@ -40433,6 +41945,37 @@ snapshots:
       schema-utils: 4.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.12(@swc/core@1.6.7(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.6.7(@swc/helpers@0.5.15)))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.14.1
+      browserslist: 4.24.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.6.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.2
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.12(@swc/core@1.6.7(@swc/helpers@0.5.15))(webpack@5.99.7(@swc/core@1.6.7(@swc/helpers@0.5.15)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -40643,11 +42186,13 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
       lodash: 4.17.21
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   yaml@1.10.2: {}
 
   yaml@2.7.0: {}
+
+  yaml@2.7.1: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
… for very verbose output.

- Updated `yaml` from 2.7.0 to 2.7.1 in package.json and pnpm-lock.yaml.
- Upgraded `@babel/core` to 7.27.1 and `@vitest/ui` to 3.1.2.
- Enhanced README.md with new features and usage instructions.

fixes #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Significantly expanded and reorganized README for improved clarity, detailed usage instructions, configuration guidance, and comprehensive examples.
  - Added new sections for features, usage modes, configuration, contributing, and license.

- **Chores**
  - Updated multiple dependencies to newer versions for improved stability and compatibility.

- **Style**
  - Changed the command-line "very verbose" flag from -vv to -d for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->