### PR TITLE
ci: Add caching for native build outputs in CI workflow

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -127,8 +127,16 @@ jobs:
               with:
                   persist-credentials: false
 
-            - name: "Setup resources and environment"
+            - name: "Cache native build output"
               if: "github.event_name != 'pull_request' || matrix.package.changed == 'true'"
+              id: "native-cache"
+              uses: "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684" # v4.2.3
+              with:
+                  path: "${{ matrix.package.dir }}/*.node"
+                  key: "native-${{ matrix.package.name }}-${{ matrix.settings.target }}-${{ hashFiles(format('{0}/native/Cargo.toml', matrix.package.dir), format('{0}/native/Cargo.lock', matrix.package.dir), format('{0}/native/build.rs', matrix.package.dir), format('{0}/native/src/**', matrix.package.dir)) }}"
+
+            - name: "Setup resources and environment"
+              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && steps.native-cache.outputs.cache-hit != 'true'"
               id: "setup"
               uses: "anolilab/workflows/step/setup@c7103f1bfdb14c19596c4f80156c824951bfc117" # main
               with:
@@ -137,7 +145,7 @@ jobs:
                   run-signatures-audit: false
 
             - name: "Install Rust toolchain"
-              if: "github.event_name != 'pull_request' || matrix.package.changed == 'true'"
+              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && steps.native-cache.outputs.cache-hit != 'true'"
               uses: "oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82" # v1.0.16
               with:
                   cache-key: "build-native-${{ matrix.package.name }}"
@@ -145,17 +153,17 @@ jobs:
                   tools: "${{ matrix.settings.cross == '-x' && 'cargo-zigbuild' || '' }}"
 
             - name: "Add Rust target"
-              if: "github.event_name != 'pull_request' || matrix.package.changed == 'true'"
+              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && steps.native-cache.outputs.cache-hit != 'true'"
               run: "rustup target add ${{ matrix.settings.target }}"
 
             - name: "Install Zig (cross-compilation)"
-              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && matrix.settings.cross == '-x'"
+              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && steps.native-cache.outputs.cache-hit != 'true' && matrix.settings.cross == '-x'"
               uses: "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29" # v2.2.1
               with:
                   version: "0.14.1"
 
             - name: "Build native"
-              if: "github.event_name != 'pull_request' || matrix.package.changed == 'true'"
+              if: "(github.event_name != 'pull_request' || matrix.package.changed == 'true') && steps.native-cache.outputs.cache-hit != 'true'"
               run: "pnpm build:native --target ${{ matrix.settings.target }} ${{ matrix.settings.cross || '' }}"
               working-directory: "${{ matrix.package.dir }}"
 


### PR DESCRIPTION
## Summary
This PR adds caching support for native build outputs in the build-native GitHub Actions workflow to improve CI performance by avoiding redundant builds of unchanged native modules.

## Key Changes
- **Added native build cache step**: Introduced a new caching step that stores and retrieves compiled `.node` files based on a hash of Rust source files (Cargo.toml, Cargo.lock, build.rs, and src/**).
- **Conditional build steps**: Updated all build-related steps (Setup resources, Install Rust toolchain, Add Rust target, Install Zig, and Build native) to skip execution when a cache hit is detected, reducing unnecessary work.
- **Cache key strategy**: The cache key includes the package name, target platform, and a hash of relevant Rust build files to ensure cache invalidation when dependencies or source code changes.

## Implementation Details
- Cache is only populated/used when not in a pull request context or when the package has changed
- The cache stores `*.node` files from the package directory
- All downstream build steps check `steps.native-cache.outputs.cache-hit` to determine if they should run
- This optimization particularly benefits the main branch where builds are more frequent

https://claude.ai/code/session_01GCDKX1LgnDCMSUQWtkTg4Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the native build workflow with intelligent caching of build artifacts to reduce CI/CD pipeline execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->