### PR TITLE
fix: Replace resetTerminal with clearScreenAndHomeCursor to preserve scrollback

### DIFF
--- a/packages/terminal/tui/__tests__/ink/render.test.tsx
+++ b/packages/terminal/tui/__tests__/ink/render.test.tsx
@@ -5,7 +5,7 @@ import process from "node:process";
 import { Writable } from "node:stream";
 import url from "node:url";
 
-import { eraseLines, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
+import { clearScreenAndHomeCursor, eraseLines, eraseScreenAndScrollback, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
 import { boxen } from "@visulima/boxen";
 import delay from "delay";
 import type { ReactElement } from "react";
@@ -109,13 +109,15 @@ const getContentWrites = (writeSpy: any): string[] =>
 // eslint-disable-next-line vitest/prefer-describe-function-title -- String title is conventional for test describe blocks
 describe("render", () => {
     it.skipIf(!ptyAvailable)("do not erase screen", async () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
         const ps = term("erase", ["4"]);
 
         await ps.waitForExit();
 
         expect(ps.output).not.toContain(resetTerminal);
+        // Regression guard for vadimdemedes/ink#935: no scrollback wipe on rerender.
+        expect(ps.output).not.toContain(eraseScreenAndScrollback);
 
         ["A", "B", "C"].forEach((letter) => {
             expect(ps.output).toContain(letter);
@@ -123,13 +125,15 @@ describe("render", () => {
     });
 
     it.skipIf(!ptyAvailable)("do not erase screen where <Static> is taller than viewport", async () => {
-        expect.assertions(7);
+        expect.assertions(8);
 
         const ps = term("erase-with-static", ["4"]);
 
         await ps.waitForExit();
 
         expect(ps.output).not.toContain(resetTerminal);
+        // Regression guard for vadimdemedes/ink#935: no scrollback wipe on rerender.
+        expect(ps.output).not.toContain(eraseScreenAndScrollback);
 
         ["A", "B", "C", "D", "E", "F"].forEach((letter) => {
             expect(ps.output).toContain(letter);
@@ -137,14 +141,21 @@ describe("render", () => {
     });
 
     it.skipIf(!ptyAvailable)("erase screen", async () => {
-        expect.assertions(4);
+        expect.assertions(6);
 
         const ps = term("erase", ["3"]);
 
         await ps.waitForExit();
-        await waitFor(() => ps.output.includes(resetTerminal) && ps.output.includes("C"));
+        await waitFor(() => ps.output.includes(clearScreenAndHomeCursor) && ps.output.includes("C"));
 
-        expect(ps.output).toContain(resetTerminal);
+        // Fullscreen rerenders must clear the viewport so the next frame starts at the top.
+        expect(ps.output).toContain(clearScreenAndHomeCursor);
+
+        // Regression guard for vadimdemedes/ink#935: the render loop must never emit
+        // the scrollback-erase sequence (CSI 3J) or RIS (ESC c) — doing so wipes the
+        // user's terminal history in VT-compliant terminals (tmux, xterm.js, Alacritty, …).
+        expect(ps.output).not.toContain(eraseScreenAndScrollback);
+        expect(ps.output).not.toContain(resetTerminal);
 
         ["A", "B", "C"].forEach((letter) => {
             expect(ps.output).toContain(letter);

--- a/packages/terminal/tui/__tests__/ink/render.test.tsx
+++ b/packages/terminal/tui/__tests__/ink/render.test.tsx
@@ -5,7 +5,7 @@ import process from "node:process";
 import { Writable } from "node:stream";
 import url from "node:url";
 
-import { cursorTo, eraseLines, eraseScreen, eraseScreenAndScrollback, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
+import { clearScreenAndHomeCursor, eraseLines, eraseScreenAndScrollback, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
 import { boxen } from "@visulima/boxen";
 import delay from "delay";
 import type { ReactElement } from "react";
@@ -18,10 +18,6 @@ import { run } from "../helpers/ink-run";
 import waitFor from "../helpers/wait-for";
 
 const require = createRequire(import.meta.url);
-
-// Viewport-only clear emitted by Ink on fullscreen rerenders — matches the
-// constant used in vadimdemedes/ink#936 (the upstream fix for ink#935).
-const eraseScreenSequence = eraseScreen + cursorTo(0, 0);
 
 const _request = createRequire(import.meta.url);
 const ptyAvailable = (() => {
@@ -150,10 +146,10 @@ describe("render", () => {
         const ps = term("erase", ["3"]);
 
         await ps.waitForExit();
-        await waitFor(() => ps.output.includes(eraseScreenSequence) && ps.output.includes("C"));
+        await waitFor(() => ps.output.includes(clearScreenAndHomeCursor) && ps.output.includes("C"));
 
         // Fullscreen rerenders must clear the viewport so the next frame starts at the top.
-        expect(ps.output).toContain(eraseScreenSequence);
+        expect(ps.output).toContain(clearScreenAndHomeCursor);
 
         // Regression guard for vadimdemedes/ink#935: the render loop must never emit
         // the scrollback-erase sequence (CSI 3J) or RIS (ESC c) — doing so wipes the

--- a/packages/terminal/tui/__tests__/ink/render.test.tsx
+++ b/packages/terminal/tui/__tests__/ink/render.test.tsx
@@ -5,7 +5,7 @@ import process from "node:process";
 import { Writable } from "node:stream";
 import url from "node:url";
 
-import { clearScreenAndHomeCursor, eraseLines, eraseScreenAndScrollback, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
+import { cursorTo, eraseLines, eraseScreen, eraseScreenAndScrollback, resetTerminal, strip as stripAnsi } from "@visulima/ansi";
 import { boxen } from "@visulima/boxen";
 import delay from "delay";
 import type { ReactElement } from "react";
@@ -18,6 +18,10 @@ import { run } from "../helpers/ink-run";
 import waitFor from "../helpers/wait-for";
 
 const require = createRequire(import.meta.url);
+
+// Viewport-only clear emitted by Ink on fullscreen rerenders — matches the
+// constant used in vadimdemedes/ink#936 (the upstream fix for ink#935).
+const eraseScreenSequence = eraseScreen + cursorTo(0, 0);
 
 const _request = createRequire(import.meta.url);
 const ptyAvailable = (() => {
@@ -146,10 +150,10 @@ describe("render", () => {
         const ps = term("erase", ["3"]);
 
         await ps.waitForExit();
-        await waitFor(() => ps.output.includes(clearScreenAndHomeCursor) && ps.output.includes("C"));
+        await waitFor(() => ps.output.includes(eraseScreenSequence) && ps.output.includes("C"));
 
         // Fullscreen rerenders must clear the viewport so the next frame starts at the top.
-        expect(ps.output).toContain(clearScreenAndHomeCursor);
+        expect(ps.output).toContain(eraseScreenSequence);
 
         // Regression guard for vadimdemedes/ink#935: the render loop must never emit
         // the scrollback-erase sequence (CSI 3J) or RIS (ESC c) — doing so wipes the

--- a/packages/terminal/tui/src/core/app.ts
+++ b/packages/terminal/tui/src/core/app.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention, import/no-named-as-default, unicorn/no-null */
+import { createDecMode, resetMode, setMode } from "@visulima/ansi";
 import EventEmitter from "eventemitter3";
 
 import type { RendererInstance, TerminalGuardInstance } from "./native-binding";
 import { Renderer, TerminalGuard } from "./native-binding";
 
-const DEC_2026_ON = "\u001B[?2026h";
-const DEC_2026_OFF = "\u001B[?2026l";
+// DEC Private Mode 2026 — Synchronized Output. Precomputed once.
+// `setMode`/`resetMode` emit `CSI ?2026h` / `CSI ?2026l`.
+const SynchronizedOutputMode = createDecMode(2026);
+const DEC_2026_ON = setMode(SynchronizedOutputMode);
+const DEC_2026_OFF = resetMode(SynchronizedOutputMode);
 
 export class TuiApp extends EventEmitter {
     private renderer: RendererInstance;

--- a/packages/terminal/tui/src/core/inline.ts
+++ b/packages/terminal/tui/src/core/inline.ts
@@ -13,11 +13,30 @@
  * render tick.
  */
 
+import {
+    BracketedPasteMode,
+    createDecMode,
+    cursorHide,
+    cursorPosition,
+    cursorShow,
+    cursorToColumn1,
+    cursorUp,
+    eraseLine,
+    REQUEST_CURSOR_POSITION,
+    resetMode,
+    setMode,
+} from "@visulima/ansi";
+
 import type { RendererInstance } from "./native-binding";
 import { Renderer, terminalSize } from "./native-binding";
 
-const DEC_2026_ON = "\u001B[?2026h";
-const DEC_2026_OFF = "\u001B[?2026l";
+// DEC Private Mode 2026 — Synchronized Output. Precomputed once.
+const SynchronizedOutputMode = createDecMode(2026);
+const DEC_2026_ON = setMode(SynchronizedOutputMode);
+const DEC_2026_OFF = resetMode(SynchronizedOutputMode);
+
+const enableBracketedPaste = setMode(BracketedPasteMode);
+const disableBracketedPaste = resetMode(BracketedPasteMode);
 
 export interface InlineOptions {
     /** Frames per second. Default: 60 */
@@ -77,7 +96,7 @@ export function createInlineLoop(paint: InlinePaintFn, options: InlineOptions = 
 
     function startRendering(cursorRow: number) {
         regionTopRow = cursorRow - renderRows;
-        write(`\u001B[${renderRows}A\u001B[1G`);
+        write(cursorUp(renderRows) + cursorToColumn1);
 
         // rowOffset: Rust emits \x1b[offset+bufRow+1;colH
         // We need offset+0+1 = regionTopRow+1 → offset = regionTopRow
@@ -116,10 +135,10 @@ export function createInlineLoop(paint: InlinePaintFn, options: InlineOptions = 
         // Pre-render setup: these writes happen BEFORE the first render tick.
         // The CPR response arrives asynchronously, so these will have flushed
         // through Node's stdout before Rust's stdout is used.
-        write("\u001B[?25l"); // hide cursor
-        write("\u001B[?2004h"); // enable bracketed paste for usePaste/useTextInput
+        write(cursorHide);
+        write(enableBracketedPaste); // for usePaste/useTextInput
         write("\n".repeat(renderRows));
-        write("\u001B[6n"); // CPR request
+        write(REQUEST_CURSOR_POSITION);
 
         process.on("SIGINT", stop);
 
@@ -148,18 +167,18 @@ export function createInlineLoop(paint: InlinePaintFn, options: InlineOptions = 
                 // Use absolute positioning — cursor could be anywhere after last render.
                 // Region occupies terminal rows (regionTopRow+1) through (regionTopRow+renderRows).
                 for (let i = 0; i < renderRows; i++) {
-                    write(`\u001B[${regionTopRow + 1 + i};1H\u001B[2K`);
+                    write(cursorPosition(regionTopRow + 1 + i, 1) + eraseLine);
                 }
 
                 // Leave cursor at top of cleared region
-                write(`\u001B[${regionTopRow + 1};1H`);
+                write(cursorPosition(regionTopRow + 1, 1));
             } else {
                 // preserve: move cursor just below the region so prompt appears after content
-                write(`\u001B[${regionTopRow + renderRows + 1};1H`);
+                write(cursorPosition(regionTopRow + renderRows + 1, 1));
             }
 
-            write("\u001B[?2004l"); // disable bracketed paste
-            write("\u001B[?25h"); // show cursor
+            write(disableBracketedPaste);
+            write(cursorShow);
         }
 
         if (process.stdin.isTTY)

--- a/packages/terminal/tui/src/ink/components/App.tsx
+++ b/packages/terminal/tui/src/ink/components/App.tsx
@@ -2,7 +2,7 @@
 import { EventEmitter } from "node:events";
 import process from "node:process";
 
-import { cursorShow } from "@visulima/ansi";
+import { BracketedPasteMode, cursorShow, resetMode, setMode } from "@visulima/ansi";
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -20,6 +20,11 @@ import StdoutContext from "./StdoutContext";
 const tab = "\t";
 const shiftTab = "\u001B[Z";
 const escape = "\u001B";
+
+// Precomputed once at module load — `BracketedPasteMode` is a DEC private mode
+// (code 2004) exported by @visulima/ansi; setMode/resetMode emit `CSI ?2004h/l`.
+const enableBracketedPaste = setMode(BracketedPasteMode);
+const disableBracketedPaste = resetMode(BracketedPasteMode);
 
 type AnimationSubscriber = {
     readonly callback: (currentTime: number) => void;
@@ -369,7 +374,7 @@ const App = ({
 
             if (isEnabled) {
                 if (bracketedPasteModeEnabledCount.current === 0) {
-                    stdout.write("\u001B[?2004h");
+                    stdout.write(enableBracketedPaste);
                 }
 
                 bracketedPasteModeEnabledCount.current++;
@@ -382,7 +387,7 @@ const App = ({
             }
 
             if (--bracketedPasteModeEnabledCount.current === 0) {
-                stdout.write("\u001B[?2004l");
+                stdout.write(disableBracketedPaste);
             }
         },
         [stdout],
@@ -581,7 +586,7 @@ const App = ({
 
             if (bracketedPasteModeEnabledCount.current > 0) {
                 if (stdout.isTTY && canWriteToStdout) {
-                    stdout.write("\u001B[?2004l");
+                    stdout.write(disableBracketedPaste);
                 }
 
                 bracketedPasteModeEnabledCount.current = 0;

--- a/packages/terminal/tui/src/ink/cursor-helpers.ts
+++ b/packages/terminal/tui/src/ink/cursor-helpers.ts
@@ -1,14 +1,9 @@
-import { cursorDown, cursorTo, cursorUp } from "@visulima/ansi";
+import { cursorDown, cursorHide, cursorShow, cursorTo, cursorUp } from "@visulima/ansi";
 
 export type CursorPosition = {
     x: number;
     y: number;
 };
-
-const showCursorEscape = "\u001B[?25h";
-const hideCursorEscape = "\u001B[?25l";
-
-export { hideCursorEscape, showCursorEscape };
 
 /**
  * Compare two cursor positions. Returns true if they differ.
@@ -26,7 +21,7 @@ export const buildCursorSuffix = (visibleLineCount: number, cursorPosition: Curs
 
     const moveUp = visibleLineCount - cursorPosition.y;
 
-    return (moveUp > 0 ? cursorUp(moveUp) : "") + cursorTo(cursorPosition.x) + showCursorEscape;
+    return (moveUp > 0 ? cursorUp(moveUp) : "") + cursorTo(cursorPosition.x) + cursorShow;
 };
 
 /**
@@ -58,7 +53,7 @@ export type CursorOnlyInput = {
  * Hides cursor if it was previously shown, returns to bottom, then repositions.
  */
 export const buildCursorOnlySequence = (input: CursorOnlyInput): string => {
-    const hidePrefix = input.cursorWasShown ? hideCursorEscape : "";
+    const hidePrefix = input.cursorWasShown ? cursorHide : "";
     const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition);
     const cursorSuffix = buildCursorSuffix(input.visibleLineCount, input.cursorPosition);
 
@@ -74,5 +69,5 @@ export const buildReturnToBottomPrefix = (cursorWasShown: boolean, previousLineC
         return "";
     }
 
-    return hideCursorEscape + buildReturnToBottom(previousLineCount, previousCursorPosition);
+    return cursorHide + buildReturnToBottom(previousLineCount, previousCursorPosition);
 };

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import { Console as NodeConsole } from "node:console";
 import process from "node:process";
 
-import { ALT_SCREEN_OFF, ALT_SCREEN_ON, clearScreenAndHomeCursor, eraseLines } from "@visulima/ansi";
+import { ALT_SCREEN_OFF, ALT_SCREEN_ON, clearScreenAndHomeCursor, cursorHide, cursorShow, eraseLines } from "@visulima/ansi";
 import { wordWrap } from "@visulima/string";
 // autoBind removed — only methods passed as callbacks need binding,
 // and those are defined as arrow function properties.
@@ -19,7 +19,6 @@ import Yoga from "yoga-layout";
 
 import { accessibilityContext as AccessibilityContext } from "./components/AccessibilityContext";
 import App from "./components/App";
-import { hideCursorEscape, showCursorEscape } from "./cursor-helpers";
 import * as dom from "./dom";
 import instances from "./instances";
 import type { KittyFlagName, KittyKeyboardOptions } from "./kitty-keyboard";
@@ -1093,7 +1092,7 @@ export default class Ink {
 
                     // Switch back to the primary screen buffer
                     this.writeBestEffort(this.options.stdout, ALT_SCREEN_OFF);
-                    this.writeBestEffort(this.options.stdout, showCursorEscape);
+                    this.writeBestEffort(this.options.stdout, cursorShow);
                     this.alternateScreen = false;
                 } else if (!this.interactive) {
                     // Non-interactive environments don't handle erasing ansi escapes well.
@@ -1261,7 +1260,7 @@ export default class Ink {
 
         if (this.alternateScreen) {
             this.writeBestEffort(this.options.stdout, ALT_SCREEN_ON);
-            this.writeBestEffort(this.options.stdout, hideCursorEscape);
+            this.writeBestEffort(this.options.stdout, cursorHide);
         }
     }
 

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import { Console as NodeConsole } from "node:console";
 import process from "node:process";
 
-import { ALT_SCREEN_OFF, ALT_SCREEN_ON, clearScreenAndHomeCursor, eraseLines } from "@visulima/ansi";
+import { ALT_SCREEN_OFF, ALT_SCREEN_ON, cursorTo, eraseLines, eraseScreen } from "@visulima/ansi";
 import { wordWrap } from "@visulima/string";
 // autoBind removed — only methods passed as callbacks need binding,
 // and those are defined as arrow function properties.
@@ -169,6 +169,14 @@ const shouldClearTerminalForFrame = ({
         || shouldClearOnUnmount
     );
 };
+
+// Viewport-only clear used by the fullscreen rerender path. Equivalent to
+// `CSI 2J` + `CSI 1;1H`: erases the visible screen and moves the cursor to
+// the top-left corner without touching the scrollback buffer. This matches
+// the upstream fix in vadimdemedes/ink#936 for vadimdemedes/ink#935, which
+// replaced `clearTerminal` (emitting `CSI 3J` + RIS) with this sequence so
+// terminal scrollback history is preserved across rerenders.
+const eraseScreenSequence: string = eraseScreen + cursorTo(0, 0);
 
 const isErrorInput = (value: unknown): value is Error => value instanceof Error || Object.prototype.toString.call(value) === "[object Error]";
 
@@ -1359,12 +1367,13 @@ export default class Ink {
                 this.options.stdout.write(bsu);
             }
 
-            // Use a viewport-only clear (CSI H + CSI 2J) instead of resetTerminal
+            // Use a viewport-only clear (CSI 2J + CSI 1;1H) instead of resetTerminal
             // (which includes CSI 3J + RIS). Emitting CSI 3J during a rerender wipes
             // the terminal scrollback buffer in VT-compliant terminals (tmux, xterm.js,
             // Microsoft Terminal, WezTerm, Alacritty, Kitty, Ghostty, etc.), destroying
-            // the user's history. See vadimdemedes/ink#935.
-            this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + output);
+            // the user's history. See vadimdemedes/ink#935 and the upstream fix in
+            // vadimdemedes/ink#936.
+            this.options.stdout.write(eraseScreenSequence + this.fullStaticOutput + output);
             this.lastOutput = output;
             this.lastOutputToRender = outputToRender;
             this.lastOutputHeight = outputHeight;

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import { Console as NodeConsole } from "node:console";
 import process from "node:process";
 
-import { ALT_SCREEN_OFF, ALT_SCREEN_ON, cursorTo, eraseLines, eraseScreen } from "@visulima/ansi";
+import { ALT_SCREEN_OFF, ALT_SCREEN_ON, clearScreenAndHomeCursor, eraseLines } from "@visulima/ansi";
 import { wordWrap } from "@visulima/string";
 // autoBind removed — only methods passed as callbacks need binding,
 // and those are defined as arrow function properties.
@@ -169,14 +169,6 @@ const shouldClearTerminalForFrame = ({
         || shouldClearOnUnmount
     );
 };
-
-// Viewport-only clear used by the fullscreen rerender path. Equivalent to
-// `CSI 2J` + `CSI 1;1H`: erases the visible screen and moves the cursor to
-// the top-left corner without touching the scrollback buffer. This matches
-// the upstream fix in vadimdemedes/ink#936 for vadimdemedes/ink#935, which
-// replaced `clearTerminal` (emitting `CSI 3J` + RIS) with this sequence so
-// terminal scrollback history is preserved across rerenders.
-const eraseScreenSequence: string = eraseScreen + cursorTo(0, 0);
 
 const isErrorInput = (value: unknown): value is Error => value instanceof Error || Object.prototype.toString.call(value) === "[object Error]";
 
@@ -1367,13 +1359,13 @@ export default class Ink {
                 this.options.stdout.write(bsu);
             }
 
-            // Use a viewport-only clear (CSI 2J + CSI 1;1H) instead of resetTerminal
+            // Use a viewport-only clear (CSI H + CSI 2J) instead of resetTerminal
             // (which includes CSI 3J + RIS). Emitting CSI 3J during a rerender wipes
             // the terminal scrollback buffer in VT-compliant terminals (tmux, xterm.js,
             // Microsoft Terminal, WezTerm, Alacritty, Kitty, Ghostty, etc.), destroying
             // the user's history. See vadimdemedes/ink#935 and the upstream fix in
             // vadimdemedes/ink#936.
-            this.options.stdout.write(eraseScreenSequence + this.fullStaticOutput + output);
+            this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + output);
             this.lastOutput = output;
             this.lastOutputToRender = outputToRender;
             this.lastOutputHeight = outputHeight;

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import { Console as NodeConsole } from "node:console";
 import process from "node:process";
 
-import { ALT_SCREEN_OFF, ALT_SCREEN_ON, eraseLines, resetTerminal } from "@visulima/ansi";
+import { ALT_SCREEN_OFF, ALT_SCREEN_ON, clearScreenAndHomeCursor, eraseLines } from "@visulima/ansi";
 import { wordWrap } from "@visulima/string";
 // autoBind removed — only methods passed as callbacks need binding,
 // and those are defined as arrow function properties.
@@ -1359,7 +1359,12 @@ export default class Ink {
                 this.options.stdout.write(bsu);
             }
 
-            this.options.stdout.write(resetTerminal + this.fullStaticOutput + output);
+            // Use a viewport-only clear (CSI H + CSI 2J) instead of resetTerminal
+            // (which includes CSI 3J + RIS). Emitting CSI 3J during a rerender wipes
+            // the terminal scrollback buffer in VT-compliant terminals (tmux, xterm.js,
+            // Microsoft Terminal, WezTerm, Alacritty, Kitty, Ghostty, etc.), destroying
+            // the user's history. See vadimdemedes/ink#935.
+            this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + output);
             this.lastOutput = output;
             this.lastOutputToRender = outputToRender;
             this.lastOutputHeight = outputHeight;

--- a/packages/terminal/tui/src/ink/log-update-native.ts
+++ b/packages/terminal/tui/src/ink/log-update-native.ts
@@ -9,6 +9,7 @@
  * by comparing the current buffer against the previous frame cell-by-cell.
  */
 import type { RendererConstructor, RendererInstance } from "../core/native-binding";
+import { bsu, esu } from "./write-synchronized";
 
 export type NativeLogUpdate = {
     clear: () => void;
@@ -106,14 +107,14 @@ export const createNative = (stream: NodeJS.WriteStream): NativeLogUpdate | unde
 
             // Wrap in synchronized update (DEC 2026)
             if (stream.isTTY) {
-                renderer.writeRaw("\u001B[?2026h");
+                renderer.writeRaw(bsu);
             }
 
             try {
                 renderer.render(buffer);
             } finally {
                 if (stream.isTTY) {
-                    renderer.writeRaw("\u001B[?2026l");
+                    renderer.writeRaw(esu);
                 }
             }
         },

--- a/packages/terminal/tui/src/ink/log-update.ts
+++ b/packages/terminal/tui/src/ink/log-update.ts
@@ -4,7 +4,7 @@ import type { Writable } from "node:stream";
 import { cursorHide, cursorNextLine, cursorShow, cursorTo, cursorUp, eraseLineEnd, eraseLines } from "@visulima/ansi";
 
 import type { CursorPosition } from "./cursor-helpers";
-import { buildCursorOnlySequence, buildCursorSuffix, buildReturnToBottomPrefix, cursorPositionChanged, hideCursorEscape } from "./cursor-helpers";
+import { buildCursorOnlySequence, buildCursorSuffix, buildReturnToBottomPrefix, cursorPositionChanged } from "./cursor-helpers";
 
 export type { CursorPosition } from "./cursor-helpers";
 
@@ -133,7 +133,7 @@ const createStandard = (stream: Writable, { showCursor = false } = {}): LogUpdat
         previousLineCount = lines.length;
 
         if (!activeCursor && cursorWasShown) {
-            stream.write(hideCursorEscape);
+            stream.write(cursorHide);
         }
 
         if (activeCursor) {
@@ -317,7 +317,7 @@ const createIncremental = (stream: Writable, { showCursor = false } = {}): LogUp
         previousLines = lines;
 
         if (!activeCursor && cursorWasShown) {
-            stream.write(hideCursorEscape);
+            stream.write(cursorHide);
         }
 
         if (activeCursor) {

--- a/packages/terminal/tui/src/ink/mouse/constants.ts
+++ b/packages/terminal/tui/src/ink/mouse/constants.ts
@@ -2,40 +2,54 @@
  * Ported from `\@zenobius/ink-mouse` (https://github.com/zenobi-us/ink-mouse)
  * Copyright Zeno Jiricek, licensed under Apache-2.0
  */
+import {
+    disableAnyEventMouse,
+    disableButtonEventMouse,
+    disableFocusTracking,
+    disableNormalMouse,
+    disableSgrMouse,
+    disableX10Mouse,
+    enableAnyEventMouse,
+    enableButtonEventMouse,
+    enableFocusTracking,
+    enableNormalMouse,
+    enableSgrMouse,
+    enableX10Mouse,
+} from "@visulima/ansi";
 
 const ANSI_CODES = {
-    // SET_ALTERNATE_SCROLL
+    // SET_ALTERNATE_SCROLL — no dedicated helper in @visulima/ansi
     alternateScroll: { off: "\u001B[?1007l", on: "\u001B[?1007h" },
 
     // SET_VT200_MOUSE - Terminal will send event on button pressed with mouse position
-    mouseButton: { off: "\u001B[?1000l", on: "\u001B[?1000h" },
+    mouseButton: { off: disableNormalMouse, on: enableNormalMouse },
 
     // SET_BTN_EVENT_MOUSE - Terminal will send event on button pressed and mouse motion as long as a button is down
-    mouseDrag: { off: "\u001B[?1002l", on: "\u001B[?1002h" },
+    mouseDrag: { off: disableButtonEventMouse, on: enableButtonEventMouse },
 
     // SET_FOCUS_EVENT_MOUSE
-    mouseFocus: { off: "\u001B[?1004l", on: "\u001B[?1004h" },
+    mouseFocus: { off: disableFocusTracking, on: enableFocusTracking },
 
-    // SET_VT200_HIGHLIGHT_MOUSE - Terminal will send position of the column highlighted
+    // SET_VT200_HIGHLIGHT_MOUSE - Terminal will send position of the column highlighted — no dedicated helper in @visulima/ansi
     mouseHighlight: { off: "\u001B[?1001l", on: "\u001B[?1001h" },
 
     // SET_ANY_EVENT_MOUSE - Terminal will send event on button pressed and motion
-    mouseMotion: { off: "\u001B[?1003l", on: "\u001B[?1003h" },
+    mouseMotion: { off: disableAnyEventMouse, on: enableAnyEventMouse },
 
-    // SET_URXVT_EXT_MODE_MOUSE
+    // SET_URXVT_EXT_MODE_MOUSE — no dedicated helper in @visulima/ansi
     mouseMotionOthers: { off: "\u001B[?1015l", on: "\u001B[?1015h" },
 
-    // SET_PIXEL_POSITION_MOUSE
+    // SET_PIXEL_POSITION_MOUSE — no dedicated helper in @visulima/ansi
     mousePixelMode: { off: "\u001B[?1016l", on: "\u001B[?1016h" },
 
     // SET_SGR_EXT_MODE_MOUSE - Another mouse protocol that extends coordinate mapping (without it, supports only 223 rows and columns)
-    mouseSGR: { off: "\u001B[?1006l", on: "\u001B[?1006h" },
+    mouseSGR: { off: disableSgrMouse, on: enableSgrMouse },
 
-    // SET_EXT_MODE_MOUSE
+    // SET_EXT_MODE_MOUSE — no dedicated helper in @visulima/ansi
     mouseUtf8: { off: "\u001B[?1005l", on: "\u001B[?1005h" },
 
     // SET_X10_MOUSE
-    mouseX10: { off: "\u001B[?9l", on: "\u001B[?9h" },
+    mouseX10: { off: disableX10Mouse, on: enableX10Mouse },
 };
 
 /**

--- a/packages/terminal/tui/src/ink/write-synchronized.ts
+++ b/packages/terminal/tui/src/ink/write-synchronized.ts
@@ -1,10 +1,17 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import type { Writable } from "node:stream";
 
+import { createDecMode, resetMode, setMode } from "@visulima/ansi";
 import isInCi from "is-in-ci";
 
-export const bsu = "\u001B[?2026h";
-export const esu = "\u001B[?2026l";
+// DEC Private Mode 2026 — Synchronized Output Mode.
+// `bsu` (Begin Sync Update) and `esu` (End Sync Update) bracket a batch of
+// writes so VT-compliant terminals paint them atomically instead of tearing.
+// `setMode`/`resetMode` emit `CSI ?2026h` / `CSI ?2026l`.
+const SynchronizedOutputMode = createDecMode(2026);
+
+export const bsu: string = setMode(SynchronizedOutputMode);
+export const esu: string = resetMode(SynchronizedOutputMode);
 
 export function shouldSynchronize(stream: Writable, interactive?: boolean): boolean {
     return "isTTY" in stream && (stream as Writable & { isTTY: boolean }).isTTY && (interactive ?? !isInCi);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -125,7 +125,7 @@ catalogs:
     '@shikijs/langs': ^4.0.2
     '@shikijs/themes': ^4.0.2
     '@sveltejs/adapter-auto': ^7.0.1
-    '@sveltejs/kit': 2.57.0
+    '@sveltejs/kit': ^2.57.1
     '@total-typescript/ts-reset': ^0.6.1
     '@tsconfig/node22': ^22.0.5
     '@vercel/blob': 2.3.3
@@ -754,11 +754,14 @@ overrides:
   '@modelcontextprotocol/sdk@<1.25.2': '>=1.25.2'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '>=1.26.0'
   '@sveltejs/kit@>=2.49.0 <=2.52.1': '>=2.52.2'
+  '@sveltejs/kit@<=2.57.0': '>=2.57.1'
   ajv@>=6.0.0 <6.14.0: '>=6.14.0 <7.0.0'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   axios@<1.12.0: '>=1.12.2'
   axios@<=1.13.4: '>=1.13.5'
+  axios@<1.15.0: '>=1.15.0'
   basic-ftp@<5.2.0: '>=5.2.0'
+  basic-ftp@<=5.2.1: '>=5.2.2'
   body-parser@>=2.2.0 <2.2.1: '>=2.2.1'
   brace-expansion@<5.0.5: '>=5.0.5'
   chrono-node@<2.2.4: '>=2.9.0'
@@ -844,6 +847,7 @@ overrides:
   tar@<=7.5.2: '>=7.5.3'
   tar@<=7.5.3: '>=7.5.4'
   tmp@<=0.2.3: '>=0.2.5'
+  unhead@<2.1.13: '>=2.1.13'
   undici@<6.23.0: '>=6.23.0'
   undici@<6.24.0: '>=6.24.0'
   undici@>=6.0.0 <6.24.0: '>=6.24.0'


### PR DESCRIPTION
## Summary
This PR fixes a regression where the render loop was erasing the terminal's scrollback buffer during rerenders, destroying the user's command history. The fix replaces `resetTerminal` (which includes scrollback-erase sequences) with `clearScreenAndHomeCursor` (which only clears the viewport).

## Key Changes
- **Updated imports**: Added `clearScreenAndHomeCursor` and `eraseScreenAndScrollback` from `@visulima/ansi`
- **Replaced terminal reset sequence**: Changed from `resetTerminal` to `clearScreenAndHomeCursor` in the render output path
- **Enhanced test coverage**: Added regression guards to ensure scrollback-erase sequences (`CSI 3J`) and full reset sequences (`RIS`) are never emitted during rerenders
- **Updated test assertions**: Increased assertion counts to validate the new behavior

## Implementation Details
The core issue was that `resetTerminal` includes both `CSI 3J` (erase scrollback) and `RIS` (reset terminal state), which wipes terminal history in VT-compliant terminals (tmux, xterm.js, Alacritty, Microsoft Terminal, WezTerm, Kitty, Ghostty, etc.).

The fix uses `clearScreenAndHomeCursor` instead, which only performs:
- `CSI H` (move cursor to home position)
- `CSI 2J` (erase viewport only)

This preserves the user's scrollback history while still clearing the viewport for fullscreen rerenders.

Addresses vadimdemedes/ink#935.

https://claude.ai/code/session_01P8bE4JY3r54rzGy9nKkAXK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal clearing during interactive updates now avoids full resets, preserving scrollback and producing smoother rerenders.
  * Cursor show/hide behavior restored more reliably during mode switches and unmounts.

* **Improvements**
  * More consistent handling of paste mode, mouse reporting, and synchronized output for improved terminal interactivity and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->