### PR TITLE
feat: Add Socket.dev security intelligence integration

### DIFF
--- a/packages/tooling/vis/__tests__/audit-config.test.ts
+++ b/packages/tooling/vis/__tests__/audit-config.test.ts
@@ -4,12 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import {
-    isAdvisoryExcluded,
-    isPackageExcluded,
-    readNativeAuditExclusions,
-    syncAcceptedRisksToNativeConfig,
-} from "../src/audit-config";
+import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../src/audit-config";
 
 let tmpDir: string;
 

--- a/packages/tooling/vis/__tests__/audit-config.test.ts
+++ b/packages/tooling/vis/__tests__/audit-config.test.ts
@@ -1,0 +1,230 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    isAdvisoryExcluded,
+    isPackageExcluded,
+    readNativeAuditExclusions,
+    syncAcceptedRisksToNativeConfig,
+} from "../src/audit-config";
+
+let tmpDir: string;
+
+beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vis-audit-config-"));
+});
+
+afterEach(() => {
+    rmSync(tmpDir, { force: true, recursive: true });
+});
+
+// --- Readers ---
+
+describe("readNativeAuditExclusions", () => {
+    describe("pnpm", () => {
+        it("should parse ignoreCves and ignoreGhsas from pnpm-workspace.yaml", () => {
+            expect.assertions(3);
+
+            writeFileSync(
+                join(tmpDir, "pnpm-workspace.yaml"),
+                `packages:
+  - packages/*
+
+auditConfig:
+  ignoreCves:
+    - CVE-2022-36313
+    - CVE-2023-44270
+  ignoreGhsas:
+    - GHSA-42xw-2xvc-qx8m
+`,
+            );
+
+            const result = readNativeAuditExclusions(tmpDir, "pnpm");
+
+            expect(result.ignoredAdvisories).toContain("CVE-2022-36313");
+            expect(result.ignoredAdvisories).toContain("GHSA-42xw-2xvc-qx8m");
+            expect(result.excludedPackages).toHaveLength(0);
+        });
+
+        it("should return empty when no pnpm-workspace.yaml", () => {
+            expect.assertions(1);
+
+            const result = readNativeAuditExclusions(tmpDir, "pnpm");
+
+            expect(result.ignoredAdvisories).toHaveLength(0);
+        });
+
+        it("should return empty when no auditConfig section", () => {
+            expect.assertions(1);
+
+            writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+
+            const result = readNativeAuditExclusions(tmpDir, "pnpm");
+
+            expect(result.ignoredAdvisories).toHaveLength(0);
+        });
+    });
+
+    describe("yarn berry", () => {
+        it("should parse npmAuditIgnoreAdvisories and npmAuditExcludePackages", () => {
+            expect.assertions(3);
+
+            writeFileSync(
+                join(tmpDir, ".yarnrc.yml"),
+                `nodeLinker: node-modules
+
+npmAuditIgnoreAdvisories:
+  - "1234567"
+  - "GHSA-42xw-2xvc-qx8m"
+
+npmAuditExcludePackages:
+  - "debug"
+  - "@scope/*"
+`,
+            );
+
+            const result = readNativeAuditExclusions(tmpDir, "yarn");
+
+            expect(result.ignoredAdvisories).toContain("GHSA-42xw-2xvc-qx8m");
+            expect(result.excludedPackages).toContain("debug");
+            expect(result.excludedPackages).toContain("@scope/*");
+        });
+
+        it("should return empty when no .yarnrc.yml", () => {
+            expect.assertions(2);
+
+            const result = readNativeAuditExclusions(tmpDir, "yarn");
+
+            expect(result.ignoredAdvisories).toHaveLength(0);
+            expect(result.excludedPackages).toHaveLength(0);
+        });
+    });
+
+    describe("npm/bun", () => {
+        it("should return empty for npm", () => {
+            expect.assertions(2);
+
+            const result = readNativeAuditExclusions(tmpDir, "npm");
+
+            expect(result.ignoredAdvisories).toHaveLength(0);
+            expect(result.excludedPackages).toHaveLength(0);
+        });
+
+        it("should return empty for bun", () => {
+            expect.assertions(2);
+
+            const result = readNativeAuditExclusions(tmpDir, "bun");
+
+            expect(result.ignoredAdvisories).toHaveLength(0);
+            expect(result.excludedPackages).toHaveLength(0);
+        });
+    });
+});
+
+// --- Matching helpers ---
+
+describe("isAdvisoryExcluded", () => {
+    const exclusions = { excludedPackages: [], ignoredAdvisories: ["CVE-2022-36313", "GHSA-*"] };
+
+    it("should match exact advisory ID", () => {
+        expect.assertions(1);
+        expect(isAdvisoryExcluded("CVE-2022-36313", exclusions)).toBe(true);
+    });
+
+    it("should match glob patterns", () => {
+        expect.assertions(1);
+        expect(isAdvisoryExcluded("GHSA-abcd-1234-wxyz", exclusions)).toBe(true);
+    });
+
+    it("should not match unrelated IDs", () => {
+        expect.assertions(1);
+        expect(isAdvisoryExcluded("CVE-2099-99999", exclusions)).toBe(false);
+    });
+});
+
+describe("isPackageExcluded", () => {
+    const exclusions = { excludedPackages: ["debug", "@scope/*"], ignoredAdvisories: [] };
+
+    it("should match exact package name", () => {
+        expect.assertions(1);
+        expect(isPackageExcluded("debug", exclusions)).toBe(true);
+    });
+
+    it("should match glob patterns", () => {
+        expect.assertions(1);
+        expect(isPackageExcluded("@scope/utils", exclusions)).toBe(true);
+    });
+
+    it("should not match unrelated packages", () => {
+        expect.assertions(1);
+        expect(isPackageExcluded("express", exclusions)).toBe(false);
+    });
+});
+
+// --- Writers ---
+
+describe("syncAcceptedRisksToNativeConfig", () => {
+    describe("pnpm", () => {
+        it("should add auditConfig section to pnpm-workspace.yaml", () => {
+            expect.assertions(3);
+
+            writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+
+            const actions = syncAcceptedRisksToNativeConfig("pnpm", tmpDir, ["CVE-2022-36313", "GHSA-abcd-1234-wxyz"]);
+
+            expect(actions).toHaveLength(2);
+
+            const content = readFileSync(join(tmpDir, "pnpm-workspace.yaml"), "utf8");
+
+            expect(content).toContain("CVE-2022-36313");
+            expect(content).toContain("GHSA-abcd-1234-wxyz");
+        });
+    });
+
+    describe("yarn", () => {
+        it("should add npmAuditIgnoreAdvisories to .yarnrc.yml", () => {
+            expect.assertions(2);
+
+            writeFileSync(join(tmpDir, ".yarnrc.yml"), "nodeLinker: node-modules\n");
+
+            const actions = syncAcceptedRisksToNativeConfig("yarn", tmpDir, ["CVE-2022-36313"]);
+
+            expect(actions[0]).toContain("1 advisory");
+
+            const content = readFileSync(join(tmpDir, ".yarnrc.yml"), "utf8");
+
+            expect(content).toContain("CVE-2022-36313");
+        });
+    });
+
+    describe("npm", () => {
+        it("should note that npm has no native mechanism", () => {
+            expect.assertions(1);
+
+            const actions = syncAcceptedRisksToNativeConfig("npm", tmpDir, ["CVE-2022-36313"]);
+
+            expect(actions[0]).toContain("no native audit exclusion config");
+        });
+    });
+
+    describe("bun", () => {
+        it("should suggest CLI flags for bun", () => {
+            expect.assertions(1);
+
+            const actions = syncAcceptedRisksToNativeConfig("bun", tmpDir, ["CVE-2022-36313"]);
+
+            expect(actions[0]).toContain("--ignore");
+        });
+    });
+
+    it("should handle empty advisory list", () => {
+        expect.assertions(1);
+
+        const actions = syncAcceptedRisksToNativeConfig("pnpm", tmpDir, []);
+
+        expect(actions[0]).toContain("No advisory IDs");
+    });
+});

--- a/packages/tooling/vis/__tests__/socket-security.test.ts
+++ b/packages/tooling/vis/__tests__/socket-security.test.ts
@@ -167,7 +167,13 @@ describe("formatReportDetailed", () => {
 
         const report = makeReport({
             alerts: [
-                { category: "security", key: "a1", props: { cveId: "CVE-2024-1234", lastPublish: "2024-01-01" }, severity: "critical", type: "prototype-pollution" },
+                {
+                    category: "security",
+                    key: "a1",
+                    props: { cveId: "CVE-2024-1234", lastPublish: "2024-01-01" },
+                    severity: "critical",
+                    type: "prototype-pollution",
+                },
             ],
         });
         const detailed = formatReportDetailed(report);
@@ -232,7 +238,7 @@ describe("buildSocketOptions", () => {
 
 describe("findAcceptedRisk", () => {
     const risks: Record<string, AcceptedRisk> = {
-        "lodash": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.3, reason: "reviewed" },
+        lodash: { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.3, reason: "reviewed" },
         "react@18.0.0": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.35, reason: "pinned" },
         "@myorg/*": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.2, reason: "internal" },
     };

--- a/packages/tooling/vis/__tests__/socket-security.test.ts
+++ b/packages/tooling/vis/__tests__/socket-security.test.ts
@@ -1,0 +1,325 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock homedir before importing the module under test
+const TEST_HOME = join(tmpdir(), `vis-socket-test-${String(process.pid)}-${String(Date.now())}`);
+
+vi.mock(import("node:os"), async (importOriginal) => {
+    const original = await importOriginal<typeof import("node:os")>();
+
+    return { ...original, homedir: () => TEST_HOME };
+});
+
+const {
+    buildSocketOptions,
+    calculateOverallScore,
+    clearSocketCache,
+    findAcceptedRisk,
+    formatAcceptedRiskSnippet,
+    formatReportDetailed,
+    formatReportSummary,
+    formatSecurityOverview,
+    isPackageReportData,
+    scoreColor,
+    scoreLabel,
+} = await import("../src/socket-security");
+
+import type { AcceptedRisk, PackageReportData, PackageScore } from "../src/socket-security";
+
+// --- Helpers ---
+
+const makeScore = (overrides: Partial<PackageScore> = {}): PackageScore => ({
+    license: 0.8,
+    maintenance: 0.7,
+    overall: 0.75,
+    quality: 0.9,
+    supplyChain: 0.6,
+    vulnerability: 0.85,
+    ...overrides,
+});
+
+const makeReport = (overrides: Partial<PackageReportData> = {}): PackageReportData => ({
+    alerts: [],
+    author: ["test-author"],
+    id: "pkg:npm/test-pkg@1.0.0",
+    license: "MIT",
+    name: "test-pkg",
+    score: makeScore(),
+    size: 1024,
+    type: "npm",
+    version: "1.0.0",
+    ...overrides,
+});
+
+// --- Pure function tests ---
+
+describe("isPackageReportData", () => {
+    it("should return true for valid report data", () => {
+        expect.assertions(1);
+        expect(isPackageReportData(makeReport())).toBe(true);
+    });
+
+    it("should return false for non-npm type", () => {
+        expect.assertions(1);
+        expect(isPackageReportData({ ...makeReport(), type: "pypi" })).toBe(false);
+    });
+
+    it("should return false for missing fields", () => {
+        expect.assertions(2);
+        expect(isPackageReportData({})).toBe(false);
+        expect(isPackageReportData(null)).toBe(false);
+    });
+});
+
+describe("calculateOverallScore", () => {
+    it("should average the five score components", () => {
+        expect.assertions(1);
+
+        const score = { license: 1, maintenance: 0.5, quality: 0.5, supplyChain: 0.5, vulnerability: 0.5 };
+
+        expect(calculateOverallScore(score)).toBe(0.6);
+    });
+
+    it("should handle all zeros", () => {
+        expect.assertions(1);
+        expect(calculateOverallScore({ license: 0, maintenance: 0, quality: 0, supplyChain: 0, vulnerability: 0 })).toBe(0);
+    });
+
+    it("should handle all ones", () => {
+        expect.assertions(1);
+        expect(calculateOverallScore({ license: 1, maintenance: 1, quality: 1, supplyChain: 1, vulnerability: 1 })).toBe(1);
+    });
+});
+
+describe("scoreLabel", () => {
+    it("should return correct labels for score ranges", () => {
+        expect.assertions(5);
+        expect(scoreLabel(0.9)).toBe("excellent");
+        expect(scoreLabel(0.7)).toBe("good");
+        expect(scoreLabel(0.5)).toBe("fair");
+        expect(scoreLabel(0.3)).toBe("poor");
+        expect(scoreLabel(0.1)).toBe("critical");
+    });
+});
+
+describe("scoreColor", () => {
+    it("should return green for high scores", () => {
+        expect.assertions(1);
+        expect(scoreColor(0.8)).toBe("green");
+    });
+
+    it("should return yellow for medium scores", () => {
+        expect.assertions(1);
+        expect(scoreColor(0.5)).toBe("yellow");
+    });
+
+    it("should return red for low scores", () => {
+        expect.assertions(1);
+        expect(scoreColor(0.2)).toBe("red");
+    });
+});
+
+describe("formatReportSummary", () => {
+    it("should format a one-line summary", () => {
+        expect.assertions(2);
+
+        const summary = formatReportSummary(makeReport());
+
+        expect(summary).toContain("test-pkg@1.0.0");
+        expect(summary).toContain("75%");
+    });
+
+    it("should include alert count when present", () => {
+        expect.assertions(1);
+
+        const report = makeReport({
+            alerts: [{ category: "security", key: "a1", severity: "high", type: "prototype-pollution" }],
+        });
+
+        expect(formatReportSummary(report)).toContain("1 alert");
+    });
+
+    it("should handle scoped packages", () => {
+        expect.assertions(1);
+
+        const report = makeReport({ name: "core", namespace: "@babel" });
+
+        expect(formatReportSummary(report)).toContain("@babel/core@1.0.0");
+    });
+});
+
+describe("formatReportDetailed", () => {
+    it("should include score breakdown", () => {
+        expect.assertions(3);
+
+        const detailed = formatReportDetailed(makeReport());
+
+        expect(detailed).toContain("Overall Score:");
+        expect(detailed).toContain("Supply Chain:");
+        expect(detailed).toContain("License: MIT");
+    });
+
+    it("should show alerts when present", () => {
+        expect.assertions(2);
+
+        const report = makeReport({
+            alerts: [
+                { category: "security", key: "a1", props: { cveId: "CVE-2024-1234", lastPublish: "2024-01-01" }, severity: "critical", type: "prototype-pollution" },
+            ],
+        });
+        const detailed = formatReportDetailed(report);
+
+        expect(detailed).toContain("[CRITICAL]");
+        expect(detailed).toContain("CVE-2024-1234");
+    });
+});
+
+describe("formatSecurityOverview", () => {
+    it("should return empty string for no reports", () => {
+        expect.assertions(1);
+        expect(formatSecurityOverview(new Map())).toBe("");
+    });
+
+    it("should show scanned count and alert breakdown", () => {
+        expect.assertions(3);
+
+        const reports = new Map<string, PackageReportData>();
+
+        reports.set("a@1", makeReport({ alerts: [{ category: "sec", key: "a", severity: "critical", type: "vuln" }] }));
+        reports.set("b@1", makeReport({ alerts: [], name: "b" }));
+
+        const overview = formatSecurityOverview(reports);
+
+        expect(overview).toContain("scanned 2 packages");
+        expect(overview).toContain("1 total");
+        expect(overview).toContain("1 critical");
+    });
+
+    it("should count low-score packages", () => {
+        expect.assertions(1);
+
+        const reports = new Map<string, PackageReportData>();
+
+        reports.set("a@1", makeReport({ score: makeScore({ overall: 0.2 }) }));
+
+        const overview = formatSecurityOverview(reports);
+
+        expect(overview).toContain("1 package with low security score");
+    });
+});
+
+describe("buildSocketOptions", () => {
+    it("should return undefined when not enabled", () => {
+        expect.assertions(2);
+        expect(buildSocketOptions(undefined)).toBeUndefined();
+        expect(buildSocketOptions({ enabled: false })).toBeUndefined();
+    });
+
+    it("should return options when enabled", () => {
+        expect.assertions(2);
+
+        const result = buildSocketOptions({ enabled: true, timeoutMs: 5000 });
+
+        expect(result).toBeDefined();
+        expect(result?.timeoutMs).toBe(5000);
+    });
+});
+
+// --- Accepted risks ---
+
+describe("findAcceptedRisk", () => {
+    const risks: Record<string, AcceptedRisk> = {
+        "lodash": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.3, reason: "reviewed" },
+        "react@18.0.0": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.35, reason: "pinned" },
+        "@myorg/*": { acceptedAt: "2026-01-01T00:00:00Z", acceptedScore: 0.2, reason: "internal" },
+    };
+
+    it("should match by unversioned name", () => {
+        expect.assertions(2);
+
+        const result = findAcceptedRisk("lodash", "4.17.21", risks);
+
+        expect(result).toBeDefined();
+        expect(result?.reason).toBe("reviewed");
+    });
+
+    it("should match by exact name@version", () => {
+        expect.assertions(2);
+
+        const result = findAcceptedRisk("react", "18.0.0", risks);
+
+        expect(result).toBeDefined();
+        expect(result?.reason).toBe("pinned");
+    });
+
+    it("should not match different version when versioned key exists", () => {
+        expect.assertions(1);
+        expect(findAcceptedRisk("react", "19.0.0", risks)).toBeUndefined();
+    });
+
+    it("should match glob patterns", () => {
+        expect.assertions(2);
+
+        const result = findAcceptedRisk("@myorg/utils", "1.0.0", risks);
+
+        expect(result).toBeDefined();
+        expect(result?.reason).toBe("internal");
+    });
+
+    it("should return undefined for unknown packages", () => {
+        expect.assertions(1);
+        expect(findAcceptedRisk("unknown-pkg", "1.0.0", risks)).toBeUndefined();
+    });
+
+    it("should return undefined when no risks configured", () => {
+        expect.assertions(1);
+        expect(findAcceptedRisk("lodash", "4.17.21", undefined)).toBeUndefined();
+    });
+});
+
+describe("formatAcceptedRiskSnippet", () => {
+    it("should produce a valid config snippet", () => {
+        expect.assertions(3);
+
+        const snippet = formatAcceptedRiskSnippet("lodash", "4.17.21", 0.3, "Reviewed and accepted");
+
+        expect(snippet).toContain('"lodash"');
+        expect(snippet).toContain("Reviewed and accepted");
+        expect(snippet).toContain("acceptedScore: 0.3");
+    });
+});
+
+// --- Cache tests ---
+
+describe("socket cache", () => {
+    beforeEach(() => {
+        mkdirSync(TEST_HOME, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(TEST_HOME, { force: true, recursive: true });
+    });
+
+    it("clearSocketCache should return 0 when no cache exists", () => {
+        expect.assertions(1);
+        expect(clearSocketCache()).toBe(0);
+    });
+
+    it("clearSocketCache should remove cached files", () => {
+        expect.assertions(2);
+
+        const cacheDir = join(TEST_HOME, ".vis", "cache", "socket-security");
+
+        mkdirSync(cacheDir, { recursive: true });
+        writeFileSync(join(cacheDir, "test@1.0.0.json"), "{}");
+
+        expect(existsSync(join(cacheDir, "test@1.0.0.json"))).toBe(true);
+
+        const deleted = clearSocketCache();
+
+        expect(deleted).toBe(1);
+    });
+});

--- a/packages/tooling/vis/package.json
+++ b/packages/tooling/vis/package.json
@@ -88,7 +88,8 @@
         "@visulima/task-runner": "1.0.0-alpha.3",
         "@visulima/tui": "workspace:*",
         "jiti": "catalog:dev",
-        "react": "catalog:frontend"
+        "react": "catalog:frontend",
+        "semver": "^7.7.1"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -103,6 +104,7 @@
         "@total-typescript/ts-reset": "catalog:dev",
         "@types/node": "catalog:types",
         "@types/react": "catalog:types",
+        "@types/semver": "^7.7.0",
         "@visulima/packem": "catalog:dev",
         "@vitest/coverage-v8": "catalog:test",
         "@vitest/ui": "catalog:test",

--- a/packages/tooling/vis/src/ai-analysis.ts
+++ b/packages/tooling/vis/src/ai-analysis.ts
@@ -96,7 +96,29 @@ const buildPackageList = (outdated: OutdatedEntry[]): string =>
                     ? ` [VULNERABILITIES: ${entry.vulnerabilities.map((v) => `${v.severity} ${v.id}`).join(", ")}]`
                     : "";
 
-            return `- ${entry.packageName}: ${entry.currentRange} → ${entry.newRange} (${entry.updateType})${vulnInfo}`;
+            let socketInfo = "";
+
+            if (entry.socketReport) {
+                const score = Math.round(entry.socketReport.score.overall * 100);
+                const parts = [`score:${String(score)}%`];
+
+                if (entry.socketReport.alerts.length > 0) {
+                    const alertsByLevel = entry.socketReport.alerts.reduce<Record<string, number>>((acc, a) => {
+                        acc[a.severity] = (acc[a.severity] ?? 0) + 1;
+
+                        return acc;
+                    }, {});
+                    const alertSummary = Object.entries(alertsByLevel).map(([s, c]) => `${String(c)} ${s}`).join(", ");
+
+                    parts.push(`alerts: ${alertSummary}`);
+                }
+
+                parts.push(`supply-chain:${String(Math.round(entry.socketReport.score.supplyChain * 100))}%`);
+                parts.push(`quality:${String(Math.round(entry.socketReport.score.quality * 100))}%`);
+                socketInfo = ` [SOCKET.DEV: ${parts.join(", ")}]`;
+            }
+
+            return `- ${entry.packageName}: ${entry.currentRange} → ${entry.newRange} (${entry.updateType})${vulnInfo}${socketInfo}`;
         })
         .join("\n");
 
@@ -153,6 +175,7 @@ Consider:
 3. Best practices for the specific package ecosystem
 4. Risk vs. benefit analysis
 5. Suggested update order
+6. If Socket.dev scores are provided, prioritize packages with low supply chain or quality scores
 
 ${JSON_RESPONSE_SCHEMA}`,
 
@@ -166,6 +189,7 @@ For each package:
 3. Evaluate if this is a security-sensitive package (auth, crypto, session, etc.)
 4. Recommend urgency of the update based on vulnerability severity
 5. Flag any packages where skipping the update poses security risk
+6. If Socket.dev scores are provided, factor in supply chain and quality scores — low scores indicate higher risk
 
 ${JSON_RESPONSE_SCHEMA}`,
 };

--- a/packages/tooling/vis/src/ai-analysis.ts
+++ b/packages/tooling/vis/src/ai-analysis.ts
@@ -91,8 +91,8 @@ const AI_TIMEOUT_MS = 120_000;
 const buildPackageList = (outdated: OutdatedEntry[]): string =>
     outdated
         .map((entry) => {
-            const vulnInfo
-                = entry.vulnerabilities && entry.vulnerabilities.length > 0
+            const vulnInfo =
+                entry.vulnerabilities && entry.vulnerabilities.length > 0
                     ? ` [VULNERABILITIES: ${entry.vulnerabilities.map((v) => `${v.severity} ${v.id}`).join(", ")}]`
                     : "";
 
@@ -108,7 +108,9 @@ const buildPackageList = (outdated: OutdatedEntry[]): string =>
 
                         return acc;
                     }, {});
-                    const alertSummary = Object.entries(alertsByLevel).map(([s, c]) => `${String(c)} ${s}`).join(", ");
+                    const alertSummary = Object.entries(alertsByLevel)
+                        .map(([s, c]) => `${String(c)} ${s}`)
+                        .join(", ");
 
                     parts.push(`alerts: ${alertSummary}`);
                 }
@@ -306,8 +308,8 @@ const ruleBasedAnalysis = (outdated: OutdatedEntry[], analysisType: AnalysisType
             riskLevel = "high";
             action = breakingChanges.length > 0 ? "review" : "update";
             effort = "medium";
-            reason
-                = breakingChanges.length > 0
+            reason =
+                breakingChanges.length > 0
                     ? `Major update with known breaking changes: ${breakingChanges[0]}`
                     : "Major version update, review changelog before applying.";
         } else if (entry.updateType === "minor") {
@@ -401,7 +403,7 @@ const mergeResults = (results: AiAnalysisResult[], provider: string, analysisTyp
         analysisType,
         provider,
         recommendations,
-        summary: summaries.length === 1 ? summaries[0] ?? "" : `Analyzed ${String(recommendations.length)} packages in ${String(results.length)} batches.`,
+        summary: summaries.length === 1 ? (summaries[0] ?? "") : `Analyzed ${String(recommendations.length)} packages in ${String(results.length)} batches.`,
         warnings: [...new Set(warnings)],
     };
 };
@@ -442,12 +444,12 @@ const formatAiAnalysis = (result: AiAnalysisResult): string => {
             React.createElement(Text, null, result.summary),
             React.createElement(Text, null, ""),
             React.createElement(Table, { borderStyle: "none", data: tableData }),
-            ...result.warnings.length > 0
+            ...(result.warnings.length > 0
                 ? [
-                    React.createElement(Text, null, ""),
-                    ...result.warnings.map((warning, i) => React.createElement(Text, { dimColor: true, key: String(i) }, `  ${warning}`)),
-                ]
-                : [],
+                      React.createElement(Text, null, ""),
+                      ...result.warnings.map((warning, i) => React.createElement(Text, { dimColor: true, key: String(i) }, `  ${warning}`)),
+                  ]
+                : []),
         ),
         { columns },
     );

--- a/packages/tooling/vis/src/audit-config.ts
+++ b/packages/tooling/vis/src/audit-config.ts
@@ -119,8 +119,22 @@ const readNativeAuditExclusions = (workspaceRoot: string, pm: string): NativeAud
     }
 };
 
-const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions): boolean =>
-    matchesGlobList(vulnId, exclusions.ignoredAdvisories);
+/** Checks if any of the given IDs (primary + aliases) match the exclusion list. */
+const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions, aliases?: string[]): boolean => {
+    if (matchesGlobList(vulnId, exclusions.ignoredAdvisories)) {
+        return true;
+    }
+
+    if (aliases) {
+        for (const alias of aliases) {
+            if (matchesGlobList(alias, exclusions.ignoredAdvisories)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+};
 
 const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean =>
     matchesGlobList(packageName, exclusions.excludedPackages);
@@ -147,13 +161,30 @@ const syncAcceptedRisksToNativeConfig = (
                 break;
             }
 
+            // Read existing exclusions to merge with new ones
+            const existing = readPnpmAuditExclusions(workspaceRoot);
+            const existingCves = new Set(existing.ignoredAdvisories.filter((id) => id.startsWith("CVE-")));
+            const existingGhsas = new Set(existing.ignoredAdvisories.filter((id) => id.startsWith("GHSA-")));
+
+            const newCves = advisoryIds.filter((id) => id.startsWith("CVE-"));
+            const newGhsas = advisoryIds.filter((id) => id.startsWith("GHSA-"));
+
+            // Merge and deduplicate
+            const mergedCves = [...new Set([...existingCves, ...newCves])];
+            const mergedGhsas = [...new Set([...existingGhsas, ...newGhsas])];
+
+            const addedCves = newCves.filter((id) => !existingCves.has(id)).length;
+            const addedGhsas = newGhsas.filter((id) => !existingGhsas.has(id)).length;
+
+            if (addedCves === 0 && addedGhsas === 0) {
+                actions.push("All advisory IDs already present in pnpm-workspace.yaml.");
+                break;
+            }
+
             let content = readFileSync(filePath, "utf8");
 
-            const cves = advisoryIds.filter((id) => id.startsWith("CVE-"));
-            const ghsas = advisoryIds.filter((id) => id.startsWith("GHSA-"));
-
-            if (cves.length > 0) {
-                const cveBlock = `  ignoreCves:\n${cves.map((id) => `    - ${id}`).join("\n")}\n`;
+            if (mergedCves.length > 0) {
+                const cveBlock = `  ignoreCves:\n${mergedCves.map((id) => `    - ${id}`).join("\n")}\n`;
 
                 if (/auditConfig:/m.test(content)) {
                     if (/ignoreCves:/m.test(content)) {
@@ -165,11 +196,13 @@ const syncAcceptedRisksToNativeConfig = (
                     content = `${content.trimEnd()}\n\nauditConfig:\n${cveBlock}`;
                 }
 
-                actions.push(`Synced ${String(cves.length)} CVE${cves.length === 1 ? "" : "s"} to pnpm-workspace.yaml auditConfig.ignoreCves`);
+                if (addedCves > 0) {
+                    actions.push(`Added ${String(addedCves)} new CVE${addedCves === 1 ? "" : "s"} to pnpm-workspace.yaml (${String(mergedCves.length)} total)`);
+                }
             }
 
-            if (ghsas.length > 0) {
-                const ghsaBlock = `  ignoreGhsas:\n${ghsas.map((id) => `    - ${id}`).join("\n")}\n`;
+            if (mergedGhsas.length > 0) {
+                const ghsaBlock = `  ignoreGhsas:\n${mergedGhsas.map((id) => `    - ${id}`).join("\n")}\n`;
 
                 if (/auditConfig:/m.test(content)) {
                     if (/ignoreGhsas:/m.test(content)) {
@@ -179,7 +212,9 @@ const syncAcceptedRisksToNativeConfig = (
                     }
                 }
 
-                actions.push(`Synced ${String(ghsas.length)} GHSA${ghsas.length === 1 ? "" : "s"} to pnpm-workspace.yaml auditConfig.ignoreGhsas`);
+                if (addedGhsas > 0) {
+                    actions.push(`Added ${String(addedGhsas)} new GHSA${addedGhsas === 1 ? "" : "s"} to pnpm-workspace.yaml (${String(mergedGhsas.length)} total)`);
+                }
             }
 
             writeFileSync(filePath, content);
@@ -194,9 +229,20 @@ const syncAcceptedRisksToNativeConfig = (
                 break;
             }
 
+            // Read existing exclusions to merge
+            const existingYarn = readYarnAuditExclusions(workspaceRoot);
+            const existingSet = new Set(existingYarn.ignoredAdvisories);
+            const merged = [...new Set([...existingSet, ...advisoryIds])];
+            const added = advisoryIds.filter((id) => !existingSet.has(id)).length;
+
+            if (added === 0) {
+                actions.push("All advisory IDs already present in .yarnrc.yml.");
+                break;
+            }
+
             let content = readFileSync(filePath, "utf8");
 
-            const advisoryBlock = `npmAuditIgnoreAdvisories:\n${advisoryIds.map((id) => `  - "${id}"`).join("\n")}\n`;
+            const advisoryBlock = `npmAuditIgnoreAdvisories:\n${merged.map((id) => `  - "${id}"`).join("\n")}\n`;
 
             if (/npmAuditIgnoreAdvisories:/m.test(content)) {
                 content = content.replace(/npmAuditIgnoreAdvisories:\s*\n(?:\s+-\s+.+\n)*/m, advisoryBlock);
@@ -205,7 +251,7 @@ const syncAcceptedRisksToNativeConfig = (
             }
 
             writeFileSync(filePath, content);
-            actions.push(`Synced ${String(advisoryIds.length)} advisor${advisoryIds.length === 1 ? "y" : "ies"} to .yarnrc.yml npmAuditIgnoreAdvisories`);
+            actions.push(`Added ${String(added)} new advisor${added === 1 ? "y" : "ies"} to .yarnrc.yml (${String(merged.length)} total)`);
             break;
         }
 

--- a/packages/tooling/vis/src/audit-config.ts
+++ b/packages/tooling/vis/src/audit-config.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
+import { isAccessibleSync, readYamlSync } from "@visulima/fs";
 import { join } from "@visulima/path";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -23,34 +24,13 @@ interface NativeAuditExclusions {
 
 // ── Shared helpers ──────────────────────────────────────────────────
 
-const YAML_ENTRY_STRIP_RE = /^\s+-\s+['"]?/;
-const YAML_TRAILING_QUOTE_RE = /['"]?$/;
-
-/** Extracts values from a YAML list section like `key:\n  - value1\n  - value2`. */
-const parseYamlList = (content: string, keyRegex: RegExp): string[] => {
-    const match = keyRegex.exec(content);
-
-    if (!match?.[1]) {
+/** Safely coerces a YAML value to a string array. */
+const toStringArray = (value: unknown): string[] => {
+    if (!Array.isArray(value)) {
         return [];
     }
 
-    const entries = match[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
-
-    if (!entries) {
-        return [];
-    }
-
-    const results: string[] = [];
-
-    for (const entry of entries) {
-        const value = entry.replace(YAML_ENTRY_STRIP_RE, "").replace(YAML_TRAILING_QUOTE_RE, "").trim();
-
-        if (value) {
-            results.push(value);
-        }
-    }
-
-    return results;
+    return value.filter((v): v is string => typeof v === "string");
 };
 
 /** Checks if a value matches any pattern in a list (exact or trailing glob). */
@@ -68,48 +48,59 @@ const matchesGlobList = (value: string, patterns: string[]): boolean => {
     return false;
 };
 
-// ── Readers ─────────────────────────────────────────────────────────
+// ── Readers (use @visulima/fs readYamlSync for proper parsing) ──────
+
+interface PnpmWorkspaceYaml {
+    auditConfig?: {
+        ignoreCves?: string[];
+        ignoreGhsas?: string[];
+    };
+}
+
+interface YarnrcYml {
+    npmAuditExcludePackages?: string[];
+    npmAuditIgnoreAdvisories?: string[];
+}
 
 const readPnpmAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
     const filePath = join(workspaceRoot, "pnpm-workspace.yaml");
 
-    if (!existsSync(filePath)) {
+    if (!isAccessibleSync(filePath)) {
         return { excludedPackages: [], ignoredAdvisories: [] };
     }
 
-    const content = readFileSync(filePath, "utf8");
+    try {
+        const data = readYamlSync<PnpmWorkspaceYaml>(filePath);
 
-    // Extract the auditConfig block first
-    const sectionMatch = /^auditConfig:\s*\n([\s\S]*?)(?=^\S|\z)/m.exec(content);
-
-    if (!sectionMatch) {
+        return {
+            excludedPackages: [],
+            ignoredAdvisories: [
+                ...toStringArray(data?.auditConfig?.ignoreCves),
+                ...toStringArray(data?.auditConfig?.ignoreGhsas),
+            ],
+        };
+    } catch {
         return { excludedPackages: [], ignoredAdvisories: [] };
     }
-
-    const block = sectionMatch[1];
-
-    return {
-        excludedPackages: [],
-        ignoredAdvisories: [
-            ...parseYamlList(block, /ignoreCves:\s*\n((?:\s+-\s+.+\n)*)/m),
-            ...parseYamlList(block, /ignoreGhsas:\s*\n((?:\s+-\s+.+\n)*)/m),
-        ],
-    };
 };
 
 const readYarnAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
     const filePath = join(workspaceRoot, ".yarnrc.yml");
 
-    if (!existsSync(filePath)) {
+    if (!isAccessibleSync(filePath)) {
         return { excludedPackages: [], ignoredAdvisories: [] };
     }
 
-    const content = readFileSync(filePath, "utf8");
+    try {
+        const data = readYamlSync<YarnrcYml>(filePath);
 
-    return {
-        excludedPackages: parseYamlList(content, /npmAuditExcludePackages:\s*\n((?:\s+-\s+.+\n)*)/m),
-        ignoredAdvisories: parseYamlList(content, /npmAuditIgnoreAdvisories:\s*\n((?:\s+-\s+.+\n)*)/m),
-    };
+        return {
+            excludedPackages: toStringArray(data?.npmAuditExcludePackages),
+            ignoredAdvisories: toStringArray(data?.npmAuditIgnoreAdvisories),
+        };
+    } catch {
+        return { excludedPackages: [], ignoredAdvisories: [] };
+    }
 };
 
 const readNativeAuditExclusions = (workspaceRoot: string, pm: string): NativeAuditExclusions => {

--- a/packages/tooling/vis/src/audit-config.ts
+++ b/packages/tooling/vis/src/audit-config.ts
@@ -21,120 +21,97 @@ interface NativeAuditExclusions {
     excludedPackages: string[];
 }
 
+// ── Shared helpers ──────────────────────────────────────────────────
+
+const YAML_ENTRY_STRIP_RE = /^\s+-\s+['"]?/;
+const YAML_TRAILING_QUOTE_RE = /['"]?$/;
+
+/** Extracts values from a YAML list section like `key:\n  - value1\n  - value2`. */
+const parseYamlList = (content: string, keyRegex: RegExp): string[] => {
+    const match = keyRegex.exec(content);
+
+    if (!match?.[1]) {
+        return [];
+    }
+
+    const entries = match[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
+
+    if (!entries) {
+        return [];
+    }
+
+    const results: string[] = [];
+
+    for (const entry of entries) {
+        const value = entry.replace(YAML_ENTRY_STRIP_RE, "").replace(YAML_TRAILING_QUOTE_RE, "").trim();
+
+        if (value) {
+            results.push(value);
+        }
+    }
+
+    return results;
+};
+
+/** Checks if a value matches any pattern in a list (exact or trailing glob). */
+const matchesGlobList = (value: string, patterns: string[]): boolean => {
+    for (const pattern of patterns) {
+        if (pattern === value) {
+            return true;
+        }
+
+        if (pattern.endsWith("*") && value.startsWith(pattern.slice(0, -1))) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
 // ── Readers ─────────────────────────────────────────────────────────
 
-/**
- * Reads pnpm auditConfig from pnpm-workspace.yaml.
- * Parses ignoreCves and ignoreGhsas arrays.
- */
 const readPnpmAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
-    const result: NativeAuditExclusions = { excludedPackages: [], ignoredAdvisories: [] };
     const filePath = join(workspaceRoot, "pnpm-workspace.yaml");
 
     if (!existsSync(filePath)) {
-        return result;
+        return { excludedPackages: [], ignoredAdvisories: [] };
     }
 
     const content = readFileSync(filePath, "utf8");
 
-    // Parse ignoreCves
-    const cveSection = /^auditConfig:\s*\n([\s\S]*?)(?=^\S|\z)/m.exec(content);
+    // Extract the auditConfig block first
+    const sectionMatch = /^auditConfig:\s*\n([\s\S]*?)(?=^\S|\z)/m.exec(content);
 
-    if (cveSection) {
-        const block = cveSection[1];
-
-        // Extract ignoreCves entries
-        const cveMatch = /ignoreCves:\s*\n((?:\s+-\s+.+\n)*)/m.exec(block);
-
-        if (cveMatch) {
-            const entries = cveMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
-
-            if (entries) {
-                for (const entry of entries) {
-                    const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
-
-                    if (value) {
-                        result.ignoredAdvisories.push(value);
-                    }
-                }
-            }
-        }
-
-        // Extract ignoreGhsas entries
-        const ghsaMatch = /ignoreGhsas:\s*\n((?:\s+-\s+.+\n)*)/m.exec(block);
-
-        if (ghsaMatch) {
-            const entries = ghsaMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
-
-            if (entries) {
-                for (const entry of entries) {
-                    const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
-
-                    if (value) {
-                        result.ignoredAdvisories.push(value);
-                    }
-                }
-            }
-        }
+    if (!sectionMatch) {
+        return { excludedPackages: [], ignoredAdvisories: [] };
     }
 
-    return result;
+    const block = sectionMatch[1];
+
+    return {
+        excludedPackages: [],
+        ignoredAdvisories: [
+            ...parseYamlList(block, /ignoreCves:\s*\n((?:\s+-\s+.+\n)*)/m),
+            ...parseYamlList(block, /ignoreGhsas:\s*\n((?:\s+-\s+.+\n)*)/m),
+        ],
+    };
 };
 
-/**
- * Reads yarn berry audit exclusions from .yarnrc.yml.
- * Parses npmAuditIgnoreAdvisories and npmAuditExcludePackages arrays.
- */
 const readYarnAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
-    const result: NativeAuditExclusions = { excludedPackages: [], ignoredAdvisories: [] };
     const filePath = join(workspaceRoot, ".yarnrc.yml");
 
     if (!existsSync(filePath)) {
-        return result;
+        return { excludedPackages: [], ignoredAdvisories: [] };
     }
 
     const content = readFileSync(filePath, "utf8");
 
-    // Parse npmAuditIgnoreAdvisories
-    const advisoryMatch = /npmAuditIgnoreAdvisories:\s*\n((?:\s+-\s+.+\n)*)/m.exec(content);
-
-    if (advisoryMatch) {
-        const entries = advisoryMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
-
-        if (entries) {
-            for (const entry of entries) {
-                const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
-
-                if (value) {
-                    result.ignoredAdvisories.push(value);
-                }
-            }
-        }
-    }
-
-    // Parse npmAuditExcludePackages
-    const excludeMatch = /npmAuditExcludePackages:\s*\n((?:\s+-\s+.+\n)*)/m.exec(content);
-
-    if (excludeMatch) {
-        const entries = excludeMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
-
-        if (entries) {
-            for (const entry of entries) {
-                const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
-
-                if (value) {
-                    result.excludedPackages.push(value);
-                }
-            }
-        }
-    }
-
-    return result;
+    return {
+        excludedPackages: parseYamlList(content, /npmAuditExcludePackages:\s*\n((?:\s+-\s+.+\n)*)/m),
+        ignoredAdvisories: parseYamlList(content, /npmAuditIgnoreAdvisories:\s*\n((?:\s+-\s+.+\n)*)/m),
+    };
 };
 
-/**
- * Reads native audit exclusions for the detected package manager.
- */
 const readNativeAuditExclusions = (workspaceRoot: string, pm: string): NativeAuditExclusions => {
     switch (pm) {
         case "pnpm": {
@@ -146,55 +123,19 @@ const readNativeAuditExclusions = (workspaceRoot: string, pm: string): NativeAud
         }
 
         default: {
-            // npm and bun have no config-file-based exclusion mechanism
             return { excludedPackages: [], ignoredAdvisories: [] };
         }
     }
 };
 
-/**
- * Checks if a vulnerability ID (CVE-*, GHSA-*, or numeric) is in the
- * native PM exclusion list.
- */
-const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions): boolean => {
-    for (const id of exclusions.ignoredAdvisories) {
-        if (id === vulnId) {
-            return true;
-        }
+const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions): boolean =>
+    matchesGlobList(vulnId, exclusions.ignoredAdvisories);
 
-        // Glob support (yarn berry): "GHSA-*"
-        if (id.endsWith("*") && vulnId.startsWith(id.slice(0, -1))) {
-            return true;
-        }
-    }
-
-    return false;
-};
-
-/**
- * Checks if a package name is excluded from audit (yarn berry only).
- */
-const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean => {
-    for (const pattern of exclusions.excludedPackages) {
-        if (pattern === packageName) {
-            return true;
-        }
-
-        // Glob: "@scope/*" or "lodash*"
-        if (pattern.endsWith("*") && packageName.startsWith(pattern.slice(0, -1))) {
-            return true;
-        }
-    }
-
-    return false;
-};
+const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean =>
+    matchesGlobList(packageName, exclusions.excludedPackages);
 
 // ── Writers (sync vis → native PM config) ───────────────────────────
 
-/**
- * Syncs vis accepted risk CVE/GHSA IDs to native PM audit exclusion config.
- * Returns a description of actions taken.
- */
 const syncAcceptedRisksToNativeConfig = (
     pm: string,
     workspaceRoot: string,
@@ -225,17 +166,9 @@ const syncAcceptedRisksToNativeConfig = (
 
                 if (/auditConfig:/m.test(content)) {
                     if (/ignoreCves:/m.test(content)) {
-                        // Replace existing ignoreCves block
-                        content = content.replace(
-                            /ignoreCves:\s*\n(?:\s+-\s+.+\n)*/m,
-                            cveBlock,
-                        );
+                        content = content.replace(/ignoreCves:\s*\n(?:\s+-\s+.+\n)*/m, cveBlock);
                     } else {
-                        // Add ignoreCves to existing auditConfig
-                        content = content.replace(
-                            /auditConfig:\s*\n/m,
-                            `auditConfig:\n${cveBlock}`,
-                        );
+                        content = content.replace(/auditConfig:\s*\n/m, `auditConfig:\n${cveBlock}`);
                     }
                 } else {
                     content = `${content.trimEnd()}\n\nauditConfig:\n${cveBlock}`;
@@ -249,15 +182,9 @@ const syncAcceptedRisksToNativeConfig = (
 
                 if (/auditConfig:/m.test(content)) {
                     if (/ignoreGhsas:/m.test(content)) {
-                        content = content.replace(
-                            /ignoreGhsas:\s*\n(?:\s+-\s+.+\n)*/m,
-                            ghsaBlock,
-                        );
+                        content = content.replace(/ignoreGhsas:\s*\n(?:\s+-\s+.+\n)*/m, ghsaBlock);
                     } else {
-                        content = content.replace(
-                            /(auditConfig:[\s\S]*?)(\n\S|\n?$)/m,
-                            `$1${ghsaBlock}$2`,
-                        );
+                        content = content.replace(/(auditConfig:[\s\S]*?)(\n\S|\n?$)/m, `$1${ghsaBlock}$2`);
                     }
                 }
 
@@ -281,10 +208,7 @@ const syncAcceptedRisksToNativeConfig = (
             const advisoryBlock = `npmAuditIgnoreAdvisories:\n${advisoryIds.map((id) => `  - "${id}"`).join("\n")}\n`;
 
             if (/npmAuditIgnoreAdvisories:/m.test(content)) {
-                content = content.replace(
-                    /npmAuditIgnoreAdvisories:\s*\n(?:\s+-\s+.+\n)*/m,
-                    advisoryBlock,
-                );
+                content = content.replace(/npmAuditIgnoreAdvisories:\s*\n(?:\s+-\s+.+\n)*/m, advisoryBlock);
             } else {
                 content = `${content.trimEnd()}\n\n${advisoryBlock}`;
             }
@@ -316,6 +240,7 @@ export type { NativeAuditExclusions };
 export {
     isAdvisoryExcluded,
     isPackageExcluded,
+    matchesGlobList,
     readNativeAuditExclusions,
     syncAcceptedRisksToNativeConfig,
 };

--- a/packages/tooling/vis/src/audit-config.ts
+++ b/packages/tooling/vis/src/audit-config.ts
@@ -74,10 +74,7 @@ const readPnpmAuditExclusions = (workspaceRoot: string): NativeAuditExclusions =
 
         return {
             excludedPackages: [],
-            ignoredAdvisories: [
-                ...toStringArray(data?.auditConfig?.ignoreCves),
-                ...toStringArray(data?.auditConfig?.ignoreGhsas),
-            ],
+            ignoredAdvisories: [...toStringArray(data?.auditConfig?.ignoreCves), ...toStringArray(data?.auditConfig?.ignoreGhsas)],
         };
     } catch {
         return { excludedPackages: [], ignoredAdvisories: [] };
@@ -136,16 +133,11 @@ const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions, a
     return false;
 };
 
-const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean =>
-    matchesGlobList(packageName, exclusions.excludedPackages);
+const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean => matchesGlobList(packageName, exclusions.excludedPackages);
 
 // ── Writers (sync vis → native PM config) ───────────────────────────
 
-const syncAcceptedRisksToNativeConfig = (
-    pm: string,
-    workspaceRoot: string,
-    advisoryIds: string[],
-): string[] => {
+const syncAcceptedRisksToNativeConfig = (pm: string, workspaceRoot: string, advisoryIds: string[]): string[] => {
     if (advisoryIds.length === 0) {
         return ["No advisory IDs to sync."];
     }
@@ -213,7 +205,9 @@ const syncAcceptedRisksToNativeConfig = (
                 }
 
                 if (addedGhsas > 0) {
-                    actions.push(`Added ${String(addedGhsas)} new GHSA${addedGhsas === 1 ? "" : "s"} to pnpm-workspace.yaml (${String(mergedGhsas.length)} total)`);
+                    actions.push(
+                        `Added ${String(addedGhsas)} new GHSA${addedGhsas === 1 ? "" : "s"} to pnpm-workspace.yaml (${String(mergedGhsas.length)} total)`,
+                    );
                 }
             }
 
@@ -274,10 +268,4 @@ const syncAcceptedRisksToNativeConfig = (
 };
 
 export type { NativeAuditExclusions };
-export {
-    isAdvisoryExcluded,
-    isPackageExcluded,
-    matchesGlobList,
-    readNativeAuditExclusions,
-    syncAcceptedRisksToNativeConfig,
-};
+export { isAdvisoryExcluded, isPackageExcluded, matchesGlobList, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig };

--- a/packages/tooling/vis/src/audit-config.ts
+++ b/packages/tooling/vis/src/audit-config.ts
@@ -1,0 +1,321 @@
+/**
+ * Read and sync native package manager audit exclusion configs.
+ *
+ * Supports:
+ * - pnpm: auditConfig.ignoreCves / ignoreGhsas in pnpm-workspace.yaml
+ * - yarn berry: npmAuditIgnoreAdvisories / npmAuditExcludePackages in .yarnrc.yml
+ * - npm: no native mechanism (vis provides the only exclusion layer)
+ * - bun: CLI-only --ignore (no config file), vis provides the config layer
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+import { join } from "@visulima/path";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface NativeAuditExclusions {
+    /** Advisory IDs to ignore (CVE-*, GHSA-*, or numeric IDs). */
+    ignoredAdvisories: string[];
+    /** Package names to exclude from audit (yarn berry only). */
+    excludedPackages: string[];
+}
+
+// ── Readers ─────────────────────────────────────────────────────────
+
+/**
+ * Reads pnpm auditConfig from pnpm-workspace.yaml.
+ * Parses ignoreCves and ignoreGhsas arrays.
+ */
+const readPnpmAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
+    const result: NativeAuditExclusions = { excludedPackages: [], ignoredAdvisories: [] };
+    const filePath = join(workspaceRoot, "pnpm-workspace.yaml");
+
+    if (!existsSync(filePath)) {
+        return result;
+    }
+
+    const content = readFileSync(filePath, "utf8");
+
+    // Parse ignoreCves
+    const cveSection = /^auditConfig:\s*\n([\s\S]*?)(?=^\S|\z)/m.exec(content);
+
+    if (cveSection) {
+        const block = cveSection[1];
+
+        // Extract ignoreCves entries
+        const cveMatch = /ignoreCves:\s*\n((?:\s+-\s+.+\n)*)/m.exec(block);
+
+        if (cveMatch) {
+            const entries = cveMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
+
+            if (entries) {
+                for (const entry of entries) {
+                    const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
+
+                    if (value) {
+                        result.ignoredAdvisories.push(value);
+                    }
+                }
+            }
+        }
+
+        // Extract ignoreGhsas entries
+        const ghsaMatch = /ignoreGhsas:\s*\n((?:\s+-\s+.+\n)*)/m.exec(block);
+
+        if (ghsaMatch) {
+            const entries = ghsaMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
+
+            if (entries) {
+                for (const entry of entries) {
+                    const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
+
+                    if (value) {
+                        result.ignoredAdvisories.push(value);
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+};
+
+/**
+ * Reads yarn berry audit exclusions from .yarnrc.yml.
+ * Parses npmAuditIgnoreAdvisories and npmAuditExcludePackages arrays.
+ */
+const readYarnAuditExclusions = (workspaceRoot: string): NativeAuditExclusions => {
+    const result: NativeAuditExclusions = { excludedPackages: [], ignoredAdvisories: [] };
+    const filePath = join(workspaceRoot, ".yarnrc.yml");
+
+    if (!existsSync(filePath)) {
+        return result;
+    }
+
+    const content = readFileSync(filePath, "utf8");
+
+    // Parse npmAuditIgnoreAdvisories
+    const advisoryMatch = /npmAuditIgnoreAdvisories:\s*\n((?:\s+-\s+.+\n)*)/m.exec(content);
+
+    if (advisoryMatch) {
+        const entries = advisoryMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
+
+        if (entries) {
+            for (const entry of entries) {
+                const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
+
+                if (value) {
+                    result.ignoredAdvisories.push(value);
+                }
+            }
+        }
+    }
+
+    // Parse npmAuditExcludePackages
+    const excludeMatch = /npmAuditExcludePackages:\s*\n((?:\s+-\s+.+\n)*)/m.exec(content);
+
+    if (excludeMatch) {
+        const entries = excludeMatch[1].match(/^\s+-\s+['"]?([^'"\s]+)['"]?/gm);
+
+        if (entries) {
+            for (const entry of entries) {
+                const value = entry.replace(/^\s+-\s+['"]?/, "").replace(/['"]?$/, "").trim();
+
+                if (value) {
+                    result.excludedPackages.push(value);
+                }
+            }
+        }
+    }
+
+    return result;
+};
+
+/**
+ * Reads native audit exclusions for the detected package manager.
+ */
+const readNativeAuditExclusions = (workspaceRoot: string, pm: string): NativeAuditExclusions => {
+    switch (pm) {
+        case "pnpm": {
+            return readPnpmAuditExclusions(workspaceRoot);
+        }
+
+        case "yarn": {
+            return readYarnAuditExclusions(workspaceRoot);
+        }
+
+        default: {
+            // npm and bun have no config-file-based exclusion mechanism
+            return { excludedPackages: [], ignoredAdvisories: [] };
+        }
+    }
+};
+
+/**
+ * Checks if a vulnerability ID (CVE-*, GHSA-*, or numeric) is in the
+ * native PM exclusion list.
+ */
+const isAdvisoryExcluded = (vulnId: string, exclusions: NativeAuditExclusions): boolean => {
+    for (const id of exclusions.ignoredAdvisories) {
+        if (id === vulnId) {
+            return true;
+        }
+
+        // Glob support (yarn berry): "GHSA-*"
+        if (id.endsWith("*") && vulnId.startsWith(id.slice(0, -1))) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+/**
+ * Checks if a package name is excluded from audit (yarn berry only).
+ */
+const isPackageExcluded = (packageName: string, exclusions: NativeAuditExclusions): boolean => {
+    for (const pattern of exclusions.excludedPackages) {
+        if (pattern === packageName) {
+            return true;
+        }
+
+        // Glob: "@scope/*" or "lodash*"
+        if (pattern.endsWith("*") && packageName.startsWith(pattern.slice(0, -1))) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+// ── Writers (sync vis → native PM config) ───────────────────────────
+
+/**
+ * Syncs vis accepted risk CVE/GHSA IDs to native PM audit exclusion config.
+ * Returns a description of actions taken.
+ */
+const syncAcceptedRisksToNativeConfig = (
+    pm: string,
+    workspaceRoot: string,
+    advisoryIds: string[],
+): string[] => {
+    if (advisoryIds.length === 0) {
+        return ["No advisory IDs to sync."];
+    }
+
+    const actions: string[] = [];
+
+    switch (pm) {
+        case "pnpm": {
+            const filePath = join(workspaceRoot, "pnpm-workspace.yaml");
+
+            if (!existsSync(filePath)) {
+                actions.push("pnpm-workspace.yaml not found. Cannot sync.");
+                break;
+            }
+
+            let content = readFileSync(filePath, "utf8");
+
+            const cves = advisoryIds.filter((id) => id.startsWith("CVE-"));
+            const ghsas = advisoryIds.filter((id) => id.startsWith("GHSA-"));
+
+            if (cves.length > 0) {
+                const cveBlock = `  ignoreCves:\n${cves.map((id) => `    - ${id}`).join("\n")}\n`;
+
+                if (/auditConfig:/m.test(content)) {
+                    if (/ignoreCves:/m.test(content)) {
+                        // Replace existing ignoreCves block
+                        content = content.replace(
+                            /ignoreCves:\s*\n(?:\s+-\s+.+\n)*/m,
+                            cveBlock,
+                        );
+                    } else {
+                        // Add ignoreCves to existing auditConfig
+                        content = content.replace(
+                            /auditConfig:\s*\n/m,
+                            `auditConfig:\n${cveBlock}`,
+                        );
+                    }
+                } else {
+                    content = `${content.trimEnd()}\n\nauditConfig:\n${cveBlock}`;
+                }
+
+                actions.push(`Synced ${String(cves.length)} CVE${cves.length === 1 ? "" : "s"} to pnpm-workspace.yaml auditConfig.ignoreCves`);
+            }
+
+            if (ghsas.length > 0) {
+                const ghsaBlock = `  ignoreGhsas:\n${ghsas.map((id) => `    - ${id}`).join("\n")}\n`;
+
+                if (/auditConfig:/m.test(content)) {
+                    if (/ignoreGhsas:/m.test(content)) {
+                        content = content.replace(
+                            /ignoreGhsas:\s*\n(?:\s+-\s+.+\n)*/m,
+                            ghsaBlock,
+                        );
+                    } else {
+                        content = content.replace(
+                            /(auditConfig:[\s\S]*?)(\n\S|\n?$)/m,
+                            `$1${ghsaBlock}$2`,
+                        );
+                    }
+                }
+
+                actions.push(`Synced ${String(ghsas.length)} GHSA${ghsas.length === 1 ? "" : "s"} to pnpm-workspace.yaml auditConfig.ignoreGhsas`);
+            }
+
+            writeFileSync(filePath, content);
+            break;
+        }
+
+        case "yarn": {
+            const filePath = join(workspaceRoot, ".yarnrc.yml");
+
+            if (!existsSync(filePath)) {
+                actions.push(".yarnrc.yml not found. Cannot sync.");
+                break;
+            }
+
+            let content = readFileSync(filePath, "utf8");
+
+            const advisoryBlock = `npmAuditIgnoreAdvisories:\n${advisoryIds.map((id) => `  - "${id}"`).join("\n")}\n`;
+
+            if (/npmAuditIgnoreAdvisories:/m.test(content)) {
+                content = content.replace(
+                    /npmAuditIgnoreAdvisories:\s*\n(?:\s+-\s+.+\n)*/m,
+                    advisoryBlock,
+                );
+            } else {
+                content = `${content.trimEnd()}\n\n${advisoryBlock}`;
+            }
+
+            writeFileSync(filePath, content);
+            actions.push(`Synced ${String(advisoryIds.length)} advisor${advisoryIds.length === 1 ? "y" : "ies"} to .yarnrc.yml npmAuditIgnoreAdvisories`);
+            break;
+        }
+
+        case "npm": {
+            actions.push("npm has no native audit exclusion config. vis accepted risks are the only layer.");
+            break;
+        }
+
+        case "bun": {
+            actions.push("bun has no audit config file. Use CLI flags: bun audit " + advisoryIds.map((id) => `--ignore ${id}`).join(" "));
+            break;
+        }
+
+        default: {
+            actions.push(`Unknown package manager: ${pm}`);
+        }
+    }
+
+    return actions;
+};
+
+export type { NativeAuditExclusions };
+export {
+    isAdvisoryExcluded,
+    isPackageExcluded,
+    readNativeAuditExclusions,
+    syncAcceptedRisksToNativeConfig,
+};

--- a/packages/tooling/vis/src/bin.ts
+++ b/packages/tooling/vis/src/bin.ts
@@ -12,6 +12,7 @@ import affectedCommand from "./commands/affected";
 import aiCommand from "./commands/ai";
 import analyzeCommand from "./commands/analyze";
 import approveBuildsCommand from "./commands/approve-builds";
+import auditCommand from "./commands/audit";
 import checkCommand from "./commands/check";
 import cleanCommand from "./commands/clean";
 import createCommand from "./commands/create";
@@ -125,6 +126,7 @@ cli.addCommand(implodeCommand);
 
 // Security commands
 cli.addCommand(approveBuildsCommand);
+cli.addCommand(auditCommand);
 
 // Post-command: upgrade notice + tips
 cli.addPlugin(postCommandPlugin(upgradeCheckCallback));

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -1117,7 +1117,7 @@ const buildOutdatedEntries = (
 
 /** Formats a ParsedVersion as "major.minor.patch", or "" if parsing failed. */
 const formatVersionString = (parsed: ParsedVersion | undefined): string =>
-    formatVersionString(parsed);
+    parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
 
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
@@ -1602,7 +1602,7 @@ const formatSummary = (outdated: OutdatedEntry[]): string => {
 
     if (lowScoreCount > 0) {
         children.push(
-            React.createElement(Text, { color: "yellow" }, `  ${String(lowScoreCount)} package${lowScoreCount === 1 ? "" : "s"} with low Socket.dev score (<40%)`),
+            React.createElement(Text, { color: "yellow" }, `  ${String(lowScoreCount)} package${lowScoreCount === 1 ? "" : "s"} with low Socket.dev score (<${String(DEFAULT_LOW_SCORE_THRESHOLD * 100)}%)`),
         );
     }
 

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -5,7 +5,7 @@ import { Box, renderToString, Table, Text } from "@visulima/tui";
 import React from "react";
 
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "./socket-security";
-import { fetchSocketReports, findAcceptedRisk } from "./socket-security";
+import { DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk } from "./socket-security";
 import { readPnpmWorkspacePatterns, resolveWorkspacePatterns } from "./workspace";
 
 // --- Module-level regex constants (e18e/prefer-static-regex) ---
@@ -64,18 +64,7 @@ interface SecurityVulnerability {
     summary: string;
 }
 
-interface SocketReport {
-    alerts: { category: string; key: string; severity: "critical" | "high" | "low" | "medium"; type: string }[];
-    license: string;
-    score: {
-        license: number;
-        maintenance: number;
-        overall: number;
-        quality: number;
-        supplyChain: number;
-        vulnerability: number;
-    };
-}
+type SocketReport = Pick<PackageReportData, "alerts" | "license" | "score">;
 
 interface OutdatedEntry {
     acceptedRisk?: { acceptedAt: string; reason: string };
@@ -1126,7 +1115,7 @@ const buildOutdatedEntries = (
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
     entries: { catalogName: string; packageName: string; range: string }[],
-    socketOptions?: SocketSecurityOptions & { enabled?: boolean },
+    socketOptions?: SocketSecurityOptions,
     acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<void> => {
     // Check current versions for known vulnerabilities
@@ -1144,7 +1133,7 @@ const enrichWithSecurity = async (
     ].filter((p) => p.version);
 
     // Fetch OSV vulnerabilities and Socket.dev reports in parallel
-    const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions?.enabled
+    const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions
         ? fetchSocketReports(packagesToScan, {
               apiToken: socketOptions.apiToken ?? process.env.VIS_SOCKET_TOKEN,
               cacheTtlMs: socketOptions.cacheTtlMs,
@@ -1271,7 +1260,7 @@ const checkOutdated = async (
     npmrcConfig?: NpmrcConfig,
     onProgress?: (current: number, total: number) => void,
     workspaceRoot?: string,
-    socketOptions?: SocketSecurityOptions & { enabled?: boolean },
+    socketOptions?: SocketSecurityOptions,
     acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<CheckOutdatedResult> => {
     const hash = computeCacheHash(catalogs, options);
@@ -1290,7 +1279,7 @@ const checkOutdated = async (
     const { failed, versionCache } = await fetchVersionsBatched(uniquePackages, npmrcConfig, onProgress);
     const outdated = buildOutdatedEntries(entries, versionCache, options);
 
-    if ((options.security || socketOptions?.enabled) && outdated.length > 0) {
+    if ((options.security || socketOptions) && outdated.length > 0) {
         await enrichWithSecurity(outdated, entries, socketOptions, acceptedRisks);
     }
 
@@ -1556,7 +1545,7 @@ const formatSummary = (outdated: OutdatedEntry[]): string => {
 
         if (entry.vulnerabilities && entry.vulnerabilities.length > 0) securityCount++;
         if (entry.socketReport?.alerts.length) socketAlertCount++;
-        if (entry.socketReport && entry.socketReport.score.overall < 0.4) lowScoreCount++;
+        if (entry.socketReport && entry.socketReport.score.overall < DEFAULT_LOW_SCORE_THRESHOLD) lowScoreCount++;
     }
 
     const parts: string[] = [];

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -1164,10 +1164,12 @@ const enrichWithSecurity = async (
             entry.vulnerabilities = vulns;
         }
 
+        // Parse version once for both socket report and accepted risk lookups
+        const parsed = parseVersion(entry.currentRange);
+        const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
+
         // Attach Socket.dev report data if available
         if (socketReports) {
-            const parsed = parseVersion(entry.currentRange);
-            const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
             const report = socketReports.get(`${entry.packageName}@${version}`);
 
             if (report) {
@@ -1181,8 +1183,6 @@ const enrichWithSecurity = async (
 
         // Cross-reference accepted risks
         if (acceptedRisks) {
-            const parsed = parseVersion(entry.currentRange);
-            const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
             const risk = findAcceptedRisk(entry.packageName, version, acceptedRisks);
 
             if (risk) {
@@ -1542,12 +1542,23 @@ const formatOutdatedTable = (outdated: OutdatedEntry[], logger: Console): void =
 };
 
 const formatSummary = (outdated: OutdatedEntry[]): string => {
-    const majors = outdated.filter((entry) => entry.updateType === "major").length;
-    const minors = outdated.filter((entry) => entry.updateType === "minor").length;
-    const patches = outdated.filter((entry) => entry.updateType === "patch").length;
-    const securityCount = outdated.filter((entry) => entry.vulnerabilities && entry.vulnerabilities.length > 0).length;
-    const socketAlertCount = outdated.filter((entry) => entry.socketReport && entry.socketReport.alerts.length > 0).length;
-    const lowScoreCount = outdated.filter((entry) => entry.socketReport && entry.socketReport.score.overall < 0.4).length;
+    let majors = 0;
+    let minors = 0;
+    let patches = 0;
+    let securityCount = 0;
+    let socketAlertCount = 0;
+    let lowScoreCount = 0;
+
+    for (const entry of outdated) {
+        if (entry.updateType === "major") majors++;
+        else if (entry.updateType === "minor") minors++;
+        else patches++;
+
+        if (entry.vulnerabilities && entry.vulnerabilities.length > 0) securityCount++;
+        if (entry.socketReport?.alerts.length) socketAlertCount++;
+        if (entry.socketReport && entry.socketReport.score.overall < 0.4) lowScoreCount++;
+    }
+
     const parts: string[] = [];
 
     if (majors) {

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -69,7 +69,7 @@ interface SecurityVulnerability {
 type SocketReport = Pick<PackageReportData, "alerts" | "license" | "score">;
 
 interface OutdatedEntry {
-    acceptedRisk?: { acceptedAt: string; reason: string };
+    acceptedRisk?: AcceptedRisk;
     catalogName: string;
     currentRange: string;
     newRange: string;
@@ -1115,6 +1115,10 @@ const buildOutdatedEntries = (
     return outdated;
 };
 
+/** Formats a ParsedVersion as "major.minor.patch", or "" if parsing failed. */
+const formatVersionString = (parsed: ParsedVersion | undefined): string =>
+    formatVersionString(parsed);
+
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
     entries: { catalogName: string; packageName: string; range: string }[],
@@ -1129,7 +1133,7 @@ const enrichWithSecurity = async (
 
                 return [
                     entry.packageName,
-                    { name: entry.packageName, version: parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "" },
+                    { name: entry.packageName, version: formatVersionString(parsed) },
                 ];
             }),
         ).values(),
@@ -1158,7 +1162,7 @@ const enrichWithSecurity = async (
 
         // Parse version once for both socket report and accepted risk lookups
         const parsed = parseVersion(entry.currentRange);
-        const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
+        const version = formatVersionString(parsed);
 
         // Attach Socket.dev report data if available
         if (socketReports) {
@@ -1178,7 +1182,7 @@ const enrichWithSecurity = async (
             const risk = findAcceptedRisk(entry.packageName, version, acceptedRisks);
 
             if (risk) {
-                entry.acceptedRisk = { acceptedAt: risk.acceptedAt, reason: risk.reason };
+                entry.acceptedRisk = risk;
             }
         }
     }

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -62,11 +62,25 @@ interface SecurityVulnerability {
     summary: string;
 }
 
+interface SocketReport {
+    alerts: { category: string; key: string; severity: "critical" | "high" | "low" | "medium"; type: string }[];
+    license: string;
+    score: {
+        license: number;
+        maintenance: number;
+        overall: number;
+        quality: number;
+        supplyChain: number;
+        vulnerability: number;
+    };
+}
+
 interface OutdatedEntry {
     catalogName: string;
     currentRange: string;
     newRange: string;
     packageName: string;
+    socketReport?: SocketReport;
     targetVersion: string;
     updateType: "major" | "minor" | "patch";
     vulnerabilities?: SecurityVulnerability[];
@@ -1106,7 +1120,11 @@ const buildOutdatedEntries = (
     return outdated;
 };
 
-const enrichWithSecurity = async (outdated: OutdatedEntry[], entries: { catalogName: string; packageName: string; range: string }[]): Promise<void> => {
+const enrichWithSecurity = async (
+    outdated: OutdatedEntry[],
+    entries: { catalogName: string; packageName: string; range: string }[],
+    socketOptions?: { apiToken?: string; cacheTtlMs?: number; enabled?: boolean; timeoutMs?: number },
+): Promise<void> => {
     // Check current versions for known vulnerabilities
     const packagesToScan = [
         ...new Map(
@@ -1121,13 +1139,44 @@ const enrichWithSecurity = async (outdated: OutdatedEntry[], entries: { catalogN
         ).values(),
     ].filter((p) => p.version);
 
-    const vulnMap = await fetchVulnerabilities(packagesToScan);
+    // Fetch OSV vulnerabilities and Socket.dev reports in parallel
+    const promises: [Promise<Map<string, SecurityVulnerability[]>>, Promise<Map<string, import("./socket-security").PackageReportData>> | undefined] = [
+        fetchVulnerabilities(packagesToScan),
+        undefined,
+    ];
+
+    if (socketOptions?.enabled) {
+        const { fetchSocketReports } = await import("./socket-security");
+
+        promises[1] = fetchSocketReports(packagesToScan, {
+            apiToken: socketOptions.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+            cacheTtlMs: socketOptions.cacheTtlMs,
+            timeoutMs: socketOptions.timeoutMs,
+        });
+    }
+
+    const [vulnMap, socketReports] = await Promise.all([promises[0], promises[1]]);
 
     for (const entry of outdated) {
         const vulns = vulnMap.get(entry.packageName);
 
         if (vulns && vulns.length > 0) {
             entry.vulnerabilities = vulns;
+        }
+
+        // Attach Socket.dev report data if available
+        if (socketReports) {
+            const parsed = parseVersion(entry.currentRange);
+            const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
+            const report = socketReports.get(`${entry.packageName}@${version}`);
+
+            if (report) {
+                entry.socketReport = {
+                    alerts: report.alerts,
+                    license: report.license,
+                    score: report.score,
+                };
+            }
         }
     }
 };
@@ -1211,6 +1260,7 @@ const checkOutdated = async (
     npmrcConfig?: NpmrcConfig,
     onProgress?: (current: number, total: number) => void,
     workspaceRoot?: string,
+    socketOptions?: { apiToken?: string; cacheTtlMs?: number; enabled?: boolean; timeoutMs?: number },
 ): Promise<CheckOutdatedResult> => {
     const hash = computeCacheHash(catalogs, options);
 
@@ -1228,8 +1278,8 @@ const checkOutdated = async (
     const { failed, versionCache } = await fetchVersionsBatched(uniquePackages, npmrcConfig, onProgress);
     const outdated = buildOutdatedEntries(entries, versionCache, options);
 
-    if (options.security && outdated.length > 0) {
-        await enrichWithSecurity(outdated, entries);
+    if ((options.security || socketOptions?.enabled) && outdated.length > 0) {
+        await enrichWithSecurity(outdated, entries, socketOptions);
     }
 
     const result = { failed, ignored, outdated };
@@ -1414,19 +1464,58 @@ const formatCatalogDisplayName = (catalogName: string): string => {
 const formatOutdatedTable = (outdated: OutdatedEntry[], logger: Console): void => {
     const byCatalog = groupByCatalog(outdated);
     const columns = process.stdout.columns || 80;
+    const hasSocketData = outdated.some((entry) => entry.socketReport);
 
     for (const [catalogName, entries] of byCatalog) {
         const tableData = entries.flatMap((entry) => {
             const hasSec = entry.vulnerabilities && entry.vulnerabilities.length > 0;
-            const displayName = hasSec ? `[SEC] ${entry.packageName}` : entry.packageName;
+            const hasSocketAlerts = entry.socketReport && entry.socketReport.alerts.length > 0;
+            const prefix = hasSec || hasSocketAlerts ? "[SEC] " : "";
+            const displayName = `${prefix}${entry.packageName}`;
 
-            const rows: { current: string; package: string; target: string; type: string }[] = [
-                { current: entry.currentRange, package: displayName, target: entry.newRange, type: entry.updateType },
-            ];
+            const scoreStr = entry.socketReport
+                ? `${String(Math.round(entry.socketReport.score.overall * 100))}%`
+                : "";
+
+            const row: Record<string, string> = {
+                current: entry.currentRange,
+                package: displayName,
+                target: entry.newRange,
+                type: entry.updateType,
+            };
+
+            if (hasSocketData) {
+                row.score = scoreStr;
+            }
+
+            const rows: Record<string, string>[] = [row];
 
             if (entry.vulnerabilities) {
                 for (const vuln of entry.vulnerabilities) {
-                    rows.push({ current: vuln.summary, package: `  ${vuln.severity} ${vuln.id}`, target: "", type: "" });
+                    const vulnRow: Record<string, string> = { current: vuln.summary, package: `  ${vuln.severity} ${vuln.id}`, target: "", type: "" };
+
+                    if (hasSocketData) {
+                        vulnRow.score = "";
+                    }
+
+                    rows.push(vulnRow);
+                }
+            }
+
+            if (entry.socketReport) {
+                for (const alert of entry.socketReport.alerts) {
+                    const alertRow: Record<string, string> = {
+                        current: alert.category,
+                        package: `  [${alert.severity.toUpperCase()}] ${alert.type}`,
+                        target: "",
+                        type: "",
+                    };
+
+                    if (hasSocketData) {
+                        alertRow.score = "";
+                    }
+
+                    rows.push(alertRow);
                 }
             }
 
@@ -1445,6 +1534,8 @@ const formatSummary = (outdated: OutdatedEntry[]): string => {
     const minors = outdated.filter((entry) => entry.updateType === "minor").length;
     const patches = outdated.filter((entry) => entry.updateType === "patch").length;
     const securityCount = outdated.filter((entry) => entry.vulnerabilities && entry.vulnerabilities.length > 0).length;
+    const socketAlertCount = outdated.filter((entry) => entry.socketReport && entry.socketReport.alerts.length > 0).length;
+    const lowScoreCount = outdated.filter((entry) => entry.socketReport && entry.socketReport.score.overall < 0.4).length;
     const parts: string[] = [];
 
     if (majors) {
@@ -1463,15 +1554,29 @@ const formatSummary = (outdated: OutdatedEntry[]): string => {
         parts.push(`${String(securityCount)} with vulnerabilities`);
     }
 
+    if (socketAlertCount) {
+        parts.push(`${String(socketAlertCount)} with Socket.dev alerts`);
+    }
+
     const summary = `Found ${String(outdated.length)} outdated (${parts.join(", ")})`;
     const columns = process.stdout.columns || 80;
+
+    const children = [
+        React.createElement(Text, { bold: true }, "\u2500 Summary"),
+        React.createElement(Text, null, "  " + summary),
+    ];
+
+    if (lowScoreCount > 0) {
+        children.push(
+            React.createElement(Text, { color: "yellow" }, `  ${String(lowScoreCount)} package${lowScoreCount === 1 ? "" : "s"} with low Socket.dev score (<40%)`),
+        );
+    }
 
     return renderToString(
         React.createElement(
             Box,
             { flexDirection: "column", paddingX: 1 },
-            React.createElement(Text, { bold: true }, "\u2500 Summary"),
-            React.createElement(Text, null, "  " + summary),
+            ...children,
         ),
         { columns },
     );
@@ -1793,6 +1898,7 @@ export type {
     ParsedVersion,
     ReadCatalogOptions,
     SecurityVulnerability,
+    SocketReport,
     UpdateTarget,
 };
 

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -3,6 +3,7 @@ import { ensureDirSync, isAccessibleSync, readFileSync, readJsonSync, removeSync
 import { dirname, join } from "@visulima/path";
 import { Box, renderToString, Table, Text } from "@visulima/tui";
 import React from "react";
+import type { SemVer } from "semver";
 import { coerce, diff, gt, parse, rcompare } from "semver";
 
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "./socket-security";
@@ -86,8 +87,6 @@ interface ReadCatalogOptions {
 }
 
 // --- Version utilities (backed by `semver` package) ---
-
-import type { SemVer } from "semver";
 
 const parseVersion = (input: string): SemVer | null => {
     // coerce handles ranges like "^1.2.3" → "1.2.3", partial like "19" → "19.0.0"

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -717,7 +717,9 @@ const fetchPackageVersions = async (
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => { controller.abort(); }, timeoutMs);
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
 
     try {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins -- fetch is available in Node 20.19+ via undici
@@ -838,7 +840,9 @@ const fetchVulnerabilities = async (
     });
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => { controller.abort(); }, timeoutMs);
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
 
     try {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins -- fetch is available in Node 20.19+ via undici
@@ -1065,8 +1069,7 @@ const buildOutdatedEntries = (
 };
 
 /** Formats a SemVer as "major.minor.patch", or "" if parsing failed. */
-const formatVersionString = (parsed: SemVer | null): string =>
-    parsed ? parsed.version : "";
+const formatVersionString = (parsed: SemVer | null): string => (parsed ? parsed.version : "");
 
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
@@ -1080,23 +1083,15 @@ const enrichWithSecurity = async (
             entries.map((entry) => {
                 const parsed = parseVersion(entry.range);
 
-                return [
-                    entry.packageName,
-                    { name: entry.packageName, version: formatVersionString(parsed) },
-                ];
+                return [entry.packageName, { name: entry.packageName, version: formatVersionString(parsed) }];
             }),
         ).values(),
     ].filter((p) => p.version);
 
     // Fetch OSV vulnerabilities and Socket.dev reports in parallel
-    const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions
-        ? fetchSocketReports(packagesToScan, socketOptions)
-        : undefined;
+    const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions ? fetchSocketReports(packagesToScan, socketOptions) : undefined;
 
-    const [vulnMap, socketReports] = await Promise.all([
-        fetchVulnerabilities(packagesToScan),
-        socketPromise,
-    ]);
+    const [vulnMap, socketReports] = await Promise.all([fetchVulnerabilities(packagesToScan), socketPromise]);
 
     for (const entry of outdated) {
         const vulns = vulnMap.get(entry.packageName);
@@ -1225,12 +1220,7 @@ const checkOutdated = async (
     socketOptions?: SocketSecurityOptions,
     acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<CheckOutdatedResult> => {
-    const hash = computeCacheHash(
-        catalogs,
-        options,
-        Boolean(socketOptions),
-        acceptedRisks ? Object.keys(acceptedRisks) : undefined,
-    );
+    const hash = computeCacheHash(catalogs, options, Boolean(socketOptions), acceptedRisks ? Object.keys(acceptedRisks) : undefined);
 
     if (workspaceRoot) {
         const cached = readOutdatedCache(workspaceRoot, hash);
@@ -1441,9 +1431,7 @@ const formatOutdatedTable = (outdated: OutdatedEntry[], logger: Console): void =
             const prefix = hasSec || hasSocketAlerts ? "[SEC] " : "";
             const displayName = `${prefix}${entry.packageName}`;
 
-            const scoreStr = entry.socketReport
-                ? `${String(Math.round(entry.socketReport.score.overall * 100))}%`
-                : "";
+            const scoreStr = entry.socketReport ? `${String(Math.round(entry.socketReport.score.overall * 100))}%` : "";
 
             const row: Record<string, string> = {
                 current: entry.currentRange,
@@ -1540,25 +1528,19 @@ const formatSummary = (outdated: OutdatedEntry[]): string => {
     const summary = `Found ${String(outdated.length)} outdated (${parts.join(", ")})`;
     const columns = process.stdout.columns || 80;
 
-    const children = [
-        React.createElement(Text, { bold: true }, "\u2500 Summary"),
-        React.createElement(Text, null, "  " + summary),
-    ];
+    const children = [React.createElement(Text, { bold: true }, "\u2500 Summary"), React.createElement(Text, null, "  " + summary)];
 
     if (lowScoreCount > 0) {
         children.push(
-            React.createElement(Text, { color: "yellow" }, `  ${String(lowScoreCount)} package${lowScoreCount === 1 ? "" : "s"} with low Socket.dev score (<${String(DEFAULT_LOW_SCORE_THRESHOLD * 100)}%)`),
+            React.createElement(
+                Text,
+                { color: "yellow" },
+                `  ${String(lowScoreCount)} package${lowScoreCount === 1 ? "" : "s"} with low Socket.dev score (<${String(DEFAULT_LOW_SCORE_THRESHOLD * 100)}%)`,
+            ),
         );
     }
 
-    return renderToString(
-        React.createElement(
-            Box,
-            { flexDirection: "column", paddingX: 1 },
-            ...children,
-        ),
-        { columns },
-    );
+    return renderToString(React.createElement(Box, { flexDirection: "column", paddingX: 1 }, ...children), { columns });
 };
 
 // --- Apply updates ---
@@ -1753,7 +1735,9 @@ const promptPackageSelection = async (outdated: OutdatedEntry[]): Promise<Outdat
 
     const ask = (question: string): Promise<string> =>
         new Promise((resolve) => {
-            rl.question(question, (answer) => { resolve(answer.trim()); });
+            rl.question(question, (answer) => {
+                resolve(answer.trim());
+            });
         });
 
     process.stdout.write("\nOutdated catalog dependencies:\n");
@@ -1816,7 +1800,9 @@ const fetchChangelogInfo = async (packages: OutdatedEntry[], timeoutMs: number =
     const results: ChangelogInfo[] = [];
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => { controller.abort(); }, timeoutMs);
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
 
     try {
         const fetches = packages.map(async (entry): Promise<ChangelogInfo> => {
@@ -1856,7 +1842,7 @@ const fetchChangelogInfo = async (packages: OutdatedEntry[], timeoutMs: number =
             }
         });
 
-        results.push(...await Promise.all(fetches));
+        results.push(...(await Promise.all(fetches)));
     } finally {
         clearTimeout(timeout);
     }

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -1141,11 +1141,7 @@ const enrichWithSecurity = async (
 
     // Fetch OSV vulnerabilities and Socket.dev reports in parallel
     const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions
-        ? fetchSocketReports(packagesToScan, {
-              apiToken: socketOptions.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-              cacheTtlMs: socketOptions.cacheTtlMs,
-              timeoutMs: socketOptions.timeoutMs,
-          })
+        ? fetchSocketReports(packagesToScan, socketOptions)
         : undefined;
 
     const [vulnMap, socketReports] = await Promise.all([

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -3,6 +3,7 @@ import { ensureDirSync, isAccessibleSync, readFileSync, readJsonSync, removeSync
 import { dirname, join } from "@visulima/path";
 import { Box, renderToString, Table, Text } from "@visulima/tui";
 import React from "react";
+import { coerce, diff, gt, parse, rcompare } from "semver";
 
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "./socket-security";
 import { DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk } from "./socket-security";
@@ -10,9 +11,6 @@ import { readPnpmWorkspacePatterns, resolveWorkspacePatterns } from "./workspace
 
 // --- Module-level regex constants (e18e/prefer-static-regex) ---
 
-// sonarjs/slow-regex -- constrained by input format; not actually vulnerable
-// eslint-disable-next-line sonarjs/slow-regex
-const VERSION_REGEX = /(\d+)\.(\d+)\.(\d+)(?:-([a-z0-9.]+))?/i;
 const PREFIX_REGEX = /^([\^~]|>=|<=|[><=])/;
 // sonarjs/regex-complexity -- cannot simplify without breaking YAML key:value parsing
 // eslint-disable-next-line sonarjs/regex-complexity
@@ -48,13 +46,6 @@ const getBackupDir = (workspaceRoot: string): string => {
 // --- Types ---
 
 type UpdateTarget = "latest" | "minor" | "patch";
-
-interface ParsedVersion {
-    major: number;
-    minor: number;
-    patch: number;
-    prerelease: string;
-}
 
 interface SecurityVulnerability {
     /** Alternate identifiers (CVE-*, GHSA-*, etc.) from the OSV database. */
@@ -94,21 +85,13 @@ interface ReadCatalogOptions {
     prod?: boolean;
 }
 
-// --- Version utilities ---
+// --- Version utilities (backed by `semver` package) ---
 
-const parseVersion = (input: string): ParsedVersion | undefined => {
-    const match = VERSION_REGEX.exec(input);
+import type { SemVer } from "semver";
 
-    if (!match) {
-        return undefined;
-    }
-
-    return {
-        major: Number(match[1]),
-        minor: Number(match[2]),
-        patch: Number(match[3]),
-        prerelease: match[4] ?? "",
-    };
+const parseVersion = (input: string): SemVer | null => {
+    // coerce handles ranges like "^1.2.3" → "1.2.3", partial like "19" → "19.0.0"
+    return coerce(input) ?? parse(input);
 };
 
 const extractPrefix = (range: string): string => {
@@ -117,47 +100,25 @@ const extractPrefix = (range: string): string => {
     return match?.[1] ?? "";
 };
 
-const getUpdateType = (current: ParsedVersion, target: ParsedVersion): "major" | "minor" | "none" | "patch" => {
-    if (current.major !== target.major) {
+const getUpdateType = (current: SemVer, target: SemVer): "major" | "minor" | "none" | "patch" => {
+    const d = diff(current, target);
+
+    if (!d) {
+        return "none";
+    }
+
+    if (d.includes("major")) {
         return "major";
     }
 
-    if (current.minor !== target.minor) {
+    if (d.includes("minor")) {
         return "minor";
     }
 
-    if (current.patch !== target.patch) {
-        return "patch";
-    }
-
-    return "none";
+    return "patch";
 };
 
-const isNewer = (current: ParsedVersion, target: ParsedVersion): boolean => {
-    if (target.major !== current.major) {
-        return target.major > current.major;
-    }
-
-    if (target.minor !== current.minor) {
-        return target.minor > current.minor;
-    }
-
-    if (target.patch !== current.patch) {
-        return target.patch > current.patch;
-    }
-
-    // Equal versions: non-prerelease is "newer" than prerelease
-    if (current.prerelease && !target.prerelease) {
-        return true;
-    }
-
-    // Both prereleases of same version: compare lexicographically
-    if (current.prerelease && target.prerelease) {
-        return target.prerelease > current.prerelease;
-    }
-
-    return false;
-};
+const isNewer = (current: SemVer, target: SemVer): boolean => gt(target, current);
 
 // --- Glob matching ---
 
@@ -917,18 +878,6 @@ const fetchVulnerabilities = async (
 
 // --- Target version resolution ---
 
-const sortVersionCandidates = (a: { parsed: ParsedVersion; raw: string }, b: { parsed: ParsedVersion; raw: string }): number => {
-    if (a.parsed.major !== b.parsed.major) {
-        return b.parsed.major - a.parsed.major;
-    }
-
-    if (a.parsed.minor !== b.parsed.minor) {
-        return b.parsed.minor - a.parsed.minor;
-    }
-
-    return b.parsed.patch - a.parsed.patch;
-};
-
 const findTargetVersion = (versions: string[], latest: string, currentRange: string, target: UpdateTarget, includePrerelease: boolean): string | undefined => {
     const current = parseVersion(currentRange);
 
@@ -943,7 +892,7 @@ const findTargetVersion = (versions: string[], latest: string, currentRange: str
             return undefined;
         }
 
-        if (!includePrerelease && latestParsed.prerelease) {
+        if (!includePrerelease && latestParsed.prerelease.length > 0) {
             return undefined;
         }
 
@@ -959,12 +908,12 @@ const findTargetVersion = (versions: string[], latest: string, currentRange: str
         .map((v) => {
             return { parsed: parseVersion(v), raw: v };
         })
-        .filter((v): v is { parsed: ParsedVersion; raw: string } => {
+        .filter((v): v is { parsed: SemVer; raw: string } => {
             if (!v.parsed) {
                 return false;
             }
 
-            if (!includePrerelease && v.parsed.prerelease) {
+            if (!includePrerelease && v.parsed.prerelease.length > 0) {
                 return false;
             }
 
@@ -979,7 +928,7 @@ const findTargetVersion = (versions: string[], latest: string, currentRange: str
             // target === "minor"
             return v.parsed.major === current.major;
         })
-        .toSorted(sortVersionCandidates);
+        .toSorted((a, b) => rcompare(a.raw, b.raw));
 
     return candidates[0]?.raw;
 };
@@ -1115,9 +1064,9 @@ const buildOutdatedEntries = (
     return outdated;
 };
 
-/** Formats a ParsedVersion as "major.minor.patch", or "" if parsing failed. */
-const formatVersionString = (parsed: ParsedVersion | undefined): string =>
-    parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
+/** Formats a SemVer as "major.minor.patch", or "" if parsing failed. */
+const formatVersionString = (parsed: SemVer | null): string =>
+    parsed ? parsed.version : "";
 
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
@@ -1925,7 +1874,6 @@ export type {
     NpmrcConfig,
     OutdatedEntry,
     OutputFormat,
-    ParsedVersion,
     ReadCatalogOptions,
     SecurityVulnerability,
     SocketReport,

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -57,6 +57,8 @@ interface ParsedVersion {
 }
 
 interface SecurityVulnerability {
+    /** Alternate identifiers (CVE-*, GHSA-*, etc.) from the OSV database. */
+    aliases?: string[];
     cvssScore?: number;
     fixedVersions: string[];
     id: string;
@@ -850,6 +852,7 @@ const mapOsvFixedVersions = (vuln: OsvVuln): string[] => {
 
 const mapOsvVuln = (vuln: OsvVuln): SecurityVulnerability => {
     return {
+        aliases: vuln.aliases?.length ? vuln.aliases : undefined,
         cvssScore: mapOsvCvss(vuln),
         fixedVersions: mapOsvFixedVersions(vuln),
         id: vuln.id,
@@ -1191,7 +1194,12 @@ interface OutdatedCache {
     timestamp: number;
 }
 
-const computeCacheHash = (catalogs: Map<string, Map<string, string>>, options: CatalogCheckOptions): string => {
+const computeCacheHash = (
+    catalogs: Map<string, Map<string, string>>,
+    options: CatalogCheckOptions,
+    socketEnabled?: boolean,
+    acceptedRiskKeys?: string[],
+): string => {
     const parts: string[] = [];
 
     for (const [name, deps] of catalogs) {
@@ -1202,6 +1210,11 @@ const computeCacheHash = (catalogs: Map<string, Map<string, string>>, options: C
 
     parts.push(`target=${options.target},pre=${String(options.includePrerelease)},sec=${String(options.security ?? false)}`);
     parts.push(`in=${options.include.join(",")},ex=${options.exclude.join(",")},ig=${options.ignore.join(",")}`);
+    parts.push(`socket=${String(socketEnabled ?? false)}`);
+
+    if (acceptedRiskKeys && acceptedRiskKeys.length > 0) {
+        parts.push(`risks=${acceptedRiskKeys.toSorted().join(",")}`);
+    }
 
     let hash = 5381;
     const str = parts.join("|");
@@ -1263,7 +1276,12 @@ const checkOutdated = async (
     socketOptions?: SocketSecurityOptions,
     acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<CheckOutdatedResult> => {
-    const hash = computeCacheHash(catalogs, options);
+    const hash = computeCacheHash(
+        catalogs,
+        options,
+        Boolean(socketOptions),
+        acceptedRisks ? Object.keys(acceptedRisks) : undefined,
+    );
 
     if (workspaceRoot) {
         const cached = readOutdatedCache(workspaceRoot, hash);

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -4,8 +4,8 @@ import { dirname, join } from "@visulima/path";
 import { Box, renderToString, Table, Text } from "@visulima/tui";
 import React from "react";
 
-import type { PackageReportData, SocketSecurityOptions } from "./socket-security";
-import { fetchSocketReports } from "./socket-security";
+import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "./socket-security";
+import { fetchSocketReports, findAcceptedRisk } from "./socket-security";
 import { readPnpmWorkspacePatterns, resolveWorkspacePatterns } from "./workspace";
 
 // --- Module-level regex constants (e18e/prefer-static-regex) ---
@@ -78,6 +78,7 @@ interface SocketReport {
 }
 
 interface OutdatedEntry {
+    acceptedRisk?: { acceptedAt: string; reason: string };
     catalogName: string;
     currentRange: string;
     newRange: string;
@@ -1126,6 +1127,7 @@ const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
     entries: { catalogName: string; packageName: string; range: string }[],
     socketOptions?: SocketSecurityOptions & { enabled?: boolean },
+    acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<void> => {
     // Check current versions for known vulnerabilities
     const packagesToScan = [
@@ -1174,6 +1176,17 @@ const enrichWithSecurity = async (
                     license: report.license,
                     score: report.score,
                 };
+            }
+        }
+
+        // Cross-reference accepted risks
+        if (acceptedRisks) {
+            const parsed = parseVersion(entry.currentRange);
+            const version = parsed ? `${String(parsed.major)}.${String(parsed.minor)}.${String(parsed.patch)}` : "";
+            const risk = findAcceptedRisk(entry.packageName, version, acceptedRisks);
+
+            if (risk) {
+                entry.acceptedRisk = { acceptedAt: risk.acceptedAt, reason: risk.reason };
             }
         }
     }
@@ -1259,6 +1272,7 @@ const checkOutdated = async (
     onProgress?: (current: number, total: number) => void,
     workspaceRoot?: string,
     socketOptions?: SocketSecurityOptions & { enabled?: boolean },
+    acceptedRisks?: Record<string, AcceptedRisk>,
 ): Promise<CheckOutdatedResult> => {
     const hash = computeCacheHash(catalogs, options);
 
@@ -1277,7 +1291,7 @@ const checkOutdated = async (
     const outdated = buildOutdatedEntries(entries, versionCache, options);
 
     if ((options.security || socketOptions?.enabled) && outdated.length > 0) {
-        await enrichWithSecurity(outdated, entries, socketOptions);
+        await enrichWithSecurity(outdated, entries, socketOptions, acceptedRisks);
     }
 
     const result = { failed, ignored, outdated };

--- a/packages/tooling/vis/src/catalog.ts
+++ b/packages/tooling/vis/src/catalog.ts
@@ -4,6 +4,8 @@ import { dirname, join } from "@visulima/path";
 import { Box, renderToString, Table, Text } from "@visulima/tui";
 import React from "react";
 
+import type { PackageReportData, SocketSecurityOptions } from "./socket-security";
+import { fetchSocketReports } from "./socket-security";
 import { readPnpmWorkspacePatterns, resolveWorkspacePatterns } from "./workspace";
 
 // --- Module-level regex constants (e18e/prefer-static-regex) ---
@@ -1123,7 +1125,7 @@ const buildOutdatedEntries = (
 const enrichWithSecurity = async (
     outdated: OutdatedEntry[],
     entries: { catalogName: string; packageName: string; range: string }[],
-    socketOptions?: { apiToken?: string; cacheTtlMs?: number; enabled?: boolean; timeoutMs?: number },
+    socketOptions?: SocketSecurityOptions & { enabled?: boolean },
 ): Promise<void> => {
     // Check current versions for known vulnerabilities
     const packagesToScan = [
@@ -1140,22 +1142,18 @@ const enrichWithSecurity = async (
     ].filter((p) => p.version);
 
     // Fetch OSV vulnerabilities and Socket.dev reports in parallel
-    const promises: [Promise<Map<string, SecurityVulnerability[]>>, Promise<Map<string, import("./socket-security").PackageReportData>> | undefined] = [
+    const socketPromise: Promise<Map<string, PackageReportData>> | undefined = socketOptions?.enabled
+        ? fetchSocketReports(packagesToScan, {
+              apiToken: socketOptions.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+              cacheTtlMs: socketOptions.cacheTtlMs,
+              timeoutMs: socketOptions.timeoutMs,
+          })
+        : undefined;
+
+    const [vulnMap, socketReports] = await Promise.all([
         fetchVulnerabilities(packagesToScan),
-        undefined,
-    ];
-
-    if (socketOptions?.enabled) {
-        const { fetchSocketReports } = await import("./socket-security");
-
-        promises[1] = fetchSocketReports(packagesToScan, {
-            apiToken: socketOptions.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-            cacheTtlMs: socketOptions.cacheTtlMs,
-            timeoutMs: socketOptions.timeoutMs,
-        });
-    }
-
-    const [vulnMap, socketReports] = await Promise.all([promises[0], promises[1]]);
+        socketPromise,
+    ]);
 
     for (const entry of outdated) {
         const vulns = vulnMap.get(entry.packageName);
@@ -1260,7 +1258,7 @@ const checkOutdated = async (
     npmrcConfig?: NpmrcConfig,
     onProgress?: (current: number, total: number) => void,
     workspaceRoot?: string,
-    socketOptions?: { apiToken?: string; cacheTtlMs?: number; enabled?: boolean; timeoutMs?: number },
+    socketOptions?: SocketSecurityOptions & { enabled?: boolean },
 ): Promise<CheckOutdatedResult> => {
     const hash = computeCacheHash(catalogs, options);
 

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -2,10 +2,10 @@ import { createInterface } from "node:readline";
 
 import type { Command } from "@visulima/cerebro";
 
-import { info, warn } from "../output";
+import { info, note, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
-import { buildSocketOptions, fetchSocketReports, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
-import type { PackageReportData, SocketSecurityOptions } from "../socket-security";
+import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
+import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -93,25 +93,32 @@ const resolveLatestVersions = async (
 
 /**
  * Displays Socket.dev security reports for packages being added.
- * Returns the list of packages with low scores that need confirmation.
+ * Returns the list of packages with low scores that need confirmation
+ * (excludes packages with accepted risks).
  */
 const displaySecurityReports = (
     reports: Map<string, PackageReportData>,
     minimumScore: number,
+    acceptedRisks: Record<string, AcceptedRisk> | undefined,
 ): PackageReportData[] => {
     const lowScorePackages: PackageReportData[] = [];
 
     for (const report of reports.values()) {
         const overall = report.score.overall;
         const color = scoreColor(overall);
-        const label = scoreLabel(overall);
         const pct = `${String(Math.round(overall * 100))}%`;
         const alertCount = report.alerts.length;
+        const fullName = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+        const accepted = findAcceptedRisk(fullName, report.version, acceptedRisks);
 
         const colorFn = color === "red" ? "\u001B[31m" : color === "yellow" ? "\u001B[33m" : "\u001B[32m";
         const reset = "\u001B[0m";
 
-        info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)}`);
+        if (accepted) {
+            info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)} \u001B[90m[accepted: ${accepted.reason}]\u001B[0m`);
+        } else {
+            info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)}`);
+        }
 
         if (alertCount > 0) {
             const critHigh = report.alerts.filter((a) => a.severity === "critical" || a.severity === "high").length;
@@ -121,7 +128,7 @@ const displaySecurityReports = (
             }
         }
 
-        if (overall < minimumScore) {
+        if (overall < minimumScore && !accepted) {
             lowScorePackages.push(report);
         }
     }
@@ -159,9 +166,33 @@ const confirmLowScorePackages = async (lowScorePackages: PackageReportData[], mi
 
     const answer = await ask("Continue adding these packages? [y/N] ");
 
+    if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
+        rl.close();
+
+        return false;
+    }
+
+    // Offer to print accepted risk snippet
+    const rememberAnswer = await ask("Remember this decision? (prints config snippet) [y/N] ");
+
     rl.close();
 
-    return answer.toLowerCase() === "y" || answer.toLowerCase() === "yes";
+    if (rememberAnswer.toLowerCase() === "y" || rememberAnswer.toLowerCase() === "yes") {
+        note("");
+        note("Add the following to security.socket.acceptedRisks in vis.config.ts:");
+        note("");
+
+        for (const report of lowScorePackages) {
+            const fullName = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+            const snippet = formatAcceptedRiskSnippet(fullName, report.version, report.score.overall, "Reviewed and accepted");
+
+            note(snippet);
+        }
+
+        note("");
+    }
+
+    return true;
 };
 
 /**
@@ -172,6 +203,7 @@ const runSocketPreCheck = async (
     packages: string[],
     socketOptions: SocketSecurityOptions,
     minimumScore: number,
+    acceptedRisks: Record<string, AcceptedRisk> | undefined,
 ): Promise<boolean> => {
     const parsed = packages.map(parseAddArgument);
     const names = parsed.map((p) => p.name);
@@ -206,7 +238,7 @@ const runSocketPreCheck = async (
         return true;
     }
 
-    const lowScorePackages = displaySecurityReports(reports, minimumScore);
+    const lowScorePackages = displaySecurityReports(reports, minimumScore, acceptedRisks);
 
     if (lowScorePackages.length === 0) {
         info("");
@@ -255,7 +287,12 @@ const add: Command = {
             if (socketOpts) {
                 const minimumScore = visConfig?.security?.socket?.minimumScore ?? DEFAULT_MINIMUM_SCORE;
 
-                const shouldContinue = await runSocketPreCheck(packages, socketOpts, minimumScore);
+                const shouldContinue = await runSocketPreCheck(
+                    packages,
+                    socketOpts,
+                    minimumScore,
+                    visConfig?.security?.socket?.acceptedRisks,
+                );
 
                 if (!shouldContinue) {
                     process.exitCode = 1;

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -6,14 +6,13 @@ import { dim, green, red, yellow } from "@visulima/colorize";
 
 import { info, note, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
-import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
+import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, getFullPackageName, scoreColor, scoreLabel } from "../socket-security";
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
 const VERSION_SPEC_REGEX = /^(.+?)(?:@(.+))?$/;
-const DEFAULT_MINIMUM_SCORE = 0.4;
 
 /**
  * Extracts the package name from an add argument like "react", "react@19", "@scope/pkg@^2".
@@ -110,7 +109,7 @@ const displaySecurityReports = (
         const color = scoreColor(overall);
         const pct = `${String(Math.round(overall * 100))}%`;
         const alertCount = report.alerts.length;
-        const fullName = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+        const fullName = getFullPackageName(report);
         const accepted = findAcceptedRisk(fullName, report.version, acceptedRisks);
 
         const colorFn = color === "red" ? red : color === "yellow" ? yellow : green;
@@ -157,7 +156,7 @@ const confirmLowScorePackages = async (lowScorePackages: PackageReportData[], mi
     warn(`${String(lowScorePackages.length)} package${lowScorePackages.length === 1 ? "" : "s"} scored below the minimum threshold (${pct}%):`);
 
     for (const report of lowScorePackages) {
-        const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+        const name = getFullPackageName(report);
         const score = `${String(Math.round(report.score.overall * 100))}%`;
 
         warn(`  \u2022 ${name}@${report.version} — score: ${score} (${scoreLabel(report.score.overall)})`);
@@ -184,7 +183,7 @@ const confirmLowScorePackages = async (lowScorePackages: PackageReportData[], mi
         note("");
 
         for (const report of lowScorePackages) {
-            const fullName = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+            const fullName = getFullPackageName(report);
             const snippet = formatAcceptedRiskSnippet(fullName, report.version, report.score.overall, "Reviewed and accepted");
 
             note(snippet);
@@ -207,7 +206,6 @@ const runSocketPreCheck = async (
     acceptedRisks: Record<string, AcceptedRisk> | undefined,
 ): Promise<boolean> => {
     const parsed = packages.map(parseAddArgument);
-    const names = parsed.map((p) => p.name);
 
     // Resolve versions for packages without an explicit version
     const needsResolution = parsed.filter((p) => !p.versionSpec).map((p) => p.name);
@@ -286,7 +284,7 @@ const add: Command = {
             const socketOpts = buildSocketOptions(visConfig?.security?.socket);
 
             if (socketOpts) {
-                const minimumScore = visConfig?.security?.socket?.minimumScore ?? DEFAULT_MINIMUM_SCORE;
+                const minimumScore = visConfig?.security?.socket?.minimumScore ?? DEFAULT_LOW_SCORE_THRESHOLD;
 
                 const shouldContinue = await runSocketPreCheck(
                     packages,

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -3,14 +3,13 @@ import { createInterface } from "node:readline";
 import type { Command } from "@visulima/cerebro";
 
 import { dim, green, red, yellow } from "@visulima/colorize";
+import { coerce } from "semver";
 
 import { info, note, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
 import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, getFullPackageName, scoreColor, scoreLabel } from "../socket-security";
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
-
-const SEMVER_RE = /^\d+\.\d+\.\d+/;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -209,28 +208,28 @@ const runSocketPreCheck = async (
 ): Promise<boolean> => {
     const parsed = packages.map(parseAddArgument);
 
-    // Strip semver operators and check if result is a concrete version
-    const strippedSpecs = new Map<string, string>();
+    // Coerce version specs to concrete semver (handles "^1.2.3", "19", "latest" etc.)
+    const coercedSpecs = new Map<string, string>();
 
     for (const p of parsed) {
         if (p.versionSpec) {
-            const stripped = p.versionSpec.replace(/^[\^~>=<]+/, "");
+            const coerced = coerce(p.versionSpec);
 
-            if (SEMVER_RE.test(stripped)) {
-                strippedSpecs.set(p.name, stripped);
+            if (coerced) {
+                coercedSpecs.set(p.name, coerced.version);
             }
         }
     }
 
-    // Resolve packages without a concrete semver (dist-tags, partial versions, no spec)
-    const needsResolution = parsed.filter((p) => !strippedSpecs.has(p.name)).map((p) => p.name);
+    // Resolve packages that couldn't be coerced (dist-tags like "latest", "next")
+    const needsResolution = parsed.filter((p) => !coercedSpecs.has(p.name)).map((p) => p.name);
     const resolvedVersions = needsResolution.length > 0 ? await resolveLatestVersions(needsResolution) : new Map<string, string>();
 
     // Build lookup list with concrete semver only
     const lookupPackages: { name: string; version: string }[] = [];
 
     for (const p of parsed) {
-        const version = strippedSpecs.get(p.name) ?? resolvedVersions.get(p.name);
+        const version = coercedSpecs.get(p.name) ?? resolvedVersions.get(p.name);
 
         if (version) {
             lookupPackages.push({ name: p.name, version });

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -1,7 +1,230 @@
+import { createInterface } from "node:readline";
+
 import type { Command } from "@visulima/cerebro";
 
+import { info, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
+import { buildSocketOptions, fetchSocketReports, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
+import type { PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const VERSION_SPEC_REGEX = /^(.+?)(?:@(.+))?$/;
+const DEFAULT_MINIMUM_SCORE = 0.4;
+
+/**
+ * Extracts the package name from an add argument like "react", "react@19", "@scope/pkg@^2".
+ * Returns { name, versionSpec } where versionSpec may be undefined.
+ */
+const parseAddArgument = (arg: string): { name: string; versionSpec: string | undefined } => {
+    // Handle scoped packages: @scope/name@version
+    if (arg.startsWith("@")) {
+        const slashIndex = arg.indexOf("/");
+
+        if (slashIndex === -1) {
+            return { name: arg, versionSpec: undefined };
+        }
+
+        const afterSlash = arg.slice(slashIndex + 1);
+        const atIndex = afterSlash.indexOf("@");
+
+        if (atIndex === -1) {
+            return { name: arg, versionSpec: undefined };
+        }
+
+        return {
+            name: arg.slice(0, slashIndex + 1 + atIndex),
+            versionSpec: afterSlash.slice(atIndex + 1),
+        };
+    }
+
+    const match = VERSION_SPEC_REGEX.exec(arg);
+
+    if (!match) {
+        return { name: arg, versionSpec: undefined };
+    }
+
+    return { name: match[1], versionSpec: match[2] };
+};
+
+/**
+ * Resolves the latest version for each package from the npm registry.
+ * Used to get a concrete version for Socket.dev lookup when only a name is given.
+ */
+const resolveLatestVersions = async (
+    packageNames: string[],
+    timeoutMs: number = 10_000,
+): Promise<Map<string, string>> => {
+    const results = new Map<string, string>();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
+
+    try {
+        const fetches = packageNames.map(async (name) => {
+            try {
+                // eslint-disable-next-line n/no-unsupported-features/node-builtins -- fetch is available in Node 20.19+
+                const response = await fetch(`https://registry.npmjs.org/${name}/latest`, {
+                    headers: { Accept: "application/json" },
+                    signal: controller.signal,
+                });
+
+                if (response.ok) {
+                    const data = (await response.json()) as { version?: string };
+
+                    if (data.version) {
+                        results.set(name, data.version);
+                    }
+                }
+            } catch {
+                // Skip unresolvable packages
+            }
+        });
+
+        await Promise.all(fetches);
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    return results;
+};
+
+/**
+ * Displays Socket.dev security reports for packages being added.
+ * Returns the list of packages with low scores that need confirmation.
+ */
+const displaySecurityReports = (
+    reports: Map<string, PackageReportData>,
+    minimumScore: number,
+): PackageReportData[] => {
+    const lowScorePackages: PackageReportData[] = [];
+
+    for (const report of reports.values()) {
+        const overall = report.score.overall;
+        const color = scoreColor(overall);
+        const label = scoreLabel(overall);
+        const pct = `${String(Math.round(overall * 100))}%`;
+        const alertCount = report.alerts.length;
+
+        const colorFn = color === "red" ? "\u001B[31m" : color === "yellow" ? "\u001B[33m" : "\u001B[32m";
+        const reset = "\u001B[0m";
+
+        info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)}`);
+
+        if (alertCount > 0) {
+            const critHigh = report.alerts.filter((a) => a.severity === "critical" || a.severity === "high").length;
+
+            if (critHigh > 0) {
+                warn(`    ${String(critHigh)} critical/high alert${critHigh === 1 ? "" : "s"}`);
+            }
+        }
+
+        if (overall < minimumScore) {
+            lowScorePackages.push(report);
+        }
+    }
+
+    return lowScorePackages;
+};
+
+/**
+ * Prompts the user to confirm adding packages with low security scores.
+ * Returns true if the user confirms, false otherwise.
+ */
+const confirmLowScorePackages = async (lowScorePackages: PackageReportData[], minimumScore: number): Promise<boolean> => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+    const ask = (question: string): Promise<string> =>
+        new Promise((resolve) => {
+            rl.question(question, (answer) => {
+                resolve(answer.trim());
+            });
+        });
+
+    const pct = String(Math.round(minimumScore * 100));
+
+    warn("");
+    warn(`${String(lowScorePackages.length)} package${lowScorePackages.length === 1 ? "" : "s"} scored below the minimum threshold (${pct}%):`);
+
+    for (const report of lowScorePackages) {
+        const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+        const score = `${String(Math.round(report.score.overall * 100))}%`;
+
+        warn(`  \u2022 ${name}@${report.version} — score: ${score} (${scoreLabel(report.score.overall)})`);
+    }
+
+    warn("");
+
+    const answer = await ask("Continue adding these packages? [y/N] ");
+
+    rl.close();
+
+    return answer.toLowerCase() === "y" || answer.toLowerCase() === "yes";
+};
+
+/**
+ * Runs the Socket.dev pre-add security check.
+ * Returns true to proceed, false to abort.
+ */
+const runSocketPreCheck = async (
+    packages: string[],
+    socketOptions: SocketSecurityOptions,
+    minimumScore: number,
+): Promise<boolean> => {
+    const parsed = packages.map(parseAddArgument);
+    const names = parsed.map((p) => p.name);
+
+    // Resolve versions for packages without an explicit version
+    const needsResolution = parsed.filter((p) => !p.versionSpec).map((p) => p.name);
+    const resolvedVersions = needsResolution.length > 0 ? await resolveLatestVersions(needsResolution) : new Map<string, string>();
+
+    // Build lookup list
+    const lookupPackages: { name: string; version: string }[] = [];
+
+    for (const p of parsed) {
+        const version = p.versionSpec?.replace(/^[\^~>=<]+/, "") ?? resolvedVersions.get(p.name);
+
+        if (version) {
+            lookupPackages.push({ name: p.name, version });
+        }
+    }
+
+    if (lookupPackages.length === 0) {
+        return true;
+    }
+
+    info("");
+    info("Socket.dev security check:");
+
+    const reports = await fetchSocketReports(lookupPackages, socketOptions);
+
+    if (reports.size === 0) {
+        info("  Could not fetch security data. Proceeding.");
+
+        return true;
+    }
+
+    const lowScorePackages = displaySecurityReports(reports, minimumScore);
+
+    if (lowScorePackages.length === 0) {
+        info("");
+
+        return true;
+    }
+
+    // In non-interactive mode (CI, piped), fail instead of prompting
+    if (!process.stdin.isTTY) {
+        warn(`Aborting: ${String(lowScorePackages.length)} package${lowScorePackages.length === 1 ? "" : "s"} below minimum score. Use --no-socket-check to skip.`);
+
+        return false;
+    }
+
+    return confirmLowScorePackages(lowScorePackages, minimumScore);
+};
+
+// ── Command ─────────────────────────────────────────────────────────
 
 const add: Command = {
     argument: {
@@ -16,12 +239,30 @@ const add: Command = {
         ["vis add react --filter app", "Add to specific workspace package"],
         ["vis add -g typescript", "Add globally (uses npm)"],
         ["vis add lodash -w", "Add to workspace root"],
+        ["vis add lodash --no-socket-check", "Add without Socket.dev check"],
     ],
-    execute: async ({ argument, logger, options, workspaceRoot: wsRoot }) => {
+    execute: async ({ argument, logger, options, visConfig, workspaceRoot: wsRoot }) => {
         const packages = argument;
 
         if (!packages || packages.length === 0) {
             throw new Error("No packages specified. Usage: vis add <packages...>");
+        }
+
+        // Socket.dev pre-add check (unless disabled)
+        if (!options["no-socket-check"]) {
+            const socketOpts = buildSocketOptions(visConfig?.security?.socket);
+
+            if (socketOpts) {
+                const minimumScore = visConfig?.security?.socket?.minimumScore ?? DEFAULT_MINIMUM_SCORE;
+
+                const shouldContinue = await runSocketPreCheck(packages, socketOpts, minimumScore);
+
+                if (!shouldContinue) {
+                    process.exitCode = 1;
+
+                    return;
+                }
+            }
         }
 
         // Default to current directory; workspace root used only for PM detection
@@ -59,6 +300,7 @@ const add: Command = {
         { alias: "w", defaultValue: false, description: "Add to workspace root", name: "workspace-root", type: Boolean },
         { defaultValue: false, description: "Use workspace protocol (pnpm)", name: "workspace", type: Boolean },
         { alias: "F", description: "Filter by workspace package name", multiple: true, name: "filter", type: String },
+        { defaultValue: false, description: "Skip Socket.dev security check before adding", name: "no-socket-check", type: Boolean },
     ],
 };
 

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -7,7 +7,17 @@ import { coerce } from "semver";
 
 import { info, note, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
-import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, getFullPackageName, scoreColor, scoreLabel } from "../socket-security";
+import {
+    buildSocketOptions,
+    DEFAULT_LOW_SCORE_THRESHOLD,
+    fetchSocketReports,
+    findAcceptedRisk,
+    formatAcceptedRiskSnippet,
+    formatReportSummary,
+    getFullPackageName,
+    scoreColor,
+    scoreLabel,
+} from "../socket-security";
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
 
@@ -54,10 +64,7 @@ const parseAddArgument = (arg: string): { name: string; versionSpec: string | un
  * Resolves the latest version for each package from the npm registry.
  * Used to get a concrete version for Socket.dev lookup when only a name is given.
  */
-const resolveLatestVersions = async (
-    packageNames: string[],
-    timeoutMs: number = 10_000,
-): Promise<Map<string, string>> => {
+const resolveLatestVersions = async (packageNames: string[], timeoutMs: number = 10_000): Promise<Map<string, string>> => {
     const results = new Map<string, string>();
     const controller = new AbortController();
     const timeout = setTimeout(() => {
@@ -261,7 +268,9 @@ const runSocketPreCheck = async (
 
     // In non-interactive mode (CI, piped), fail instead of prompting
     if (!process.stdin.isTTY) {
-        warn(`Aborting: ${String(lowScorePackages.length)} package${lowScorePackages.length === 1 ? "" : "s"} below minimum score. Use --no-socket-check to skip.`);
+        warn(
+            `Aborting: ${String(lowScorePackages.length)} package${lowScorePackages.length === 1 ? "" : "s"} below minimum score. Use --no-socket-check to skip.`,
+        );
 
         return false;
     }
@@ -300,12 +309,7 @@ const add: Command = {
             if (socketOpts) {
                 const minimumScore = socketOpts.minimumScore ?? DEFAULT_LOW_SCORE_THRESHOLD;
 
-                const shouldContinue = await runSocketPreCheck(
-                    packages,
-                    socketOpts,
-                    minimumScore,
-                    visConfig?.security?.socket?.acceptedRisks,
-                );
+                const shouldContinue = await runSocketPreCheck(packages, socketOpts, minimumScore, visConfig?.security?.socket?.acceptedRisks);
 
                 if (!shouldContinue) {
                     process.exitCode = 1;

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -2,7 +2,9 @@ import { createInterface } from "node:readline";
 
 import type { Command } from "@visulima/cerebro";
 
-import { dim, green, info, note, red, warn, yellow } from "../output";
+import { dim, green, red, yellow } from "@visulima/colorize";
+
+import { info, note, warn } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
 import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -284,7 +284,7 @@ const add: Command = {
             const socketOpts = buildSocketOptions(visConfig?.security?.socket);
 
             if (socketOpts) {
-                const minimumScore = visConfig?.security?.socket?.minimumScore ?? DEFAULT_LOW_SCORE_THRESHOLD;
+                const minimumScore = socketOpts.minimumScore ?? DEFAULT_LOW_SCORE_THRESHOLD;
 
                 const shouldContinue = await runSocketPreCheck(
                     packages,

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -10,6 +10,8 @@ import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, fi
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
 import { toStringArray } from "../utils";
 
+const SEMVER_RE = /^\d+\.\d+\.\d+/;
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 const VERSION_SPEC_REGEX = /^(.+?)(?:@(.+))?$/;
@@ -207,15 +209,28 @@ const runSocketPreCheck = async (
 ): Promise<boolean> => {
     const parsed = packages.map(parseAddArgument);
 
-    // Resolve versions for packages without an explicit version
-    const needsResolution = parsed.filter((p) => !p.versionSpec).map((p) => p.name);
+    // Strip semver operators and check if result is a concrete version
+    const strippedSpecs = new Map<string, string>();
+
+    for (const p of parsed) {
+        if (p.versionSpec) {
+            const stripped = p.versionSpec.replace(/^[\^~>=<]+/, "");
+
+            if (SEMVER_RE.test(stripped)) {
+                strippedSpecs.set(p.name, stripped);
+            }
+        }
+    }
+
+    // Resolve packages without a concrete semver (dist-tags, partial versions, no spec)
+    const needsResolution = parsed.filter((p) => !strippedSpecs.has(p.name)).map((p) => p.name);
     const resolvedVersions = needsResolution.length > 0 ? await resolveLatestVersions(needsResolution) : new Map<string, string>();
 
-    // Build lookup list
+    // Build lookup list with concrete semver only
     const lookupPackages: { name: string; version: string }[] = [];
 
     for (const p of parsed) {
-        const version = p.versionSpec?.replace(/^[\^~>=<]+/, "") ?? resolvedVersions.get(p.name);
+        const version = strippedSpecs.get(p.name) ?? resolvedVersions.get(p.name);
 
         if (version) {
             lookupPackages.push({ name: p.name, version });

--- a/packages/tooling/vis/src/commands/add.ts
+++ b/packages/tooling/vis/src/commands/add.ts
@@ -2,7 +2,7 @@ import { createInterface } from "node:readline";
 
 import type { Command } from "@visulima/cerebro";
 
-import { info, note, warn } from "../output";
+import { dim, green, info, note, red, warn, yellow } from "../output";
 import { detectPm, runAdd } from "../pm-runner";
 import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, formatAcceptedRiskSnippet, formatReportSummary, scoreColor, scoreLabel } from "../socket-security";
 import type { AcceptedRisk, PackageReportData, SocketSecurityOptions } from "../socket-security";
@@ -111,13 +111,12 @@ const displaySecurityReports = (
         const fullName = report.namespace ? `${report.namespace}/${report.name}` : report.name;
         const accepted = findAcceptedRisk(fullName, report.version, acceptedRisks);
 
-        const colorFn = color === "red" ? "\u001B[31m" : color === "yellow" ? "\u001B[33m" : "\u001B[32m";
-        const reset = "\u001B[0m";
+        const colorFn = color === "red" ? red : color === "yellow" ? yellow : green;
 
         if (accepted) {
-            info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)} \u001B[90m[accepted: ${accepted.reason}]\u001B[0m`);
+            info(`  ${colorFn(pct)} ${formatReportSummary(report)} ${dim(`[accepted: ${accepted.reason}]`)}`);
         } else {
-            info(`  ${colorFn}${pct}${reset} ${formatReportSummary(report)}`);
+            info(`  ${colorFn(pct)} ${formatReportSummary(report)}`);
         }
 
         if (alertCount > 0) {

--- a/packages/tooling/vis/src/commands/ai.ts
+++ b/packages/tooling/vis/src/commands/ai.ts
@@ -6,6 +6,7 @@ import React from "react";
 import type { AiConfig } from "../ai-analysis";
 import { DEFAULT_PRIORITY, resolveProvider } from "../ai-analysis";
 import { clearCache, getCacheStats } from "../ai-cache";
+import { clearSocketCache } from "../socket-security";
 
 const handleCacheStats = (format: string, logger: Console): void => {
     const stats = getCacheStats();
@@ -113,9 +114,14 @@ const ai: Command = {
         }
 
         if (options["clear-cache"]) {
-            const deleted = clearCache();
+            const aiDeleted = clearCache();
+            const socketDeleted = clearSocketCache();
 
-            logger.info(`Cleared ${String(deleted)} cached AI response${deleted === 1 ? "" : "s"}.`);
+            logger.info(`Cleared ${String(aiDeleted)} cached AI response${aiDeleted === 1 ? "" : "s"}.`);
+
+            if (socketDeleted > 0) {
+                logger.info(`Cleared ${String(socketDeleted)} cached Socket.dev report${socketDeleted === 1 ? "" : "s"}.`);
+            }
 
             return;
         }

--- a/packages/tooling/vis/src/commands/analyze.ts
+++ b/packages/tooling/vis/src/commands/analyze.ts
@@ -105,11 +105,36 @@ const analyze: Command = {
         if (analysisType === "security" || options.security) {
             logger.info("Checking for known vulnerabilities...\n");
 
-            const vulnMap = await fetchVulnerabilities([{ name: packageName, version: currentRange.replace(VERSION_PREFIX_REGEX, "") }]);
+            const version = currentRange.replace(VERSION_PREFIX_REGEX, "");
+            const vulnMap = await fetchVulnerabilities([{ name: packageName, version }]);
             const vulns = vulnMap.get(packageName);
 
             if (vulns && vulns.length > 0) {
                 entry.vulnerabilities = vulns;
+            }
+
+            // Also fetch Socket.dev report if enabled
+            if (visConfig?.security?.socket?.enabled) {
+                try {
+                    const { fetchSocketReports } = await import("../socket-security");
+                    const socketConfig = visConfig.security.socket;
+                    const reports = await fetchSocketReports([{ name: packageName, version }], {
+                        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+                        cacheTtlMs: socketConfig.cacheTtlMs,
+                        timeoutMs: socketConfig.timeoutMs,
+                    });
+                    const report = reports.get(`${packageName}@${version}`);
+
+                    if (report) {
+                        entry.socketReport = {
+                            alerts: report.alerts,
+                            license: report.license,
+                            score: report.score,
+                        };
+                    }
+                } catch {
+                    // Graceful degradation
+                }
             }
         }
 

--- a/packages/tooling/vis/src/commands/analyze.ts
+++ b/packages/tooling/vis/src/commands/analyze.ts
@@ -4,6 +4,7 @@ import { findPackageManagerSync } from "@visulima/package";
 import { formatAiAnalysis, runAiAnalysis, validateAnalysisType } from "../ai-analysis";
 import type { OutdatedEntry } from "../catalog";
 import { extractPrefix, fetchPackageVersions, fetchVulnerabilities, getUpdateType, parseVersion, readCatalogs } from "../catalog";
+import { buildSocketOptions, fetchSocketReports } from "../socket-security";
 
 const VERSION_PREFIX_REGEX = /^[\^~>=<]+/;
 
@@ -114,26 +115,18 @@ const analyze: Command = {
             }
 
             // Also fetch Socket.dev report if enabled
-            if (visConfig?.security?.socket?.enabled) {
-                try {
-                    const { fetchSocketReports } = await import("../socket-security");
-                    const socketConfig = visConfig.security.socket;
-                    const reports = await fetchSocketReports([{ name: packageName, version }], {
-                        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-                        cacheTtlMs: socketConfig.cacheTtlMs,
-                        timeoutMs: socketConfig.timeoutMs,
-                    });
-                    const report = reports.get(`${packageName}@${version}`);
+            const socketOpts = buildSocketOptions(visConfig?.security?.socket);
 
-                    if (report) {
-                        entry.socketReport = {
-                            alerts: report.alerts,
-                            license: report.license,
-                            score: report.score,
-                        };
-                    }
-                } catch {
-                    // Graceful degradation
+            if (socketOpts) {
+                const reports = await fetchSocketReports([{ name: packageName, version }], socketOpts);
+                const report = reports.get(`${packageName}@${version}`);
+
+                if (report) {
+                    entry.socketReport = {
+                        alerts: report.alerts,
+                        license: report.license,
+                        score: report.score,
+                    };
                 }
             }
         }

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -98,6 +98,13 @@ const scanInstalledPackages = (workspaceRoot: string): InstalledPackage[] => {
                         version: pkg.version,
                     });
                 }
+
+                // Recurse into nested node_modules (npm non-flat installs)
+                const nestedNm = join(fullPath, "node_modules");
+
+                if (existsSync(nestedNm)) {
+                    scanDir(nestedNm, "");
+                }
             } catch {
                 // Skip unreadable packages
             }

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -7,7 +7,9 @@ import type { NativeAuditExclusions } from "../audit-config";
 import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../audit-config";
 import type { SecurityVulnerability } from "../catalog";
 import { fetchVulnerabilities } from "../catalog";
-import { error as errorOutput, cyan, dim, info, note, red, success, warn, yellow } from "../output";
+import { cyan, dim, magenta, red, yellow } from "@visulima/colorize";
+
+import { error as errorOutput, info, note, success, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
 import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, scoreLabel } from "../socket-security";
@@ -136,7 +138,7 @@ const severityPassesFilter = (severity: string, filter: SeverityFilter): boolean
 
 const SEVERITY_COLOR_FN: Record<string, (s: string) => string> = {
     CRITICAL: red,
-    HIGH: (s: string) => `\u001B[35m${s}\u001B[0m`, // magenta (not in output.ts)
+    HIGH: magenta,
     LOW: cyan,
     MODERATE: yellow,
     UNKNOWN: dim,

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -3,9 +3,12 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import type { Command } from "@visulima/cerebro";
 import { join } from "@visulima/path";
 
+import type { NativeAuditExclusions } from "../audit-config";
+import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../audit-config";
 import type { SecurityVulnerability } from "../catalog";
 import { fetchVulnerabilities } from "../catalog";
 import { error as errorOutput, info, note, success, warn } from "../output";
+import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
 import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, scoreLabel } from "../socket-security";
 
@@ -20,6 +23,8 @@ interface InstalledPackage {
 interface AuditEntry {
     acceptedRisk?: AcceptedRisk;
     name: string;
+    /** True if the package or its advisory IDs are excluded by native PM config. */
+    nativeExcluded: boolean;
     socketReport?: PackageReportData;
     version: string;
     vulnerabilities: SecurityVulnerability[];
@@ -174,6 +179,14 @@ const executeAudit = async (
     const socketConfig = (visConfig as { security?: { socket?: Record<string, unknown> } } | undefined)?.security?.socket;
     const acceptedRisks = socketConfig?.acceptedRisks as Record<string, AcceptedRisk> | undefined;
 
+    // Read native PM audit exclusions
+    const pm = detectPm(workspaceRoot);
+    const nativeExclusions = readNativeAuditExclusions(workspaceRoot, pm.name);
+
+    if (nativeExclusions.ignoredAdvisories.length > 0 || nativeExclusions.excludedPackages.length > 0) {
+        info(`Loaded ${String(nativeExclusions.ignoredAdvisories.length)} ignored advisor${nativeExclusions.ignoredAdvisories.length === 1 ? "y" : "ies"} and ${String(nativeExclusions.excludedPackages.length)} excluded package${nativeExclusions.excludedPackages.length === 1 ? "" : "s"} from ${pm.name} config.`);
+    }
+
     // 1. Discover installed packages
     info("Scanning installed packages...");
 
@@ -201,9 +214,17 @@ const executeAudit = async (
     const entries: AuditEntry[] = [];
 
     for (const pkg of installed) {
+        // Skip packages excluded by native PM config (yarn npmAuditExcludePackages)
+        if (isPackageExcluded(pkg.name, nativeExclusions)) {
+            continue;
+        }
+
         const vulns = vulnMap.get(pkg.name) ?? [];
         const report = socketReports.get(`${pkg.name}@${pkg.version}`);
         const accepted = findAcceptedRisk(pkg.name, pkg.version, acceptedRisks);
+
+        // Check if all vulns are excluded by native PM config
+        const nativeExcluded = vulns.length > 0 && vulns.every((v) => isAdvisoryExcluded(v.id, nativeExclusions));
 
         const hasVulns = vulns.length > 0;
         const hasLowScore = report ? report.score.overall < 0.4 : false;
@@ -213,6 +234,7 @@ const executeAudit = async (
             entries.push({
                 acceptedRisk: accepted,
                 name: pkg.name,
+                nativeExcluded,
                 socketReport: report,
                 version: pkg.version,
                 vulnerabilities: vulns,
@@ -298,9 +320,9 @@ const executeAudit = async (
         info(`\n\u2500\u2500 ${severity} (${String(items.length)}) \u2500\u2500`);
 
         for (const { entry, vuln } of items) {
-            const isAccepted = Boolean(entry.acceptedRisk);
+            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded || isAdvisoryExcluded(vuln.id, nativeExclusions);
 
-            if (isAccepted) {
+            if (isExcluded) {
                 acknowledgedVulns++;
 
                 if (!showAccepted) {
@@ -309,7 +331,7 @@ const executeAudit = async (
             }
 
             totalVulns++;
-            info(formatVulnLine(entry.name, entry.version, vuln, isAccepted));
+            info(formatVulnLine(entry.name, entry.version, vuln, isExcluded));
 
             if (showFixes && vuln.fixedVersions.length > 0) {
                 note(`    Fix: update to ${vuln.fixedVersions[vuln.fixedVersions.length - 1]}`);
@@ -328,13 +350,13 @@ const executeAudit = async (
                 continue;
             }
 
-            const isAccepted = Boolean(entry.acceptedRisk);
+            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded;
 
-            if (isAccepted && !showAccepted) {
+            if (isExcluded && !showAccepted) {
                 continue;
             }
 
-            info(formatSocketLine(entry.socketReport, isAccepted));
+            info(formatSocketLine(entry.socketReport, isExcluded));
 
             for (const alert of entry.socketReport.alerts) {
                 const color = SOCKET_SEVERITY_ORDER[alert.severity] !== undefined && SOCKET_SEVERITY_ORDER[alert.severity] <= 1 ? "\u001B[31m" : "\u001B[33m";
@@ -345,15 +367,20 @@ const executeAudit = async (
     }
 
     // Summary
-    const unacknowledgedCount = filtered.filter((e) => !e.acceptedRisk).length;
+    const isEntryExcluded = (e: AuditEntry): boolean => Boolean(e.acceptedRisk) || e.nativeExcluded;
+    const unacknowledgedCount = filtered.filter((e) => !isEntryExcluded(e)).length;
 
     info("");
     info(`\u2500 Audit Summary`);
     info(`  ${String(installed.length)} packages scanned`);
 
+    if (nativeExclusions.ignoredAdvisories.length > 0) {
+        info(`  ${String(nativeExclusions.ignoredAdvisories.length)} ${pm.name} audit exclusion${nativeExclusions.ignoredAdvisories.length === 1 ? "" : "s"} applied`);
+    }
+
     if (totalVulns > 0) {
-        const critCount = vulnsBySeverity.CRITICAL?.filter((i) => !i.entry.acceptedRisk).length ?? 0;
-        const highCount = vulnsBySeverity.HIGH?.filter((i) => !i.entry.acceptedRisk).length ?? 0;
+        const critCount = vulnsBySeverity.CRITICAL?.filter((i) => !isEntryExcluded(i.entry)).length ?? 0;
+        const highCount = vulnsBySeverity.HIGH?.filter((i) => !isEntryExcluded(i.entry)).length ?? 0;
 
         errorOutput(`  ${String(totalVulns)} vulnerabilit${totalVulns === 1 ? "y" : "ies"} found`);
 
@@ -369,7 +396,7 @@ const executeAudit = async (
     }
 
     if (socketIssues.length > 0) {
-        const unacknowledgedSocket = socketIssues.filter((e) => !e.acceptedRisk).length;
+        const unacknowledgedSocket = socketIssues.filter((e) => !isEntryExcluded(e)).length;
 
         warn(`  ${String(unacknowledgedSocket)} package${unacknowledgedSocket === 1 ? "" : "s"} with Socket.dev supply chain issues`);
     }
@@ -384,6 +411,33 @@ const executeAudit = async (
 
     if (unacknowledgedCount === 0) {
         success("\n  All issues are acknowledged. No action required.");
+    }
+
+    // Sync accepted risks to native PM config
+    if (options.sync && acceptedRisks) {
+        const advisoryIds: string[] = [];
+
+        // Collect CVE/GHSA IDs from accepted risk entries by looking at their vuln data
+        for (const entry of filtered) {
+            if (entry.acceptedRisk) {
+                for (const vuln of entry.vulnerabilities) {
+                    if (vuln.id.startsWith("CVE-") || vuln.id.startsWith("GHSA-")) {
+                        advisoryIds.push(vuln.id);
+                    }
+                }
+            }
+        }
+
+        if (advisoryIds.length > 0) {
+            info("");
+            const actions = syncAcceptedRisksToNativeConfig(pm.name, workspaceRoot, advisoryIds);
+
+            for (const action of actions) {
+                success(`  ${action}`);
+            }
+        } else {
+            info("\nNo advisory IDs to sync to native PM config.");
+        }
     }
 
     if (options["exit-code"] && unacknowledgedCount > 0) {
@@ -403,6 +457,7 @@ const audit: Command = {
         ["vis audit --fix", "Show fix suggestions for vulnerabilities"],
         ["vis audit --exit-code", "Exit with code 1 if issues found (for CI)"],
         ["vis audit --show-accepted", "Include acknowledged risks in output"],
+        ["vis audit --sync", `Sync accepted risks to native PM config (pnpm-workspace.yaml / .yarnrc.yml)`],
     ],
     execute: async ({ logger, options, visConfig, workspaceRoot: wsRoot }) => {
         if (!wsRoot) {
@@ -440,6 +495,12 @@ const audit: Command = {
             defaultValue: false,
             description: "Include acknowledged (accepted risk) issues in output",
             name: "show-accepted",
+            type: Boolean,
+        },
+        {
+            defaultValue: false,
+            description: "Sync vis accepted risks to native PM config (pnpm-workspace.yaml / .yarnrc.yml)",
+            name: "sync",
             type: Boolean,
         },
     ],

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -12,7 +12,8 @@ import { cyan, dim, magenta, red, yellow } from "@visulima/colorize";
 import { error as errorOutput, info, note, success, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
-import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, scoreLabel } from "../socket-security";
+import type { VisConfig } from "../workspace";
+import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, getFullPackageName, scoreLabel } from "../socket-security";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -153,7 +154,7 @@ const formatVulnLine = (name: string, version: string, vuln: SecurityVulnerabili
 };
 
 const formatSocketLine = (report: PackageReportData, isAccepted: boolean): string => {
-    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const name = getFullPackageName(report);
     const pct = `${String(Math.round(report.score.overall * 100))}%`;
     const badge = isAccepted ? ` ${dim("[acknowledged]")}` : "";
     const alerts = report.alerts.length > 0
@@ -169,15 +170,15 @@ const formatSocketLine = (report: PackageReportData, isAccepted: boolean): strin
 const executeAudit = async (
     workspaceRoot: string,
     options: Record<string, unknown>,
-    visConfig: Record<string, unknown> | undefined,
+    visConfig: VisConfig | undefined,
     logger: Console,
 ): Promise<void> => {
     const severityFilter = (options.severity as SeverityFilter | undefined) ?? "low";
     const isJson = Boolean(options.json);
     const showFixes = Boolean(options.fix);
     const showAccepted = Boolean(options["show-accepted"]);
-    const socketConfig = (visConfig as { security?: { socket?: Record<string, unknown> } } | undefined)?.security?.socket;
-    const acceptedRisks = socketConfig?.acceptedRisks as Record<string, AcceptedRisk> | undefined;
+    const socketConfig = visConfig?.security?.socket;
+    const acceptedRisks = socketConfig?.acceptedRisks;
 
     // Read native PM audit exclusions
     const pm = detectPm(workspaceRoot);
@@ -203,7 +204,7 @@ const executeAudit = async (
     // 2. Fetch vulnerability and security data in parallel
     const packagesToScan = installed.map((p) => ({ name: p.name, version: p.version }));
 
-    const socketOpts = buildSocketOptions(socketConfig as Record<string, unknown> | undefined);
+    const socketOpts = buildSocketOptions(socketConfig);
 
     const [vulnMap, socketReports] = await Promise.all([
         fetchVulnerabilities(packagesToScan),
@@ -227,7 +228,7 @@ const executeAudit = async (
         const nativeExcluded = vulns.length > 0 && vulns.every((v) => isAdvisoryExcluded(v.id, nativeExclusions));
 
         const hasVulns = vulns.length > 0;
-        const hasLowScore = report ? report.score.overall < 0.4 : false;
+        const hasLowScore = report ? report.score.overall < DEFAULT_LOW_SCORE_THRESHOLD : false;
         const hasAlerts = report ? report.alerts.length > 0 : false;
 
         if (hasVulns || hasLowScore || hasAlerts) {
@@ -248,7 +249,7 @@ const executeAudit = async (
         const socketPasses = entry.socketReport?.alerts.some((a) =>
             severityPassesFilter(a.severity === "medium" ? "MODERATE" : a.severity.toUpperCase(), severityFilter),
         );
-        const lowScorePasses = entry.socketReport && entry.socketReport.score.overall < 0.4;
+        const lowScorePasses = entry.socketReport && entry.socketReport.score.overall < DEFAULT_LOW_SCORE_THRESHOLD;
 
         return vulnPasses || socketPasses || lowScorePasses;
     });
@@ -340,7 +341,7 @@ const executeAudit = async (
     }
 
     // Print Socket.dev supply chain issues
-    const socketIssues = filtered.filter((e) => e.socketReport && (e.socketReport.score.overall < 0.4 || e.socketReport.alerts.length > 0));
+    const socketIssues = filtered.filter((e) => e.socketReport && (e.socketReport.score.overall < DEFAULT_LOW_SCORE_THRESHOLD || e.socketReport.alerts.length > 0));
 
     if (socketIssues.length > 0) {
         info(`\n\u2500\u2500 Socket.dev Supply Chain (${String(socketIssues.length)}) \u2500\u2500`);

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -153,7 +153,8 @@ const SEVERITY_COLOR_FN: Record<string, (s: string) => string> = {
 const formatVulnLine = (name: string, version: string, vuln: SecurityVulnerability, isAccepted: boolean): string => {
     const colorFn = SEVERITY_COLOR_FN[vuln.severity] ?? dim;
     const badge = isAccepted ? ` ${dim("[acknowledged]")}` : "";
-    const fixed = vuln.fixedVersions.length > 0 ? ` (fix: ${vuln.fixedVersions.join(", ")})` : "";
+    const fixedVersions = vuln.fixedVersions ?? [];
+    const fixed = fixedVersions.length > 0 ? ` (fix: ${fixedVersions.join(", ")})` : "";
 
     return `  ${colorFn(vuln.severity)} ${vuln.id} — ${name}@${version}${badge}\n    ${vuln.summary}${fixed}`;
 };
@@ -322,7 +323,7 @@ const executeAudit = async (
         info(`\n\u2500\u2500 ${severity} (${String(items.length)}) \u2500\u2500`);
 
         for (const { entry, vuln } of items) {
-            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded || isAdvisoryExcluded(vuln.id, nativeExclusions, vuln.aliases);
+            const isExcluded = Boolean(entry.acceptedRisk) || isAdvisoryExcluded(vuln.id, nativeExclusions, vuln.aliases);
 
             if (isExcluded) {
                 acknowledgedVulns++;
@@ -335,7 +336,7 @@ const executeAudit = async (
             totalVulns++;
             info(formatVulnLine(entry.name, entry.version, vuln, isExcluded));
 
-            if (showFixes && vuln.fixedVersions.length > 0) {
+            if (showFixes && (vuln.fixedVersions ?? []).length > 0) {
                 note(`    Fix: update to ${vuln.fixedVersions[vuln.fixedVersions.length - 1]}`);
             }
         }

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -1,0 +1,448 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+
+import type { Command } from "@visulima/cerebro";
+import { join } from "@visulima/path";
+
+import type { SecurityVulnerability } from "../catalog";
+import { fetchVulnerabilities } from "../catalog";
+import { error as errorOutput, info, note, success, warn } from "../output";
+import type { AcceptedRisk, PackageReportData } from "../socket-security";
+import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, scoreLabel } from "../socket-security";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface InstalledPackage {
+    isDev: boolean;
+    name: string;
+    version: string;
+}
+
+interface AuditEntry {
+    acceptedRisk?: AcceptedRisk;
+    name: string;
+    socketReport?: PackageReportData;
+    version: string;
+    vulnerabilities: SecurityVulnerability[];
+}
+
+type SeverityFilter = "critical" | "high" | "low" | "medium";
+
+// ── Package discovery ───────────────────────────────────────────────
+
+const scanInstalledPackages = (workspaceRoot: string): InstalledPackage[] => {
+    const nodeModulesPath = join(workspaceRoot, "node_modules");
+
+    if (!existsSync(nodeModulesPath)) {
+        return [];
+    }
+
+    const packages: InstalledPackage[] = [];
+
+    // Read root package.json to determine dev vs prod
+    const rootPkgPath = join(workspaceRoot, "package.json");
+    let devDeps = new Set<string>();
+
+    if (existsSync(rootPkgPath)) {
+        try {
+            const pkg = JSON.parse(readFileSync(rootPkgPath, "utf8")) as {
+                devDependencies?: Record<string, string>;
+            };
+
+            devDeps = new Set(Object.keys(pkg.devDependencies ?? {}));
+        } catch {
+            // Non-critical
+        }
+    }
+
+    const scanDir = (dir: string, prefix: string): void => {
+        let entries: string[];
+
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            return;
+        }
+
+        for (const entry of entries) {
+            if (entry.startsWith(".")) {
+                continue;
+            }
+
+            const fullPath = join(dir, entry);
+
+            if (entry.startsWith("@")) {
+                scanDir(fullPath, `${entry}/`);
+                continue;
+            }
+
+            const pkgName = prefix + entry;
+            const pkgJsonPath = join(fullPath, "package.json");
+
+            try {
+                if (!statSync(fullPath).isDirectory() || !existsSync(pkgJsonPath)) {
+                    continue;
+                }
+
+                const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { version?: string };
+
+                if (pkg.version) {
+                    packages.push({
+                        isDev: devDeps.has(pkgName),
+                        name: pkgName,
+                        version: pkg.version,
+                    });
+                }
+            } catch {
+                // Skip unreadable packages
+            }
+        }
+    };
+
+    scanDir(nodeModulesPath, "");
+
+    return packages;
+};
+
+// ── Severity helpers ────────────────────────────────────────────────
+
+const SEVERITY_ORDER: Record<string, number> = {
+    CRITICAL: 0,
+    HIGH: 1,
+    MODERATE: 2,
+    LOW: 3,
+    UNKNOWN: 4,
+};
+
+const SOCKET_SEVERITY_ORDER: Record<string, number> = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+};
+
+const severityPassesFilter = (severity: string, filter: SeverityFilter): boolean => {
+    const filterLevel = SEVERITY_ORDER[filter.toUpperCase()] ?? SEVERITY_ORDER.MODERATE ?? 2;
+    const vulnLevel = SEVERITY_ORDER[severity.toUpperCase()] ?? 4;
+
+    return vulnLevel <= filterLevel;
+};
+
+// ── Display helpers ─────────────────────────────────────────────────
+
+const SEVERITY_COLORS: Record<string, string> = {
+    CRITICAL: "\u001B[31m",
+    HIGH: "\u001B[35m",
+    LOW: "\u001B[36m",
+    MODERATE: "\u001B[33m",
+    UNKNOWN: "\u001B[90m",
+};
+
+const RESET = "\u001B[0m";
+
+const formatVulnLine = (name: string, version: string, vuln: SecurityVulnerability, isAccepted: boolean): string => {
+    const color = SEVERITY_COLORS[vuln.severity] ?? SEVERITY_COLORS.UNKNOWN;
+    const badge = isAccepted ? " \u001B[90m[acknowledged]\u001B[0m" : "";
+    const fixed = vuln.fixedVersions.length > 0 ? ` (fix: ${vuln.fixedVersions.join(", ")})` : "";
+
+    return `  ${color ?? ""}${vuln.severity}${RESET} ${vuln.id} — ${name}@${version}${badge}\n    ${vuln.summary}${fixed}`;
+};
+
+const formatSocketLine = (report: PackageReportData, isAccepted: boolean): string => {
+    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const pct = `${String(Math.round(report.score.overall * 100))}%`;
+    const badge = isAccepted ? " \u001B[90m[acknowledged]\u001B[0m" : "";
+    const alerts = report.alerts.length > 0
+        ? `, ${String(report.alerts.length)} alert${report.alerts.length === 1 ? "" : "s"}`
+        : "";
+
+    return `  ${pct} ${name}@${report.version} (${scoreLabel(report.score.overall)}${alerts})${badge}`;
+};
+
+// ── Main audit logic ────────────────────────────────────────────────
+
+/* eslint-disable sonarjs/cognitive-complexity -- audit command with multiple output paths */
+const executeAudit = async (
+    workspaceRoot: string,
+    options: Record<string, unknown>,
+    visConfig: Record<string, unknown> | undefined,
+    logger: Console,
+): Promise<void> => {
+    const severityFilter = (options.severity as SeverityFilter | undefined) ?? "low";
+    const isJson = Boolean(options.json);
+    const showFixes = Boolean(options.fix);
+    const showAccepted = Boolean(options["show-accepted"]);
+    const socketConfig = (visConfig as { security?: { socket?: Record<string, unknown> } } | undefined)?.security?.socket;
+    const acceptedRisks = socketConfig?.acceptedRisks as Record<string, AcceptedRisk> | undefined;
+
+    // 1. Discover installed packages
+    info("Scanning installed packages...");
+
+    const installed = scanInstalledPackages(workspaceRoot);
+
+    if (installed.length === 0) {
+        info("No packages found in node_modules. Run your package manager's install command first.");
+
+        return;
+    }
+
+    info(`Found ${String(installed.length)} packages.\n`);
+
+    // 2. Fetch vulnerability and security data in parallel
+    const packagesToScan = installed.map((p) => ({ name: p.name, version: p.version }));
+
+    const socketOpts = buildSocketOptions(socketConfig as Record<string, unknown> | undefined);
+
+    const [vulnMap, socketReports] = await Promise.all([
+        fetchVulnerabilities(packagesToScan),
+        socketOpts ? fetchSocketReports(packagesToScan, socketOpts) : Promise.resolve(new Map<string, PackageReportData>()),
+    ]);
+
+    // 3. Build audit entries
+    const entries: AuditEntry[] = [];
+
+    for (const pkg of installed) {
+        const vulns = vulnMap.get(pkg.name) ?? [];
+        const report = socketReports.get(`${pkg.name}@${pkg.version}`);
+        const accepted = findAcceptedRisk(pkg.name, pkg.version, acceptedRisks);
+
+        const hasVulns = vulns.length > 0;
+        const hasLowScore = report ? report.score.overall < 0.4 : false;
+        const hasAlerts = report ? report.alerts.length > 0 : false;
+
+        if (hasVulns || hasLowScore || hasAlerts) {
+            entries.push({
+                acceptedRisk: accepted,
+                name: pkg.name,
+                socketReport: report,
+                version: pkg.version,
+                vulnerabilities: vulns,
+            });
+        }
+    }
+
+    // 4. Filter by severity
+    const filtered = entries.filter((entry) => {
+        const vulnPasses = entry.vulnerabilities.some((v) => severityPassesFilter(v.severity, severityFilter));
+        const socketPasses = entry.socketReport?.alerts.some((a) =>
+            severityPassesFilter(a.severity === "medium" ? "MODERATE" : a.severity.toUpperCase(), severityFilter),
+        );
+        const lowScorePasses = entry.socketReport && entry.socketReport.score.overall < 0.4;
+
+        return vulnPasses || socketPasses || lowScorePasses;
+    });
+
+    // 5. JSON output
+    if (isJson) {
+        const jsonResult = {
+            packages: installed.length,
+            results: filtered.map((e) => ({
+                acceptedRisk: e.acceptedRisk ?? null,
+                name: e.name,
+                socketScore: e.socketReport?.score.overall ?? null,
+                socketAlerts: e.socketReport?.alerts ?? [],
+                version: e.version,
+                vulnerabilities: e.vulnerabilities,
+            })),
+            summary: {
+                accepted: filtered.filter((e) => e.acceptedRisk).length,
+                issues: filtered.filter((e) => !e.acceptedRisk).length,
+                total: filtered.length,
+            },
+        };
+
+        process.stdout.write(`${JSON.stringify(jsonResult, undefined, 2)}\n`);
+
+        if (options["exit-code"] && jsonResult.summary.issues > 0) {
+            process.exitCode = 1;
+        }
+
+        return;
+    }
+
+    // 6. Human-readable output
+    if (filtered.length === 0) {
+        success(`No security issues found across ${String(installed.length)} packages.`);
+
+        return;
+    }
+
+    // Group vulnerabilities by severity
+    const vulnsBySeverity: Record<string, { entry: AuditEntry; vuln: SecurityVulnerability }[]> = {
+        CRITICAL: [],
+        HIGH: [],
+        LOW: [],
+        MODERATE: [],
+    };
+
+    for (const entry of filtered) {
+        for (const vuln of entry.vulnerabilities) {
+            if (severityPassesFilter(vuln.severity, severityFilter)) {
+                const key = vuln.severity === "UNKNOWN" ? "LOW" : vuln.severity;
+
+                vulnsBySeverity[key]?.push({ entry, vuln });
+            }
+        }
+    }
+
+    // Print vulnerabilities
+    let totalVulns = 0;
+    let acknowledgedVulns = 0;
+
+    for (const severity of ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const) {
+        const items = vulnsBySeverity[severity];
+
+        if (!items || items.length === 0) {
+            continue;
+        }
+
+        info(`\n\u2500\u2500 ${severity} (${String(items.length)}) \u2500\u2500`);
+
+        for (const { entry, vuln } of items) {
+            const isAccepted = Boolean(entry.acceptedRisk);
+
+            if (isAccepted) {
+                acknowledgedVulns++;
+
+                if (!showAccepted) {
+                    continue;
+                }
+            }
+
+            totalVulns++;
+            info(formatVulnLine(entry.name, entry.version, vuln, isAccepted));
+
+            if (showFixes && vuln.fixedVersions.length > 0) {
+                note(`    Fix: update to ${vuln.fixedVersions[vuln.fixedVersions.length - 1]}`);
+            }
+        }
+    }
+
+    // Print Socket.dev supply chain issues
+    const socketIssues = filtered.filter((e) => e.socketReport && (e.socketReport.score.overall < 0.4 || e.socketReport.alerts.length > 0));
+
+    if (socketIssues.length > 0) {
+        info(`\n\u2500\u2500 Socket.dev Supply Chain (${String(socketIssues.length)}) \u2500\u2500`);
+
+        for (const entry of socketIssues) {
+            if (!entry.socketReport) {
+                continue;
+            }
+
+            const isAccepted = Boolean(entry.acceptedRisk);
+
+            if (isAccepted && !showAccepted) {
+                continue;
+            }
+
+            info(formatSocketLine(entry.socketReport, isAccepted));
+
+            for (const alert of entry.socketReport.alerts) {
+                const color = SOCKET_SEVERITY_ORDER[alert.severity] !== undefined && SOCKET_SEVERITY_ORDER[alert.severity] <= 1 ? "\u001B[31m" : "\u001B[33m";
+
+                info(`    ${color}[${alert.severity.toUpperCase()}]${RESET} ${alert.type} — ${alert.category}`);
+            }
+        }
+    }
+
+    // Summary
+    const unacknowledgedCount = filtered.filter((e) => !e.acceptedRisk).length;
+
+    info("");
+    info(`\u2500 Audit Summary`);
+    info(`  ${String(installed.length)} packages scanned`);
+
+    if (totalVulns > 0) {
+        const critCount = vulnsBySeverity.CRITICAL?.filter((i) => !i.entry.acceptedRisk).length ?? 0;
+        const highCount = vulnsBySeverity.HIGH?.filter((i) => !i.entry.acceptedRisk).length ?? 0;
+
+        errorOutput(`  ${String(totalVulns)} vulnerabilit${totalVulns === 1 ? "y" : "ies"} found`);
+
+        if (critCount > 0) {
+            errorOutput(`    ${String(critCount)} critical`);
+        }
+
+        if (highCount > 0) {
+            warn(`    ${String(highCount)} high`);
+        }
+    } else {
+        success("  No vulnerabilities found");
+    }
+
+    if (socketIssues.length > 0) {
+        const unacknowledgedSocket = socketIssues.filter((e) => !e.acceptedRisk).length;
+
+        warn(`  ${String(unacknowledgedSocket)} package${unacknowledgedSocket === 1 ? "" : "s"} with Socket.dev supply chain issues`);
+    }
+
+    if (acknowledgedVulns > 0) {
+        info(`  ${String(acknowledgedVulns)} acknowledged (accepted risks)`);
+
+        if (!showAccepted) {
+            note("  Use --show-accepted to see acknowledged issues.");
+        }
+    }
+
+    if (unacknowledgedCount === 0) {
+        success("\n  All issues are acknowledged. No action required.");
+    }
+
+    if (options["exit-code"] && unacknowledgedCount > 0) {
+        process.exitCode = 1;
+    }
+};
+/* eslint-enable sonarjs/cognitive-complexity */
+
+// ── Command ─────────────────────────────────────────────────────────
+
+const audit: Command = {
+    description: "Audit installed packages for vulnerabilities and supply chain risks",
+    examples: [
+        ["vis audit", "Full audit of all installed packages"],
+        ["vis audit --severity high", "Show only high/critical issues"],
+        ["vis audit --json", "Output as JSON for CI integration"],
+        ["vis audit --fix", "Show fix suggestions for vulnerabilities"],
+        ["vis audit --exit-code", "Exit with code 1 if issues found (for CI)"],
+        ["vis audit --show-accepted", "Include acknowledged risks in output"],
+    ],
+    execute: async ({ logger, options, visConfig, workspaceRoot: wsRoot }) => {
+        if (!wsRoot) {
+            throw new Error("Could not determine workspace root. Run this command inside a monorepo.");
+        }
+
+        await executeAudit(wsRoot, options, visConfig, logger);
+    },
+    name: "audit",
+    options: [
+        {
+            description: "Minimum severity to report: low, medium, high, critical (default: low)",
+            name: "severity",
+            type: String,
+        },
+        {
+            defaultValue: false,
+            description: "Output results as JSON",
+            name: "json",
+            type: Boolean,
+        },
+        {
+            defaultValue: false,
+            description: "Show fix suggestions for vulnerabilities",
+            name: "fix",
+            type: Boolean,
+        },
+        {
+            defaultValue: false,
+            description: "Exit with code 1 if unacknowledged issues found (for CI)",
+            name: "exit-code",
+            type: Boolean,
+        },
+        {
+            defaultValue: false,
+            description: "Include acknowledged (accepted risk) issues in output",
+            name: "show-accepted",
+            type: Boolean,
+        },
+    ],
+};
+
+export default audit;

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -3,7 +3,6 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import type { Command } from "@visulima/cerebro";
 import { join } from "@visulima/path";
 
-import type { NativeAuditExclusions } from "../audit-config";
 import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../audit-config";
 import type { SecurityVulnerability } from "../catalog";
 import { fetchVulnerabilities } from "../catalog";
@@ -13,7 +12,7 @@ import { error as errorOutput, info, note, success, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
 import type { VisConfig } from "../workspace";
-import { alertSeverityColor, buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, getFullPackageName, scoreLabel } from "../socket-security";
+import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, getFullPackageName, scoreLabel } from "../socket-security";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -163,9 +162,7 @@ const formatSocketLine = (report: PackageReportData, isAccepted: boolean): strin
     const name = getFullPackageName(report);
     const pct = `${String(Math.round(report.score.overall * 100))}%`;
     const badge = isAccepted ? ` ${dim("[acknowledged]")}` : "";
-    const alerts = report.alerts.length > 0
-        ? `, ${String(report.alerts.length)} alert${report.alerts.length === 1 ? "" : "s"}`
-        : "";
+    const alerts = report.alerts.length > 0 ? `, ${String(report.alerts.length)} alert${report.alerts.length === 1 ? "" : "s"}` : "";
 
     return `  ${pct} ${name}@${report.version} (${scoreLabel(report.score.overall)}${alerts})${badge}`;
 };
@@ -173,12 +170,7 @@ const formatSocketLine = (report: PackageReportData, isAccepted: boolean): strin
 // ── Main audit logic ────────────────────────────────────────────────
 
 /* eslint-disable sonarjs/cognitive-complexity -- audit command with multiple output paths */
-const executeAudit = async (
-    workspaceRoot: string,
-    options: Record<string, unknown>,
-    visConfig: VisConfig | undefined,
-    logger: Console,
-): Promise<void> => {
+const executeAudit = async (workspaceRoot: string, options: Record<string, unknown>, visConfig: VisConfig | undefined, logger: Console): Promise<void> => {
     const severityFilter = (options.severity as SeverityFilter | undefined) ?? "low";
     const isJson = Boolean(options.json);
     const showFixes = Boolean(options.fix);
@@ -191,7 +183,9 @@ const executeAudit = async (
     const nativeExclusions = readNativeAuditExclusions(workspaceRoot, pm.name);
 
     if (nativeExclusions.ignoredAdvisories.length > 0 || nativeExclusions.excludedPackages.length > 0) {
-        info(`Loaded ${String(nativeExclusions.ignoredAdvisories.length)} ignored advisor${nativeExclusions.ignoredAdvisories.length === 1 ? "y" : "ies"} and ${String(nativeExclusions.excludedPackages.length)} excluded package${nativeExclusions.excludedPackages.length === 1 ? "" : "s"} from ${pm.name} config.`);
+        info(
+            `Loaded ${String(nativeExclusions.ignoredAdvisories.length)} ignored advisor${nativeExclusions.ignoredAdvisories.length === 1 ? "y" : "ies"} and ${String(nativeExclusions.excludedPackages.length)} excluded package${nativeExclusions.excludedPackages.length === 1 ? "" : "s"} from ${pm.name} config.`,
+        );
     }
 
     // 1. Discover installed packages
@@ -343,7 +337,9 @@ const executeAudit = async (
     }
 
     // Print Socket.dev supply chain issues
-    const socketIssues = filtered.filter((e) => e.socketReport && (e.socketReport.score.overall < DEFAULT_LOW_SCORE_THRESHOLD || e.socketReport.alerts.length > 0));
+    const socketIssues = filtered.filter(
+        (e) => e.socketReport && (e.socketReport.score.overall < DEFAULT_LOW_SCORE_THRESHOLD || e.socketReport.alerts.length > 0),
+    );
 
     if (socketIssues.length > 0) {
         info(`\n\u2500\u2500 Socket.dev Supply Chain (${String(socketIssues.length)}) \u2500\u2500`);
@@ -371,8 +367,7 @@ const executeAudit = async (
 
     // Summary
     const isEntryExcluded = (e: AuditEntry): boolean =>
-        Boolean(e.acceptedRisk)
-        || (e.vulnerabilities.length > 0 && e.vulnerabilities.every((v) => isAdvisoryExcluded(v.id, nativeExclusions, v.aliases)));
+        Boolean(e.acceptedRisk) || (e.vulnerabilities.length > 0 && e.vulnerabilities.every((v) => isAdvisoryExcluded(v.id, nativeExclusions, v.aliases)));
     const unacknowledgedCount = filtered.filter((e) => !isEntryExcluded(e)).length;
 
     info("");
@@ -380,7 +375,9 @@ const executeAudit = async (
     info(`  ${String(installed.length)} packages scanned`);
 
     if (nativeExclusions.ignoredAdvisories.length > 0) {
-        info(`  ${String(nativeExclusions.ignoredAdvisories.length)} ${pm.name} audit exclusion${nativeExclusions.ignoredAdvisories.length === 1 ? "" : "s"} applied`);
+        info(
+            `  ${String(nativeExclusions.ignoredAdvisories.length)} ${pm.name} audit exclusion${nativeExclusions.ignoredAdvisories.length === 1 ? "" : "s"} applied`,
+        );
     }
 
     if (totalVulns > 0) {

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -13,7 +13,7 @@ import { error as errorOutput, info, note, success, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
 import type { VisConfig } from "../workspace";
-import { buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, getFullPackageName, scoreLabel } from "../socket-security";
+import { alertSeverityColor, buildSocketOptions, DEFAULT_LOW_SCORE_THRESHOLD, fetchSocketReports, findAcceptedRisk, getFullPackageName, scoreLabel } from "../socket-security";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -126,11 +126,11 @@ const SEVERITY_ORDER: Record<string, number> = {
     UNKNOWN: 4,
 };
 
-const SOCKET_SEVERITY_ORDER: Record<string, number> = {
-    critical: 0,
-    high: 1,
-    medium: 2,
-    low: 3,
+const SOCKET_ALERT_COLORS: Record<string, (s: string) => string> = {
+    critical: red,
+    high: magenta,
+    low: cyan,
+    medium: yellow,
 };
 
 const severityPassesFilter = (severity: string, filter: SeverityFilter): boolean => {
@@ -362,9 +362,9 @@ const executeAudit = async (
             info(formatSocketLine(entry.socketReport, isExcluded));
 
             for (const alert of entry.socketReport.alerts) {
-                const colorFn = SOCKET_SEVERITY_ORDER[alert.severity] !== undefined && SOCKET_SEVERITY_ORDER[alert.severity] <= 1 ? red : yellow;
+                const alertColorFn = SOCKET_ALERT_COLORS[alert.severity] ?? dim;
 
-                info(`    ${colorFn(`[${alert.severity.toUpperCase()}]`)} ${alert.type} — ${alert.category}`);
+                info(`    ${alertColorFn(`[${alert.severity.toUpperCase()}]`)} ${alert.type} — ${alert.category}`);
             }
         }
     }

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -1,13 +1,12 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 
 import type { Command } from "@visulima/cerebro";
+import { cyan, dim, magenta, red, yellow } from "@visulima/colorize";
 import { join } from "@visulima/path";
 
 import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../audit-config";
 import type { SecurityVulnerability } from "../catalog";
 import { fetchVulnerabilities } from "../catalog";
-import { cyan, dim, magenta, red, yellow } from "@visulima/colorize";
-
 import { error as errorOutput, info, note, success, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -26,8 +26,6 @@ interface InstalledPackage {
 interface AuditEntry {
     acceptedRisk?: AcceptedRisk;
     name: string;
-    /** True if the package or its advisory IDs are excluded by native PM config. */
-    nativeExcluded: boolean;
     socketReport?: PackageReportData;
     version: string;
     vulnerabilities: SecurityVulnerability[];
@@ -224,9 +222,6 @@ const executeAudit = async (
         const report = socketReports.get(`${pkg.name}@${pkg.version}`);
         const accepted = findAcceptedRisk(pkg.name, pkg.version, acceptedRisks);
 
-        // Check if all vulns are excluded by native PM config
-        const nativeExcluded = vulns.length > 0 && vulns.every((v) => isAdvisoryExcluded(v.id, nativeExclusions));
-
         const hasVulns = vulns.length > 0;
         const hasLowScore = report ? report.score.overall < DEFAULT_LOW_SCORE_THRESHOLD : false;
         const hasAlerts = report ? report.alerts.length > 0 : false;
@@ -235,7 +230,6 @@ const executeAudit = async (
             entries.push({
                 acceptedRisk: accepted,
                 name: pkg.name,
-                nativeExcluded,
                 socketReport: report,
                 version: pkg.version,
                 vulnerabilities: vulns,
@@ -321,7 +315,7 @@ const executeAudit = async (
         info(`\n\u2500\u2500 ${severity} (${String(items.length)}) \u2500\u2500`);
 
         for (const { entry, vuln } of items) {
-            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded || isAdvisoryExcluded(vuln.id, nativeExclusions);
+            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded || isAdvisoryExcluded(vuln.id, nativeExclusions, vuln.aliases);
 
             if (isExcluded) {
                 acknowledgedVulns++;
@@ -351,7 +345,7 @@ const executeAudit = async (
                 continue;
             }
 
-            const isExcluded = Boolean(entry.acceptedRisk) || entry.nativeExcluded;
+            const isExcluded = Boolean(entry.acceptedRisk);
 
             if (isExcluded && !showAccepted) {
                 continue;
@@ -368,7 +362,9 @@ const executeAudit = async (
     }
 
     // Summary
-    const isEntryExcluded = (e: AuditEntry): boolean => Boolean(e.acceptedRisk) || e.nativeExcluded;
+    const isEntryExcluded = (e: AuditEntry): boolean =>
+        Boolean(e.acceptedRisk)
+        || (e.vulnerabilities.length > 0 && e.vulnerabilities.every((v) => isAdvisoryExcluded(v.id, nativeExclusions, v.aliases)));
     const unacknowledgedCount = filtered.filter((e) => !isEntryExcluded(e)).length;
 
     info("");
@@ -416,18 +412,29 @@ const executeAudit = async (
 
     // Sync accepted risks to native PM config
     if (options.sync && acceptedRisks) {
-        const advisoryIds: string[] = [];
+        // Collect CVE/GHSA IDs from ALL accepted entries (not just severity-filtered)
+        const idSet = new Set<string>();
 
-        // Collect CVE/GHSA IDs from accepted risk entries by looking at their vuln data
-        for (const entry of filtered) {
+        for (const entry of entries) {
             if (entry.acceptedRisk) {
                 for (const vuln of entry.vulnerabilities) {
                     if (vuln.id.startsWith("CVE-") || vuln.id.startsWith("GHSA-")) {
-                        advisoryIds.push(vuln.id);
+                        idSet.add(vuln.id);
+                    }
+
+                    // Also include aliases (CVE/GHSA variants)
+                    if (vuln.aliases) {
+                        for (const alias of vuln.aliases) {
+                            if (alias.startsWith("CVE-") || alias.startsWith("GHSA-")) {
+                                idSet.add(alias);
+                            }
+                        }
                     }
                 }
             }
         }
+
+        const advisoryIds = [...idSet];
 
         if (advisoryIds.length > 0) {
             info("");

--- a/packages/tooling/vis/src/commands/audit.ts
+++ b/packages/tooling/vis/src/commands/audit.ts
@@ -7,7 +7,7 @@ import type { NativeAuditExclusions } from "../audit-config";
 import { isAdvisoryExcluded, isPackageExcluded, readNativeAuditExclusions, syncAcceptedRisksToNativeConfig } from "../audit-config";
 import type { SecurityVulnerability } from "../catalog";
 import { fetchVulnerabilities } from "../catalog";
-import { error as errorOutput, info, note, success, warn } from "../output";
+import { error as errorOutput, cyan, dim, info, note, red, success, warn, yellow } from "../output";
 import { detectPm } from "../pm-runner";
 import type { AcceptedRisk, PackageReportData } from "../socket-security";
 import { buildSocketOptions, fetchSocketReports, findAcceptedRisk, scoreLabel } from "../socket-security";
@@ -134,28 +134,26 @@ const severityPassesFilter = (severity: string, filter: SeverityFilter): boolean
 
 // ── Display helpers ─────────────────────────────────────────────────
 
-const SEVERITY_COLORS: Record<string, string> = {
-    CRITICAL: "\u001B[31m",
-    HIGH: "\u001B[35m",
-    LOW: "\u001B[36m",
-    MODERATE: "\u001B[33m",
-    UNKNOWN: "\u001B[90m",
+const SEVERITY_COLOR_FN: Record<string, (s: string) => string> = {
+    CRITICAL: red,
+    HIGH: (s: string) => `\u001B[35m${s}\u001B[0m`, // magenta (not in output.ts)
+    LOW: cyan,
+    MODERATE: yellow,
+    UNKNOWN: dim,
 };
 
-const RESET = "\u001B[0m";
-
 const formatVulnLine = (name: string, version: string, vuln: SecurityVulnerability, isAccepted: boolean): string => {
-    const color = SEVERITY_COLORS[vuln.severity] ?? SEVERITY_COLORS.UNKNOWN;
-    const badge = isAccepted ? " \u001B[90m[acknowledged]\u001B[0m" : "";
+    const colorFn = SEVERITY_COLOR_FN[vuln.severity] ?? dim;
+    const badge = isAccepted ? ` ${dim("[acknowledged]")}` : "";
     const fixed = vuln.fixedVersions.length > 0 ? ` (fix: ${vuln.fixedVersions.join(", ")})` : "";
 
-    return `  ${color ?? ""}${vuln.severity}${RESET} ${vuln.id} — ${name}@${version}${badge}\n    ${vuln.summary}${fixed}`;
+    return `  ${colorFn(vuln.severity)} ${vuln.id} — ${name}@${version}${badge}\n    ${vuln.summary}${fixed}`;
 };
 
 const formatSocketLine = (report: PackageReportData, isAccepted: boolean): string => {
     const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
     const pct = `${String(Math.round(report.score.overall * 100))}%`;
-    const badge = isAccepted ? " \u001B[90m[acknowledged]\u001B[0m" : "";
+    const badge = isAccepted ? ` ${dim("[acknowledged]")}` : "";
     const alerts = report.alerts.length > 0
         ? `, ${String(report.alerts.length)} alert${report.alerts.length === 1 ? "" : "s"}`
         : "";
@@ -359,9 +357,9 @@ const executeAudit = async (
             info(formatSocketLine(entry.socketReport, isExcluded));
 
             for (const alert of entry.socketReport.alerts) {
-                const color = SOCKET_SEVERITY_ORDER[alert.severity] !== undefined && SOCKET_SEVERITY_ORDER[alert.severity] <= 1 ? "\u001B[31m" : "\u001B[33m";
+                const colorFn = SOCKET_SEVERITY_ORDER[alert.severity] !== undefined && SOCKET_SEVERITY_ORDER[alert.severity] <= 1 ? red : yellow;
 
-                info(`    ${color}[${alert.severity.toUpperCase()}]${RESET} ${alert.type} — ${alert.category}`);
+                info(`    ${colorFn(`[${alert.severity.toUpperCase()}]`)} ${alert.type} — ${alert.category}`);
             }
         }
     }

--- a/packages/tooling/vis/src/commands/check.ts
+++ b/packages/tooling/vis/src/commands/check.ts
@@ -136,6 +136,7 @@ const check: Command = {
             onProgress,
             workspaceRoot,
             socketOptions ? { ...socketOptions, enabled: true } : undefined,
+            visConfig?.security?.socket?.acceptedRisks,
         );
 
         if (progressInstance) {
@@ -187,8 +188,9 @@ const check: Command = {
 
             for (const entry of outdated) {
                 const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
-                const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
-                const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
+                const isAck = Boolean(entry.acceptedRisk);
+                const icon = hasSecurityIssue ? (isAck ? "\u2713" : "\u26A0") : "\u2713";
+                const iconColor = isAck ? "gray" : entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
                 const socketOverall = entry.socketReport?.score.overall;
                 const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
                 const socketColor = socketOverall !== undefined

--- a/packages/tooling/vis/src/commands/check.ts
+++ b/packages/tooling/vis/src/commands/check.ts
@@ -10,6 +10,7 @@ import { checkOutdated, formatOutdatedMinimal, formatOutdatedTable, formatSummar
 import { info, success } from "../output";
 import { detectPm } from "../pm-runner";
 import { previewPnpmSync, printSecurityReport } from "../security";
+import { buildSocketOptions } from "../socket-security";
 import CheckProgressApp from "../tui/components/CheckProgressApp";
 import { UpdateStore } from "../tui/components/update/UpdateStore";
 import VisUpdateApp from "../tui/components/update/VisUpdateApp";
@@ -126,17 +127,16 @@ const check: Command = {
             logger.info(`Checking ${String(totalDeps)} catalog dependencies against npm registry...\n`);
         }
 
-        // Build Socket.dev options from config
-        const socketOptions = visConfig?.security?.socket?.enabled
-            ? {
-                  apiToken: visConfig.security.socket.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-                  cacheTtlMs: visConfig.security.socket.cacheTtlMs,
-                  enabled: true,
-                  timeoutMs: visConfig.security.socket.timeoutMs,
-              }
-            : undefined;
+        const socketOptions = buildSocketOptions(visConfig?.security?.socket);
 
-        const { failed, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot, socketOptions);
+        const { failed, outdated } = await checkOutdated(
+            catalogs,
+            checkOptions,
+            npmrcConfig,
+            onProgress,
+            workspaceRoot,
+            socketOptions ? { ...socketOptions, enabled: true } : undefined,
+        );
 
         if (progressInstance) {
             progressInstance.clear();
@@ -189,9 +189,11 @@ const check: Command = {
                 const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
                 const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
                 const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
-                const scoreSuffix = entry.socketReport
-                    ? ` [${String(Math.round(entry.socketReport.score.overall * 100))}%]`
-                    : "";
+                const socketOverall = entry.socketReport?.score.overall;
+                const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
+                const socketColor = socketOverall !== undefined
+                    ? socketOverall >= 0.6 ? "green" : socketOverall >= 0.4 ? "yellow" : "red"
+                    : undefined;
 
                 process.stdout.write(
                     renderToString(
@@ -202,7 +204,7 @@ const check: Command = {
                             React.createElement(Text, { color: iconColor }, icon),
                             `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                             React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
-                            scoreSuffix ? React.createElement(Text, { color: entry.socketReport!.score.overall >= 0.6 ? "green" : entry.socketReport!.score.overall >= 0.4 ? "yellow" : "red" }, scoreSuffix) : null,
+                            socketColor ? React.createElement(Text, { color: socketColor }, scoreSuffix) : null,
                         ),
                         { columns },
                     ) + "\n",

--- a/packages/tooling/vis/src/commands/check.ts
+++ b/packages/tooling/vis/src/commands/check.ts
@@ -135,7 +135,7 @@ const check: Command = {
             npmrcConfig,
             onProgress,
             workspaceRoot,
-            socketOptions ? { ...socketOptions, enabled: true } : undefined,
+            socketOptions,
             visConfig?.security?.socket?.acceptedRisks,
         );
 

--- a/packages/tooling/vis/src/commands/check.ts
+++ b/packages/tooling/vis/src/commands/check.ts
@@ -10,7 +10,7 @@ import { checkOutdated, formatOutdatedMinimal, formatOutdatedTable, formatSummar
 import { info, success } from "../output";
 import { detectPm } from "../pm-runner";
 import { previewPnpmSync, printSecurityReport } from "../security";
-import { buildSocketOptions } from "../socket-security";
+import { buildSocketOptions, scoreColor } from "../socket-security";
 import CheckProgressApp from "../tui/components/CheckProgressApp";
 import { UpdateStore } from "../tui/components/update/UpdateStore";
 import VisUpdateApp from "../tui/components/update/VisUpdateApp";
@@ -193,9 +193,7 @@ const check: Command = {
                 const iconColor = isAck ? "gray" : entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
                 const socketOverall = entry.socketReport?.score.overall;
                 const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
-                const socketColor = socketOverall !== undefined
-                    ? socketOverall >= 0.6 ? "green" : socketOverall >= 0.4 ? "yellow" : "red"
-                    : undefined;
+                const socketColorName = socketOverall !== undefined ? scoreColor(socketOverall) : undefined;
 
                 process.stdout.write(
                     renderToString(
@@ -206,7 +204,7 @@ const check: Command = {
                             React.createElement(Text, { color: iconColor }, icon),
                             `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                             React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
-                            socketColor ? React.createElement(Text, { color: socketColor }, scoreSuffix) : null,
+                            socketColorName ? React.createElement(Text, { color: socketColorName }, scoreSuffix) : null,
                         ),
                         { columns },
                     ) + "\n",

--- a/packages/tooling/vis/src/commands/check.ts
+++ b/packages/tooling/vis/src/commands/check.ts
@@ -126,7 +126,17 @@ const check: Command = {
             logger.info(`Checking ${String(totalDeps)} catalog dependencies against npm registry...\n`);
         }
 
-        const { failed, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot);
+        // Build Socket.dev options from config
+        const socketOptions = visConfig?.security?.socket?.enabled
+            ? {
+                  apiToken: visConfig.security.socket.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+                  cacheTtlMs: visConfig.security.socket.cacheTtlMs,
+                  enabled: true,
+                  timeoutMs: visConfig.security.socket.timeoutMs,
+              }
+            : undefined;
+
+        const { failed, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot, socketOptions);
 
         if (progressInstance) {
             progressInstance.clear();
@@ -176,8 +186,12 @@ const check: Command = {
             process.stdout.write("\n");
 
             for (const entry of outdated) {
-                const icon = entry.vulnerabilities?.length ? "\u26A0" : "\u2713";
+                const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
+                const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
                 const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
+                const scoreSuffix = entry.socketReport
+                    ? ` [${String(Math.round(entry.socketReport.score.overall * 100))}%]`
+                    : "";
 
                 process.stdout.write(
                     renderToString(
@@ -188,6 +202,7 @@ const check: Command = {
                             React.createElement(Text, { color: iconColor }, icon),
                             `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                             React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
+                            scoreSuffix ? React.createElement(Text, { color: entry.socketReport!.score.overall >= 0.6 ? "green" : entry.socketReport!.score.overall >= 0.4 ? "yellow" : "red" }, scoreSuffix) : null,
                         ),
                         { columns },
                     ) + "\n",

--- a/packages/tooling/vis/src/commands/init.ts
+++ b/packages/tooling/vis/src/commands/init.ts
@@ -50,6 +50,9 @@ export default defineConfig({
             // "@prisma/client": true,
         },
 
+        // Enable Socket.dev for package security scores and supply chain alerts:
+        // socket: { enabled: true },
+
         // Override any default if needed:
         // minimumReleaseAge: 1440,    // relax to 24 hours
         // strictDepBuilds: false,     // warn instead of fail
@@ -103,6 +106,11 @@ const init: Command = {
         info("  \u2713 strictDepBuilds: true (unapproved build scripts = hard error)");
         info("  \u2713 update.security: true (OSV.dev vulnerability checking)");
         info("  \u2713 allowBuilds: {} (run 'vis approve-builds' to add packages)");
+        info("");
+        info("Optional — Socket.dev integration:");
+        info("  \u25CB security.socket.enabled: false (opt-in: package scores, alerts, supply chain data)");
+        info("    Enable in vis.config.ts: security: { socket: { enabled: true } }");
+        info("    Or set VIS_SOCKET_TOKEN env var for a custom API token.");
 
         // Sync to native PM config if requested
         if (options["sync-native"]) {

--- a/packages/tooling/vis/src/commands/update.ts
+++ b/packages/tooling/vis/src/commands/update.ts
@@ -192,6 +192,7 @@ const executeCatalogUpdate = async (
         onProgress,
         workspaceRoot,
         socketOptions ? { ...socketOptions, enabled: true } : undefined,
+        visConfig.security?.socket?.acceptedRisks,
     );
 
     if (progressInstance) {
@@ -276,8 +277,9 @@ const executeCatalogUpdate = async (
 
         for (const entry of outdated) {
             const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
-            const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
-            const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
+            const isAck = Boolean(entry.acceptedRisk);
+            const icon = hasSecurityIssue ? (isAck ? "\u2713" : "\u26A0") : "\u2713";
+            const iconColor = isAck ? "gray" : entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
             const socketOverall = entry.socketReport?.score.overall;
             const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
             const socketColor = socketOverall !== undefined

--- a/packages/tooling/vis/src/commands/update.ts
+++ b/packages/tooling/vis/src/commands/update.ts
@@ -32,6 +32,7 @@ import { resolveUpdateCommand } from "../package-manager";
 import CheckProgressApp from "../tui/components/CheckProgressApp";
 import { UpdateStore } from "../tui/components/update/UpdateStore";
 import VisUpdateApp from "../tui/components/update/VisUpdateApp";
+import { buildSocketOptions } from "../socket-security";
 import type { VisConfig } from "../workspace";
 
 type CatalogPackageManager = "bun" | "npm" | "pnpm" | "yarn";
@@ -182,17 +183,16 @@ const executeCatalogUpdate = async (
         logger.info(`Checking ${String(totalDeps)} catalog dependencies...\n`);
     }
 
-    // Build Socket.dev options from config
-    const socketOptions = visConfig.security?.socket?.enabled
-        ? {
-              apiToken: visConfig.security.socket.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-              cacheTtlMs: visConfig.security.socket.cacheTtlMs,
-              enabled: true,
-              timeoutMs: visConfig.security.socket.timeoutMs,
-          }
-        : undefined;
+    const socketOptions = buildSocketOptions(visConfig.security?.socket);
 
-    const { failed, ignored, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot, socketOptions);
+    const { failed, ignored, outdated } = await checkOutdated(
+        catalogs,
+        checkOptions,
+        npmrcConfig,
+        onProgress,
+        workspaceRoot,
+        socketOptions ? { ...socketOptions, enabled: true } : undefined,
+    );
 
     if (progressInstance) {
         progressInstance.clear();
@@ -278,9 +278,11 @@ const executeCatalogUpdate = async (
             const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
             const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
             const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
-            const scoreSuffix = entry.socketReport
-                ? ` [${String(Math.round(entry.socketReport.score.overall * 100))}%]`
-                : "";
+            const socketOverall = entry.socketReport?.score.overall;
+            const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
+            const socketColor = socketOverall !== undefined
+                ? socketOverall >= 0.6 ? "green" : socketOverall >= 0.4 ? "yellow" : "red"
+                : undefined;
 
             process.stdout.write(
                 renderToString(
@@ -291,7 +293,7 @@ const executeCatalogUpdate = async (
                         React.createElement(Text, { color: iconColor }, icon),
                         `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                         React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
-                        scoreSuffix ? React.createElement(Text, { color: entry.socketReport!.score.overall >= 0.6 ? "green" : entry.socketReport!.score.overall >= 0.4 ? "yellow" : "red" }, scoreSuffix) : null,
+                        socketColor ? React.createElement(Text, { color: socketColor }, scoreSuffix) : null,
                     ),
                     { columns },
                 ) + "\n",

--- a/packages/tooling/vis/src/commands/update.ts
+++ b/packages/tooling/vis/src/commands/update.ts
@@ -191,7 +191,7 @@ const executeCatalogUpdate = async (
         npmrcConfig,
         onProgress,
         workspaceRoot,
-        socketOptions ? { ...socketOptions, enabled: true } : undefined,
+        socketOptions,
         visConfig.security?.socket?.acceptedRisks,
     );
 

--- a/packages/tooling/vis/src/commands/update.ts
+++ b/packages/tooling/vis/src/commands/update.ts
@@ -32,7 +32,7 @@ import { resolveUpdateCommand } from "../package-manager";
 import CheckProgressApp from "../tui/components/CheckProgressApp";
 import { UpdateStore } from "../tui/components/update/UpdateStore";
 import VisUpdateApp from "../tui/components/update/VisUpdateApp";
-import { buildSocketOptions } from "../socket-security";
+import { buildSocketOptions, scoreColor } from "../socket-security";
 import type { VisConfig } from "../workspace";
 
 type CatalogPackageManager = "bun" | "npm" | "pnpm" | "yarn";
@@ -282,9 +282,7 @@ const executeCatalogUpdate = async (
             const iconColor = isAck ? "gray" : entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
             const socketOverall = entry.socketReport?.score.overall;
             const scoreSuffix = socketOverall !== undefined ? ` [${String(Math.round(socketOverall * 100))}%]` : "";
-            const socketColor = socketOverall !== undefined
-                ? socketOverall >= 0.6 ? "green" : socketOverall >= 0.4 ? "yellow" : "red"
-                : undefined;
+            const socketColorName = socketOverall !== undefined ? scoreColor(socketOverall) : undefined;
 
             process.stdout.write(
                 renderToString(
@@ -295,7 +293,7 @@ const executeCatalogUpdate = async (
                         React.createElement(Text, { color: iconColor }, icon),
                         `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                         React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
-                        socketColor ? React.createElement(Text, { color: socketColor }, scoreSuffix) : null,
+                        socketColorName ? React.createElement(Text, { color: socketColorName }, scoreSuffix) : null,
                     ),
                     { columns },
                 ) + "\n",

--- a/packages/tooling/vis/src/commands/update.ts
+++ b/packages/tooling/vis/src/commands/update.ts
@@ -182,7 +182,17 @@ const executeCatalogUpdate = async (
         logger.info(`Checking ${String(totalDeps)} catalog dependencies...\n`);
     }
 
-    const { failed, ignored, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot);
+    // Build Socket.dev options from config
+    const socketOptions = visConfig.security?.socket?.enabled
+        ? {
+              apiToken: visConfig.security.socket.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+              cacheTtlMs: visConfig.security.socket.cacheTtlMs,
+              enabled: true,
+              timeoutMs: visConfig.security.socket.timeoutMs,
+          }
+        : undefined;
+
+    const { failed, ignored, outdated } = await checkOutdated(catalogs, checkOptions, npmrcConfig, onProgress, workspaceRoot, socketOptions);
 
     if (progressInstance) {
         progressInstance.clear();
@@ -265,8 +275,12 @@ const executeCatalogUpdate = async (
         process.stdout.write("\n");
 
         for (const entry of outdated) {
-            const icon = entry.vulnerabilities?.length ? "\u26A0" : "\u2713";
+            const hasSecurityIssue = entry.vulnerabilities?.length || (entry.socketReport && entry.socketReport.alerts.length > 0);
+            const icon = hasSecurityIssue ? "\u26A0" : "\u2713";
             const iconColor = entry.updateType === "major" ? "red" : entry.updateType === "minor" ? "yellow" : "green";
+            const scoreSuffix = entry.socketReport
+                ? ` [${String(Math.round(entry.socketReport.score.overall * 100))}%]`
+                : "";
 
             process.stdout.write(
                 renderToString(
@@ -277,6 +291,7 @@ const executeCatalogUpdate = async (
                         React.createElement(Text, { color: iconColor }, icon),
                         `  ${entry.packageName}  ${entry.currentRange} \u2192 ${entry.newRange}`,
                         React.createElement(Text, { dimColor: true }, `  ${entry.updateType}`),
+                        scoreSuffix ? React.createElement(Text, { color: entry.socketReport!.score.overall >= 0.6 ? "green" : entry.socketReport!.score.overall >= 0.4 ? "yellow" : "red" }, scoreSuffix) : null,
                     ),
                     { columns },
                 ) + "\n",

--- a/packages/tooling/vis/src/plugins/security-enforcement.ts
+++ b/packages/tooling/vis/src/plugins/security-enforcement.ts
@@ -21,6 +21,57 @@ const securityEnforcementPlugin: Plugin = {
         if (enforcement?.postInstallPackages.length && toolbox.workspaceRoot) {
             runApprovedScripts(toolbox.workspaceRoot, enforcement.postInstallPackages);
         }
+
+        // Display Socket.dev security summary after install/update commands
+        const command = process.argv[2] ?? "";
+
+        if (INSTALL_COMMANDS.has(command) && toolbox.visConfig?.security?.socket?.enabled && toolbox.workspaceRoot) {
+            try {
+                const { fetchSocketReports, formatSecurityOverview } = await import("../socket-security");
+                const { info, warn } = await import("../output");
+                const socketConfig = toolbox.visConfig.security.socket;
+
+                // Read lockfile to discover installed packages
+                const packages = await resolveInstalledPackages(toolbox.workspaceRoot);
+
+                if (packages.length > 0) {
+                    const reports = await fetchSocketReports(packages, {
+                        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+                        cacheTtlMs: socketConfig.cacheTtlMs,
+                        timeoutMs: socketConfig.timeoutMs,
+                    });
+
+                    if (reports.size > 0) {
+                        const overview = formatSecurityOverview(reports);
+
+                        if (overview) {
+                            info("");
+                            info(overview);
+
+                            // Warn about critical/high alerts
+                            let criticalHighCount = 0;
+
+                            for (const report of reports.values()) {
+                                for (const alert of report.alerts) {
+                                    if (alert.severity === "critical" || alert.severity === "high") {
+                                        criticalHighCount++;
+                                    }
+                                }
+                            }
+
+                            if (criticalHighCount > 0) {
+                                warn(
+                                    `${String(criticalHighCount)} critical/high severity alert${criticalHighCount === 1 ? "" : "s"} detected. `
+                                    + "Run 'vis check --security' for details.",
+                                );
+                            }
+                        }
+                    }
+                }
+            } catch {
+                // Graceful degradation: don't fail the install if Socket.dev is unreachable
+            }
+        }
     },
     beforeCommand: async (toolbox) => {
         const command = process.argv[2] ?? "";
@@ -45,5 +96,59 @@ const securityEnforcementPlugin: Plugin = {
 };
 
 /* eslint-enable no-param-reassign */
+
+/**
+ * Resolves recently installed/updated packages from the workspace root.
+ * Reads the top-level package.json dependencies to get a representative sample.
+ */
+const resolveInstalledPackages = async (workspaceRoot: string): Promise<{ name: string; version: string }[]> => {
+    const { existsSync, readFileSync } = await import("node:fs");
+    const { join } = await import("@visulima/path");
+
+    const packages: { name: string; version: string }[] = [];
+    const pkgJsonPath = join(workspaceRoot, "package.json");
+
+    if (!existsSync(pkgJsonPath)) {
+        return packages;
+    }
+
+    try {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+            dependencies?: Record<string, string>;
+            devDependencies?: Record<string, string>;
+        };
+
+        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+        for (const [name, range] of Object.entries(allDeps)) {
+            // Try to resolve actual installed version from node_modules
+            const installedPkgPath = join(workspaceRoot, "node_modules", name, "package.json");
+
+            if (existsSync(installedPkgPath)) {
+                try {
+                    const installedPkg = JSON.parse(readFileSync(installedPkgPath, "utf8")) as { version?: string };
+
+                    if (installedPkg.version) {
+                        packages.push({ name, version: installedPkg.version });
+                        continue;
+                    }
+                } catch {
+                    // Fall through to range parsing
+                }
+            }
+
+            // Fall back to parsing version from range
+            const versionMatch = /(\d+\.\d+\.\d+)/.exec(range);
+
+            if (versionMatch) {
+                packages.push({ name, version: versionMatch[1] });
+            }
+        }
+    } catch {
+        // Non-critical
+    }
+
+    return packages;
+};
 
 export default securityEnforcementPlugin;

--- a/packages/tooling/vis/src/plugins/security-enforcement.ts
+++ b/packages/tooling/vis/src/plugins/security-enforcement.ts
@@ -1,10 +1,69 @@
-import type { Plugin } from "@visulima/cerebro";
+import { existsSync, readFileSync } from "node:fs";
 
+import type { Plugin } from "@visulima/cerebro";
+import { join } from "@visulima/path";
+
+import { info, warn } from "../output";
 import { detectPm } from "../pm-runner";
 import { emitSecurityWarnings, enforceScriptSecurity, runApprovedScripts } from "../security";
+import { buildSocketOptions, fetchSocketReports, formatSecurityOverview } from "../socket-security";
 
 const INSTALL_COMMANDS = new Set(["add", "install", "update"]);
 const PM_COMMANDS = new Set(["add", "dedupe", "install", "remove", "update"]);
+
+const VERSION_REGEX = /(\d+\.\d+\.\d+)/;
+
+/**
+ * Resolves installed packages from the workspace root.
+ * Reads the top-level package.json and resolves actual versions from node_modules.
+ */
+const resolveInstalledPackages = (workspaceRoot: string): { name: string; version: string }[] => {
+    const pkgJsonPath = join(workspaceRoot, "package.json");
+
+    if (!existsSync(pkgJsonPath)) {
+        return [];
+    }
+
+    const packages: { name: string; version: string }[] = [];
+
+    try {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+            dependencies?: Record<string, string>;
+            devDependencies?: Record<string, string>;
+        };
+
+        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+        for (const [name, range] of Object.entries(allDeps)) {
+            // Try to resolve actual installed version from node_modules
+            const installedPkgPath = join(workspaceRoot, "node_modules", name, "package.json");
+
+            if (existsSync(installedPkgPath)) {
+                try {
+                    const installedPkg = JSON.parse(readFileSync(installedPkgPath, "utf8")) as { version?: string };
+
+                    if (installedPkg.version) {
+                        packages.push({ name, version: installedPkg.version });
+                        continue;
+                    }
+                } catch {
+                    // Fall through to range parsing
+                }
+            }
+
+            // Fall back to parsing version from range
+            const versionMatch = VERSION_REGEX.exec(range);
+
+            if (versionMatch) {
+                packages.push({ name, version: versionMatch[1] });
+            }
+        }
+    } catch {
+        // Non-critical
+    }
+
+    return packages;
+};
 
 /* eslint-disable no-param-reassign -- cerebro plugin pattern */
 
@@ -25,21 +84,14 @@ const securityEnforcementPlugin: Plugin = {
         // Display Socket.dev security summary after install/update commands
         const command = process.argv[2] ?? "";
 
-        if (INSTALL_COMMANDS.has(command) && toolbox.visConfig?.security?.socket?.enabled && toolbox.workspaceRoot) {
-            try {
-                const { fetchSocketReports, formatSecurityOverview } = await import("../socket-security");
-                const { info, warn } = await import("../output");
-                const socketConfig = toolbox.visConfig.security.socket;
+        const socketOpts = buildSocketOptions(toolbox.visConfig?.security?.socket);
 
-                // Read lockfile to discover installed packages
-                const packages = await resolveInstalledPackages(toolbox.workspaceRoot);
+        if (INSTALL_COMMANDS.has(command) && socketOpts && toolbox.workspaceRoot) {
+            try {
+                const packages = resolveInstalledPackages(toolbox.workspaceRoot);
 
                 if (packages.length > 0) {
-                    const reports = await fetchSocketReports(packages, {
-                        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
-                        cacheTtlMs: socketConfig.cacheTtlMs,
-                        timeoutMs: socketConfig.timeoutMs,
-                    });
+                    const reports = await fetchSocketReports(packages, socketOpts);
 
                     if (reports.size > 0) {
                         const overview = formatSecurityOverview(reports);
@@ -96,59 +148,5 @@ const securityEnforcementPlugin: Plugin = {
 };
 
 /* eslint-enable no-param-reassign */
-
-/**
- * Resolves recently installed/updated packages from the workspace root.
- * Reads the top-level package.json dependencies to get a representative sample.
- */
-const resolveInstalledPackages = async (workspaceRoot: string): Promise<{ name: string; version: string }[]> => {
-    const { existsSync, readFileSync } = await import("node:fs");
-    const { join } = await import("@visulima/path");
-
-    const packages: { name: string; version: string }[] = [];
-    const pkgJsonPath = join(workspaceRoot, "package.json");
-
-    if (!existsSync(pkgJsonPath)) {
-        return packages;
-    }
-
-    try {
-        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
-            dependencies?: Record<string, string>;
-            devDependencies?: Record<string, string>;
-        };
-
-        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-
-        for (const [name, range] of Object.entries(allDeps)) {
-            // Try to resolve actual installed version from node_modules
-            const installedPkgPath = join(workspaceRoot, "node_modules", name, "package.json");
-
-            if (existsSync(installedPkgPath)) {
-                try {
-                    const installedPkg = JSON.parse(readFileSync(installedPkgPath, "utf8")) as { version?: string };
-
-                    if (installedPkg.version) {
-                        packages.push({ name, version: installedPkg.version });
-                        continue;
-                    }
-                } catch {
-                    // Fall through to range parsing
-                }
-            }
-
-            // Fall back to parsing version from range
-            const versionMatch = /(\d+\.\d+\.\d+)/.exec(range);
-
-            if (versionMatch) {
-                packages.push({ name, version: versionMatch[1] });
-            }
-        }
-    } catch {
-        // Non-critical
-    }
-
-    return packages;
-};
 
 export default securityEnforcementPlugin;

--- a/packages/tooling/vis/src/plugins/security-enforcement.ts
+++ b/packages/tooling/vis/src/plugins/security-enforcement.ts
@@ -73,9 +73,7 @@ const securityEnforcementPlugin: Plugin = {
             return;
         }
 
-        const enforcement = (toolbox as unknown as Record<string, unknown>).scriptEnforcement as
-            | ReturnType<typeof enforceScriptSecurity>
-            | undefined;
+        const enforcement = (toolbox as unknown as Record<string, unknown>).scriptEnforcement as ReturnType<typeof enforceScriptSecurity> | undefined;
 
         if (enforcement?.postInstallPackages.length && toolbox.workspaceRoot) {
             runApprovedScripts(toolbox.workspaceRoot, enforcement.postInstallPackages);
@@ -113,8 +111,8 @@ const securityEnforcementPlugin: Plugin = {
 
                             if (criticalHighCount > 0) {
                                 warn(
-                                    `${String(criticalHighCount)} critical/high severity alert${criticalHighCount === 1 ? "" : "s"} detected. `
-                                    + "Run 'vis check --security' for details.",
+                                    `${String(criticalHighCount)} critical/high severity alert${criticalHighCount === 1 ? "" : "s"} detected. ` +
+                                        "Run 'vis check --security' for details.",
                                 );
                             }
                         }

--- a/packages/tooling/vis/src/security.ts
+++ b/packages/tooling/vis/src/security.ts
@@ -124,6 +124,12 @@ const printSecurityReport = (config: VisConfig, packageManager: string): void =>
         info(`  strictDepBuilds:        ${security.strictDepBuilds ?? false}`);
         info(`  allowBuilds:            ${security.allowBuilds ? `${Object.keys(security.allowBuilds).length} entries` : "not configured"}`);
         info("");
+        info("Socket.dev integration:");
+        info(`  socket.enabled:         ${security.socket?.enabled ?? false}`);
+        info(`  socket.apiToken:        ${security.socket?.apiToken || process.env.VIS_SOCKET_TOKEN ? "configured" : "using public token"}`);
+        info(`  socket.cacheTtlMs:      ${security.socket?.cacheTtlMs ?? "default (1 hour)"}`);
+        info(`  socket.timeoutMs:       ${security.socket?.timeoutMs ?? "default (15s)"}`);
+        info("");
     }
 
     if (result.errors.length === 0 && result.warnings.length === 0) {

--- a/packages/tooling/vis/src/security.ts
+++ b/packages/tooling/vis/src/security.ts
@@ -81,6 +81,22 @@ const checkSecurityConfig = (config: VisConfig, packageManager: string): Securit
         );
     }
 
+    // Warn about stale accepted risks (>90 days old)
+    if (security.socket?.acceptedRisks) {
+        const staleThresholdMs = 90 * 24 * 60 * 60 * 1000;
+        const now = Date.now();
+
+        for (const [pkg, risk] of Object.entries(security.socket.acceptedRisks)) {
+            const acceptedTime = new Date(risk.acceptedAt).getTime();
+
+            if (now - acceptedTime > staleThresholdMs) {
+                result.warnings.push(
+                    `Accepted risk for "${pkg}" is over 90 days old (accepted ${risk.acceptedAt}). Consider re-evaluating with 'vis audit'.`,
+                );
+            }
+        }
+    }
+
     return result;
 };
 
@@ -130,6 +146,19 @@ const printSecurityReport = (config: VisConfig, packageManager: string): void =>
         info(`  socket.minimumScore:    ${security.socket?.minimumScore ?? "default (0.4)"}`);
         info(`  socket.cacheTtlMs:      ${security.socket?.cacheTtlMs ?? "default (1 hour)"}`);
         info(`  socket.timeoutMs:       ${security.socket?.timeoutMs ?? "default (15s)"}`);
+
+        if (security.socket?.acceptedRisks) {
+            const risks = Object.entries(security.socket.acceptedRisks);
+
+            info(`  socket.acceptedRisks:   ${String(risks.length)} entr${risks.length === 1 ? "y" : "ies"}`);
+
+            for (const [pkg, risk] of risks) {
+                info(`    ${pkg}: ${risk.reason} (accepted ${risk.acceptedAt.slice(0, 10)})`);
+            }
+        } else {
+            info("  socket.acceptedRisks:   none");
+        }
+
         info("");
     }
 

--- a/packages/tooling/vis/src/security.ts
+++ b/packages/tooling/vis/src/security.ts
@@ -127,6 +127,7 @@ const printSecurityReport = (config: VisConfig, packageManager: string): void =>
         info("Socket.dev integration:");
         info(`  socket.enabled:         ${security.socket?.enabled ?? false}`);
         info(`  socket.apiToken:        ${security.socket?.apiToken || process.env.VIS_SOCKET_TOKEN ? "configured" : "using public token"}`);
+        info(`  socket.minimumScore:    ${security.socket?.minimumScore ?? "default (0.4)"}`);
         info(`  socket.cacheTtlMs:      ${security.socket?.cacheTtlMs ?? "default (1 hour)"}`);
         info(`  socket.timeoutMs:       ${security.socket?.timeoutMs ?? "default (15s)"}`);
         info("");

--- a/packages/tooling/vis/src/security.ts
+++ b/packages/tooling/vis/src/security.ts
@@ -76,8 +76,8 @@ const checkSecurityConfig = (config: VisConfig, packageManager: string): Securit
     // Error: strictDepBuilds is on but no allowBuilds
     if (security.strictDepBuilds && (!security.allowBuilds || Object.keys(security.allowBuilds).length === 0)) {
         result.errors.push(
-            "security.strictDepBuilds is enabled but security.allowBuilds is empty. All dependencies with build scripts will be blocked. "
-            + "Run 'vis approve-builds' to review and add packages.",
+            "security.strictDepBuilds is enabled but security.allowBuilds is empty. All dependencies with build scripts will be blocked. " +
+                "Run 'vis approve-builds' to review and add packages.",
         );
     }
 
@@ -90,9 +90,7 @@ const checkSecurityConfig = (config: VisConfig, packageManager: string): Securit
             const acceptedTime = new Date(risk.acceptedAt).getTime();
 
             if (now - acceptedTime > staleThresholdMs) {
-                result.warnings.push(
-                    `Accepted risk for "${pkg}" is over 90 days old (accepted ${risk.acceptedAt}). Consider re-evaluating with 'vis audit'.`,
-                );
+                result.warnings.push(`Accepted risk for "${pkg}" is over 90 days old (accepted ${risk.acceptedAt}). Consider re-evaluating with 'vis audit'.`);
             }
         }
     }
@@ -117,8 +115,8 @@ const emitSecurityWarnings = (config: VisConfig, packageManager: string): void =
 
     if (result.warnings.length > 0) {
         warn(
-            `${result.warnings.length} security recommendation${result.warnings.length === 1 ? "" : "s"} found. `
-            + "Run 'vis check --security-config' for details.",
+            `${result.warnings.length} security recommendation${result.warnings.length === 1 ? "" : "s"} found. ` +
+                "Run 'vis check --security-config' for details.",
         );
     }
 };
@@ -279,14 +277,11 @@ const scanUnapprovedBuildScripts = (cwd: string, allowBuilds: Record<string, boo
                 }
 
                 const isApproved = Object.entries(allowBuilds).some(([pattern, allowed]) => {
-                    if (!allowed)
-                        return false;
+                    if (!allowed) return false;
 
-                    if (pattern === pkgName)
-                        return true;
+                    if (pattern === pkgName) return true;
 
-                    if (pattern.endsWith("*"))
-                        return pkgName.startsWith(pattern.slice(0, -1));
+                    if (pattern.endsWith("*")) return pkgName.startsWith(pattern.slice(0, -1));
 
                     return false;
                 });
@@ -370,8 +365,7 @@ const enforceScriptSecurity = (pm: PackageManagerName, workspaceRoot: string, co
 
             if (hasAllowList) {
                 for (const [pattern, allowed] of Object.entries(allowBuilds)) {
-                    if (allowed)
-                        result.postInstallPackages.push(pattern);
+                    if (allowed) result.postInstallPackages.push(pattern);
                 }
             }
 
@@ -406,8 +400,7 @@ const enforceScriptSecurity = (pm: PackageManagerName, workspaceRoot: string, co
                     result.extraArgs.push("--ignore-scripts");
 
                     for (const [pattern, allowed] of Object.entries(allowBuilds)) {
-                        if (allowed)
-                            result.postInstallPackages.push(pattern);
+                        if (allowed) result.postInstallPackages.push(pattern);
                     }
                 }
             }
@@ -551,13 +544,11 @@ const expandPatterns = (workspaceRoot: string, patterns: string[]): string[] => 
  * Runs postinstall scripts for approved packages after --ignore-scripts install.
  */
 const runApprovedScripts = (workspaceRoot: string, patterns: string[]): void => {
-    if (patterns.length === 0)
-        return;
+    if (patterns.length === 0) return;
 
     const packages = expandPatterns(workspaceRoot, patterns);
 
-    if (packages.length === 0)
-        return;
+    if (packages.length === 0) return;
 
     const nodeModulesPath = join(workspaceRoot, "node_modules");
     let hadFailure = false;
@@ -578,8 +569,7 @@ const runApprovedScripts = (workspaceRoot: string, patterns: string[]): void => 
         const pkgDir = join(nodeModulesPath, pkg);
         const pkgJsonPath = join(pkgDir, "package.json");
 
-        if (!existsSync(pkgJsonPath))
-            continue;
+        if (!existsSync(pkgJsonPath)) continue;
 
         try {
             const scripts = JSON.parse(readFileSync(pkgJsonPath, "utf8")).scripts ?? {};

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -300,6 +300,8 @@ const parseNdjsonResponse = (
         lookupMap.set(`${pkg.name}@${pkg.version}`, pkg);
     }
 
+    // Socket.dev returns NDJSON where each line is a JSON object ending with "}\n".
+    // Split on "}\n" and re-append the brace for parsing. Malformed lines are skipped.
     const lines = text.split("}\n");
 
     for (const line of lines) {

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -14,6 +14,8 @@ import { homedir } from "node:os";
 
 import { join } from "@visulima/path";
 
+import { matchesGlobList } from "./audit-config";
+
 // ── Constants ───────────────────────────────────────────────────────
 
 const SOCKET_API_V0_URL = "https://api.socket.dev/v0/purl?alerts=true";
@@ -134,10 +136,6 @@ const getCachedReport = (name: string, version: string): PackageReportData | und
     const key = buildCacheKey(name, version);
     const filePath = join(getCacheDirectory(), `${key}.json`);
 
-    if (!existsSync(filePath)) {
-        return undefined;
-    }
-
     try {
         const raw = readFileSync(filePath, "utf8");
         const entry = JSON.parse(raw) as CacheEntry;
@@ -150,7 +148,7 @@ const getCachedReport = (name: string, version: string): PackageReportData | und
 
         return entry.report;
     } catch {
-        rmSync(filePath, { force: true });
+        // File doesn't exist, is corrupt, or was removed — ignore
 
         return undefined;
     }
@@ -233,9 +231,7 @@ const fetchSocketReports = async (
     // Pre-compute auth header and ensure cache dir exists before batch loop
     const authHeader = `Basic ${Buffer.from(`${apiToken}:`).toString("base64")}`;
 
-    if (uncached.length > 0) {
-        ensureCacheDirectory();
-    }
+    ensureCacheDirectory();
 
     // Batch uncached packages into groups of MAX_BATCH_SIZE
     const batches: { name: string; version: string }[][] = [];
@@ -611,22 +607,26 @@ const findAcceptedRisk = (
         return undefined;
     }
 
-    // Check exact name@version first
+    // Check exact name@version, then unversioned name
     const versionedKey = `${packageName}@${version}`;
 
     if (acceptedRisks[versionedKey]) {
         return acceptedRisks[versionedKey];
     }
 
-    // Check unversioned name
     if (acceptedRisks[packageName]) {
         return acceptedRisks[packageName];
     }
 
-    // Check glob patterns (e.g., "@myorg/*")
-    for (const [pattern, risk] of Object.entries(acceptedRisks)) {
-        if (pattern.endsWith("*") && packageName.startsWith(pattern.slice(0, -1))) {
-            return risk;
+    // Check glob patterns (e.g., "@myorg/*") via shared matcher
+    const patterns = Object.keys(acceptedRisks);
+
+    if (matchesGlobList(packageName, patterns)) {
+        // Find the matching pattern to return its risk
+        for (const [pattern, risk] of Object.entries(acceptedRisks)) {
+            if (pattern.endsWith("*") && matchesGlobList(packageName, [pattern])) {
+                return risk;
+            }
         }
     }
 

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -108,15 +108,15 @@ interface CacheEntry {
 // ── Type guards ─────────────────────────────────────────────────────
 
 const isPackageReportData = (o: unknown): o is PackageReportData =>
-    typeof o === "object"
-    && o != null
-    && "id" in o
-    && "type" in o
-    && "name" in o
-    && "version" in o
-    && "alerts" in o
-    && "score" in o
-    && (o as Record<string, unknown>).type === "npm";
+    typeof o === "object" &&
+    o != null &&
+    "id" in o &&
+    "type" in o &&
+    "name" in o &&
+    "version" in o &&
+    "alerts" in o &&
+    "score" in o &&
+    (o as Record<string, unknown>).type === "npm";
 
 // ── Cache helpers (file-based, matching ai-cache.ts pattern) ────────
 
@@ -168,17 +168,9 @@ const setCachedReport = (name: string, version: string, report: PackageReportDat
 // ── Score calculation ───────────────────────────────────────────────
 
 const calculateOverallScore = (score: Omit<PackageScore, "overall">): number => {
-    const components = [
-        score.license,
-        score.maintenance,
-        score.quality,
-        score.supplyChain,
-        score.vulnerability,
-    ];
+    const components = [score.license, score.maintenance, score.quality, score.supplyChain, score.vulnerability];
 
-    return Number(
-        (components.reduce((sum, s) => sum + s, 0) / components.length).toFixed(2),
-    );
+    return Number((components.reduce((sum, s) => sum + s, 0) / components.length).toFixed(2));
 };
 
 // ── API client ──────────────────────────────────────────────────────
@@ -195,11 +187,7 @@ const fetchSocketReports = async (
     packages: { name: string; version: string }[],
     options: SocketSecurityOptions = {},
 ): Promise<Map<string, PackageReportData>> => {
-    const {
-        apiToken,
-        cacheTtlMs = DEFAULT_TTL_MS,
-        timeoutMs = 15_000,
-    } = options;
+    const { apiToken, cacheTtlMs = DEFAULT_TTL_MS, timeoutMs = 15_000 } = options;
 
     const results = new Map<string, PackageReportData>();
 
@@ -255,7 +243,7 @@ const fetchSocketReports = async (
             const response = await fetch(SOCKET_API_V0_URL, {
                 body: JSON.stringify({ components }),
                 headers: {
-                    "Authorization": authHeader,
+                    Authorization: authHeader,
                     "Content-Type": "application/json",
                     "User-Agent": "@visulima/vis",
                 },
@@ -283,12 +271,7 @@ const fetchSocketReports = async (
 /**
  * Parses the NDJSON response from Socket.dev API and populates the results map.
  */
-const parseNdjsonResponse = (
-    text: string,
-    batch: { name: string; version: string }[],
-    results: Map<string, PackageReportData>,
-    cacheTtlMs: number,
-): void => {
+const parseNdjsonResponse = (text: string, batch: { name: string; version: string }[], results: Map<string, PackageReportData>, cacheTtlMs: number): void => {
     // Build lookup map for matching responses back to requests
     const lookupMap = new Map<string, { name: string; version: string }>();
 
@@ -415,9 +398,7 @@ const formatReportSummary = (report: PackageReportData): string => {
     const name = getFullPackageName(report);
     const score = `score: ${String(Math.round(report.score.overall * 100))}%`;
     const alertCount = report.alerts.length;
-    const alertSummary = alertCount > 0
-        ? `${String(alertCount)} alert${alertCount === 1 ? "" : "s"}`
-        : "no alerts";
+    const alertSummary = alertCount > 0 ? `${String(alertCount)} alert${alertCount === 1 ? "" : "s"}` : "no alerts";
 
     return `${name}@${report.version} (${score}, ${alertSummary})`;
 };
@@ -598,11 +579,7 @@ interface AcceptedRisk {
  * Matches by exact name@version, unversioned name, or trailing glob patterns.
  * Returns the matching AcceptedRisk if found, undefined otherwise.
  */
-const findAcceptedRisk = (
-    packageName: string,
-    version: string,
-    acceptedRisks: Record<string, AcceptedRisk> | undefined,
-): AcceptedRisk | undefined => {
+const findAcceptedRisk = (packageName: string, version: string, acceptedRisks: Record<string, AcceptedRisk> | undefined): AcceptedRisk | undefined => {
     if (!acceptedRisks) {
         return undefined;
     }
@@ -637,12 +614,7 @@ const findAcceptedRisk = (
  * Formats a config snippet for the user to paste into vis.config.ts
  * to persist an accepted risk decision.
  */
-const formatAcceptedRiskSnippet = (
-    packageName: string,
-    version: string,
-    score: number,
-    reason: string,
-): string => {
+const formatAcceptedRiskSnippet = (packageName: string, version: string, score: number, reason: string): string => {
     const key = `"${packageName}@${version}"`;
     const lines = [
         `    // Add to security.socket.acceptedRisks in vis.config.ts:`,
@@ -656,14 +628,7 @@ const formatAcceptedRiskSnippet = (
     return lines.join("\n");
 };
 
-export type {
-    AcceptedRisk,
-    PackageAlert,
-    PackageAlertProps,
-    PackageReportData,
-    PackageScore,
-    SocketSecurityOptions,
-};
+export type { AcceptedRisk, PackageAlert, PackageAlertProps, PackageReportData, PackageScore, SocketSecurityOptions };
 
 export {
     alertSeverityColor,

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -20,7 +20,7 @@ const SOCKET_API_V0_URL = "https://api.socket.dev/v0/purl?alerts=true";
 const SOCKET_PUBLIC_API_TOKEN = "sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMqiwKo_api";
 
 const getCacheDirectory = (): string => join(homedir(), ".vis", "cache", "socket-security");
-const DEFAULT_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
 const MAX_BATCH_SIZE = 100;
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -75,7 +75,7 @@ interface PackageReportData {
 interface SocketSecurityOptions {
     /** Custom API token. Falls back to the public token. */
     apiToken?: string;
-    /** Cache TTL in milliseconds. Defaults to 3 hours. */
+    /** Cache TTL in milliseconds. Defaults to 1 hour. */
     cacheTtlMs?: number;
     /** Request timeout in milliseconds. Defaults to 15 seconds. */
     timeoutMs?: number;

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -17,7 +17,6 @@ import { join } from "@visulima/path";
 // ── Constants ───────────────────────────────────────────────────────
 
 const SOCKET_API_V0_URL = "https://api.socket.dev/v0/purl?alerts=true";
-const SOCKET_PUBLIC_API_TOKEN = "sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMqiwKo_api";
 
 const getCacheDirectory = (): string => join(homedir(), ".vis", "cache", "socket-security");
 const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -74,10 +73,12 @@ interface PackageReportData {
 
 /** Configuration options for the Socket.dev security client. */
 interface SocketSecurityOptions {
-    /** Custom API token. Falls back to the public token. */
+    /** Custom API token. Required — set via VIS_SOCKET_TOKEN env var or config. */
     apiToken?: string;
     /** Cache TTL in milliseconds. Defaults to 1 hour. */
     cacheTtlMs?: number;
+    /** Minimum overall score (0–1) below which packages are flagged. Defaults to 0.4. */
+    minimumScore?: number;
     /** Request timeout in milliseconds. Defaults to 15 seconds. */
     timeoutMs?: number;
 }
@@ -126,8 +127,7 @@ const ensureCacheDirectory = (): void => {
 };
 
 const buildCacheKey = (name: string, version: string): string => {
-    // Simple key: scope and name with version, sanitized for filesystem
-    return `${name.replaceAll("/", "__").replace("@", "")}@${version}`;
+    return `${encodeURIComponent(name)}@${encodeURIComponent(version)}`;
 };
 
 const getCachedReport = (name: string, version: string): PackageReportData | undefined => {
@@ -198,7 +198,7 @@ const fetchSocketReports = async (
     options: SocketSecurityOptions = {},
 ): Promise<Map<string, PackageReportData>> => {
     const {
-        apiToken = SOCKET_PUBLIC_API_TOKEN,
+        apiToken,
         cacheTtlMs = DEFAULT_TTL_MS,
         timeoutMs = 15_000,
     } = options;
@@ -206,6 +206,10 @@ const fetchSocketReports = async (
     const results = new Map<string, PackageReportData>();
 
     if (packages.length === 0) {
+        return results;
+    }
+
+    if (!apiToken) {
         return results;
     }
 
@@ -227,7 +231,7 @@ const fetchSocketReports = async (
     }
 
     // Pre-compute auth header and ensure cache dir exists before batch loop
-    const authHeader = `Basic ${Buffer.from(`${apiToken}:`).toString("base64url")}`;
+    const authHeader = `Basic ${Buffer.from(`${apiToken}:`).toString("base64")}`;
 
     if (uncached.length > 0) {
         ensureCacheDirectory();
@@ -552,21 +556,29 @@ interface SocketConfigLike {
     apiToken?: string;
     cacheTtlMs?: number;
     enabled?: boolean;
+    minimumScore?: number;
     timeoutMs?: number;
 }
 
 /**
  * Builds SocketSecurityOptions from the VisConfig socket config section.
- * Returns undefined if Socket.dev is not enabled.
+ * Returns undefined if Socket.dev is not enabled or no API token is available.
  */
 const buildSocketOptions = (socketConfig: SocketConfigLike | undefined): SocketSecurityOptions | undefined => {
     if (!socketConfig?.enabled) {
         return undefined;
     }
 
+    const apiToken = socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN;
+
+    if (!apiToken) {
+        return undefined;
+    }
+
     return {
-        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+        apiToken,
         cacheTtlMs: socketConfig.cacheTtlMs,
+        minimumScore: socketConfig.minimumScore,
         timeoutMs: socketConfig.timeoutMs,
     };
 };
@@ -629,7 +641,7 @@ const formatAcceptedRiskSnippet = (
     score: number,
     reason: string,
 ): string => {
-    const key = `"${packageName}"`;
+    const key = `"${packageName}@${version}"`;
     const lines = [
         `    // Add to security.socket.acceptedRisks in vis.config.ts:`,
         `    ${key}: {`,

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -21,6 +21,7 @@ const SOCKET_PUBLIC_API_TOKEN = "sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMq
 
 const getCacheDirectory = (): string => join(homedir(), ".vis", "cache", "socket-security");
 const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_LOW_SCORE_THRESHOLD = 0.4;
 const MAX_BATCH_SIZE = 100;
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -344,6 +345,12 @@ const parseNdjsonResponse = (
     }
 };
 
+// ── Name helpers ────────────────────────────────────────────────────
+
+/** Returns the full package name including namespace scope if present. */
+const getFullPackageName = (report: Pick<PackageReportData, "name" | "namespace">): string =>
+    report.namespace ? `${report.namespace}/${report.name}` : report.name;
+
 // ── Display helpers ─────────────────────────────────────────────────
 
 /** Maps a 0–1 score to a human-readable label. */
@@ -403,7 +410,7 @@ const alertSeverityColor = (severity: PackageAlert["severity"]): "cyan" | "magen
 
 /** Formats a PackageReportData into a compact one-line summary string. */
 const formatReportSummary = (report: PackageReportData): string => {
-    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const name = getFullPackageName(report);
     const score = `score: ${String(Math.round(report.score.overall * 100))}%`;
     const alertCount = report.alerts.length;
     const alertSummary = alertCount > 0
@@ -415,7 +422,7 @@ const formatReportSummary = (report: PackageReportData): string => {
 
 /** Formats a detailed multi-line report for a single package. */
 const formatReportDetailed = (report: PackageReportData): string => {
-    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const name = getFullPackageName(report);
     const lines: string[] = [];
 
     lines.push(`${name}@${report.version}`);
@@ -482,7 +489,7 @@ const formatSecurityOverview = (reports: Map<string, PackageReportData>): string
             }
         }
 
-        if (report.score.overall < 0.4) {
+        if (report.score.overall < DEFAULT_LOW_SCORE_THRESHOLD) {
             lowScorePackages++;
         }
     }
@@ -649,9 +656,11 @@ export {
     buildSocketOptions,
     calculateOverallScore,
     clearSocketCache,
+    DEFAULT_LOW_SCORE_THRESHOLD,
     fetchSocketReports,
     findAcceptedRisk,
     formatAcceptedRiskSnippet,
+    getFullPackageName,
     formatReportDetailed,
     formatReportSummary,
     formatSecurityOverview,

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -14,8 +14,6 @@ import { homedir } from "node:os";
 
 import { join } from "@visulima/path";
 
-import { matchesGlobList } from "./audit-config";
-
 // ── Constants ───────────────────────────────────────────────────────
 
 const SOCKET_API_V0_URL = "https://api.socket.dev/v0/purl?alerts=true";
@@ -595,15 +593,10 @@ const findAcceptedRisk = (packageName: string, version: string, acceptedRisks: R
         return acceptedRisks[packageName];
     }
 
-    // Check glob patterns (e.g., "@myorg/*") via shared matcher
-    const patterns = Object.keys(acceptedRisks);
-
-    if (matchesGlobList(packageName, patterns)) {
-        // Find the matching pattern to return its risk
-        for (const [pattern, risk] of Object.entries(acceptedRisks)) {
-            if (pattern.endsWith("*") && matchesGlobList(packageName, [pattern])) {
-                return risk;
-            }
+    // Check glob patterns (e.g., "@myorg/*")
+    for (const [pattern, risk] of Object.entries(acceptedRisks)) {
+        if (pattern.endsWith("*") && packageName.startsWith(pattern.slice(0, -1))) {
+            return risk;
         }
     }
 
@@ -631,7 +624,6 @@ const formatAcceptedRiskSnippet = (packageName: string, version: string, score: 
 export type { AcceptedRisk, PackageAlert, PackageAlertProps, PackageReportData, PackageScore, SocketSecurityOptions };
 
 export {
-    alertSeverityColor,
     buildSocketOptions,
     calculateOverallScore,
     clearSocketCache,

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -3,7 +3,7 @@
  *
  * Ported from @vltpkg/security-archive and adapted to use the Socket.dev
  * public API for fetching package security scores, alerts, and report data.
- * Uses a file-based cache (following the ai-cache.ts pattern) with a 3-hour TTL.
+ * Uses a file-based cache (following the ai-cache.ts pattern) with a 1-hour TTL.
  *
  * @see https://socket.dev
  * @see https://github.com/vltpkg/vltpkg/tree/main/src/security-archive
@@ -535,6 +535,30 @@ const clearSocketCache = (): number => {
     return files.length;
 };
 
+/** Socket.dev config shape as it appears in VisConfig.security.socket. */
+interface SocketConfigLike {
+    apiToken?: string;
+    cacheTtlMs?: number;
+    enabled?: boolean;
+    timeoutMs?: number;
+}
+
+/**
+ * Builds SocketSecurityOptions from the VisConfig socket config section.
+ * Returns undefined if Socket.dev is not enabled.
+ */
+const buildSocketOptions = (socketConfig: SocketConfigLike | undefined): SocketSecurityOptions | undefined => {
+    if (!socketConfig?.enabled) {
+        return undefined;
+    }
+
+    return {
+        apiToken: socketConfig.apiToken ?? process.env.VIS_SOCKET_TOKEN,
+        cacheTtlMs: socketConfig.cacheTtlMs,
+        timeoutMs: socketConfig.timeoutMs,
+    };
+};
+
 export type {
     PackageAlert,
     PackageAlertProps,
@@ -545,6 +569,7 @@ export type {
 
 export {
     alertSeverityColor,
+    buildSocketOptions,
     calculateOverallScore,
     clearSocketCache,
     fetchSocketReports,

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -156,8 +156,6 @@ const getCachedReport = (name: string, version: string): PackageReportData | und
 };
 
 const setCachedReport = (name: string, version: string, report: PackageReportData, ttlMs: number): void => {
-    ensureCacheDirectory();
-
     const key = buildCacheKey(name, version);
     const entry: CacheEntry = {
         createdAt: Date.now(),
@@ -227,6 +225,13 @@ const fetchSocketReports = async (
         return results;
     }
 
+    // Pre-compute auth header and ensure cache dir exists before batch loop
+    const authHeader = `Basic ${Buffer.from(`${apiToken}:`).toString("base64url")}`;
+
+    if (uncached.length > 0) {
+        ensureCacheDirectory();
+    }
+
     // Batch uncached packages into groups of MAX_BATCH_SIZE
     const batches: { name: string; version: string }[][] = [];
 
@@ -249,7 +254,7 @@ const fetchSocketReports = async (
             const response = await fetch(SOCKET_API_V0_URL, {
                 body: JSON.stringify({ components }),
                 headers: {
-                    "Authorization": `Basic ${Buffer.from(`${apiToken}:`).toString("base64url")}`,
+                    "Authorization": authHeader,
                     "Content-Type": "application/json",
                     "User-Agent": "@visulima/vis",
                 },

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -1,0 +1,557 @@
+/**
+ * Socket.dev security helpers for package security intelligence.
+ *
+ * Ported from @vltpkg/security-archive and adapted to use the Socket.dev
+ * public API for fetching package security scores, alerts, and report data.
+ * Uses a file-based cache (following the ai-cache.ts pattern) with a 3-hour TTL.
+ *
+ * @see https://socket.dev
+ * @see https://github.com/vltpkg/vltpkg/tree/main/src/security-archive
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+import { join } from "@visulima/path";
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const SOCKET_API_V0_URL = "https://api.socket.dev/v0/purl?alerts=true";
+const SOCKET_PUBLIC_API_TOKEN = "sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMqiwKo_api";
+
+const getCacheDirectory = (): string => join(homedir(), ".vis", "cache", "socket-security");
+const DEFAULT_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours
+const MAX_BATCH_SIZE = 100;
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/** Extra properties attached to a package alert. */
+interface PackageAlertProps {
+    cveId?: `CVE-${string}`;
+    cwes?: { id: `CWE-${string}` }[];
+    lastPublish: string;
+}
+
+/** A known security alert for a given package. */
+interface PackageAlert {
+    category: string;
+    key: string;
+    props?: PackageAlertProps;
+    severity: "critical" | "high" | "low" | "medium";
+    type: string;
+}
+
+/** Security scores for a given package (each 0–1). */
+interface PackageScore {
+    /** Average of all score factors. */
+    overall: number;
+    /** Score factors relating to package licensing. */
+    license: number;
+    /** Score factors relating to package maintenance. */
+    maintenance: number;
+    /** Score factors relating to code quality. */
+    quality: number;
+    /** Score factors relating to supply chain security. */
+    supplyChain: number;
+    /** Score factors relating to package vulnerabilities. */
+    vulnerability: number;
+}
+
+/** Full report data for a single package from Socket.dev. */
+interface PackageReportData {
+    alerts: PackageAlert[];
+    author: string[];
+    id: string;
+    license: string;
+    name: string;
+    namespace?: `@${string}`;
+    score: PackageScore;
+    size: number;
+    type: "npm";
+    version: string;
+}
+
+/** Configuration options for the Socket.dev security client. */
+interface SocketSecurityOptions {
+    /** Custom API token. Falls back to the public token. */
+    apiToken?: string;
+    /** Cache TTL in milliseconds. Defaults to 3 hours. */
+    cacheTtlMs?: number;
+    /** Request timeout in milliseconds. Defaults to 15 seconds. */
+    timeoutMs?: number;
+}
+
+/** Raw NDJSON item from the Socket.dev API response. */
+interface SocketApiItem {
+    alerts: PackageAlert[];
+    author: string[];
+    id: string;
+    license: string;
+    name: string;
+    namespace?: string;
+    score: Omit<PackageScore, "overall"> & { overall?: number };
+    size: number;
+    type: string;
+    version: string;
+}
+
+interface CacheEntry {
+    createdAt: number;
+    report: PackageReportData;
+    ttlMs: number;
+}
+
+// ── Type guards ─────────────────────────────────────────────────────
+
+const isPackageReportData = (o: unknown): o is PackageReportData =>
+    typeof o === "object"
+    && o != null
+    && "id" in o
+    && "type" in o
+    && "name" in o
+    && "version" in o
+    && "alerts" in o
+    && "score" in o
+    && (o as Record<string, unknown>).type === "npm";
+
+// ── Cache helpers (file-based, matching ai-cache.ts pattern) ────────
+
+const ensureCacheDirectory = (): void => {
+    const cacheDirectory = getCacheDirectory();
+
+    if (!existsSync(cacheDirectory)) {
+        mkdirSync(cacheDirectory, { recursive: true });
+    }
+};
+
+const buildCacheKey = (name: string, version: string): string => {
+    // Simple key: scope and name with version, sanitized for filesystem
+    return `${name.replaceAll("/", "__").replace("@", "")}@${version}`;
+};
+
+const getCachedReport = (name: string, version: string): PackageReportData | undefined => {
+    const key = buildCacheKey(name, version);
+    const filePath = join(getCacheDirectory(), `${key}.json`);
+
+    if (!existsSync(filePath)) {
+        return undefined;
+    }
+
+    try {
+        const raw = readFileSync(filePath, "utf8");
+        const entry = JSON.parse(raw) as CacheEntry;
+
+        if (Date.now() - entry.createdAt > entry.ttlMs) {
+            rmSync(filePath, { force: true });
+
+            return undefined;
+        }
+
+        return entry.report;
+    } catch {
+        rmSync(filePath, { force: true });
+
+        return undefined;
+    }
+};
+
+const setCachedReport = (name: string, version: string, report: PackageReportData, ttlMs: number): void => {
+    ensureCacheDirectory();
+
+    const key = buildCacheKey(name, version);
+    const entry: CacheEntry = {
+        createdAt: Date.now(),
+        report,
+        ttlMs,
+    };
+
+    writeFileSync(join(getCacheDirectory(), `${key}.json`), JSON.stringify(entry), "utf8");
+};
+
+// ── Score calculation ───────────────────────────────────────────────
+
+const calculateOverallScore = (score: Omit<PackageScore, "overall">): number => {
+    const components = [
+        score.license,
+        score.maintenance,
+        score.quality,
+        score.supplyChain,
+        score.vulnerability,
+    ];
+
+    return Number(
+        (components.reduce((sum, s) => sum + s, 0) / components.length).toFixed(2),
+    );
+};
+
+// ── API client ──────────────────────────────────────────────────────
+
+/**
+ * Fetches security report data from the Socket.dev API for the given packages.
+ * Batches requests to stay within API limits.
+ *
+ * @param packages - Array of { name, version } to look up.
+ * @param options - Optional configuration.
+ * @returns Map of "name@version" to PackageReportData.
+ */
+const fetchSocketReports = async (
+    packages: { name: string; version: string }[],
+    options: SocketSecurityOptions = {},
+): Promise<Map<string, PackageReportData>> => {
+    const {
+        apiToken = SOCKET_PUBLIC_API_TOKEN,
+        cacheTtlMs = DEFAULT_TTL_MS,
+        timeoutMs = 15_000,
+    } = options;
+
+    const results = new Map<string, PackageReportData>();
+
+    if (packages.length === 0) {
+        return results;
+    }
+
+    // Check cache first, collect uncached packages
+    const uncached: { name: string; version: string }[] = [];
+
+    for (const pkg of packages) {
+        const cached = getCachedReport(pkg.name, pkg.version);
+
+        if (cached) {
+            results.set(`${pkg.name}@${pkg.version}`, cached);
+        } else {
+            uncached.push(pkg);
+        }
+    }
+
+    if (uncached.length === 0) {
+        return results;
+    }
+
+    // Batch uncached packages into groups of MAX_BATCH_SIZE
+    const batches: { name: string; version: string }[][] = [];
+
+    for (let index = 0; index < uncached.length; index += MAX_BATCH_SIZE) {
+        batches.push(uncached.slice(index, index + MAX_BATCH_SIZE));
+    }
+
+    for (const batch of batches) {
+        const components = batch.map((pkg) => ({
+            purl: `pkg:npm/${pkg.name}@${pkg.version}`,
+        }));
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => {
+            controller.abort();
+        }, timeoutMs);
+
+        try {
+            // eslint-disable-next-line n/no-unsupported-features/node-builtins -- fetch is available in Node 20.19+ via undici
+            const response = await fetch(SOCKET_API_V0_URL, {
+                body: JSON.stringify({ components }),
+                headers: {
+                    "Authorization": `Basic ${Buffer.from(`${apiToken}:`).toString("base64url")}`,
+                    "Content-Type": "application/json",
+                    "User-Agent": "@visulima/vis",
+                },
+                method: "POST",
+                signal: controller.signal,
+            });
+
+            if (!response.ok) {
+                continue;
+            }
+
+            const text = await response.text();
+
+            parseNdjsonResponse(text, batch, results, cacheTtlMs);
+        } catch {
+            // Graceful degradation: skip failed batches
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    return results;
+};
+
+/**
+ * Parses the NDJSON response from Socket.dev API and populates the results map.
+ */
+const parseNdjsonResponse = (
+    text: string,
+    batch: { name: string; version: string }[],
+    results: Map<string, PackageReportData>,
+    cacheTtlMs: number,
+): void => {
+    // Build lookup map for matching responses back to requests
+    const lookupMap = new Map<string, { name: string; version: string }>();
+
+    for (const pkg of batch) {
+        lookupMap.set(`${pkg.name}@${pkg.version}`, pkg);
+    }
+
+    const lines = text.split("}\n");
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        try {
+            const data = JSON.parse(trimmed.endsWith("}") ? trimmed : trimmed + "}") as SocketApiItem;
+
+            const scope = data.namespace ? `${data.namespace}/` : "";
+            const fullName = `${scope}${data.name}`;
+            const key = `${fullName}@${data.version}`;
+
+            if (!lookupMap.has(key)) {
+                continue;
+            }
+
+            // Calculate average score
+            const overall = data.score.overall ?? calculateOverallScore(data.score);
+
+            const reportData: PackageReportData = {
+                alerts: data.alerts,
+                author: data.author,
+                id: data.id,
+                license: data.license,
+                name: data.name,
+                score: { ...data.score, overall },
+                size: data.size,
+                type: "npm",
+                version: data.version,
+            };
+
+            if (data.namespace) {
+                reportData.namespace = data.namespace as `@${string}`;
+            }
+
+            if (isPackageReportData(reportData)) {
+                results.set(key, reportData);
+                setCachedReport(fullName, data.version, reportData, cacheTtlMs);
+            }
+        } catch {
+            // Skip malformed lines
+        }
+    }
+};
+
+// ── Display helpers ─────────────────────────────────────────────────
+
+/** Maps a 0–1 score to a human-readable label. */
+const scoreLabel = (score: number): string => {
+    if (score >= 0.8) {
+        return "excellent";
+    }
+
+    if (score >= 0.6) {
+        return "good";
+    }
+
+    if (score >= 0.4) {
+        return "fair";
+    }
+
+    if (score >= 0.2) {
+        return "poor";
+    }
+
+    return "critical";
+};
+
+/** Maps a 0–1 score to a color name for terminal output. */
+const scoreColor = (score: number): "green" | "red" | "yellow" => {
+    if (score >= 0.6) {
+        return "green";
+    }
+
+    if (score >= 0.4) {
+        return "yellow";
+    }
+
+    return "red";
+};
+
+/** Maps alert severity to a color name. */
+const alertSeverityColor = (severity: PackageAlert["severity"]): "cyan" | "magenta" | "red" | "yellow" => {
+    switch (severity) {
+        case "critical": {
+            return "red";
+        }
+
+        case "high": {
+            return "magenta";
+        }
+
+        case "medium": {
+            return "yellow";
+        }
+
+        default: {
+            return "cyan";
+        }
+    }
+};
+
+/** Formats a PackageReportData into a compact one-line summary string. */
+const formatReportSummary = (report: PackageReportData): string => {
+    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const score = `score: ${String(Math.round(report.score.overall * 100))}%`;
+    const alertCount = report.alerts.length;
+    const alertSummary = alertCount > 0
+        ? `${String(alertCount)} alert${alertCount === 1 ? "" : "s"}`
+        : "no alerts";
+
+    return `${name}@${report.version} (${score}, ${alertSummary})`;
+};
+
+/** Formats a detailed multi-line report for a single package. */
+const formatReportDetailed = (report: PackageReportData): string => {
+    const name = report.namespace ? `${report.namespace}/${report.name}` : report.name;
+    const lines: string[] = [];
+
+    lines.push(`${name}@${report.version}`);
+    lines.push(`  License: ${report.license || "unknown"}`);
+    lines.push(`  Overall Score: ${String(Math.round(report.score.overall * 100))}% (${scoreLabel(report.score.overall)})`);
+    lines.push(`    Supply Chain: ${String(Math.round(report.score.supplyChain * 100))}%`);
+    lines.push(`    Quality:      ${String(Math.round(report.score.quality * 100))}%`);
+    lines.push(`    Maintenance:  ${String(Math.round(report.score.maintenance * 100))}%`);
+    lines.push(`    Vulnerability: ${String(Math.round(report.score.vulnerability * 100))}%`);
+    lines.push(`    License:      ${String(Math.round(report.score.license * 100))}%`);
+
+    if (report.alerts.length > 0) {
+        lines.push(`  Alerts (${String(report.alerts.length)}):`);
+
+        for (const alert of report.alerts) {
+            const cve = alert.props?.cveId ? ` (${alert.props.cveId})` : "";
+
+            lines.push(`    [${alert.severity.toUpperCase()}] ${alert.type}${cve} — ${alert.category}`);
+        }
+    }
+
+    return lines.join("\n");
+};
+
+/**
+ * Formats a security summary for a list of packages.
+ * Suitable for displaying after install/update commands.
+ */
+const formatSecurityOverview = (reports: Map<string, PackageReportData>): string => {
+    if (reports.size === 0) {
+        return "";
+    }
+
+    let totalAlerts = 0;
+    let criticalCount = 0;
+    let highCount = 0;
+    let mediumCount = 0;
+    let lowCount = 0;
+    let lowScorePackages = 0;
+
+    for (const report of reports.values()) {
+        for (const alert of report.alerts) {
+            totalAlerts++;
+
+            switch (alert.severity) {
+                case "critical": {
+                    criticalCount++;
+                    break;
+                }
+
+                case "high": {
+                    highCount++;
+                    break;
+                }
+
+                case "medium": {
+                    mediumCount++;
+                    break;
+                }
+
+                default: {
+                    lowCount++;
+                }
+            }
+        }
+
+        if (report.score.overall < 0.4) {
+            lowScorePackages++;
+        }
+    }
+
+    const lines: string[] = [];
+
+    lines.push(`Socket.dev: scanned ${String(reports.size)} package${reports.size === 1 ? "" : "s"}`);
+
+    if (totalAlerts > 0) {
+        const parts: string[] = [];
+
+        if (criticalCount > 0) {
+            parts.push(`${String(criticalCount)} critical`);
+        }
+
+        if (highCount > 0) {
+            parts.push(`${String(highCount)} high`);
+        }
+
+        if (mediumCount > 0) {
+            parts.push(`${String(mediumCount)} medium`);
+        }
+
+        if (lowCount > 0) {
+            parts.push(`${String(lowCount)} low`);
+        }
+
+        lines.push(`  Alerts: ${String(totalAlerts)} total (${parts.join(", ")})`);
+    } else {
+        lines.push("  No security alerts found.");
+    }
+
+    if (lowScorePackages > 0) {
+        lines.push(`  ${String(lowScorePackages)} package${lowScorePackages === 1 ? "" : "s"} with low security score (<40%)`);
+    }
+
+    return lines.join("\n");
+};
+
+// ── Cache management ────────────────────────────────────────────────
+
+const clearSocketCache = (): number => {
+    const cacheDirectory = getCacheDirectory();
+
+    if (!existsSync(cacheDirectory)) {
+        return 0;
+    }
+
+    const files = readdirSync(cacheDirectory).filter((f) => f.endsWith(".json"));
+
+    for (const file of files) {
+        rmSync(join(cacheDirectory, file), { force: true });
+    }
+
+    return files.length;
+};
+
+export type {
+    PackageAlert,
+    PackageAlertProps,
+    PackageReportData,
+    PackageScore,
+    SocketSecurityOptions,
+};
+
+export {
+    alertSeverityColor,
+    calculateOverallScore,
+    clearSocketCache,
+    fetchSocketReports,
+    formatReportDetailed,
+    formatReportSummary,
+    formatSecurityOverview,
+    isPackageReportData,
+    scoreColor,
+    scoreLabel,
+};

--- a/packages/tooling/vis/src/socket-security.ts
+++ b/packages/tooling/vis/src/socket-security.ts
@@ -559,7 +559,79 @@ const buildSocketOptions = (socketConfig: SocketConfigLike | undefined): SocketS
     };
 };
 
+// ── Accepted risks ──────────────────────────────────────────────────
+
+/** A persisted "accepted risk" entry from the vis config. */
+interface AcceptedRisk {
+    /** ISO 8601 timestamp when the risk was accepted. */
+    acceptedAt: string;
+    /** The overall Socket.dev score at the time of acceptance. */
+    acceptedScore: number;
+    /** User-provided reason for accepting the risk. */
+    reason: string;
+}
+
+/**
+ * Checks if a package has an accepted risk entry.
+ * Matches by exact name@version, unversioned name, or trailing glob patterns.
+ * Returns the matching AcceptedRisk if found, undefined otherwise.
+ */
+const findAcceptedRisk = (
+    packageName: string,
+    version: string,
+    acceptedRisks: Record<string, AcceptedRisk> | undefined,
+): AcceptedRisk | undefined => {
+    if (!acceptedRisks) {
+        return undefined;
+    }
+
+    // Check exact name@version first
+    const versionedKey = `${packageName}@${version}`;
+
+    if (acceptedRisks[versionedKey]) {
+        return acceptedRisks[versionedKey];
+    }
+
+    // Check unversioned name
+    if (acceptedRisks[packageName]) {
+        return acceptedRisks[packageName];
+    }
+
+    // Check glob patterns (e.g., "@myorg/*")
+    for (const [pattern, risk] of Object.entries(acceptedRisks)) {
+        if (pattern.endsWith("*") && packageName.startsWith(pattern.slice(0, -1))) {
+            return risk;
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Formats a config snippet for the user to paste into vis.config.ts
+ * to persist an accepted risk decision.
+ */
+const formatAcceptedRiskSnippet = (
+    packageName: string,
+    version: string,
+    score: number,
+    reason: string,
+): string => {
+    const key = `"${packageName}"`;
+    const lines = [
+        `    // Add to security.socket.acceptedRisks in vis.config.ts:`,
+        `    ${key}: {`,
+        `      reason: "${reason}",`,
+        `      acceptedAt: "${new Date().toISOString()}",`,
+        `      acceptedScore: ${String(score)},`,
+        `    },`,
+    ];
+
+    return lines.join("\n");
+};
+
 export type {
+    AcceptedRisk,
     PackageAlert,
     PackageAlertProps,
     PackageReportData,
@@ -573,6 +645,8 @@ export {
     calculateOverallScore,
     clearSocketCache,
     fetchSocketReports,
+    findAcceptedRisk,
+    formatAcceptedRiskSnippet,
     formatReportDetailed,
     formatReportSummary,
     formatSecurityOverview,

--- a/packages/tooling/vis/src/tips.ts
+++ b/packages/tooling/vis/src/tips.ts
@@ -107,6 +107,13 @@ const tips: Tip[] = [
         probability: 0.2,
     },
     {
+        cooldownMs: 24 * 60 * 60 * 1000, // 24 hours
+        id: "socket-security",
+        matches: (context) => (context.command === "install" || context.command === "update" || context.command === "check") && context.success,
+        message: () => "Enable Socket.dev in vis.config.ts for security scores and supply chain alerts: security.socket.enabled = true",
+        probability: 0.15,
+    },
+    {
         id: "dedupe-after-install",
         matches: (context) => context.command === "install" && context.success,
         message: () => "Run 'vis dedupe' periodically to remove duplicate dependencies.",

--- a/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
@@ -64,6 +64,10 @@ const PackageDetailPanel = ({ changelogUrl, entry, focused, recommendation, scro
 
     const typeColor = UPDATE_TYPE_COLORS[entry.updateType] ?? "white";
     const hasVulnerabilities = entry.vulnerabilities && entry.vulnerabilities.length > 0;
+    const socketScore = entry.socketReport?.score.overall ?? 0;
+    const socketScoreColor = entry.socketReport
+        ? socketScore >= 0.6 ? "green" as const : socketScore >= 0.4 ? "yellow" as const : "red" as const
+        : "gray" as const;
 
     return (
         <Box borderColor={borderColor} borderStyle="single" flexDirection="column" flexGrow={1}>
@@ -132,8 +136,8 @@ const PackageDetailPanel = ({ changelogUrl, entry, focused, recommendation, scro
                     <Box gap={2}>
                         <Box>
                             <Text dimColor>Overall: </Text>
-                            <Text bold color={entry.socketReport.score.overall >= 0.6 ? "green" : entry.socketReport.score.overall >= 0.4 ? "yellow" : "red"}>
-                                {String(Math.round(entry.socketReport.score.overall * 100))}%
+                            <Text bold color={socketScoreColor}>
+                                {String(Math.round(socketScore * 100))}%
                             </Text>
                         </Box>
                         <Box>

--- a/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
@@ -20,6 +20,13 @@ const SEVERITY_COLORS: Record<string, string> = {
     UNKNOWN: "gray",
 };
 
+const SOCKET_SEVERITY_COLORS: Record<string, string> = {
+    critical: "red",
+    high: "red",
+    low: "gray",
+    medium: "yellow",
+};
+
 const RISK_COLORS: Record<string, string> = {
     critical: "red",
     high: "red",
@@ -114,6 +121,58 @@ const PackageDetailPanel = ({ changelogUrl, entry, focused, recommendation, scro
                             </Box>
                         </Box>
                     ))}
+                </Box>
+            )}
+
+            {/* Socket.dev section */}
+            {entry.socketReport && (
+                <Box flexDirection="column" marginTop={1}>
+                    <Text dimColor>{"\u2500\u2500 "}</Text><Text bold color="cyan">SOCKET.DEV</Text>
+                    <Text>{""}</Text>
+                    <Box gap={2}>
+                        <Box>
+                            <Text dimColor>Overall: </Text>
+                            <Text bold color={entry.socketReport.score.overall >= 0.6 ? "green" : entry.socketReport.score.overall >= 0.4 ? "yellow" : "red"}>
+                                {String(Math.round(entry.socketReport.score.overall * 100))}%
+                            </Text>
+                        </Box>
+                        <Box>
+                            <Text dimColor>Supply Chain: </Text>
+                            <Text>{String(Math.round(entry.socketReport.score.supplyChain * 100))}%</Text>
+                        </Box>
+                        <Box>
+                            <Text dimColor>Quality: </Text>
+                            <Text>{String(Math.round(entry.socketReport.score.quality * 100))}%</Text>
+                        </Box>
+                    </Box>
+                    <Box gap={2}>
+                        <Box>
+                            <Text dimColor>Maintenance: </Text>
+                            <Text>{String(Math.round(entry.socketReport.score.maintenance * 100))}%</Text>
+                        </Box>
+                        <Box>
+                            <Text dimColor>Vulnerability: </Text>
+                            <Text>{String(Math.round(entry.socketReport.score.vulnerability * 100))}%</Text>
+                        </Box>
+                        <Box>
+                            <Text dimColor>License: </Text>
+                            <Text>{entry.socketReport.license || "unknown"} ({String(Math.round(entry.socketReport.score.license * 100))}%)</Text>
+                        </Box>
+                    </Box>
+                    {entry.socketReport.alerts.length > 0 && (
+                        <Box flexDirection="column" marginTop={1}>
+                            <Text bold color="yellow">{"\u26A0"} {String(entry.socketReport.alerts.length)} alert{entry.socketReport.alerts.length === 1 ? "" : "s"}:</Text>
+                            {entry.socketReport.alerts.map((alert) => (
+                                <Box key={alert.key} paddingLeft={2} gap={1}>
+                                    <Text color={SOCKET_SEVERITY_COLORS[alert.severity] ?? "gray"} bold>
+                                        [{alert.severity.toUpperCase()}]
+                                    </Text>
+                                    <Text>{alert.type}</Text>
+                                    <Text dimColor>({alert.category})</Text>
+                                </Box>
+                            ))}
+                        </Box>
+                    )}
                 </Box>
             )}
 

--- a/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
@@ -99,6 +99,23 @@ const PackageDetailPanel = ({ changelogUrl, entry, focused, recommendation, scro
                 <Text>{entry.catalogName}</Text>
             </Box>
 
+            {/* Accepted risk notice */}
+            {entry.acceptedRisk && (
+                <Box marginTop={1} flexDirection="column">
+                    <Text color="gray">{"\u2500\u2500 "}</Text><Text bold color="gray">ACKNOWLEDGED RISK</Text>
+                    <Box paddingLeft={2} flexDirection="column">
+                        <Box>
+                            <Text dimColor>Reason: </Text>
+                            <Text>{entry.acceptedRisk.reason}</Text>
+                        </Box>
+                        <Box>
+                            <Text dimColor>Accepted: </Text>
+                            <Text>{entry.acceptedRisk.acceptedAt.slice(0, 10)}</Text>
+                        </Box>
+                    </Box>
+                </Box>
+            )}
+
             {/* Security section */}
             {hasVulnerabilities && (
                 <Box flexDirection="column" marginTop={1}>

--- a/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageDetailPanel.tsx
@@ -3,6 +3,7 @@ import { Box, ScrollView, Text } from "@visulima/tui";
 
 import type { AiRecommendation } from "../../../ai-analysis";
 import type { OutdatedEntry } from "../../../catalog";
+import { scoreColor } from "../../../socket-security";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -65,9 +66,7 @@ const PackageDetailPanel = ({ changelogUrl, entry, focused, recommendation, scro
     const typeColor = UPDATE_TYPE_COLORS[entry.updateType] ?? "white";
     const hasVulnerabilities = entry.vulnerabilities && entry.vulnerabilities.length > 0;
     const socketScore = entry.socketReport?.score.overall ?? 0;
-    const socketScoreColor = entry.socketReport
-        ? socketScore >= 0.6 ? "green" as const : socketScore >= 0.4 ? "yellow" as const : "red" as const
-        : "gray" as const;
+    const socketScoreColor = entry.socketReport ? scoreColor(socketScore) : "gray" as const;
 
     return (
         <Box borderColor={borderColor} borderStyle="single" flexDirection="column" flexGrow={1}>

--- a/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
@@ -1,6 +1,7 @@
 import { Box, ScrollBar, Text } from "@visulima/tui";
 
 import type { OutdatedEntry } from "../../../catalog";
+import { scoreColor } from "../../../socket-security";
 import type { FilterType } from "./UpdateStore";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -38,9 +39,9 @@ const PackageRow = ({ checked, entry, isSelected }: PackageRowProps): React.JSX.
     const scoreText = entry.socketReport
         ? `${String(Math.round(entry.socketReport.score.overall * 100))}%`
         : "";
-    const scoreColor = entry.socketReport
-        ? entry.socketReport.score.overall >= 0.6 ? "green" : entry.socketReport.score.overall >= 0.4 ? "yellow" : "red"
-        : "gray";
+    const scoreColorName = entry.socketReport
+        ? scoreColor(entry.socketReport.score.overall)
+        : "gray" as const;
 
     return (
         <Box height={1} flexShrink={0}>
@@ -52,7 +53,7 @@ const PackageRow = ({ checked, entry, isSelected }: PackageRowProps): React.JSX.
                     {entry.packageName}{isAcknowledged ? " [ack]" : ""}
                 </Text>
             </Box>
-            {scoreText && <Text color={scoreColor}> {scoreText}</Text>}
+            {scoreText && <Text color={scoreColorName}> {scoreText}</Text>}
             <Text dimColor> {entry.currentRange}</Text>
             <Text dimColor> {"\u2192"} </Text>
             <Text>{entry.newRange} </Text>

--- a/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
@@ -31,6 +31,7 @@ const PackageRow = ({ checked, entry, isSelected }: PackageRowProps): React.JSX.
     const typeColor = UPDATE_TYPE_COLORS[entry.updateType] ?? "white";
     const hasSecurity = entry.vulnerabilities && entry.vulnerabilities.length > 0;
     const hasSocketAlerts = entry.socketReport && entry.socketReport.alerts.length > 0;
+    const isAcknowledged = Boolean(entry.acceptedRisk);
     const checkbox = checked ? "\u2611" : "\u2610";
 
     // Socket.dev score badge
@@ -45,10 +46,10 @@ const PackageRow = ({ checked, entry, isSelected }: PackageRowProps): React.JSX.
         <Box height={1} flexShrink={0}>
             <Text>{isSelected ? ">" : " "}</Text>
             <Text color={checked ? "white" : "gray"}> {checkbox} </Text>
-            {hasSecurity || hasSocketAlerts ? <Text color="red">{"\u26A0 "}</Text> : <Text>{"  "}</Text>}
+            {hasSecurity || hasSocketAlerts ? <Text color={isAcknowledged ? "gray" : "red"}>{isAcknowledged ? "\u2713 " : "\u26A0 "}</Text> : <Text>{"  "}</Text>}
             <Box flexGrow={1}>
                 <Text bold={isSelected} inverse={isSelected} wrap="truncate">
-                    {entry.packageName}
+                    {entry.packageName}{isAcknowledged ? " [ack]" : ""}
                 </Text>
             </Box>
             {scoreText && <Text color={scoreColor}> {scoreText}</Text>}

--- a/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
@@ -30,18 +30,28 @@ interface PackageRowProps {
 const PackageRow = ({ checked, entry, isSelected }: PackageRowProps): React.JSX.Element => {
     const typeColor = UPDATE_TYPE_COLORS[entry.updateType] ?? "white";
     const hasSecurity = entry.vulnerabilities && entry.vulnerabilities.length > 0;
+    const hasSocketAlerts = entry.socketReport && entry.socketReport.alerts.length > 0;
     const checkbox = checked ? "\u2611" : "\u2610";
+
+    // Socket.dev score badge
+    const scoreText = entry.socketReport
+        ? `${String(Math.round(entry.socketReport.score.overall * 100))}%`
+        : "";
+    const scoreColor = entry.socketReport
+        ? entry.socketReport.score.overall >= 0.6 ? "green" : entry.socketReport.score.overall >= 0.4 ? "yellow" : "red"
+        : "gray";
 
     return (
         <Box height={1} flexShrink={0}>
             <Text>{isSelected ? ">" : " "}</Text>
             <Text color={checked ? "white" : "gray"}> {checkbox} </Text>
-            {hasSecurity ? <Text color="red">{"\u26A0 "}</Text> : <Text>{"  "}</Text>}
+            {hasSecurity || hasSocketAlerts ? <Text color="red">{"\u26A0 "}</Text> : <Text>{"  "}</Text>}
             <Box flexGrow={1}>
                 <Text bold={isSelected} inverse={isSelected} wrap="truncate">
                     {entry.packageName}
                 </Text>
             </Box>
+            {scoreText && <Text color={scoreColor}> {scoreText}</Text>}
             <Text dimColor> {entry.currentRange}</Text>
             <Text dimColor> {"\u2192"} </Text>
             <Text>{entry.newRange} </Text>

--- a/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
@@ -115,7 +115,7 @@ const PackageListPanel = ({
     const majors = entries.filter((e) => e.updateType === "major").length;
     const minors = entries.filter((e) => e.updateType === "minor").length;
     const patches = entries.filter((e) => e.updateType === "patch").length;
-    const secCount = entries.filter((e) => e.vulnerabilities && e.vulnerabilities.length > 0).length;
+    const secCount = entries.filter((e) => (e.vulnerabilities && e.vulnerabilities.length > 0) || (e.socketReport && e.socketReport.alerts.length > 0)).length;
 
     const summaryParts: string[] = [];
 

--- a/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
+++ b/packages/tooling/vis/src/tui/components/update/PackageListPanel.tsx
@@ -112,10 +112,18 @@ const PackageListPanel = ({
 }: PackageListPanelProps): React.JSX.Element => {
     const borderColor = focused ? "white" : "gray";
 
-    const majors = entries.filter((e) => e.updateType === "major").length;
-    const minors = entries.filter((e) => e.updateType === "minor").length;
-    const patches = entries.filter((e) => e.updateType === "patch").length;
-    const secCount = entries.filter((e) => (e.vulnerabilities && e.vulnerabilities.length > 0) || (e.socketReport && e.socketReport.alerts.length > 0)).length;
+    let majors = 0;
+    let minors = 0;
+    let patches = 0;
+    let secCount = 0;
+
+    for (const e of entries) {
+        if (e.updateType === "major") majors++;
+        else if (e.updateType === "minor") minors++;
+        else patches++;
+
+        if ((e.vulnerabilities && e.vulnerabilities.length > 0) || (e.socketReport && e.socketReport.alerts.length > 0)) secCount++;
+    }
 
     const summaryParts: string[] = [];
 

--- a/packages/tooling/vis/src/tui/components/update/UpdateStore.ts
+++ b/packages/tooling/vis/src/tui/components/update/UpdateStore.ts
@@ -60,7 +60,10 @@ const filterEntries = (entries: OutdatedEntry[], filterType: FilterType, filterT
 
     if (filterType !== "all") {
         if (filterType === "security") {
-            filtered = filtered.filter((e) => e.vulnerabilities && e.vulnerabilities.length > 0);
+            filtered = filtered.filter((e) =>
+                (e.vulnerabilities && e.vulnerabilities.length > 0)
+                || (e.socketReport && e.socketReport.alerts.length > 0),
+            );
         } else {
             filtered = filtered.filter((e) => e.updateType === filterType);
         }

--- a/packages/tooling/vis/src/workspace.ts
+++ b/packages/tooling/vis/src/workspace.ts
@@ -74,6 +74,34 @@ interface VisConfig {
          */
         socket?: {
             /**
+             * Packages whose low Socket.dev scores or alerts have been reviewed
+             * and explicitly accepted. These packages skip the confirmation
+             * prompt during `vis add` and show as "acknowledged" in `vis audit`.
+             *
+             * Key format: package name (`"lodash"`), name@version
+             * (`"lodash@4.17.21"`), or glob (`"@myorg/*"`).
+             * Unversioned keys match all versions of that package.
+             *
+             * @example
+             * ```
+             * acceptedRisks: {
+             *   "some-risky-pkg": {
+             *     reason: "Internal fork, low score expected",
+             *     acceptedAt: "2026-03-15T10:00:00Z",
+             *     acceptedScore: 0.25,
+             *   },
+             * }
+             * ```
+             */
+            acceptedRisks?: Record<string, {
+                /** ISO 8601 timestamp when the risk was accepted. */
+                acceptedAt: string;
+                /** The overall Socket.dev score at the time of acceptance. */
+                acceptedScore: number;
+                /** User-provided reason for accepting the risk. */
+                reason: string;
+            }>;
+            /**
              * Custom Socket.dev API token. Falls back to the public API token.
              * Set via VIS_SOCKET_TOKEN environment variable or here.
              */

--- a/packages/tooling/vis/src/workspace.ts
+++ b/packages/tooling/vis/src/workspace.ts
@@ -89,6 +89,14 @@ interface VisConfig {
              */
             enabled?: boolean;
             /**
+             * Minimum overall Socket.dev score (0–1) for a package to be
+             * accepted without a confirmation prompt during `vis add`.
+             * Packages scoring below this threshold trigger an interactive
+             * prompt asking the user to confirm. Set to 0 to disable.
+             * @default 0.4
+             */
+            minimumScore?: number;
+            /**
              * Request timeout in milliseconds for the Socket.dev API.
              * @default 15_000 (15 seconds)
              */

--- a/packages/tooling/vis/src/workspace.ts
+++ b/packages/tooling/vis/src/workspace.ts
@@ -67,6 +67,35 @@ interface VisConfig {
         allowBuilds?: Record<string, boolean>;
 
         /**
+         * Socket.dev security intelligence configuration.
+         * When enabled, vis fetches package security scores, alerts, and report
+         * data from the Socket.dev API during install, update, and check commands.
+         * @see https://socket.dev
+         */
+        socket?: {
+            /**
+             * Custom Socket.dev API token. Falls back to the public API token.
+             * Set via VIS_SOCKET_TOKEN environment variable or here.
+             */
+            apiToken?: string;
+            /**
+             * Cache TTL in milliseconds for Socket.dev reports.
+             * @default 10_800_000 (3 hours)
+             */
+            cacheTtlMs?: number;
+            /**
+             * Enable Socket.dev security scanning on install/update/check commands.
+             * @default false
+             */
+            enabled?: boolean;
+            /**
+             * Request timeout in milliseconds for the Socket.dev API.
+             * @default 15_000 (15 seconds)
+             */
+            timeoutMs?: number;
+        };
+
+        /**
          * When true, prevents transitive dependencies from using exotic sources
          * (git repositories, direct tarball URLs). Only direct dependencies may
          * use such sources. Equivalent to pnpm's `blockExoticSubdeps`.

--- a/packages/tooling/vis/src/workspace.ts
+++ b/packages/tooling/vis/src/workspace.ts
@@ -80,7 +80,7 @@ interface VisConfig {
             apiToken?: string;
             /**
              * Cache TTL in milliseconds for Socket.dev reports.
-             * @default 10_800_000 (3 hours)
+             * @default 3_600_000 (1 hour)
              */
             cacheTtlMs?: number;
             /**

--- a/packages/tooling/vis/src/workspace.ts
+++ b/packages/tooling/vis/src/workspace.ts
@@ -93,14 +93,17 @@ interface VisConfig {
              * }
              * ```
              */
-            acceptedRisks?: Record<string, {
-                /** ISO 8601 timestamp when the risk was accepted. */
-                acceptedAt: string;
-                /** The overall Socket.dev score at the time of acceptance. */
-                acceptedScore: number;
-                /** User-provided reason for accepting the risk. */
-                reason: string;
-            }>;
+            acceptedRisks?: Record<
+                string,
+                {
+                    /** ISO 8601 timestamp when the risk was accepted. */
+                    acceptedAt: string;
+                    /** The overall Socket.dev score at the time of acceptance. */
+                    acceptedScore: number;
+                    /** User-provided reason for accepting the risk. */
+                    reason: string;
+                }
+            >;
             /**
              * Custom Socket.dev API token. Falls back to the public API token.
              * Set via VIS_SOCKET_TOKEN environment variable or here.


### PR DESCRIPTION
## Summary

Integrates Socket.dev security intelligence into vis, enabling package security scoring, vulnerability alerts, and supply chain risk assessment during dependency checks and updates. This complements the existing OSV vulnerability scanning with additional security metrics and real-time threat detection.

## Key Changes

- **New Socket.dev client module** (`socket-security.ts`): Complete implementation for fetching and caching package security reports from the Socket.dev API, including:
  - Batch API requests with configurable timeouts and TTL-based file caching (1-hour default)
  - Type-safe parsing of NDJSON responses with score calculation and validation
  - Display helpers for formatting security summaries, detailed reports, and alert severity indicators
  - Cache management utilities for clearing stale data

- **Configuration support**: Added `security.socket` section to `VisConfig` with options for:
  - API token (falls back to public token or `VIS_SOCKET_TOKEN` env var)
  - Cache TTL and request timeout customization
  - Enable/disable toggle for security scanning

- **Catalog enrichment**: Extended `OutdatedEntry` with `socketReport` field containing alerts and security scores; integrated Socket.dev fetching into `enrichWithSecurity()` alongside OSV vulnerability checks

- **Command integration**:
  - `check` command: Passes Socket.dev options to dependency checking
  - `update` command: Includes Socket.dev security data in outdated package analysis
  - `analyze` command: Fetches Socket.dev reports for single-package analysis

- **Post-install security summary**: Security enforcement plugin now displays Socket.dev overview after install/update commands, warning about critical/high severity alerts

- **UI enhancements**:
  - Package detail panel shows Socket.dev scores (overall, supply chain, quality, maintenance, vulnerability, license) with color-coded severity
  - Package list shows security score badges
  - Alert display with severity coloring in both detailed and summary views
  - Filter support for packages with security issues

- **Tips system**: Added Socket.dev tip to encourage users to enable security scanning

## Implementation Details

- Uses file-based caching pattern matching existing `ai-cache.ts` approach
- Graceful degradation: Socket.dev failures don't block package operations
- Batch processing respects API limits (100 packages per request)
- Score calculation handles missing `overall` field by averaging component scores
- Scoped package names properly handled in cache keys and API requests

https://claude.ai/code/session_01X74rrbHZS7WY2iWSV4JkH4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Socket.dev integration everywhere: scoring, alerts, caching, accepted-risk handling; new audit command to scan installed packages (JSON and human modes); pre-add Socket checks with interactive confirmation and bypass flag.

* **Security**
  * Socket.dev details added to security reports, summaries, and warnings; accepted-risk tracking with stale-acceptance notifications; low-score highlighting and counts.

* **UI**
  * Table, summary and detail views show Socket scores, alerts, and acknowledged-risk sections; row icons/colors reflect Socket issues.

* **Chores**
  * Init/template and CLI tips mention Socket.dev; cache-clearing now includes Socket reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->