### PR TITLE
test: Add CJK text truncation tests for Text component

### DIFF
--- a/packages/terminal/tui/__tests__/ink/text-width.test.tsx
+++ b/packages/terminal/tui/__tests__/ink/text-width.test.tsx
@@ -1,4 +1,5 @@
 import { strip as stripAnsi } from "@visulima/ansi";
+import { getStringWidth } from "@visulima/string";
 import { describe, expect, it } from "vitest";
 
 import { Box, Text } from "../../src/ink/index";
@@ -102,5 +103,68 @@ describe("text-width", () => {
         );
 
         expect(output).toBe("hello");
+    });
+
+    it("truncate CJK text at end", () => {
+        expect.assertions(1);
+
+        const output = renderToString(
+            <Box width={20}>
+                <Text wrap="truncate">あいうえおかきくけこ|end</Text>
+            </Box>,
+        );
+
+        const stripped = stripAnsi(output);
+
+        expect(getStringWidth(stripped)).toBeLessThanOrEqual(20);
+    });
+
+    it("truncate CJK text in the middle", () => {
+        expect.assertions(1);
+
+        const output = renderToString(
+            <Box width={20}>
+                <Text wrap="truncate-middle">あいうえおかきくけこ|end</Text>
+            </Box>,
+        );
+
+        const stripped = stripAnsi(output);
+
+        expect(getStringWidth(stripped)).toBeLessThanOrEqual(20);
+    });
+
+    it("truncate CJK text at start", () => {
+        expect.assertions(1);
+
+        const output = renderToString(
+            <Box width={20}>
+                <Text wrap="truncate-start">あいうえおかきくけこ|end</Text>
+            </Box>,
+        );
+
+        const stripped = stripAnsi(output);
+
+        expect(getStringWidth(stripped)).toBeLessThanOrEqual(20);
+    });
+
+    it("truncate CJK text does not exceed Box width", () => {
+        expect.assertions(2);
+
+        const output = renderToString(
+            <Box>
+                <Box width={20}>
+                    <Text wrap="truncate">あいうえおかきくけこ|end</Text>
+                </Box>
+                <Text>|</Text>
+            </Box>,
+        );
+
+        const lines = output.split("\n");
+
+        expect(lines).toHaveLength(1);
+
+        const stripped = stripAnsi(lines[0]!);
+
+        expect(stripped.endsWith("|")).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
Added comprehensive test coverage for CJK (Chinese, Japanese, Korean) character handling in the Text component's truncation modes.

## Key Changes
- Added import of `getStringWidth` utility from `@visulima/string` for accurate width measurement of CJK characters
- Added 4 new test cases covering CJK text truncation:
  - `truncate` mode: Verifies CJK text truncated at the end respects Box width constraints
  - `truncate-middle` mode: Verifies CJK text truncated in the middle respects Box width constraints
  - `truncate-start` mode: Verifies CJK text truncated at the start respects Box width constraints
  - Width boundary test: Ensures truncated CJK text doesn't exceed Box width and maintains proper layout

## Notable Details
- All tests use Japanese characters (あいうえおかきくけこ) as representative CJK text
- Tests validate that `getStringWidth()` returns values ≤ the specified Box width, accounting for the fact that CJK characters typically have a display width of 2 units each
- The boundary test verifies that truncation doesn't cause text to overflow into adjacent content

https://claude.ai/code/session_012JZkdoXcFARaX73vqtRgNZ