### PR TITLE
Add css injection for styling customization

### DIFF
--- a/packages/vite-overlay/README.md
+++ b/packages/vite-overlay/README.md
@@ -93,6 +93,26 @@ export default defineConfig({
             // Whether to show the balloon button in the overlay (default: true)
             showBallonButton: true,
 
+            // Overlay configuration (optional)
+            overlay: {
+                // Balloon button configuration
+                balloon: {
+                    enabled: true,
+                    position: "bottom-right", // "top-left" | "top-right" | "bottom-left" | "bottom-right"
+                    icon: "", // Optional custom icon URL
+                    style: {
+                        background: "#ff4628",
+                        color: "#ffffff",
+                    },
+                },
+                // Custom CSS to inject for styling customization
+                customCSS: `
+                    #__v_o__balloon {
+                        border-radius: 20px;
+                    }
+                `,
+            },
+
             // Custom solution finder functions (optional)
             solutionFinders: [],
 
@@ -112,6 +132,9 @@ export default defineConfig({
 | `reactPluginName`         | `string`           | `undefined` | Custom React plugin name for detection (useful for custom React plugins) |
 | `vuePluginName`           | `string`           | `undefined` | Custom Vue plugin name for detection (useful for custom Vue plugins)     |
 | `showBallonButton`        | `boolean`          | `true`      | Whether to show the floating balloon button for error navigation         |
+| `overlay`                  | `OverlayConfig`    | `undefined` | Overlay configuration options                                            |
+| `overlay.balloon`          | `BalloonConfig`    | `undefined` | Balloon button configuration                                              |
+| `overlay.customCSS`        | `string`           | `undefined` | Custom CSS to inject for styling customization                           |
 | `solutionFinders`         | `SolutionFinder[]` | `[]`        | Array of custom solution finder functions for enhanced error analysis    |
 | `logClientRuntimeError`   | `boolean`          | `undefined` | **@deprecated** Use `forwardConsole` instead                             |
 
@@ -252,6 +275,95 @@ The error overlay uses a custom design system with CSS custom properties:
 --ono-v-surface: #0d1117;
 --ono-v-text: #c9d1d9;
 ```
+
+### Custom CSS Injection
+
+You can inject custom CSS to override the default styles of the overlay and button elements. Use the `overlay.customCSS` option to provide your custom styles:
+
+```typescript
+export default defineConfig({
+    plugins: [
+        errorOverlay({
+            overlay: {
+                customCSS: `
+                    /* Customize the balloon button */
+                    #__v_o__balloon {
+                        border-radius: 20px;
+                        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+                    }
+
+                    /* Customize the overlay panel */
+                    #__v_o__panel {
+                        border-radius: 12px;
+                    }
+
+                    /* Customize the backdrop */
+                    #__v_o__backdrop {
+                        background-color: rgba(0, 0, 0, 0.7);
+                    }
+                `,
+            },
+        }),
+    ],
+});
+```
+
+#### Available Element IDs for Customization
+
+The following element IDs can be targeted in your custom CSS:
+
+**Main Overlay Elements:**
+- `__v_o__root` - Root container element
+- `__v_o__backdrop` - Backdrop element behind the overlay
+- `__v_o__notch` - Notch container at the top of the overlay
+- `__v_o__panel` - Main panel container
+- `__v_o__overlay` - Overlay content container
+
+**Navigation & Pagination:**
+- `__v_o__error-overlay-pagination-previous` - Previous error button
+- `__v_o__error-overlay-pagination-next` - Next error button
+- `__v_o__error-overlay_pagination_count` - Pagination count container
+- `__v_o__pagination_current` - Current page number display
+- `__v_o__pagination_total` - Total page number display
+
+**History:**
+- `__v_o__history_toggle` - History toggle button
+- `__v_o__history_indicator` - History indicator container
+- `__v_o__history_count` - History count display
+- `__v_o__history_total` - History total display
+- `__v_o__history_timestamp` - History timestamp display
+- `__v_o__history_layer_depth` - History layer depth container
+- `__v_o__history_layer_depth_1` - History layer depth level 1
+- `__v_o__history_layer_depth_2` - History layer depth level 2
+
+**Header Elements:**
+- `__v_o__header` - Header container
+- `__v_o__header_loader` - Header loader skeleton
+- `__v_o__title` - Title container
+- `__v_o__heading` - Error heading/name
+- `__v_o__filelink` - File link button
+- `__v_o__mode` - Mode switch container (original/compiled)
+- `__v_o__copy_error` - Copy error button
+- `__v_o__close` - Close button
+
+**Balloon Button:**
+- `__v_o__balloon` - Floating balloon button
+- `__v_o__balloon_count` - Error count badge in balloon
+- `__v_o__balloon_text` - Text label in balloon
+
+**Message & Content:**
+- `__v_o__message_loader` - Message loader skeleton
+- `__v_o__message` - Error message container
+- `__v_o__body` - Body container
+- `__v_o__body_loader` - Body loader skeleton
+- `__v_o__solutions` - Solutions container
+- `__v_o__solutions_container` - Solutions content container
+- `__v_o__stacktrace` - Stack trace details element
+
+**Other:**
+- `__v_o__editor` - Editor selector container
+- `editor-selector` - Editor selector dropdown
+- `v-o-theme-switch` - Theme switch container
 
 ## Browser Support
 

--- a/packages/vite-overlay/__tests__/unit/overlay/patch-overlay.test.ts
+++ b/packages/vite-overlay/__tests__/unit/overlay/patch-overlay.test.ts
@@ -199,4 +199,47 @@ var ErrorOverlay = class {
             }
         });
     });
+
+    describe("custom CSS injection", () => {
+        it("should include custom CSS when provided", () => {
+            expect.assertions(2);
+
+            const inputCode = `class ErrorOverlay {}`;
+            const customCSS = `#__v_o__balloon { border-radius: 20px; }`;
+
+            const result = patchOverlay(inputCode, true, undefined, customCSS);
+
+            expect(result).toContain("<style>");
+            expect(result).toContain("#__v_o__balloon { border-radius: 20px; }");
+        });
+
+        it("should not include custom CSS style tag when not provided", () => {
+            expect.assertions(1);
+
+            const inputCode = `class ErrorOverlay {}`;
+
+            const result = patchOverlay(inputCode, true);
+
+            // Should only contain the default style tag, not an empty custom one
+            const styleTagMatches = result.match(/<style>/g);
+            expect(styleTagMatches?.length).toBe(1);
+        });
+
+        it("should include custom CSS with balloon config", () => {
+            expect.assertions(3);
+
+            const inputCode = `class ErrorOverlay {}`;
+            const balloonConfig = {
+                enabled: true,
+                position: "top-left" as const,
+            };
+            const customCSS = `#__v_o__panel { border-radius: 12px; }`;
+
+            const result = patchOverlay(inputCode, true, balloonConfig, customCSS);
+
+            expect(result).toContain("balloonConfig");
+            expect(result).toContain("#__v_o__panel { border-radius: 12px; }");
+            expect(result).toContain("__v_o__balloon");
+        });
+    });
 });

--- a/packages/vite-overlay/src/index.ts
+++ b/packages/vite-overlay/src/index.ts
@@ -11,7 +11,7 @@ import type { IndexHtmlTransformResult, Plugin, PluginOption, TransformOptions, 
 import findLanguageBasedOnExtension from "../../../shared/utils/find-language-based-on-extension";
 import { DEFAULT_ERROR_MESSAGE, DEFAULT_ERROR_NAME, MESSAGE_TYPE, PLUGIN_NAME, RECENT_ERROR_TTL_MS } from "./constants";
 import { patchOverlay } from "./overlay/patch-overlay";
-import type { BalloonConfig, DevelopmentLogger, ExtendedError, RawErrorData, RecentErrorTracker, VisulimaViteOverlayErrorPayload, ViteErrorData } from "./types";
+import type { BalloonConfig, DevelopmentLogger, ExtendedError, OverlayConfig, RawErrorData, RecentErrorTracker, VisulimaViteOverlayErrorPayload, ViteErrorData } from "./types";
 import createViteSolutionFinder from "./utils/create-vite-solution-finder";
 import buildExtendedErrorData from "./utils/error-processing";
 import generateClientScript from "./utils/generate-client-script";
@@ -571,8 +571,9 @@ const hasVuePlugin = (plugins: PluginOption[], vuePluginName?: string): boolean 
  * @param options.solutionFinders Custom solution finders (optional)
  * @param options.vuePluginName Custom Vue plugin name (optional)
  * @param options.showBallonButton Whether to show the balloon button (optional, deprecated - use overlay.balloon.enabled)
- * @param options.overlay Balloon overlay configuration (optional)
+ * @param options.overlay Overlay configuration (optional)
  * @param options.overlay.balloon Balloon trigger configuration (optional)
+ * @param options.overlay.customCSS Custom CSS to inject for styling customization (optional)
  * @returns The Vite plugin configuration
  */
 const errorOverlayPlugin = (
@@ -581,9 +582,7 @@ const errorOverlayPlugin = (
         forwardedConsoleMethods?: string[];
         // @deprecated Please use the new forwardConsole option
         logClientRuntimeError?: boolean;
-        overlay?: {
-            balloon?: BalloonConfig;
-        };
+        overlay?: OverlayConfig;
         reactPluginName?: string;
         showBallonButton?: boolean;
         solutionFinders?: SolutionFinder[];
@@ -691,7 +690,7 @@ const errorOverlayPlugin = (
                 ? options.showBallonButton
                 : (options?.overlay?.balloon?.enabled ?? true);
 
-            return patchOverlay(code, balloonEnabled, options?.overlay?.balloon);
+            return patchOverlay(code, balloonEnabled, options?.overlay?.balloon, options?.overlay?.customCSS);
         },
 
         transformIndexHtml(): IndexHtmlTransformResult {

--- a/packages/vite-overlay/src/overlay/patch-overlay.ts
+++ b/packages/vite-overlay/src/overlay/patch-overlay.ts
@@ -280,10 +280,12 @@ const generateBalloonButton = (balloonConfig?: BalloonConfig): string => {
 /**
  * Generates the overlay template with dynamic editor options.
  */
-const generateOverlayTemplate = (showBalloonButton: boolean, balloonConfig?: BalloonConfig): string => {
+const generateOverlayTemplate = (showBalloonButton: boolean, balloonConfig?: BalloonConfig, customCSS?: string): string => {
     const editorOptions = generateEditorOptions();
+    const customStyleTag = customCSS ? `<style>${customCSS}</style>` : "";
 
     return `<style>${styleCss}</style>
+${customStyleTag}
 ${rootElement("__v_o__root", editorOptions)}
 
 ${showBalloonButton ? generateBalloonButton(balloonConfig) : ""}`;
@@ -294,9 +296,10 @@ ${showBalloonButton ? generateBalloonButton(balloonConfig) : ""}`;
  * @param code The Vite client code to patch
  * @param showBalloonButton Whether to show the balloon button
  * @param balloonConfig Optional balloon configuration
+ * @param customCSS Optional custom CSS to inject into the overlay
  */
-export const patchOverlay = (code: string, showBalloonButton: boolean, balloonConfig?: BalloonConfig): string => {
-    const overlayTemplate = generateOverlayTemplate(showBalloonButton, balloonConfig);
+export const patchOverlay = (code: string, showBalloonButton: boolean, balloonConfig?: BalloonConfig, customCSS?: string): string => {
+    const overlayTemplate = generateOverlayTemplate(showBalloonButton, balloonConfig, customCSS);
     const balloonConfigJson = JSON.stringify(balloonConfig || null);
 
     const templateString = `const overlayTemplate = ${JSON.stringify(overlayTemplate)};`;

--- a/packages/vite-overlay/src/types.ts
+++ b/packages/vite-overlay/src/types.ts
@@ -129,3 +129,16 @@ export interface BalloonConfig {
     readonly icon?: string;
     readonly style?: BalloonStyle;
 }
+
+/**
+ * Overlay configuration options
+ */
+export interface OverlayConfig {
+    readonly balloon?: BalloonConfig;
+    /**
+     * Custom CSS to inject into the overlay for styling customization.
+     * This CSS will be injected into the shadow DOM and can be used to override
+     * the default styles of the overlay and button elements.
+     */
+    readonly customCSS?: string;
+}


### PR DESCRIPTION
Add `customCSS` option to the plugin to allow users to override overlay and button styles, and update documentation with customizable IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-0211aeee-1c55-481f-b679-f98828171917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0211aeee-1c55-481f-b679-f98828171917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

