### PR TITLE
feat(storage): add exists() to Files facade

### DIFF
--- a/packages/storage/storage/__tests__/files/files.test.ts
+++ b/packages/storage/storage/__tests__/files/files.test.ts
@@ -154,6 +154,32 @@ describe("files facade", () => {
         });
     });
 
+    describe("exists", () => {
+        it("returns true for an existing object and false for a missing one", async () => {
+            const { facade } = makeFiles(directory);
+
+            await facade.upload("present.txt", "hi");
+
+            await expect(facade.exists("present.txt")).resolves.toBe(true);
+            await expect(facade.exists("absent.txt")).resolves.toBe(false);
+        });
+
+        it("returns false after the object is deleted", async () => {
+            const { facade } = makeFiles(directory);
+
+            await facade.upload("gone.txt", "bye");
+            await facade.delete("gone.txt");
+
+            await expect(facade.exists("gone.txt")).resolves.toBe(false);
+        });
+
+        it("rejects an unsafe key", async () => {
+            const { facade } = makeFiles(directory);
+
+            await expect(facade.exists("../escape.txt")).rejects.toThrow(/Invalid file id|InvalidFileName/);
+        });
+    });
+
     describe("delete + copy + list", () => {
         it("delete() removes the object", async () => {
             const { facade } = makeFiles(directory);

--- a/packages/storage/storage/docs/files-facade.mdx
+++ b/packages/storage/storage/docs/files-facade.mdx
@@ -1,6 +1,6 @@
 # `Files` facade
 
-Files-SDK–style unified facade over any `BaseStorage` adapter. Eight methods + a `.raw` escape hatch, web-standard body types, provider-agnostic return shape.
+Files-SDK–style unified facade over any `BaseStorage` adapter. Nine methods + a `.raw` escape hatch, web-standard body types, provider-agnostic return shape.
 
 ```ts
 import { Files } from "@visulima/storage";
@@ -29,6 +29,7 @@ For client-driven uploads (browser forms, large resumable files, chunked transfe
 | `upload`          | `(key, body, opts?) → Promise<FileObject>`           | Accepts any [supported body type](#body-types).                   |
 | `download`        | `(key) → Promise<DownloadResult>`                    | Returns `{ body: Buffer, ...FileObject }`.                        |
 | `head`            | `(key) → Promise<FileObject>`                        | Metadata only.                                                    |
+| `exists`          | `(key) → Promise<boolean>`                           | Never throws for a missing object.                                |
 | `delete`          | `(key) → Promise<void>`                              | Idempotent on most providers.                                     |
 | `copy`            | `(source, destination, opts?) → Promise<FileObject>` | Server-side where supported; download + re-upload otherwise.      |
 | `list`            | `(opts?) → Promise<FileObject[]>`                    | Optional `prefix` filter and `limit`.                             |

--- a/packages/storage/storage/src/files/index.ts
+++ b/packages/storage/storage/src/files/index.ts
@@ -128,7 +128,7 @@ const toFileObject = (file: StorageFile, fallbackKey?: string): FileObject => {
 /**
  * Files-SDK–style unified facade over a {@link BaseStorage} instance.
  *
- * Provides a small, consistent surface (`upload`, `download`, `head`, `delete`, `copy`,
+ * Provides a small, consistent surface (`upload`, `download`, `head`, `exists`, `delete`, `copy`,
  * `list`, `url`, `signedUploadUrl`) and a `raw` escape hatch to the adapter's native client.
  *
  * The facade uses the user-supplied `key` as both the storage path and the metadata id,
@@ -220,6 +220,16 @@ export class Files<TStorage extends BaseStorage = BaseStorage> {
         const file = await this.adapter.getMeta(key);
 
         return toFileObject(file, key);
+    }
+
+    /**
+     * Resolves to `true` when an object exists at `key`, `false` otherwise. Never throws for a
+     * missing object.
+     */
+    public async exists(key: string): Promise<boolean> {
+        BaseStorage.assertSafeId(key);
+
+        return this.adapter.exists({ id: key });
     }
 
     public async delete(key: string): Promise<void> {

--- a/packages/storage/storage/src/storage/bunny/bunny-storage.ts
+++ b/packages/storage/storage/src/storage/bunny/bunny-storage.ts
@@ -114,7 +114,7 @@ const wrapBunnyError = (error: unknown, operation: string): UploadError => {
  *
  * Uses `@bunny.net/storage-sdk`. Writes go through the Storage API with an `AccessKey` header; reads either go through `data()` (server-side fetch) or, when a public Pull Zone is configured, through `publicBaseUrl`.
  *
- * **Limitations** (mirroring files-sdk PR #21):
+ * **Limitations**:
  *
  * - No native server-side `copy` — implemented as download + re-upload.
  * - No `signedUploadUrl` / presigned PUT — Bunny has no such primitive.

--- a/packages/storage/storage/src/storage/dropbox/dropbox-storage.ts
+++ b/packages/storage/storage/src/storage/dropbox/dropbox-storage.ts
@@ -218,7 +218,7 @@ const resolveAuth = (options: DropboxStorageOptions): ResolvedAuth => {
  * the simple `filesUpload` endpoint up to 150 MB and switch to chunked
  * upload sessions above that threshold.
  *
- * **Auth precedence** (same model as files-sdk's Dropbox adapter):
+ * **Auth precedence**:
  * 1. `client` (pre-built `Dropbox`)
  * 2. `accessToken` (string or `() => string | Promise&lt;string>`)
  * 3. `refreshToken` + `appKey` (+ optional `appSecret`)

--- a/packages/storage/storage/src/storage/uploadthing/uploadthing-storage.ts
+++ b/packages/storage/storage/src/storage/uploadthing/uploadthing-storage.ts
@@ -66,7 +66,7 @@ const basename = (key: string): string => {
  * keyed by user-supplied `customId` so subsequent operations (delete, signed
  * URL, list) round-trip on the user's key, not UploadThing's internal fileKey.
  *
- * **Limitations** (mirroring files-sdk):
+ * **Limitations**:
  * - No native server-side `copy` — implemented as download + re-upload.
  * - `list` has no server-side prefix filter; prefix filtering happens client-
  *   side within a page.


### PR DESCRIPTION
## Context

Evaluated [haydenbleasel/files-sdk](https://github.com/haydenbleasel/files-sdk) as a potential new storage backend for `@visulima/storage`.

**Finding:** there is nothing to adopt as a new backend. The `Files` facade is already modeled on the files-sdk design, and `@visulima/storage` already supports a strict **superset** of files-sdk's providers (S3 + 9 S3-compatible vendors, Azure, GCS, Vercel/Netlify Blob, Dropbox, Google Drive, OneDrive, Box, Supabase, UploadThing, local disk). files-sdk has zero backends visulima lacks.

The only real delta was a small API-surface gap: the facade exposed all methods except `exists()`. This PR closes that gap.

## Summary

- Add a non-throwing `exists(key): Promise<boolean>` method to the `Files` facade, delegating to the existing, independently-tested `BaseStorage.exists` check (with the same `assertSafeId` hardening as the other methods).
- Document `exists` in the facade method-surface table (`docs/files-facade.mdx`).
- Add test coverage: present/absent object, post-delete, and unsafe-key rejection.
- Minor doc/comment tidy in the facade and a few adapters.

## Test plan

- [ ] `pnpm --filter "@visulima/storage" run test` — `__tests__/files/files.test.ts` (new `exists` suite)
- [ ] `pnpm --filter "@visulima/storage" run lint:types`

> Note: tests/types were not runnable in the authoring environment (workspace `pnpm install` is blocked by a network-restricted JSR registry). The change is a thin delegate mirroring the existing `delete`/`head` methods.

https://claude.ai/code/session_01SqUWtsXqJ7eZCymPngbLub