### PR TITLE
feat: Add cache management command (list, clean, prune, size)

### DIFF
--- a/packages/tooling/task-runner/src/cache.ts
+++ b/packages/tooling/task-runner/src/cache.ts
@@ -38,6 +38,14 @@ interface CacheOptions {
 const DEFAULT_MAX_CACHE_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
+ * Directory name (relative to `workspaceRoot`) where the task runner writes
+ * its cache by default. Exported so callers that manage the cache from the
+ * outside — e.g. a CLI `cache clean` command — can reach the same default
+ * without hard-coding the literal.
+ */
+const DEFAULT_CACHE_DIRECTORY_NAME = ".task-runner-cache";
+
+/**
  * Removes a cache entry directory.
  */
 const removeEntry = async (entryPath: string): Promise<void> => {
@@ -130,7 +138,7 @@ class Cache {
 
     public constructor(options: CacheOptions) {
         this.#workspaceRoot = options.workspaceRoot;
-        this.#cacheDirectory = options.cacheDirectory ?? join(options.workspaceRoot, ".task-runner-cache");
+        this.#cacheDirectory = options.cacheDirectory ?? join(options.workspaceRoot, DEFAULT_CACHE_DIRECTORY_NAME);
         this.#maxCacheAge = options.maxCacheAge ?? DEFAULT_MAX_CACHE_AGE;
         this.#maxCacheSize = options.maxCacheSize ? parseCacheSize(options.maxCacheSize) : undefined;
     }
@@ -441,4 +449,4 @@ class Cache {
 }
 
 export type { CachedResult, CacheOptions };
-export { Cache, formatCacheSize, parseCacheSize };
+export { Cache, DEFAULT_CACHE_DIRECTORY_NAME, formatCacheSize, parseCacheSize };

--- a/packages/tooling/task-runner/src/index.ts
+++ b/packages/tooling/task-runner/src/index.ts
@@ -4,7 +4,7 @@ export { buildForwardDependencyMap, buildReverseDependencyMap, expandAffected, f
 
 // Cache
 export type { CachedResult, CacheOptions } from "./cache";
-export { Cache, formatCacheSize, parseCacheSize } from "./cache";
+export { Cache, DEFAULT_CACHE_DIRECTORY_NAME, formatCacheSize, parseCacheSize } from "./cache";
 
 // Command parser
 export type { ParseCommandsOptions } from "./command-parser";

--- a/packages/tooling/vis/__tests__/cache-directory.test.ts
+++ b/packages/tooling/vis/__tests__/cache-directory.test.ts
@@ -1,0 +1,109 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    DEFAULT_CACHE_DIRECTORY_NAME,
+    isCacheDirectoryInsideWorkspace,
+    resolveCacheDirectory,
+} from "../src/cache-directory";
+
+// Use a non-relative POSIX-ish workspace root for the tests. `resolve()` on
+// both POSIX and Windows treats `/ws` as absolute enough to build reproducible
+// paths, so we stay platform-independent by letting `resolve()` produce the
+// expectation strings too.
+const WS = resolve("/ws");
+
+describe("resolveCacheDirectory", () => {
+    it("prefers the CLI override when set", () => {
+        expect.assertions(1);
+
+        const cli = resolve("/tmp/cli-cache");
+
+        expect(resolveCacheDirectory(WS, cli, resolve("/tmp/config-cache"))).toBe(cli);
+    });
+
+    it("falls back to the config value when no CLI override is set", () => {
+        expect.assertions(1);
+
+        const cfg = resolve("/tmp/config-cache");
+
+        expect(resolveCacheDirectory(WS, undefined, cfg)).toBe(cfg);
+    });
+
+    it("falls back to the workspace default when neither is set", () => {
+        expect.assertions(1);
+        expect(resolveCacheDirectory(WS, undefined, undefined)).toBe(resolve(WS, DEFAULT_CACHE_DIRECTORY_NAME));
+    });
+
+    it("treats empty strings as unset", () => {
+        expect.assertions(2);
+
+        const expected = resolve(WS, DEFAULT_CACHE_DIRECTORY_NAME);
+
+        expect(resolveCacheDirectory(WS, "", undefined)).toBe(expected);
+        expect(resolveCacheDirectory(WS, undefined, "")).toBe(expected);
+    });
+
+    it("resolves relative CLI values against the workspace root", () => {
+        expect.assertions(1);
+        expect(resolveCacheDirectory(WS, ".cache/tasks", undefined)).toBe(resolve(WS, ".cache/tasks"));
+    });
+
+    it("resolves relative config values against the workspace root", () => {
+        expect.assertions(1);
+        expect(resolveCacheDirectory(WS, undefined, "cache")).toBe(resolve(WS, "cache"));
+    });
+
+    it("leaves absolute CLI values untouched", () => {
+        expect.assertions(1);
+
+        const abs = resolve("/custom/cache");
+
+        expect(resolveCacheDirectory(WS, abs, undefined)).toBe(abs);
+    });
+});
+
+describe("isCacheDirectoryInsideWorkspace", () => {
+    it("returns true for a direct child of the workspace", () => {
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve(WS, ".task-runner-cache"), WS)).toBe(true);
+    });
+
+    it("returns true for a deeply nested child", () => {
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve(WS, "packages/foo/.cache"), WS)).toBe(true);
+    });
+
+    it("returns true for a directory whose name starts with '..' (not a traversal)", () => {
+        // Regression: the original `startsWith("..")` check rejected any
+        // relative path beginning with ".." — including literal dir names
+        // like "..foo".
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve(WS, "..foo"), WS)).toBe(true);
+    });
+
+    it("returns false when the cache dir is outside the workspace", () => {
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve("/tmp/vis-cache"), WS)).toBe(false);
+    });
+
+    it("does NOT treat `/workspace` as inside `/work` (prefix collision)", () => {
+        // Regression: the previous `startsWith(workspaceRoot)` check matched
+        // `/workspace` against `/work` because they share a string prefix.
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve("/workspace/.cache"), resolve("/work"))).toBe(false);
+    });
+
+    it("does NOT treat a sibling directory as inside", () => {
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(resolve("/ws-other/.cache"), WS)).toBe(false);
+    });
+
+    it("returns false when the cache dir is the workspace root itself", () => {
+        // Equal paths aren't "inside" — treat them as misconfiguration so
+        // the caller prompts before doing anything destructive.
+        expect.assertions(1);
+        expect(isCacheDirectoryInsideWorkspace(WS, WS)).toBe(false);
+    });
+});

--- a/packages/tooling/vis/__tests__/cache.test.ts
+++ b/packages/tooling/vis/__tests__/cache.test.ts
@@ -1,0 +1,402 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    collectCacheEntries,
+    formatAge,
+    runClean,
+    runPrune,
+} from "../src/commands/cache";
+
+describe("formatAge", () => {
+    it("returns seconds for sub-minute ages", () => {
+        expect.assertions(1);
+
+        const now = 1_700_000_000_000;
+        const mtime = now - 5 * 1000;
+
+        expect(formatAge(mtime, now)).toBe("5s");
+    });
+
+    it("returns minutes between 1m and 1h", () => {
+        expect.assertions(1);
+
+        const now = 1_700_000_000_000;
+        const mtime = now - 10 * 60 * 1000;
+
+        expect(formatAge(mtime, now)).toBe("10m");
+    });
+
+    it("returns hours between 1h and 1d", () => {
+        expect.assertions(1);
+
+        const now = 1_700_000_000_000;
+        const mtime = now - 5 * 60 * 60 * 1000;
+
+        expect(formatAge(mtime, now)).toBe("5h");
+    });
+
+    it("returns days for older entries", () => {
+        expect.assertions(1);
+
+        const now = 1_700_000_000_000;
+        const mtime = now - 3 * 24 * 60 * 60 * 1000;
+
+        expect(formatAge(mtime, now)).toBe("3d");
+    });
+
+    it("uses Date.now() when no `now` is passed", () => {
+        expect.assertions(1);
+
+        const mtime = Date.now() - 2 * 1000;
+
+        // Regex because the implicit clock read may give 2s or 3s.
+        expect(formatAge(mtime)).toMatch(/^\ds$/u);
+    });
+});
+
+describe("collectCacheEntries", () => {
+    let cacheDirectory: string;
+
+    beforeEach(() => {
+        cacheDirectory = mkdtempSync(join(tmpdir(), "vis-cache-test-"));
+    });
+
+    afterEach(() => {
+        rmSync(cacheDirectory, { force: true, recursive: true });
+    });
+
+    it("returns an empty list for a non-existent directory", async () => {
+        expect.assertions(1);
+
+        rmSync(cacheDirectory, { force: true, recursive: true });
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toStrictEqual([]);
+    });
+
+    it("returns an empty list for an empty cache directory", async () => {
+        expect.assertions(1);
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toStrictEqual([]);
+    });
+
+    it("enumerates non-dotfile directories under the cache root", async () => {
+        expect.assertions(3);
+
+        mkdirSync(join(cacheDirectory, "abc123"));
+        writeFileSync(join(cacheDirectory, "abc123", "code"), "0");
+        writeFileSync(join(cacheDirectory, "abc123", "terminalOutput"), "hello world");
+
+        mkdirSync(join(cacheDirectory, "def456"));
+        writeFileSync(join(cacheDirectory, "def456", "code"), "0");
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toHaveLength(2);
+        expect(entries.map((entry) => entry.hash).sort()).toStrictEqual(["abc123", "def456"]);
+        expect(entries.every((entry) => entry.sizeBytes > 0)).toBe(true);
+    });
+
+    it("skips hidden entries (index files, temp dirs)", async () => {
+        expect.assertions(1);
+
+        writeFileSync(join(cacheDirectory, ".task-index.json"), "{}");
+        mkdirSync(join(cacheDirectory, ".tmp-abc"));
+        writeFileSync(join(cacheDirectory, ".tmp-abc", "x"), "y");
+
+        mkdirSync(join(cacheDirectory, "abc"));
+        writeFileSync(join(cacheDirectory, "abc", "code"), "0");
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries.map((entry) => entry.hash)).toStrictEqual(["abc"]);
+    });
+
+    it("skips plain files at the cache root", async () => {
+        expect.assertions(1);
+
+        writeFileSync(join(cacheDirectory, "stray.txt"), "not a cache entry");
+        mkdirSync(join(cacheDirectory, "abc"));
+        writeFileSync(join(cacheDirectory, "abc", "code"), "0");
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries.map((entry) => entry.hash)).toStrictEqual(["abc"]);
+    });
+});
+
+/**
+ * Writes a fully-formed cache entry — a directory with the files the task
+ * runner expects (`code`, `terminalOutput`, `.commit`). Used to exercise the
+ * `runClean` and `runPrune` subcommands against a realistic layout.
+ */
+const writeCacheEntry = (cacheDirectory: string, hash: string, options: { mtime?: Date } = {}): void => {
+    const entry = join(cacheDirectory, hash);
+
+    mkdirSync(entry, { recursive: true });
+    writeFileSync(join(entry, "code"), "0");
+    writeFileSync(join(entry, "terminalOutput"), `output for ${hash}`);
+    writeFileSync(join(entry, ".commit"), "");
+
+    if (options.mtime) {
+        utimesSync(entry, options.mtime, options.mtime);
+    }
+};
+
+describe("runClean", () => {
+    let workspaceRoot: string;
+    let cacheDirectory: string;
+
+    beforeEach(() => {
+        workspaceRoot = mkdtempSync(join(tmpdir(), "vis-cache-clean-ws-"));
+        cacheDirectory = join(workspaceRoot, ".task-runner-cache");
+        mkdirSync(cacheDirectory);
+        writeCacheEntry(cacheDirectory, "hash1");
+        writeCacheEntry(cacheDirectory, "hash2");
+    });
+
+    afterEach(() => {
+        rmSync(workspaceRoot, { force: true, recursive: true });
+    });
+
+    it("dry-run reports entries without deleting", async () => {
+        expect.assertions(1);
+
+        await runClean(cacheDirectory, workspaceRoot, { dryRun: true, force: false });
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toHaveLength(2);
+    });
+
+    it("clears all entries when the cache is inside the workspace", async () => {
+        expect.assertions(1);
+
+        await runClean(cacheDirectory, workspaceRoot, { dryRun: false, force: false });
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toStrictEqual([]);
+    });
+
+    it("is a no-op when the cache directory does not exist", async () => {
+        expect.assertions(1);
+
+        const missing = join(workspaceRoot, "does-not-exist");
+
+        // Should not throw.
+        await expect(runClean(missing, workspaceRoot, { dryRun: false, force: false })).resolves.toBeUndefined();
+    });
+
+    it("refuses to clean an out-of-workspace cache without --force on non-TTY", async () => {
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+        const originalIsTTY = process.stdin.isTTY;
+
+        try {
+            Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+
+            // `workspaceRoot` is passed as a sibling dir — the cache lives
+            // outside it, so the confirmation gate kicks in.
+            const otherWorkspace = mkdtempSync(join(tmpdir(), "vis-cache-other-"));
+
+            try {
+                await runClean(cacheDirectory, otherWorkspace, { dryRun: false, force: false });
+
+                expect(process.exitCode).toBe(1);
+
+                // Entries should still be there since we refused.
+                const entries = await collectCacheEntries(cacheDirectory);
+
+                expect(entries).toHaveLength(2);
+            } finally {
+                rmSync(otherWorkspace, { force: true, recursive: true });
+            }
+        } finally {
+            process.exitCode = originalExitCode;
+            Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalIsTTY });
+        }
+    });
+
+    it("cleans out-of-workspace cache when --force is set", async () => {
+        expect.assertions(1);
+
+        const otherWorkspace = mkdtempSync(join(tmpdir(), "vis-cache-other-force-"));
+
+        try {
+            await runClean(cacheDirectory, otherWorkspace, { dryRun: false, force: true });
+
+            const entries = await collectCacheEntries(cacheDirectory);
+
+            expect(entries).toStrictEqual([]);
+        } finally {
+            rmSync(otherWorkspace, { force: true, recursive: true });
+        }
+    });
+
+    it("refuses to delete the workspace root even with --force", async () => {
+        // Regression: `--cache-dir .` resolved to workspaceRoot. Without
+        // this guard, `--force` would have nuked the entire repo.
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+
+        try {
+            await runClean(workspaceRoot, workspaceRoot, { dryRun: false, force: true });
+
+            expect(process.exitCode).toBe(1);
+
+            // The workspace root must still exist.
+            expect(existsSync(workspaceRoot)).toBe(true);
+        } finally {
+            process.exitCode = originalExitCode;
+        }
+    });
+});
+
+describe("runPrune", () => {
+    let workspaceRoot: string;
+    let cacheDirectory: string;
+
+    beforeEach(() => {
+        workspaceRoot = mkdtempSync(join(tmpdir(), "vis-cache-prune-ws-"));
+        cacheDirectory = join(workspaceRoot, ".task-runner-cache");
+        mkdirSync(cacheDirectory);
+    });
+
+    afterEach(() => {
+        rmSync(workspaceRoot, { force: true, recursive: true });
+    });
+
+    it("is a no-op when the cache directory does not exist", async () => {
+        expect.assertions(1);
+
+        const missing = join(workspaceRoot, "no-cache");
+
+        await expect(runPrune(missing, workspaceRoot, {})).resolves.toBeUndefined();
+    });
+
+    it("rejects an invalid --max-size string and sets exit code 1", async () => {
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+
+        try {
+            writeCacheEntry(cacheDirectory, "hash1");
+
+            await runPrune(cacheDirectory, workspaceRoot, { maxCacheSize: "definitely-not-a-size" });
+
+            expect(process.exitCode).toBe(1);
+
+            // Entries should still be there since validation failed early.
+            const entries = await collectCacheEntries(cacheDirectory);
+
+            expect(entries).toHaveLength(1);
+        } finally {
+            process.exitCode = originalExitCode;
+        }
+    });
+
+    it("rejects a negative --max-size and sets exit code 1", async () => {
+        // Regression: parseCacheSize accepted "-500MB" → negative byte count →
+        // Cache.removeOldEntries() evicted everything.
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+
+        try {
+            writeCacheEntry(cacheDirectory, "hash1");
+
+            await runPrune(cacheDirectory, workspaceRoot, { maxCacheSize: "-500MB" });
+
+            expect(process.exitCode).toBe(1);
+
+            const entries = await collectCacheEntries(cacheDirectory);
+
+            expect(entries).toHaveLength(1);
+        } finally {
+            process.exitCode = originalExitCode;
+        }
+    });
+
+    it("evicts entries older than --max-age-days", async () => {
+        expect.assertions(2);
+
+        const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+
+        writeCacheEntry(cacheDirectory, "fresh");
+        writeCacheEntry(cacheDirectory, "stale", { mtime: twoDaysAgo });
+
+        await runPrune(cacheDirectory, workspaceRoot, { maxCacheAgeDays: 1 });
+
+        const entries = await collectCacheEntries(cacheDirectory);
+        const hashes = entries.map((entry) => entry.hash);
+
+        expect(hashes).toContain("fresh");
+        expect(hashes).not.toContain("stale");
+    });
+
+    it("does nothing when no entries exceed the configured limits", async () => {
+        expect.assertions(1);
+
+        writeCacheEntry(cacheDirectory, "fresh1");
+        writeCacheEntry(cacheDirectory, "fresh2");
+
+        await runPrune(cacheDirectory, workspaceRoot, { maxCacheAgeDays: 30 });
+
+        const entries = await collectCacheEntries(cacheDirectory);
+
+        expect(entries).toHaveLength(2);
+    });
+
+    it("rejects negative --max-age-days and sets exit code 1", async () => {
+        // Regression: a negative value caused maxCacheAge to be negative,
+        // making `now - mtime > negativeValue` always true — everything
+        // was evicted.
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+
+        try {
+            writeCacheEntry(cacheDirectory, "hash1");
+
+            await runPrune(cacheDirectory, workspaceRoot, { maxCacheAgeDays: -5 });
+
+            expect(process.exitCode).toBe(1);
+
+            const entries = await collectCacheEntries(cacheDirectory);
+
+            expect(entries).toHaveLength(1);
+        } finally {
+            process.exitCode = originalExitCode;
+        }
+    });
+
+    it("rejects NaN --max-age-days and sets exit code 1", async () => {
+        expect.assertions(2);
+
+        const originalExitCode = process.exitCode;
+
+        try {
+            writeCacheEntry(cacheDirectory, "hash1");
+
+            await runPrune(cacheDirectory, workspaceRoot, { maxCacheAgeDays: Number.NaN });
+
+            expect(process.exitCode).toBe(1);
+
+            const entries = await collectCacheEntries(cacheDirectory);
+
+            expect(entries).toHaveLength(1);
+        } finally {
+            process.exitCode = originalExitCode;
+        }
+    });
+});

--- a/packages/tooling/vis/src/bin.ts
+++ b/packages/tooling/vis/src/bin.ts
@@ -14,6 +14,7 @@ import aiCommand from "./commands/ai";
 import analyzeCommand from "./commands/analyze";
 import approveBuildsCommand from "./commands/approve-builds";
 import auditCommand from "./commands/audit";
+import cacheCommand from "./commands/cache";
 import checkCommand from "./commands/check";
 import ciCommand from "./commands/ci";
 import cleanCommand from "./commands/clean";
@@ -139,6 +140,7 @@ cli.addCommand(pmCommand);
 // Project & environment commands
 cli.addCommand(initCommand);
 cli.addCommand(cleanCommand);
+cli.addCommand(cacheCommand);
 cli.addCommand(createCommand);
 cli.addCommand(devcontainerCommand);
 cli.addCommand(upgradeCommand);

--- a/packages/tooling/vis/src/cache-directory.ts
+++ b/packages/tooling/vis/src/cache-directory.ts
@@ -1,0 +1,80 @@
+import { isAbsolute, relative, resolve } from "@visulima/path";
+import { DEFAULT_CACHE_DIRECTORY_NAME } from "@visulima/task-runner";
+
+/**
+ * Shared helpers for resolving the task runner's cache directory.
+ *
+ * Used by `vis run` (to configure the runner) and `vis cache` (to manage the
+ * cache from the outside) so both commands agree on:
+ *
+ * - the resolution order: `--cache-dir` flag > vis.config.ts
+ *   `taskRunnerOptions.cacheDirectory` > `{workspaceRoot}/.task-runner-cache`
+ * - relative-path normalization against `workspaceRoot`
+ * - containment checks (used to decide whether a destructive operation is
+ *   safe to perform without confirmation)
+ */
+
+/**
+ * Resolves the cache directory from CLI options and vis.config.ts.
+ *
+ * All paths returned from this helper are absolute — relative values are
+ * resolved against `workspaceRoot` so they refer to the same directory no
+ * matter what `process.cwd()` happens to be when the command runs.
+ *
+ * Precedence: `optionsCacheDir` > `configCacheDir` > `{workspaceRoot}/{@link DEFAULT_CACHE_DIRECTORY_NAME}`.
+ *
+ * @param workspaceRoot - Absolute path to the workspace root directory.
+ * @param optionsCacheDir - CLI `--cache-dir` value (may be relative or absolute). Takes highest priority.
+ * @param configCacheDir - `taskRunnerOptions.cacheDirectory` from vis.config.ts (may be relative or absolute).
+ * @returns The resolved absolute path to the cache directory.
+ */
+const resolveCacheDirectory = (
+    workspaceRoot: string,
+    optionsCacheDir: string | undefined,
+    configCacheDir: string | undefined,
+): string => {
+    const normalize = (value: string): string => (isAbsolute(value) ? value : resolve(workspaceRoot, value));
+
+    if (optionsCacheDir && optionsCacheDir.length > 0) {
+        return normalize(optionsCacheDir);
+    }
+
+    if (configCacheDir && configCacheDir.length > 0) {
+        return normalize(configCacheDir);
+    }
+
+    return resolve(workspaceRoot, DEFAULT_CACHE_DIRECTORY_NAME);
+};
+
+/**
+ * Returns `true` when `cacheDirectory` sits inside `workspaceRoot`. Uses
+ * `relative()` instead of `startsWith()` so paths with a common string
+ * prefix but different parents (e.g. `/work` vs `/workspace`) are correctly
+ * distinguished.
+ *
+ * Callers use this to decide whether a `rm -rf` on the cache directory is
+ * safe without an extra confirmation prompt.
+ *
+ * @param cacheDirectory - Absolute path to the cache directory.
+ * @param workspaceRoot - Absolute path to the workspace root directory.
+ * @returns `true` when `cacheDirectory` is a proper descendant of `workspaceRoot`; `false` otherwise
+ *          (including when the two paths are identical).
+ */
+const isCacheDirectoryInsideWorkspace = (cacheDirectory: string, workspaceRoot: string): boolean => {
+    const rel = relative(workspaceRoot, cacheDirectory);
+
+    if (rel.length === 0) {
+        // Same path — technically "inside" but probably a misconfiguration.
+        // Treat as not-inside so the caller pauses to confirm.
+        return false;
+    }
+
+    // Check for parent traversal: `relative()` emits leading `..` segments
+    // when `cacheDirectory` is above `workspaceRoot`. We only reject the exact
+    // `".."` component or `"../"` prefix — NOT any name that *starts* with
+    // `".."` (e.g. a directory literally named `"..foo"` is fine).
+    // `@visulima/path` always uses `"/"` as separator.
+    return !(rel === ".." || rel.startsWith("../")) && !isAbsolute(rel);
+};
+
+export { DEFAULT_CACHE_DIRECTORY_NAME, isCacheDirectoryInsideWorkspace, resolveCacheDirectory };

--- a/packages/tooling/vis/src/commands/cache.ts
+++ b/packages/tooling/vis/src/commands/cache.ts
@@ -1,0 +1,568 @@
+import { readdir, realpath, rm, stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+
+import type { Command } from "@visulima/cerebro";
+import { isAccessibleSync } from "@visulima/fs";
+import { formatBytes } from "@visulima/humanizer";
+import { join } from "@visulima/path";
+import { Cache, parseCacheSize } from "@visulima/task-runner";
+
+import { isCacheDirectoryInsideWorkspace, resolveCacheDirectory } from "../cache-directory";
+import { failure, info, success, warn } from "../output";
+
+/**
+ * Shape returned by `collectCacheEntries`. Kept close to what `removeOldEntries`
+ * uses internally so we can render the list identically.
+ */
+interface CacheEntry {
+    hash: string;
+    mtimeMs: number;
+    path: string;
+    sizeBytes: number;
+}
+
+/**
+ * Recursively sums the byte size of all files under `directory`.
+ * Internal-use only — not exported to keep the public surface small.
+ */
+const sumDirectorySize = async (directory: string): Promise<number> => {
+    let total = 0;
+
+    try {
+        const entries = await readdir(directory, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const full = join(directory, entry.name);
+
+            if (entry.isDirectory()) {
+                // eslint-disable-next-line no-await-in-loop
+                total += await sumDirectorySize(full);
+            } else if (entry.isFile()) {
+                // eslint-disable-next-line no-await-in-loop
+                const s = await stat(full);
+
+                total += s.size;
+            }
+        }
+    } catch {
+        // Ignore — permissions, concurrent deletes, etc.
+    }
+
+    return total;
+};
+
+/**
+ * Reads the cache directory and returns one entry per cached task hash.
+ * Skips any file/directory starting with `.` (index files, temp dirs).
+ *
+ * @param cacheDirectory - Absolute path to the cache root directory.
+ * @returns Array of cache entries sorted newest-first by modification time.
+ *          Returns an empty array when the directory does not exist or is empty.
+ */
+const collectCacheEntries = async (cacheDirectory: string): Promise<CacheEntry[]> => {
+    const entries: CacheEntry[] = [];
+
+    let dirents: Awaited<ReturnType<typeof readdir>>;
+
+    try {
+        dirents = await readdir(cacheDirectory);
+    } catch {
+        return [];
+    }
+
+    for (const name of dirents) {
+        if (name.startsWith(".")) {
+            continue;
+        }
+
+        const fullPath = join(cacheDirectory, name);
+
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            const s = await stat(fullPath);
+
+            if (!s.isDirectory()) {
+                continue;
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            const sizeBytes = await sumDirectorySize(fullPath);
+
+            entries.push({
+                hash: name,
+                mtimeMs: s.mtimeMs,
+                path: fullPath,
+                sizeBytes,
+            });
+        } catch {
+            // Ignore — entry may have been removed concurrently.
+        }
+    }
+
+    // Newest first for easier reading.
+    entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    return entries;
+};
+
+/**
+ * Formats the difference between `now` and `mtimeMs` as a short age string:
+ * "3m", "2h", "4d". The caller passes a shared `now` so rows in the same
+ * listing use a consistent baseline.
+ *
+ * @param mtimeMs - File modification time in milliseconds since epoch.
+ * @param now - Reference timestamp in milliseconds since epoch. Defaults to `Date.now()`.
+ * @returns A compact age string such as `"5s"`, `"10m"`, `"2h"`, or `"3d"`.
+ */
+const formatAge = (mtimeMs: number, now: number = Date.now()): string => {
+    const seconds = Math.floor((now - mtimeMs) / 1000);
+
+    if (seconds < 60) {
+        return `${String(seconds)}s`;
+    }
+
+    if (seconds < 3600) {
+        return `${String(Math.floor(seconds / 60))}m`;
+    }
+
+    if (seconds < 86_400) {
+        return `${String(Math.floor(seconds / 3600))}h`;
+    }
+
+    return `${String(Math.floor(seconds / 86_400))}d`;
+};
+
+/**
+ * Prompts the user with a yes/no question. Returns `true` for `y`/`yes`.
+ * Mirrors the helper used by `vis hook install` so prompts stay consistent.
+ */
+const confirmPrompt = (question: string): Promise<boolean> =>
+    new Promise((resolvePromise) => {
+        const rl = createInterface({ input: process.stdin, output: process.stderr });
+
+        rl.question(`${question} (y/N) `, (answer) => {
+            rl.close();
+            const trimmed = answer.trim().toLowerCase();
+
+            resolvePromise(trimmed === "y" || trimmed === "yes");
+        });
+    });
+
+/**
+ * `list` subcommand — prints a table of cached task entries.
+ *
+ * @param cacheDirectory - Absolute path to the cache directory to enumerate.
+ * @param format - Output format: `"table"` for a human-readable table, `"json"` for machine-readable JSON.
+ * @param logger - Console instance used for non-prefixed table rows.
+ * @returns Resolves when output has been written.
+ */
+const runList = async (cacheDirectory: string, format: string, logger: Console): Promise<void> => {
+    if (!isAccessibleSync(cacheDirectory)) {
+        if (format === "json") {
+            process.stdout.write(`${JSON.stringify({ directory: cacheDirectory, entries: [], totalBytes: 0, totalCount: 0 }, undefined, 2)}\n`);
+
+            return;
+        }
+
+        info(`No cache directory found at ${cacheDirectory}`);
+
+        return;
+    }
+
+    const entries = await collectCacheEntries(cacheDirectory);
+
+    if (entries.length === 0) {
+        if (format === "json") {
+            process.stdout.write(`${JSON.stringify({ directory: cacheDirectory, entries: [], totalBytes: 0, totalCount: 0 }, undefined, 2)}\n`);
+
+            return;
+        }
+
+        info(`Cache directory is empty: ${cacheDirectory}`);
+
+        return;
+    }
+
+    const totalBytes = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+
+    if (format === "json") {
+        const now = Date.now();
+
+        process.stdout.write(
+            `${JSON.stringify(
+                {
+                    directory: cacheDirectory,
+                    entries: entries.map((entry) => ({
+                        ageMs: now - entry.mtimeMs,
+                        hash: entry.hash,
+                        mtimeIso: new Date(entry.mtimeMs).toISOString(),
+                        sizeBytes: entry.sizeBytes,
+                    })),
+                    totalBytes,
+                    totalCount: entries.length,
+                },
+                undefined,
+                2,
+            )}\n`,
+        );
+
+        return;
+    }
+
+    info(`Cache directory: ${cacheDirectory}`);
+    info(`Entries: ${String(entries.length)} (${formatBytes(totalBytes, { decimals: 1, space: false })})`);
+    logger.info("");
+
+    // Plain text table without pulling in the TUI renderer — keeps startup
+    // fast and avoids React for a simple listing.
+    const renderedAt = Date.now();
+    const rows = entries.map((entry) => ({
+        age: formatAge(entry.mtimeMs, renderedAt),
+        hash: entry.hash.slice(0, 12),
+        size: formatBytes(entry.sizeBytes, { decimals: 1, space: false }),
+    }));
+
+    const hashWidth = Math.max(4, ...rows.map((r) => r.hash.length));
+    const sizeWidth = Math.max(4, ...rows.map((r) => r.size.length));
+    const ageWidth = Math.max(3, ...rows.map((r) => r.age.length));
+
+    logger.info(`  ${"hash".padEnd(hashWidth)}  ${"size".padEnd(sizeWidth)}  ${"age".padEnd(ageWidth)}`);
+    logger.info(`  ${"-".repeat(hashWidth)}  ${"-".repeat(sizeWidth)}  ${"-".repeat(ageWidth)}`);
+
+    for (const row of rows) {
+        logger.info(`  ${row.hash.padEnd(hashWidth)}  ${row.size.padEnd(sizeWidth)}  ${row.age.padEnd(ageWidth)}`);
+    }
+};
+
+/**
+ * `clean` subcommand — removes the entire cache directory.
+ *
+ * Uses `Cache.clear()` when the directory is inside `workspaceRoot` so we
+ * match the task runner's own cleanup semantics. For custom `--cache-dir`
+ * paths that live outside the workspace we fall back to `rm -r`, but only
+ * after prompting for confirmation: users pointing at a shared location
+ * (e.g. `~/.cache/...`) shouldn't lose unrelated data without an opt-in.
+ * The prompt is skipped in non-TTY / CI contexts and when `--force` is set.
+ *
+ * Refuses outright when `cacheDirectory` resolves to the workspace root.
+ *
+ * @param cacheDirectory - Absolute path to the cache directory to remove.
+ * @param workspaceRoot - Absolute path to the workspace root (used for containment checks and `Cache` construction).
+ * @param options - `dryRun` previews without deleting; `force` skips the out-of-workspace confirmation prompt.
+ * @returns Resolves when the operation completes (or is skipped / aborted).
+ */
+const runClean = async (
+    cacheDirectory: string,
+    workspaceRoot: string,
+    options: { dryRun: boolean; force: boolean },
+): Promise<void> => {
+    if (!isAccessibleSync(cacheDirectory)) {
+        info(`No cache directory to clean at ${cacheDirectory}`);
+
+        return;
+    }
+
+    if (options.dryRun) {
+        const entries = await collectCacheEntries(cacheDirectory);
+        const totalBytes = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+
+        info(
+            `Would remove ${String(entries.length)} cache entr${entries.length === 1 ? "y" : "ies"} `
+            + `(${formatBytes(totalBytes, { decimals: 1, space: false })}) from ${cacheDirectory}`,
+        );
+
+        return;
+    }
+
+    const insideWorkspace = isCacheDirectoryInsideWorkspace(cacheDirectory, workspaceRoot);
+
+    // Hard stop: never `rm -r` the workspace root itself, regardless of
+    // --force. Compare canonical paths via `realpath()` so the guard holds
+    // even when one side is reached through a symlink.
+    try {
+        const realCache = await realpath(cacheDirectory);
+        const realWorkspace = await realpath(workspaceRoot);
+
+        if (realCache === realWorkspace) {
+            failure("Refusing to delete the workspace root. The cache directory resolved to the same path as the workspace.");
+            process.exitCode = 1;
+
+            return;
+        }
+    } catch {
+        // One of the paths doesn't exist on disk (which `isAccessibleSync`
+        // already checked for `cacheDirectory`). Proceed — the deletion
+        // branches handle missing paths safely.
+    }
+
+    if (!insideWorkspace && !options.force) {
+        warn(`Cache directory is outside the workspace root: ${cacheDirectory}`);
+        warn("This will recursively delete the entire directory, including anything stored there by other tools.");
+
+        if (!process.stdin.isTTY) {
+            failure("Refusing to clean an out-of-workspace cache without --force (stdin is not a TTY).");
+            process.exitCode = 1;
+
+            return;
+        }
+
+        const confirmed = await confirmPrompt("  Continue?");
+
+        if (!confirmed) {
+            info("Aborted.");
+
+            return;
+        }
+    }
+
+    if (insideWorkspace) {
+        // `Cache.clear()` honors the task-runner layout (index files,
+        // `.commit` markers, etc.).
+        const cache = new Cache({ cacheDirectory, workspaceRoot });
+
+        await cache.clear();
+    } else {
+        await rm(cacheDirectory, { force: true, recursive: true });
+    }
+
+    success(`Cleared cache: ${cacheDirectory}`);
+};
+
+/**
+ * `prune` subcommand — removes stale entries (age + size) without nuking
+ * everything. Mirrors `Cache.removeOldEntries()` which the runner invokes
+ * automatically on each run.
+ *
+ * Both `--max-age-days` and `--max-size` are validated up-front so
+ * malformed values produce a friendly CLI error instead of a stack trace
+ * from inside `Cache`. The before/after count is a best-effort estimate —
+ * a concurrent `vis run` could skew it, but the cache state remains correct.
+ *
+ * @param cacheDirectory - Absolute path to the cache directory to prune.
+ * @param workspaceRoot - Absolute path to the workspace root (passed to the `Cache` constructor).
+ * @param options - `maxCacheAgeDays` evicts entries older than N days; `maxCacheSize` (e.g. `"500MB"`)
+ *                  evicts oldest entries until the total size is under the limit.
+ * @returns Resolves when pruning completes or is skipped.
+ */
+const runPrune = async (
+    cacheDirectory: string,
+    workspaceRoot: string,
+    options: { maxCacheAgeDays?: number; maxCacheSize?: string },
+): Promise<void> => {
+    if (!isAccessibleSync(cacheDirectory)) {
+        info(`No cache directory to prune at ${cacheDirectory}`);
+
+        return;
+    }
+
+    if (options.maxCacheAgeDays !== undefined) {
+        if (!Number.isFinite(options.maxCacheAgeDays) || options.maxCacheAgeDays < 0) {
+            failure(`Invalid --max-age-days value: expected a finite number >= 0, got ${String(options.maxCacheAgeDays)}`);
+            process.exitCode = 1;
+
+            return;
+        }
+    }
+
+    if (options.maxCacheSize !== undefined) {
+        let parsedBytes: number;
+
+        try {
+            parsedBytes = parseCacheSize(options.maxCacheSize);
+        } catch (error: unknown) {
+            failure(`Invalid --max-size value: ${error instanceof Error ? error.message : String(error)}`);
+            process.exitCode = 1;
+
+            return;
+        }
+
+        if (!Number.isFinite(parsedBytes) || parsedBytes <= 0) {
+            failure(`Invalid --max-size value: expected a positive size, got "${options.maxCacheSize}" (${String(parsedBytes)} bytes)`);
+            process.exitCode = 1;
+
+            return;
+        }
+    }
+
+    const maxCacheAge = options.maxCacheAgeDays !== undefined
+        ? options.maxCacheAgeDays * 24 * 60 * 60 * 1000
+        : undefined;
+
+    const before = await collectCacheEntries(cacheDirectory);
+    const beforeBytes = before.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+
+    const cache = new Cache({
+        cacheDirectory,
+        maxCacheAge,
+        maxCacheSize: options.maxCacheSize,
+        workspaceRoot,
+    });
+
+    await cache.removeOldEntries();
+
+    const after = await collectCacheEntries(cacheDirectory);
+    const afterBytes = after.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+
+    const removed = before.length - after.length;
+    const reclaimedBytes = beforeBytes - afterBytes;
+
+    if (removed <= 0) {
+        info("Nothing to prune — all entries are within the configured limits.");
+
+        return;
+    }
+
+    success(
+        `Pruned ${String(removed)} entr${removed === 1 ? "y" : "ies"}, `
+        + `freed ${formatBytes(reclaimedBytes, { decimals: 1, space: false })}.`,
+    );
+};
+
+/**
+ * `size` subcommand — prints the cache directory's on-disk footprint without
+ * the per-entry table.
+ *
+ * @param cacheDirectory - Absolute path to the cache directory to measure.
+ * @param format - `"table"` for human-readable output, `"json"` for machine-readable JSON.
+ * @returns Resolves when output has been written.
+ */
+const runSize = async (cacheDirectory: string, format: string): Promise<void> => {
+    if (!isAccessibleSync(cacheDirectory)) {
+        if (format === "json") {
+            process.stdout.write(`${JSON.stringify({ directory: cacheDirectory, exists: false, totalBytes: 0, totalCount: 0 })}\n`);
+
+            return;
+        }
+
+        info(`No cache directory at ${cacheDirectory}`);
+
+        return;
+    }
+
+    const entries = await collectCacheEntries(cacheDirectory);
+    const totalBytes = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+
+    if (format === "json") {
+        process.stdout.write(
+            `${JSON.stringify({
+                directory: cacheDirectory,
+                exists: true,
+                totalBytes,
+                totalCount: entries.length,
+            })}\n`,
+        );
+
+        return;
+    }
+
+    info(`Cache directory: ${cacheDirectory}`);
+    info(`Entries:         ${String(entries.length)}`);
+    info(`Total size:      ${formatBytes(totalBytes, { decimals: 1, space: false })}`);
+};
+
+const cache: Command = {
+    group: "Workspace",
+    argument: {
+        description: "Action to perform: list, clean, prune, or size",
+        name: "action",
+        type: String,
+    },
+    description: "Manage the task runner cache (list, clean, prune, size)",
+    examples: [
+        ["vis cache list", "List all cache entries"],
+        ["vis cache clean", "Remove all cache entries"],
+        ["vis cache clean --dry-run", "Preview what clean would remove"],
+        ["vis cache prune", "Remove old and oversized entries"],
+        ["vis cache prune --max-age-days=3 --max-size=500MB", "Prune with custom limits"],
+        ["vis cache size --format=json", "Print total size as JSON"],
+    ],
+    execute: async ({ argument, logger, options, visConfig, workspaceRoot: wsRoot }) => {
+        const workspaceRoot = wsRoot ?? process.cwd();
+        const action = argument[0] ?? "list";
+        const format = (options.format as string) ?? "table";
+
+        const taskRunnerOptions = (visConfig?.taskRunnerOptions ?? {}) as {
+            cacheDirectory?: string;
+        };
+
+        const cacheDirectory = resolveCacheDirectory(
+            workspaceRoot,
+            options.cacheDir as string | undefined,
+            taskRunnerOptions.cacheDirectory,
+        );
+
+        switch (action) {
+            case "clean": {
+                await runClean(cacheDirectory, workspaceRoot, {
+                    dryRun: Boolean(options.dryRun),
+                    force: Boolean(options.force),
+                });
+                break;
+            }
+
+            case "list": {
+                await runList(cacheDirectory, format, logger);
+                break;
+            }
+
+            case "prune": {
+                await runPrune(cacheDirectory, workspaceRoot, {
+                    maxCacheAgeDays: typeof options.maxAgeDays === "number" ? options.maxAgeDays : undefined,
+                    maxCacheSize: options.maxSize as string | undefined,
+                });
+                break;
+            }
+
+            case "size": {
+                await runSize(cacheDirectory, format);
+                break;
+            }
+
+            default: {
+                failure(`Unknown action "${action}". Use "list", "clean", "prune", or "size".`);
+                process.exitCode = 1;
+            }
+        }
+    },
+    name: "cache",
+    options: [
+        {
+            description: "Cache directory (overrides config and default). Relative paths are resolved against the workspace root.",
+            name: "cache-dir",
+            type: String,
+        },
+        {
+            description: "Output format: table or json (default: table)",
+            name: "format",
+            type: String,
+        },
+        {
+            defaultValue: false,
+            description: "For clean: preview without deleting",
+            name: "dry-run",
+            type: Boolean,
+        },
+        {
+            defaultValue: false,
+            description: "For clean: skip the confirmation prompt for out-of-workspace cache directories",
+            name: "force",
+            type: Boolean,
+        },
+        {
+            description: "For prune: remove entries older than N days",
+            name: "max-age-days",
+            type: Number,
+        },
+        {
+            description: "For prune: evict oldest entries until cache is under this size (e.g. 500MB)",
+            name: "max-size",
+            type: String,
+        },
+    ],
+};
+
+export default cache;
+// Internals exposed for unit tests. `DEFAULT_CACHE_DIRECTORY_NAME`,
+// `resolveCacheDirectory`, and `isCacheDirectoryInsideWorkspace` live in
+// `../cache-directory` — import them from there instead of re-exporting here.
+export { collectCacheEntries, formatAge, runClean, runList, runPrune, runSize };

--- a/packages/tooling/vis/src/commands/run.ts
+++ b/packages/tooling/vis/src/commands/run.ts
@@ -13,6 +13,7 @@ import {
 } from "@visulima/task-runner";
 import isInCi from "is-in-ci";
 
+import { resolveCacheDirectory } from "../cache-directory";
 import { analyzeFlakiness, formatFlakinessTable } from "../flakiness";
 import { compareDuration, formatTimingSummary } from "../run-report";
 import { filterProjectsByQuery, resolveSelector } from "../selectors";
@@ -25,8 +26,7 @@ import {
     type VisTargetConfiguration,
     type VisTargetOptions,
 } from "../target-options";
-import { collectAvailableTargets, formatTargetList, suggestTarget } from "../target-discovery";
-import { createDynamicOutputRenderer } from "../tui/dynamic-life-cycle";
+import { collectAvailableTargets, formatTargetList, suggestTarget } from "../target-discovery";import { createDynamicOutputRenderer } from "../tui/dynamic-life-cycle";
 import { StaticOutputLifeCycle } from "../tui/static-life-cycle";
 import type { StdinEntry } from "../tui/types";
 import { startWatcher } from "../watch";
@@ -577,13 +577,29 @@ const run: Command = {
 
         const startTime = Date.now();
 
+        // Resolve the cache directory through the shared helper so precedence
+        // (CLI > vis.config.ts > default) stays consistent with `vis cache`
+        // and relative --cache-dir values are normalized against the
+        // workspace root. Other fields keep their existing spread semantics
+        // to avoid changing override precedence for parallel/dryRun/etc.
+        const configTaskRunnerOptions
+            = (config.taskRunnerOptions ?? {}) as TaskRunnerOptions & { cacheDirectory?: string };
+        const resolvedCacheDirectory = resolveCacheDirectory(
+            workspaceRoot,
+            options.cacheDir as string | undefined,
+            configTaskRunnerOptions.cacheDirectory,
+        );
+
         const runnerOptions: TaskRunnerOptions = {
-            cacheDirectory: options.cacheDir as string | undefined,
             dryRun: options.dryRun as boolean,
             parallel: (options.parallel as number) ?? 3,
             skipNxCache: !options.cache,
             summarize: options.summarize as boolean,
-            ...config.taskRunnerOptions,
+            ...configTaskRunnerOptions,
+            // Applied after the config spread so the user's `--cache-dir` flag
+            // wins over a config value and relative paths are normalized
+            // against `workspaceRoot` via `resolveCacheDirectory()`.
+            cacheDirectory: resolvedCacheDirectory,
         };
 
         const isTTY = process.stdout.isTTY && !isInCi;


### PR DESCRIPTION
## Summary

Adds a new `vis cache` command that provides comprehensive cache management capabilities for the task runner. Users can now list cache entries, clean the entire cache, prune old/oversized entries, and check cache size—all from the CLI.

## Key Changes

- **New `vis cache` command** with four subcommands:
  - `list`: Display all cached task entries in a formatted table or JSON
  - `clean`: Remove the entire cache directory with safety checks for out-of-workspace locations
  - `prune`: Remove stale entries based on age and size limits (mirrors the task runner's automatic pruning)
  - `size`: Show total cache footprint and entry count

- **Shared cache directory resolution** (`cache-directory.ts`):
  - Extracted cache directory resolution logic into a reusable module
  - Ensures consistent precedence: `--cache-dir` flag > `vis.config.ts` > default
  - Normalizes relative paths against workspace root
  - Provides containment checks to determine if cache is inside workspace (used for safety prompts)

- **Safety features**:
  - Dry-run mode for `clean` to preview deletions
  - Confirmation prompt when cleaning out-of-workspace cache directories (skipped in non-TTY or with `--force`)
  - Early validation of `--max-size` format in `prune` to provide friendly error messages

- **Output formats**:
  - Human-readable table format (default) with hash, size, and age columns
  - JSON output for programmatic consumption

- **Integration with task runner**:
  - Exports `DEFAULT_CACHE_DIRECTORY_NAME` from `@visulima/task-runner` for consistent defaults
  - Uses `Cache` class methods (`clear()`, `removeOldEntries()`) to maintain compatibility with task runner semantics
  - Updated `vis run` command to use shared `resolveCacheDirectory` helper

- **Comprehensive test coverage**:
  - Unit tests for `formatAge`, `collectCacheEntries`, `runClean`, and `runPrune`
  - Tests for `resolveCacheDirectory` and `isCacheDirectoryInsideWorkspace` helpers
  - Edge cases: non-existent directories, hidden files, out-of-workspace paths, TTY detection

## Notable Implementation Details

- Cache entries are collected by scanning the cache directory and calculating directory sizes recursively
- Entries are sorted newest-first for easier reading
- Age formatting uses human-friendly units (seconds, minutes, hours, days)
- The `clean` command uses `Cache.clear()` for workspace-internal caches (respects task runner layout) and `rm -r` for external caches
- Confirmation prompts use readline interface consistent with other CLI commands

https://claude.ai/code/session_015REKHpefT8TZHzwgts9nsN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New cache management CLI with subcommands: list, clean, prune, size (text or JSON output).
  * Unified cache directory resolution across CLI and config with normalized relative paths.
  * Exposed default cache directory name for consistent tooling behavior.

* **Bug Fixes / Safety**
  * Safer cache operations: dry-run, confirmation prompts, refusal to remove workspace root, and consistent size/age reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->