### PR TITLE
fix(error): remove find cache dir dependency and add caching interface

### DIFF
--- a/packages/error/README.md
+++ b/packages/error/README.md
@@ -45,13 +45,13 @@ If you want to generate AI-powered solution hints, install these optional peer d
 
 ```sh
 # pnpm
-pnpm add ai @visulima/find-cache-dir
+pnpm add ai
 
 # npm
-npm i ai @visulima/find-cache-dir
+npm i ai
 
 # yarn
-yarn add ai @visulima/find-cache-dir
+yarn add ai
 ```
 
 ## Usage
@@ -331,7 +331,7 @@ const prompt = aiPrompt({
 const html = aiSolutionResponse(modelText);
 ```
 
-You may also use a convenience finder that calls an AI provider for you (requires optional peer deps `ai` and `@visulima/find-cache-dir`):
+You may also use a convenience finder that calls an AI provider for you (requires optional peer dep `ai`):
 
 ```ts
 import { aiFinder } from "@visulima/error/solution/ai";

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -195,7 +195,6 @@
         "@total-typescript/ts-reset": "^0.6.1",
         "@types/command-line-args": "^5.2.3",
         "@types/node": "24.3.1",
-        "@visulima/find-cache-dir": "^1.0.31",
         "@visulima/packem": "2.0.0-alpha.18",
         "@visulima/path": "1.4.0",
         "@vitest/coverage-v8": "^3.2.4",
@@ -213,13 +212,9 @@
         "vitest": "^3.2.4"
     },
     "peerDependencies": {
-        "@visulima/find-cache-dir": "^1.0.31",
         "ai": "^5.0.30"
     },
     "peerDependenciesMeta": {
-        "@visulima/find-cache-dir": {
-            "optional": true
-        },
         "ai": {
             "optional": true
         }

--- a/packages/error/project.json
+++ b/packages/error/project.json
@@ -4,5 +4,5 @@
     "sourceRoot": "packages/error/src",
     "projectType": "library",
     "tags": ["error", "type:package", "flame"],
-    "implicitDependencies": ["path", "!find-cache-dir"]
+    "implicitDependencies": ["path"]
 }

--- a/packages/error/src/solution/ai/ai-finder.ts
+++ b/packages/error/src/solution/ai/ai-finder.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join } from "@visulima/path";
 import type { LanguageModel } from "ai";
 import { generateText } from "ai";
 
@@ -45,9 +45,9 @@ const generateCacheKey = (error: Error, file: SolutionFinderFile, temperature?: 
 };
 
 // Get cache directory path
-const getCacheDirectory = (cacheOptions?: CacheOptions): string => {
-    if (cacheOptions?.directory) {
-        return cacheOptions.directory;
+const getCacheDirectory = (directory?: string): string => {
+    if (directory) {
+        return directory;
     }
     
     // Default to a cache directory in the system temp folder
@@ -118,12 +118,13 @@ const aiFinder = (
             // Check cache if enabled
             if (cacheOptions?.enabled !== false) {
                 const cacheKey = generateCacheKey(error, file, temperature);
-                const cacheDir = getCacheDirectory(cacheOptions);
+                const cacheDir = getCacheDirectory(cacheOptions?.directory);
                 const cacheFilePath = getCacheFilePath(cacheDir, cacheKey);
                 const ttl = cacheOptions?.ttl ?? 24 * 60 * 60 * 1000; // Default 24 hours
                 
                 // Try to read from cache
                 const cachedSolution = readFromCache(cacheFilePath, ttl);
+                
                 if (cachedSolution) {
                     return cachedSolution;
                 }

--- a/packages/error/src/solution/ai/ai-finder.ts
+++ b/packages/error/src/solution/ai/ai-finder.ts
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { LanguageModel } from "ai";
 import { generateText } from "ai";
 
@@ -14,6 +18,91 @@ interface CacheOptions {
     ttl?: number; // Time to live in milliseconds
 }
 
+interface CacheEntry {
+    solution: Solution;
+    timestamp: number;
+    ttl: number;
+}
+
+// Generate a cache key from error and file data
+const generateCacheKey = (error: Error, file: SolutionFinderFile, temperature?: number): string => {
+    const keyData = {
+        error: {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+        },
+        file: {
+            file: file.file,
+            language: file.language,
+            line: file.line,
+            snippet: file.snippet,
+        },
+        temperature,
+    };
+    
+    return createHash("sha256").update(JSON.stringify(keyData)).digest("hex");
+};
+
+// Get cache directory path
+const getCacheDirectory = (cacheOptions?: CacheOptions): string => {
+    if (cacheOptions?.directory) {
+        return cacheOptions.directory;
+    }
+    
+    // Default to a cache directory in the system temp folder
+    return join(tmpdir(), "visulima-error-cache");
+};
+
+// Ensure cache directory exists
+const ensureCacheDirectory = (cacheDir: string): void => {
+    if (!existsSync(cacheDir)) {
+        mkdirSync(cacheDir, { recursive: true });
+    }
+};
+
+// Get cache file path
+const getCacheFilePath = (cacheDir: string, key: string): string => {
+    return join(cacheDir, `${key}.json`);
+};
+
+// Read from cache
+const readFromCache = (cacheFilePath: string, ttl: number): Solution | null => {
+    try {
+        if (!existsSync(cacheFilePath)) {
+            return null;
+        }
+        
+        const cacheContent = readFileSync(cacheFilePath, "utf-8");
+        const cacheEntry: CacheEntry = JSON.parse(cacheContent);
+        
+        // Check if cache entry is still valid
+        const now = Date.now();
+        if (now - cacheEntry.timestamp > ttl) {
+            return null; // Cache expired
+        }
+        
+        return cacheEntry.solution;
+    } catch {
+        return null; // Cache file corrupted or unreadable
+    }
+};
+
+// Write to cache
+const writeToCache = (cacheFilePath: string, solution: Solution, ttl: number): void => {
+    try {
+        const cacheEntry: CacheEntry = {
+            solution,
+            timestamp: Date.now(),
+            ttl,
+        };
+        
+        writeFileSync(cacheFilePath, JSON.stringify(cacheEntry, null, 2), "utf-8");
+    } catch {
+        // Silently fail if cache write fails
+    }
+};
+
 const aiFinder = (
     model: LanguageModel,
     options?: {
@@ -23,36 +112,81 @@ const aiFinder = (
 ): SolutionFinder => {
     return {
         handle: async (error: Error, file: SolutionFinderFile): Promise<Solution | undefined> => {
+            const cacheOptions = options?.cache;
+            const temperature = options?.temperature ?? 0;
+            
+            // Check cache if enabled
+            if (cacheOptions?.enabled !== false) {
+                const cacheKey = generateCacheKey(error, file, temperature);
+                const cacheDir = getCacheDirectory(cacheOptions);
+                const cacheFilePath = getCacheFilePath(cacheDir, cacheKey);
+                const ttl = cacheOptions?.ttl ?? 24 * 60 * 60 * 1000; // Default 24 hours
+                
+                // Try to read from cache
+                const cachedSolution = readFromCache(cacheFilePath, ttl);
+                if (cachedSolution) {
+                    return cachedSolution;
+                }
+                
+                // Ensure cache directory exists for writing
+                ensureCacheDirectory(cacheDir);
+            }
+
             const content = aiPrompt({ applicationType: undefined, error, file });
 
             try {
                 const result = await generateText({
                     model,
                     prompt: content,
-                    temperature: options?.temperature ?? 0,
+                    temperature,
                 });
 
                 const messageContent = result.text;
 
+                let solution: Solution;
                 if (!messageContent) {
-                    return {
+                    solution = {
                         body: aiSolutionResponse(DEFAULT_ERROR_MESSAGE),
+                        header: DEFAULT_HEADER,
+                    };
+                } else {
+                    solution = {
+                        body: aiSolutionResponse(messageContent),
                         header: DEFAULT_HEADER,
                     };
                 }
 
-                return {
-                    body: aiSolutionResponse(messageContent),
-                    header: DEFAULT_HEADER,
-                };
+                // Cache the solution if caching is enabled
+                if (cacheOptions?.enabled !== false) {
+                    const cacheKey = generateCacheKey(error, file, temperature);
+                    const cacheDir = getCacheDirectory(cacheOptions);
+                    const cacheFilePath = getCacheFilePath(cacheDir, cacheKey);
+                    const ttl = cacheOptions?.ttl ?? 24 * 60 * 60 * 1000; // Default 24 hours
+                    
+                    writeToCache(cacheFilePath, solution, ttl);
+                }
+
+                return solution;
             } catch (error_) {
                 // eslint-disable-next-line no-console
                 console.error(error_);
 
-                return {
+                const solution = {
                     body: aiSolutionResponse(DEFAULT_ERROR_MESSAGE),
                     header: DEFAULT_HEADER,
                 };
+
+                // Cache the error solution as well to avoid retrying failed requests
+                if (cacheOptions?.enabled !== false) {
+                    const cacheKey = generateCacheKey(error, file, temperature);
+                    const cacheDir = getCacheDirectory(cacheOptions);
+                    const cacheFilePath = getCacheFilePath(cacheDir, cacheKey);
+                    const ttl = cacheOptions?.ttl ?? 24 * 60 * 60 * 1000; // Default 24 hours
+                    
+                    writeToCache(cacheFilePath, solution, ttl);
+                }
+
+                return solution;
             }
         },
         name: "AI SDK",

--- a/packages/error/src/solution/ai/ai-finder.ts
+++ b/packages/error/src/solution/ai/ai-finder.ts
@@ -1,4 +1,3 @@
-import { findCacheDirSync } from "@visulima/find-cache-dir";
 import type { LanguageModel } from "ai";
 import { generateText } from "ai";
 
@@ -6,19 +5,20 @@ import type { Solution, SolutionFinder, SolutionFinderFile } from "../types";
 import aiPrompt from "./ai-prompt";
 import aiSolutionResponse from "./ai-solution-response";
 
-const findCache = findCacheDirSync("visulima-error");
-
-if (findCache === undefined) {
-    console.warn("Caching is disabled, please check if you node_modules is writable.");
-}
-
 const DEFAULT_HEADER = "## Ai Generated Solution";
 const DEFAULT_ERROR_MESSAGE = "Creation of a AI solution failed.";
+
+interface CacheOptions {
+    enabled?: boolean;
+    directory?: string;
+    ttl?: number; // Time to live in milliseconds
+}
 
 const aiFinder = (
     model: LanguageModel,
     options?: {
         temperature?: number;
+        cache?: CacheOptions;
     },
 ): SolutionFinder => {
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         version: 3.1.1(@types/react@19.1.12)(react@19.1.1)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: ^11.2.0
-        version: 11.2.0
+        version: 11.2.3
       '@storybook/addon-a11y':
         specifier: ^9.1.4
         version: 9.1.4(storybook@9.1.4(@testing-library/dom@10.4.0)(msw@2.8.4(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)))
@@ -434,7 +434,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       ansi-regex:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.2.0
       conventional-changelog-conventionalcommits:
         specifier: 9.0.0
         version: 9.0.0
@@ -1598,9 +1598,6 @@ importers:
       '@types/node':
         specifier: 24.3.1
         version: 24.3.1
-      '@visulima/find-cache-dir':
-        specifier: ^1.0.31
-        version: 1.0.31(yaml@2.8.0)
       '@visulima/packem':
         specifier: 2.0.0-alpha.18
         version: 2.0.0-alpha.18(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)(@csstools/postcss-slow-plugins@2.0.0(postcss@8.5.6))(@swc/core@1.6.7(@swc/helpers@0.5.15))(@types/node@24.3.1)(@visulima/redact@1.0.15)(esbuild@0.25.9)(icss-utils@5.1.0(postcss@8.5.6))(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.6))(postcss-modules-local-by-default@4.2.0(postcss@8.5.6))(postcss-modules-scope@3.2.1(postcss@8.5.6))(postcss-modules-values@4.0.0(postcss@8.5.6))(postcss-value-parser@4.2.0)(postcss@8.5.6)(rotating-file-stream@3.2.6)(sucrase@3.35.0)(typedoc-plugin-markdown@4.6.4(typedoc@0.28.5(typescript@5.9.2)))(typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.5(typescript@5.9.2)))(typedoc@0.28.5(typescript@5.9.2))(typescript@5.9.2)(yaml@2.8.0)
@@ -1979,6 +1976,8 @@ importers:
       vitest:
         specifier: ^3.1.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(msw@2.8.4(@types/node@24.3.1)(typescript@5.8.3))(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
+
+  packages/fs/__bench__/fixtures/a/b: {}
 
   packages/fs/__fixtures__/find-up: {}
 
@@ -3675,7 +3674,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       ansi-regex:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.2.0
       conventional-changelog-conventionalcommits:
         specifier: 9.0.0
         version: 9.0.0
@@ -4728,17 +4727,11 @@ packages:
     resolution: {integrity: sha512-/ufI8CR8xZUwOaQhcITZimLGwzG3Rl6srJyFLQ3Y6KClth0t4c+Pd2fPzU4cFnXqWa9Y/BACAhHoXkOmVsNwlA==}
     engines: {node: '>=10'}
 
-  '@emnapi/core@1.4.3':
-    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
-
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
-
-  '@emnapi/wasi-threads@1.0.2':
-    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -5819,9 +5812,6 @@ packages:
 
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
-
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -7432,11 +7422,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.41.0':
-    resolution: {integrity: sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.41.1':
     resolution: {integrity: sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==}
     cpu: [arm]
@@ -7449,11 +7434,6 @@ packages:
 
   '@rollup/rollup-android-arm64@4.34.9':
     resolution: {integrity: sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.41.0':
-    resolution: {integrity: sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ==}
     cpu: [arm64]
     os: [android]
 
@@ -7472,11 +7452,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.41.0':
-    resolution: {integrity: sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.41.1':
     resolution: {integrity: sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==}
     cpu: [arm64]
@@ -7489,11 +7464,6 @@ packages:
 
   '@rollup/rollup-darwin-x64@4.34.9':
     resolution: {integrity: sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.41.0':
-    resolution: {integrity: sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -7512,11 +7482,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.41.0':
-    resolution: {integrity: sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.41.1':
     resolution: {integrity: sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==}
     cpu: [arm64]
@@ -7529,11 +7494,6 @@ packages:
 
   '@rollup/rollup-freebsd-x64@4.34.9':
     resolution: {integrity: sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.41.0':
-    resolution: {integrity: sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg==}
     cpu: [x64]
     os: [freebsd]
 
@@ -7552,11 +7512,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.41.0':
-    resolution: {integrity: sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.41.1':
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
@@ -7569,11 +7524,6 @@ packages:
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.41.0':
-    resolution: {integrity: sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==}
     cpu: [arm]
     os: [linux]
 
@@ -7592,11 +7542,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.41.0':
-    resolution: {integrity: sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
@@ -7609,11 +7554,6 @@ packages:
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.41.0':
-    resolution: {integrity: sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -7632,11 +7572,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
-    resolution: {integrity: sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==}
-    cpu: [loong64]
-    os: [linux]
-
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
@@ -7649,11 +7584,6 @@ packages:
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
-    resolution: {integrity: sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==}
     cpu: [ppc64]
     os: [linux]
 
@@ -7672,11 +7602,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.41.0':
-    resolution: {integrity: sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
@@ -7684,11 +7609,6 @@ packages:
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.0':
     resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.41.0':
-    resolution: {integrity: sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==}
     cpu: [riscv64]
     os: [linux]
 
@@ -7707,11 +7627,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.41.0':
-    resolution: {integrity: sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
@@ -7727,11 +7642,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.41.0':
-    resolution: {integrity: sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
@@ -7744,11 +7654,6 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.41.0':
-    resolution: {integrity: sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==}
     cpu: [x64]
     os: [linux]
 
@@ -7772,11 +7677,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.41.0':
-    resolution: {integrity: sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
     cpu: [arm64]
@@ -7792,11 +7692,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.41.0':
-    resolution: {integrity: sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.41.1':
     resolution: {integrity: sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==}
     cpu: [ia32]
@@ -7809,11 +7704,6 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     resolution: {integrity: sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.41.0':
-    resolution: {integrity: sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==}
     cpu: [x64]
     os: [win32]
 
@@ -7912,10 +7802,6 @@ packages:
   '@secretlint/resolver@9.3.3':
     resolution: {integrity: sha512-8N0lqD7OiI/aLK/PhKyiGh5xTlO/6TjHiOt72jnrvB9BK2QF45Mp5fivCARTKBypDiTZrOrS7blvqZ7qTnOTrA==}
 
-  '@secretlint/secretlint-rule-preset-recommend@11.2.0':
-    resolution: {integrity: sha512-3pQY45yR+RGwDSikuYXL254PAtkMSJ/X9pbgb3pFDM4lMmffhETlssvU/SOR9owlJk6RWXTogOgOqcAxUMmNug==}
-    engines: {node: '>=20.0.0'}
-
   '@secretlint/secretlint-rule-preset-recommend@11.2.3':
     resolution: {integrity: sha512-tpjzerm1KedNnf8xkittHW0sIeCARH8+JFzgQDslQNtbqJ2MSPEs5e5VcJ0i2ZdHVhq1LC1osm88RmwV4k65yA==}
     engines: {node: '>=20.0.0'}
@@ -7960,12 +7846,6 @@ packages:
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
     engines: {node: '>=18'}
 
-  '@semantic-release/exec@7.0.3':
-    resolution: {integrity: sha512-uNWwPNtWi3WTcTm3fWfFQEuj8otOvwoS5m9yo2jSVHuvqdZNsOWmuL0/FqcVyZnCI32fxyYV0G7PPb/TzCH6jw==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=24.1.0'
-
   '@semantic-release/exec@7.1.0':
     resolution: {integrity: sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==}
     engines: {node: '>=20.8.1'}
@@ -7983,12 +7863,6 @@ packages:
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=24.1.0'
-
-  '@semantic-release/npm@12.0.1':
-    resolution: {integrity: sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=20.1.0'
 
   '@semantic-release/npm@12.0.2':
     resolution: {integrity: sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==}
@@ -10616,10 +10490,6 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
 
   ansi-regex@6.2.0:
     resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
@@ -16341,10 +16211,6 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-url@8.0.1:
-    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
-    engines: {node: '>=14.16'}
-
   normalize-url@8.0.2:
     resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
     engines: {node: '>=14.16'}
@@ -16364,80 +16230,6 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
-
-  npm@10.9.2:
-    resolution: {integrity: sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   npm@10.9.3:
     resolution: {integrity: sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==}
@@ -16871,10 +16663,6 @@ packages:
   p-map@5.5.0:
     resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
     engines: {node: '>=12'}
-
-  p-map@7.0.2:
-    resolution: {integrity: sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==}
-    engines: {node: '>=18'}
 
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
@@ -18194,11 +17982,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.41.0:
-    resolution: {integrity: sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.41.1:
     resolution: {integrity: sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -19282,10 +19065,6 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
-  tinypool@1.1.0:
-    resolution: {integrity: sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -19711,9 +19490,6 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
-
-  ufo@1.5.4:
-    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -21442,7 +21218,7 @@ snapshots:
       '@visulima/path': 1.4.0
       execa: 9.6.0
       ini: 5.0.0
-      normalize-url: 8.0.1
+      normalize-url: 8.0.2
       registry-auth-token: 5.1.0
       semver: 7.7.2
     transitivePeerDependencies:
@@ -21458,7 +21234,7 @@ snapshots:
       '@visulima/path': 1.4.0
       execa: 9.6.0
       ini: 5.0.0
-      normalize-url: 8.0.1
+      normalize-url: 8.0.2
       registry-auth-token: 5.1.0
       semver: 7.7.2
     transitivePeerDependencies:
@@ -21486,7 +21262,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.4(typescript@5.8.3))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.4(typescript@5.8.3))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.4(typescript@5.8.3))
@@ -21504,7 +21280,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.7(typescript@5.8.3))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.7(typescript@5.8.3))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.7(typescript@5.8.3))
@@ -21522,7 +21298,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.4(typescript@5.8.3))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.4(typescript@5.8.3))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.4(typescript@5.8.3))
@@ -21540,7 +21316,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5(typescript@5.8.3))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.5(typescript@5.8.3))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.5(typescript@5.8.3))
@@ -21558,7 +21334,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.7(typescript@5.8.3))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.7(typescript@5.8.3))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.7(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.7(typescript@5.8.3))
@@ -21576,7 +21352,7 @@ snapshots:
       '@anolilab/semantic-release-clean-package-json': 2.0.2(yaml@2.8.0)
       '@semantic-release/changelog': 6.0.3(semantic-release@24.2.7(typescript@5.9.2))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.7(typescript@5.9.2))
-      '@semantic-release/exec': 7.0.3(semantic-release@24.2.7(typescript@5.9.2))
+      '@semantic-release/exec': 7.1.0(semantic-release@24.2.7(typescript@5.9.2))
       '@semantic-release/git': 10.0.1(semantic-release@24.2.7(typescript@5.9.2))
       '@semantic-release/github': 11.0.3(semantic-release@24.2.7(typescript@5.9.2))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.7(typescript@5.9.2))
@@ -22198,29 +21974,18 @@ snapshots:
       figures: 6.1.0
       strip-ansi: 7.1.0
 
-  '@emnapi/core@1.4.3':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.2
-      tslib: 2.8.1
-
   '@emnapi/core@1.5.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.5.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/wasi-threads@1.0.2':
     dependencies:
       tslib: 2.8.1
 
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emotion/is-prop-valid@1.2.2':
     dependencies:
@@ -23417,7 +23182,7 @@ snapshots:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))':
     dependencies:
       glob: 10.4.5
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       react-docgen-typescript: 2.2.2(typescript@5.9.2)
       vite: 7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
     optionalDependencies:
@@ -23425,7 +23190,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.30
 
   '@jridgewell/remapping@2.3.5':
@@ -23440,14 +23205,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.30':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsdevtools/ez-spawn@3.0.4':
     dependencies:
@@ -23514,14 +23277,14 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.4.3
+      '@emnapi/core': 1.5.0
       '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.10.0
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.3
+      '@emnapi/core': 1.5.0
       '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.9.0
 
@@ -24854,7 +24617,7 @@ snapshots:
 
   '@rollup/plugin-commonjs@28.0.3(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24866,7 +24629,7 @@ snapshots:
 
   '@rollup/plugin-commonjs@28.0.6(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24878,7 +24641,7 @@ snapshots:
 
   '@rollup/plugin-dynamic-import-vars@2.1.5(rollup@4.34.9)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.34.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
       astring: 1.8.6
       estree-walker: 2.0.2
       fast-glob: 3.3.3
@@ -24888,7 +24651,7 @@ snapshots:
 
   '@rollup/plugin-dynamic-import-vars@2.1.5(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
       astring: 1.8.6
       estree-walker: 2.0.2
       fast-glob: 3.3.3
@@ -24898,7 +24661,7 @@ snapshots:
 
   '@rollup/plugin-dynamic-import-vars@2.1.5(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       astring: 1.8.6
       estree-walker: 2.0.2
       fast-glob: 3.3.3
@@ -24908,7 +24671,7 @@ snapshots:
 
   '@rollup/plugin-inject@5.0.5(rollup@4.34.9)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.34.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
       estree-walker: 2.0.2
       magic-string: 0.30.18
     optionalDependencies:
@@ -24916,7 +24679,7 @@ snapshots:
 
   '@rollup/plugin-inject@5.0.5(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
       estree-walker: 2.0.2
       magic-string: 0.30.18
     optionalDependencies:
@@ -24924,7 +24687,7 @@ snapshots:
 
   '@rollup/plugin-inject@5.0.5(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       estree-walker: 2.0.2
       magic-string: 0.30.18
     optionalDependencies:
@@ -24932,19 +24695,19 @@ snapshots:
 
   '@rollup/plugin-json@6.1.0(rollup@4.34.9)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.34.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
     optionalDependencies:
       rollup: 4.34.9
 
   '@rollup/plugin-json@6.1.0(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
     optionalDependencies:
       rollup: 4.41.1
 
   '@rollup/plugin-json@6.1.0(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
     optionalDependencies:
       rollup: 4.50.0
 
@@ -24960,7 +24723,7 @@ snapshots:
 
   '@rollup/plugin-node-resolve@16.0.1(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
@@ -24970,7 +24733,7 @@ snapshots:
 
   '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
@@ -24980,40 +24743,40 @@ snapshots:
 
   '@rollup/plugin-replace@6.0.2(rollup@4.34.9)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.34.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
       magic-string: 0.30.18
     optionalDependencies:
       rollup: 4.34.9
 
   '@rollup/plugin-replace@6.0.2(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
       magic-string: 0.30.18
     optionalDependencies:
       rollup: 4.41.1
 
   '@rollup/plugin-replace@6.0.2(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       magic-string: 0.30.18
     optionalDependencies:
       rollup: 4.50.0
 
   '@rollup/plugin-wasm@6.2.2(rollup@4.34.9)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.34.9)
+      '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
     optionalDependencies:
       rollup: 4.34.9
 
   '@rollup/plugin-wasm@6.2.2(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
     optionalDependencies:
       rollup: 4.41.1
 
   '@rollup/plugin-wasm@6.2.2(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
     optionalDependencies:
       rollup: 4.50.0
 
@@ -25026,30 +24789,6 @@ snapshots:
       rollup: 4.34.9
 
   '@rollup/pluginutils@5.1.4(rollup@4.41.1)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.41.1
-
-  '@rollup/pluginutils@5.1.4(rollup@4.50.0)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.50.0
-
-  '@rollup/pluginutils@5.2.0(rollup@4.34.9)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.34.9
-
-  '@rollup/pluginutils@5.2.0(rollup@4.41.1)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
@@ -25073,10 +24812,23 @@ snapshots:
     optionalDependencies:
       rollup: 4.34.9
 
-  '@rollup/rollup-android-arm-eabi@4.34.9':
-    optional: true
+  '@rollup/pluginutils@5.3.0(rollup@4.41.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.41.1
 
-  '@rollup/rollup-android-arm-eabi@4.41.0':
+  '@rollup/pluginutils@5.3.0(rollup@4.50.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.50.0
+
+  '@rollup/rollup-android-arm-eabi@4.34.9':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.41.1':
@@ -25088,9 +24840,6 @@ snapshots:
   '@rollup/rollup-android-arm64@4.34.9':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.41.0':
-    optional: true
-
   '@rollup/rollup-android-arm64@4.41.1':
     optional: true
 
@@ -25098,9 +24847,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.34.9':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.41.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.41.1':
@@ -25112,9 +24858,6 @@ snapshots:
   '@rollup/rollup-darwin-x64@4.34.9':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.41.0':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.41.1':
     optional: true
 
@@ -25122,9 +24865,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.34.9':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.41.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.41.1':
@@ -25136,9 +24876,6 @@ snapshots:
   '@rollup/rollup-freebsd-x64@4.34.9':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.41.0':
-    optional: true
-
   '@rollup/rollup-freebsd-x64@4.41.1':
     optional: true
 
@@ -25146,9 +24883,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.34.9':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.41.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.41.1':
@@ -25160,9 +24894,6 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     optional: true
 
@@ -25170,9 +24901,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.41.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
@@ -25184,9 +24912,6 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     optional: true
 
@@ -25194,9 +24919,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
-    optional: true
-
-  '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
@@ -25208,9 +24930,6 @@ snapshots:
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     optional: true
 
@@ -25220,16 +24939,10 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.41.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
@@ -25241,9 +24954,6 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     optional: true
 
@@ -25253,9 +24963,6 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.41.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     optional: true
 
@@ -25263,9 +24970,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.41.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
@@ -25280,9 +24984,6 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.41.0':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     optional: true
 
@@ -25292,9 +24993,6 @@ snapshots:
   '@rollup/rollup-win32-ia32-msvc@4.34.9':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.41.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.41.1':
     optional: true
 
@@ -25302,9 +25000,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.34.9':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.41.1':
@@ -25466,8 +25161,6 @@ snapshots:
 
   '@secretlint/resolver@9.3.3': {}
 
-  '@secretlint/secretlint-rule-preset-recommend@11.2.0': {}
-
   '@secretlint/secretlint-rule-preset-recommend@11.2.3': {}
 
   '@secretlint/secretlint-rule-preset-recommend@9.3.3': {}
@@ -25578,7 +25271,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.0.3(semantic-release@24.2.4(typescript@5.8.3))':
+  '@semantic-release/exec@7.1.0(semantic-release@24.2.4(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -25590,7 +25283,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/exec@7.0.3(semantic-release@24.2.5(typescript@5.8.3))':
+  '@semantic-release/exec@7.1.0(semantic-release@24.2.5(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -25602,7 +25295,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/exec@7.0.3(semantic-release@24.2.7(typescript@5.8.3))':
+  '@semantic-release/exec@7.1.0(semantic-release@24.2.7(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -25611,18 +25304,6 @@ snapshots:
       lodash-es: 4.17.21
       parse-json: 8.1.0
       semantic-release: 24.2.7(typescript@5.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@semantic-release/exec@7.0.3(semantic-release@24.2.7(typescript@5.9.2))':
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 3.1.0
-      debug: 4.4.1
-      execa: 9.6.0
-      lodash-es: 4.17.21
-      parse-json: 8.1.0
-      semantic-release: 24.2.7(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -25782,40 +25463,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@12.0.1(semantic-release@24.2.4(typescript@5.8.3))':
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 5.0.0
-      execa: 9.6.0
-      fs-extra: 11.3.0
-      lodash-es: 4.17.21
-      nerf-dart: 1.0.0
-      normalize-url: 8.0.1
-      npm: 10.9.2
-      rc: 1.2.8
-      read-pkg: 9.0.1
-      registry-auth-token: 5.1.0
-      semantic-release: 24.2.4(typescript@5.8.3)
-      semver: 7.7.2
-      tempy: 3.1.0
-
-  '@semantic-release/npm@12.0.1(semantic-release@24.2.5(typescript@5.8.3))':
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 5.0.0
-      execa: 9.6.0
-      fs-extra: 11.3.0
-      lodash-es: 4.17.21
-      nerf-dart: 1.0.0
-      normalize-url: 8.0.1
-      npm: 10.9.2
-      rc: 1.2.8
-      read-pkg: 9.0.1
-      registry-auth-token: 5.1.0
-      semantic-release: 24.2.5(typescript@5.8.3)
-      semver: 7.7.2
-      tempy: 3.1.0
-
   '@semantic-release/npm@12.0.2(semantic-release@24.2.4(typescript@5.8.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
@@ -25832,7 +25479,6 @@ snapshots:
       semantic-release: 24.2.4(typescript@5.8.3)
       semver: 7.7.2
       tempy: 3.1.0
-    optional: true
 
   '@semantic-release/npm@12.0.2(semantic-release@24.2.5(typescript@5.8.3))':
     dependencies:
@@ -25850,7 +25496,6 @@ snapshots:
       semantic-release: 24.2.5(typescript@5.8.3)
       semver: 7.7.2
       tempy: 3.1.0
-    optional: true
 
   '@semantic-release/npm@12.0.2(semantic-release@24.2.7(typescript@5.8.3))':
     dependencies:
@@ -26386,11 +26031,11 @@ snapshots:
   '@storybook/react-vite@9.1.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.0)(storybook@9.1.4(@testing-library/dom@10.4.0)(msw@2.8.4(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)))(typescript@5.9.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))
-      '@rollup/pluginutils': 5.1.4(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       '@storybook/builder-vite': 9.1.4(storybook@9.1.4(@testing-library/dom@10.4.0)(msw@2.8.4(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)))(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))
       '@storybook/react': 9.1.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(msw@2.8.4(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)))(typescript@5.9.2)
       find-up: 7.0.0
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       react: 19.1.1
       react-docgen: 8.0.1
       react-dom: 19.1.1(react@19.1.1)
@@ -29727,7 +29372,7 @@ snapshots:
 
   '@visulima/rollup-plugin-css@1.0.0-alpha.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)(@csstools/postcss-slow-plugins@2.0.0(postcss@8.5.6))(@types/node@24.3.1)(icss-utils@5.1.0(postcss@8.5.6))(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.0))(postcss-modules-extract-imports@3.1.0(postcss@8.5.6))(postcss-modules-local-by-default@4.2.0(postcss@8.5.6))(postcss-modules-scope@3.2.1(postcss@8.5.6))(postcss-modules-values@4.0.0(postcss@8.5.6))(postcss-value-parser@4.2.0)(postcss@8.5.6)(rollup@4.50.0)(yaml@2.8.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.0)
       '@visulima/fs': 3.1.5(yaml@2.8.0)
       '@visulima/package': 3.5.8(@types/node@24.3.1)(yaml@2.8.0)
       '@visulima/packem-share': 1.0.0-alpha.9(@types/node@24.3.1)(rollup@4.50.0)(yaml@2.8.0)
@@ -29815,7 +29460,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/mocker': 3.2.0(msw@2.8.4(@types/node@22.15.29)(typescript@5.8.3))(vite@7.1.4(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))
       '@vitest/utils': 3.2.0
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       sirv: 3.0.1
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(msw@2.8.4(@types/node@22.15.29)(typescript@5.8.3))(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -29838,7 +29483,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.1
@@ -29857,7 +29502,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.1
@@ -29876,7 +29521,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.1
@@ -29897,7 +29542,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.1
@@ -30039,7 +29684,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@18.19.71)(typescript@5.8.3)
       vite: 7.1.4(@types/node@18.19.71)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30048,7 +29693,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@22.15.24)(typescript@5.8.3)
       vite: 7.1.4(@types/node@22.15.24)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30057,7 +29702,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@22.15.29)(typescript@5.8.3)
       vite: 7.1.4(@types/node@22.15.29)(jiti@2.4.2)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30066,7 +29711,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@22.15.29)(typescript@5.8.3)
       vite: 7.1.4(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30075,7 +29720,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@22.15.29)(typescript@5.9.2)
       vite: 7.1.4(@types/node@22.15.29)(jiti@2.4.2)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30084,7 +29729,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@22.15.29)(typescript@5.9.2)
       vite: 7.1.4(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30093,7 +29738,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@24.3.1)(typescript@5.8.3)
       vite: 7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30102,7 +29747,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.18
     optionalDependencies:
       msw: 2.8.4(@types/node@24.3.1)(typescript@5.9.2)
       vite: 7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -30627,8 +30272,6 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.1.0: {}
-
   ansi-regex@6.2.0: {}
 
   ansi-styles@3.2.1:
@@ -31070,7 +30713,7 @@ snapshots:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 8.0.0
-      chalk: 5.4.1
+      chalk: 5.6.0
       cli-boxes: 3.0.0
       string-width: 7.2.0
       type-fest: 4.41.0
@@ -31148,9 +30791,9 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  bundle-require@5.1.0(esbuild@0.25.5):
+  bundle-require@5.1.0(esbuild@0.25.9):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       load-tsconfig: 0.2.5
 
   bunyan@1.8.15:
@@ -32547,13 +32190,6 @@ snapshots:
       es5-ext: 0.10.64
       es6-iterator: 2.0.3
       es6-symbol: 3.1.4
-
-  esbuild-register@3.6.0(esbuild@0.25.5):
-    dependencies:
-      debug: 4.4.1
-      esbuild: 0.25.5
-    transitivePeerDependencies:
-      - supports-color
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
@@ -37761,7 +37397,7 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.18:
     dependencies:
@@ -39487,8 +39123,6 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  normalize-url@8.0.1: {}
-
   normalize-url@8.0.2: {}
 
   npm-normalize-package-bin@3.0.1: {}
@@ -39505,8 +39139,6 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
-
-  npm@10.9.2: {}
 
   npm@10.9.3: {}
 
@@ -39757,7 +39389,7 @@ snapshots:
     dependencies:
       destr: 2.0.3
       node-fetch-native: 1.6.4
-      ufo: 1.5.4
+      ufo: 1.6.1
 
   on-exit-leak-free@2.1.2: {}
 
@@ -39975,7 +39607,7 @@ snapshots:
 
   p-filter@4.1.0:
     dependencies:
-      p-map: 7.0.2
+      p-map: 7.0.3
 
   p-finally@1.0.0: {}
 
@@ -40034,8 +39666,6 @@ snapshots:
   p-map@5.5.0:
     dependencies:
       aggregate-error: 4.0.1
-
-  p-map@7.0.2: {}
 
   p-map@7.0.3: {}
 
@@ -41622,32 +41252,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.9
       fsevents: 2.3.3
 
-  rollup@4.41.0:
-    dependencies:
-      '@types/estree': 1.0.7
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.41.0
-      '@rollup/rollup-android-arm64': 4.41.0
-      '@rollup/rollup-darwin-arm64': 4.41.0
-      '@rollup/rollup-darwin-x64': 4.41.0
-      '@rollup/rollup-freebsd-arm64': 4.41.0
-      '@rollup/rollup-freebsd-x64': 4.41.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.41.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.41.0
-      '@rollup/rollup-linux-arm64-gnu': 4.41.0
-      '@rollup/rollup-linux-arm64-musl': 4.41.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.41.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.41.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.41.0
-      '@rollup/rollup-linux-riscv64-musl': 4.41.0
-      '@rollup/rollup-linux-s390x-gnu': 4.41.0
-      '@rollup/rollup-linux-x64-gnu': 4.41.0
-      '@rollup/rollup-linux-x64-musl': 4.41.0
-      '@rollup/rollup-win32-arm64-msvc': 4.41.0
-      '@rollup/rollup-win32-ia32-msvc': 4.41.0
-      '@rollup/rollup-win32-x64-msvc': 4.41.0
-      fsevents: 2.3.3
-
   rollup@4.41.1:
     dependencies:
       '@types/estree': 1.0.7
@@ -41867,7 +41471,7 @@ snapshots:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/error': 4.0.0
       '@semantic-release/github': 11.0.3(semantic-release@24.2.4(typescript@5.8.3))
-      '@semantic-release/npm': 12.0.1(semantic-release@24.2.4(typescript@5.8.3))
+      '@semantic-release/npm': 12.0.2(semantic-release@24.2.4(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.4(typescript@5.8.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.8.3)
@@ -41902,7 +41506,7 @@ snapshots:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/error': 4.0.0
       '@semantic-release/github': 11.0.3(semantic-release@24.2.5(typescript@5.8.3))
-      '@semantic-release/npm': 12.0.1(semantic-release@24.2.5(typescript@5.8.3))
+      '@semantic-release/npm': 12.0.2(semantic-release@24.2.5(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.5(typescript@5.8.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.8.3)
@@ -42534,8 +42138,8 @@ snapshots:
       '@vitest/mocker': 3.2.4(msw@2.8.4(@types/node@24.3.1)(typescript@5.9.2))(vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
-      esbuild: 0.25.5
-      esbuild-register: 3.6.0(esbuild@0.25.5)
+      esbuild: 0.25.9
+      esbuild-register: 3.6.0(esbuild@0.25.9)
       recast: 0.23.9
       semver: 7.7.2
       ws: 8.18.2
@@ -43238,8 +42842,6 @@ snapshots:
 
   tinypool@0.8.4: {}
 
-  tinypool@1.1.0: {}
-
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
@@ -43436,18 +43038,18 @@ snapshots:
 
   tsup@8.5.0(@swc/core@1.6.7(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.5)
+      bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.1
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.0)
       resolve-from: 5.0.0
-      rollup: 4.41.0
+      rollup: 4.50.0
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -43489,7 +43091,7 @@ snapshots:
 
   tsx@4.20.5:
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
@@ -43729,8 +43331,6 @@ snapshots:
   typical@7.3.0: {}
 
   uc.micro@2.1.0: {}
-
-  ufo@1.5.4: {}
 
   ufo@1.6.1: {}
 
@@ -44475,7 +44075,7 @@ snapshots:
 
   vite@7.1.4(@types/node@18.19.71)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -44491,7 +44091,7 @@ snapshots:
 
   vite@7.1.4(@types/node@22.15.24)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -44507,7 +44107,7 @@ snapshots:
 
   vite@7.1.4(@types/node@22.15.29)(jiti@2.4.2)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -44523,7 +44123,7 @@ snapshots:
 
   vite@7.1.4(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -44539,7 +44139,7 @@ snapshots:
 
   vite@7.1.4(@types/node@24.3.1)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -44565,7 +44165,7 @@ snapshots:
       debug: 4.4.1
       execa: 8.0.1
       local-pkg: 0.5.0
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.9.0
@@ -44601,13 +44201,13 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
-      tinypool: 1.1.0
+      tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 5.4.19(@types/node@18.19.71)(terser@5.31.1)
       vite-node: 3.1.4(@types/node@18.19.71)(terser@5.31.1)
@@ -44641,14 +44241,14 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
-      tinypool: 1.1.0
+      tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.1.4(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
       vite-node: 3.2.1(@types/node@22.15.29)(jiti@2.5.1)(terser@5.31.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -44685,7 +44285,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44729,7 +44329,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44773,7 +44373,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44818,7 +44418,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44862,7 +44462,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44906,7 +44506,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44950,7 +44550,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
@@ -44994,7 +44594,7 @@ snapshots:
       chai: 5.2.0
       debug: 4.4.1
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.18
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0


### PR DESCRIPTION
Remove `@visulima/find-cache-dir` dependency and introduce a caching interface in `aiFinder` options.

This change allows users to provide their own caching implementation and configuration, decoupling the `aiFinder` from a specific caching library.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bb578fa-c5ad-481d-93d3-c16b334d7492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bb578fa-c5ad-481d-93d3-c16b334d7492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

