### PR TITLE
refactor(crud): break handler <-> types circular imports

### DIFF
--- a/packages/api/crud/src/handler/create.ts
+++ b/packages/api/crud/src/handler/create.ts
@@ -1,6 +1,6 @@
-import type { HandlerParameters } from "../types";
+import type { CreateHandler } from "../types";
 
-const createHandler: Handler = async ({ adapter, query, request, resourceName }) => {
+const createHandler: CreateHandler = async ({ adapter, query, request, resourceName }) => {
     const resources = await adapter.create(resourceName, request.body, query);
 
     return {
@@ -8,12 +8,5 @@ const createHandler: Handler = async ({ adapter, query, request, resourceName })
         status: 201,
     };
 };
-
-export type Handler = <T, Q, Request>(
-    parameters: HandlerParameters<T, Q> & { request: Request & { body: Record<string, any> } },
-) => Promise<{
-    data: any;
-    status: number;
-}>;
 
 export default createHandler;

--- a/packages/api/crud/src/handler/delete.ts
+++ b/packages/api/crud/src/handler/delete.ts
@@ -1,8 +1,8 @@
 import createHttpError from "http-errors";
 
-import type { UniqueResourceHandlerParameters } from "../types";
+import type { DeleteHandler } from "../types";
 
-const deleteHandler: Handler = async ({ adapter, query, resourceId, resourceName }) => {
+const deleteHandler: DeleteHandler = async ({ adapter, query, resourceId, resourceName }) => {
     const resource = await adapter.getOne(resourceName, resourceId, query);
 
     if (typeof resource === "object") {
@@ -17,10 +17,4 @@ const deleteHandler: Handler = async ({ adapter, query, resourceId, resourceName
     throw createHttpError(404, `${resourceName} ${resourceId} not found`);
 };
 
-export type Handler = <T, Q>(
-    parameters: UniqueResourceHandlerParameters<T, Q>,
-) => Promise<{
-    data: any;
-    status: number;
-}>;
 export default deleteHandler;

--- a/packages/api/crud/src/handler/list.ts
+++ b/packages/api/crud/src/handler/list.ts
@@ -1,13 +1,13 @@
 import { paginate } from "@visulima/pagination";
 
-import type { HandlerParameters, PaginationConfig, ParsedQueryParameters } from "../types";
+import type { ListHandler } from "../types";
 
 interface PaginationOptions {
     page: number;
     perPage: number;
 }
 
-const listHandler: Handler = async ({ adapter, pagination, query, resourceName }) => {
+const listHandler: ListHandler = async ({ adapter, pagination, query, resourceName }) => {
     let isPaginated = false;
     let paginationOptions: PaginationOptions | undefined;
 
@@ -49,12 +49,5 @@ const listHandler: Handler = async ({ adapter, pagination, query, resourceName }
         status: 200,
     };
 };
-
-export type Handler = <T, Q extends ParsedQueryParameters>(
-    parameters: HandlerParameters<T, Q> & { pagination: PaginationConfig },
-) => Promise<{
-    data: any;
-    status: number;
-}>;
 
 export default listHandler;

--- a/packages/api/crud/src/handler/read.ts
+++ b/packages/api/crud/src/handler/read.ts
@@ -1,8 +1,8 @@
 import createHttpError from "http-errors";
 
-import type { UniqueResourceHandlerParameters } from "../types";
+import type { GetHandler } from "../types";
 
-const readHandler: Handler = async ({ adapter, query, resourceId, resourceName }) => {
+const readHandler: GetHandler = async ({ adapter, query, resourceId, resourceName }) => {
     const resource = await adapter.getOne(resourceName, resourceId, query);
 
     if (typeof resource !== "object") {
@@ -14,12 +14,5 @@ const readHandler: Handler = async ({ adapter, query, resourceId, resourceName }
         status: 200,
     };
 };
-
-export type Handler = <T, Q>(
-    parameters: UniqueResourceHandlerParameters<T, Q>,
-) => Promise<{
-    data: any;
-    status: number;
-}>;
 
 export default readHandler;

--- a/packages/api/crud/src/handler/update.ts
+++ b/packages/api/crud/src/handler/update.ts
@@ -1,8 +1,8 @@
 import createHttpError from "http-errors";
 
-import type { UniqueResourceHandlerParameters } from "../types";
+import type { UpdateHandler } from "../types";
 
-const updateHandler: Handler = async ({ adapter, query, request, resourceId, resourceName }) => {
+const updateHandler: UpdateHandler = async ({ adapter, query, request, resourceId, resourceName }) => {
     const resource = await adapter.getOne(resourceName, resourceId, query);
 
     if (typeof resource === "object") {
@@ -16,12 +16,5 @@ const updateHandler: Handler = async ({ adapter, query, request, resourceId, res
 
     throw createHttpError(404, `${resourceName} ${resourceId} not found`);
 };
-
-export type Handler = <T, Q, Request>(
-    parameters: UniqueResourceHandlerParameters<T, Q> & { request: Request & { body: Partial<T> } },
-) => Promise<{
-    data: any;
-    status: number;
-}>;
 
 export default updateHandler;

--- a/packages/api/crud/src/types.ts
+++ b/packages/api/crud/src/types.ts
@@ -1,9 +1,3 @@
-import type { Handler as CreateHandler } from "./handler/create";
-import type { Handler as DeleteHandler } from "./handler/delete";
-import type { Handler as ListHandler } from "./handler/list";
-import type { Handler as GetHandler } from "./handler/read";
-import type { Handler as UpdateHandler } from "./handler/update";
-
 export enum RouteType {
     CREATE = "CREATE",
     DELETE = "DELETE",
@@ -22,6 +16,41 @@ export interface ModelOption {
 export type ModelsOptions<M extends string = string> = {
     [key in M]?: ModelOption;
 };
+
+export type CreateHandler = <T, Q, Request>(
+    parameters: HandlerParameters<T, Q> & { request: Request & { body: Record<string, any> } },
+) => Promise<{
+    data: any;
+    status: number;
+}>;
+
+export type DeleteHandler = <T, Q>(
+    parameters: UniqueResourceHandlerParameters<T, Q>,
+) => Promise<{
+    data: any;
+    status: number;
+}>;
+
+export type GetHandler = <T, Q>(
+    parameters: UniqueResourceHandlerParameters<T, Q>,
+) => Promise<{
+    data: any;
+    status: number;
+}>;
+
+export type ListHandler = <T, Q extends ParsedQueryParameters>(
+    parameters: HandlerParameters<T, Q> & { pagination: PaginationConfig },
+) => Promise<{
+    data: any;
+    status: number;
+}>;
+
+export type UpdateHandler = <T, Q, Request>(
+    parameters: UniqueResourceHandlerParameters<T, Q> & { request: Request & { body: Partial<T> } },
+) => Promise<{
+    data: any;
+    status: number;
+}>;
 
 export interface HandlerOptions<M extends string = string> {
     exposeStrategy?: "all" | "none";

--- a/packages/storage/storage/src/storage/local/local-meta-storage.ts
+++ b/packages/storage/storage/src/storage/local/local-meta-storage.ts
@@ -8,8 +8,10 @@ import { join, normalize } from "@visulima/path";
 
 import { ERRORS, throwErrorCode } from "../../utils/errors";
 import MetaStorage from "../meta-storage";
-import type { MetaStorageOptions } from "../types";
+import type { LocalMetaStorageOptions } from "../meta-storage-options";
 import type { File } from "../utils/file";
+
+export type { LocalMetaStorageOptions } from "../meta-storage-options";
 import { parseMetadata, stringifyMetadata } from "../utils/file/metadata";
 
 /**
@@ -104,13 +106,6 @@ class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
     private async accessCheck(): Promise<void> {
         await ensureDir(this.directory);
     }
-}
-
-export interface LocalMetaStorageOptions extends MetaStorageOptions {
-    /**
-     * Where the upload metadata should be stored
-     */
-    directory?: string;
 }
 
 export default LocalMetaStorage;

--- a/packages/storage/storage/src/storage/meta-storage-options.ts
+++ b/packages/storage/storage/src/storage/meta-storage-options.ts
@@ -1,0 +1,12 @@
+export interface MetaStorageOptions {
+    logger?: Console;
+    prefix?: string;
+    suffix?: string;
+}
+
+export interface LocalMetaStorageOptions extends MetaStorageOptions {
+    /**
+     * Where the upload metadata should be stored
+     */
+    directory?: string;
+}

--- a/packages/storage/storage/src/storage/meta-storage.ts
+++ b/packages/storage/storage/src/storage/meta-storage.ts
@@ -1,4 +1,4 @@
-import type { MetaStorageOptions } from "./types";
+import type { MetaStorageOptions } from "./meta-storage-options";
 import type { File } from "./utils/file";
 
 /**

--- a/packages/storage/storage/src/storage/types.ts
+++ b/packages/storage/storage/src/storage/types.ts
@@ -3,15 +3,11 @@ import type { Readable } from "node:stream";
 import type { Cache } from "../utils/cache";
 import type { RetryConfig } from "../utils/retry";
 import type { HttpError, HttpErrorBody, Metrics, Validation } from "../utils/types";
-import type { LocalMetaStorageOptions } from "./local/local-meta-storage";
+import type { LocalMetaStorageOptions } from "./meta-storage-options";
 import type MetaStorage from "./meta-storage";
 import type { File, FileInit, FilePart, FileQuery, FileReturn, UploadFile } from "./utils/file";
 
-export interface MetaStorageOptions {
-    logger?: Console;
-    prefix?: string;
-    suffix?: string;
-}
+export type { MetaStorageOptions } from "./meta-storage-options";
 
 export type OnCreate<TFile extends File = File> = (file: TFile) => Promise<void> | void;
 

--- a/packages/storage/storage/src/transformer/base-transformer.ts
+++ b/packages/storage/storage/src/transformer/base-transformer.ts
@@ -6,7 +6,7 @@ import type { BaseStorage } from "../storage/storage";
 import type { File, FileReturn } from "../storage/utils/file";
 import type { Cache } from "../utils/cache";
 import { NoOpCache } from "../utils/cache";
-import type { BaseTransformerConfig } from "./types";
+import type { BaseTransformerConfig } from "./transformer-config";
 
 /**
  * Abstract base class for all media transformers.

--- a/packages/storage/storage/src/transformer/transformer-config.ts
+++ b/packages/storage/storage/src/transformer/transformer-config.ts
@@ -1,0 +1,17 @@
+import type { Cache } from "../utils/cache";
+
+/**
+ * Base transformer configuration with common properties
+ */
+export interface BaseTransformerConfig {
+    /** Cache instance to use for caching */
+    cache?: Cache;
+    /** Cache TTL in seconds */
+    cacheTtl?: number;
+    /** Logger instance */
+    logger?: Console;
+    /** Maximum number of cached items */
+    maxCacheSize?: number;
+    /** Supported input formats */
+    supportedFormats?: string[] | undefined;
+}

--- a/packages/storage/storage/src/transformer/types.ts
+++ b/packages/storage/storage/src/transformer/types.ts
@@ -2,6 +2,9 @@ import type { BaseStorage } from "../storage/storage";
 import type { File, FileReturn } from "../storage/utils/file";
 import type { Cache } from "../utils/cache";
 import type BaseTransformer from "./base-transformer";
+import type { BaseTransformerConfig } from "./transformer-config";
+
+export type { BaseTransformerConfig } from "./transformer-config";
 
 /**
  * Supported image formats for transformation
@@ -795,22 +798,6 @@ export interface MediaTransformQuery {
     withoutEnlargement?: boolean;
     /** Whether to avoid reducing larger images */
     withoutReduction?: boolean;
-}
-
-/**
- * Base transformer configuration with common properties
- */
-export interface BaseTransformerConfig {
-    /** Cache instance to use for caching */
-    cache?: Cache;
-    /** Cache TTL in seconds */
-    cacheTtl?: number;
-    /** Logger instance */
-    logger?: Console;
-    /** Maximum number of cached items */
-    maxCacheSize?: number;
-    /** Supported input formats */
-    supportedFormats?: string[] | undefined;
 }
 
 /**


### PR DESCRIPTION
Co-authored-by: d.bannert <d.bannert@anolilab.de>
Co-authored-by: Cursor Agent <cursoragent@cursor.com>Consolidate the 5 handler type signatures (CreateHandler, DeleteHandler,
GetHandler, ListHandler, UpdateHandler) into types.ts. Handler files
import their type from ../types instead of defining and re-exporting it
to types.ts, eliminating 10 type-only file cycles.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>