### PR TITLE
chore(repo): sort package.json keys across all packages

### DIFF
--- a/packages/api/connect/package.json
+++ b/packages/api/connect/package.json
@@ -19,11 +19,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -39,29 +34,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
-    "sideEffects": false,
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "import": {
@@ -75,10 +54,22 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/index.cjs",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -131,5 +122,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/api/crud/package.json
+++ b/packages/api/crud/package.json
@@ -11,11 +11,6 @@
         "visulima"
     ],
     "homepage": "https://visulima.com/packages/crud/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -31,31 +26,12 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "sideEffects": false,
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.cts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.d.ts"
-            ],
-            "next": [
-                "./dist/next/index.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
     "exports": {
         ".": {
             "import": {
@@ -79,10 +55,25 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/index.cjs",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.cts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.d.ts"
+            ],
+            "next": [
+                "./dist/next/index.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -157,5 +148,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/api/health-check/package.json
+++ b/packages/api/health-check/package.json
@@ -16,11 +16,6 @@
         "visulima"
     ],
     "homepage": "https://visulima.com/packages/health-check/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -36,19 +31,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -56,10 +45,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -121,5 +112,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/api/jsdoc-open-api/package.json
+++ b/packages/api/jsdoc-open-api/package.json
@@ -18,11 +18,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -38,39 +33,12 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "bin": {
-        "jsdoc-open-api": "./bin/index.js"
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
-    "files": [
-        "bin/**",
-        "cli/**",
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
     "sideEffects": false,
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.d.ts"
-            ],
-            "cli": [
-                "./dist/cli/index.d.ts"
-            ],
-            "cli/commander": [
-                "./dist/cli/commander/index.d.ts"
-            ]
-        }
-    },
     "exports": {
         ".": {
             "import": {
@@ -104,10 +72,33 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/index.cjs",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.d.ts"
+            ],
+            "cli": [
+                "./dist/cli/index.d.ts"
+            ],
+            "cli/commander": [
+                "./dist/cli/commander/index.d.ts"
+            ]
+        }
     },
+    "bin": {
+        "jsdoc-open-api": "./bin/index.js"
+    },
+    "files": [
+        "bin/**",
+        "cli/**",
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -164,5 +155,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/api/pagination/package.json
+++ b/packages/api/pagination/package.json
@@ -16,11 +16,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -36,19 +31,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -56,10 +45,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -101,5 +92,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/bytes/package.json
+++ b/packages/data-manipulation/bytes/package.json
@@ -16,11 +16,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -36,13 +31,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -50,10 +45,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -97,5 +93,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/content-safety/package.json
+++ b/packages/data-manipulation/content-safety/package.json
@@ -45,11 +45,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -65,13 +60,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -79,10 +74,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -124,5 +120,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/deep-clone/package.json
+++ b/packages/data-manipulation/deep-clone/package.json
@@ -38,11 +38,6 @@
         "visulima"
     ],
     "homepage": "https://visulima.com/packages/deep-clone/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -58,19 +53,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -86,10 +75,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -132,5 +123,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/html/package.json
+++ b/packages/data-manipulation/html/package.json
@@ -32,11 +32,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -52,13 +47,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -66,10 +61,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -122,5 +118,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/humanizer/package.json
+++ b/packages/data-manipulation/humanizer/package.json
@@ -33,11 +33,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -53,11 +48,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -69,10 +66,9 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -117,5 +113,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/iso-locale/package.json
+++ b/packages/data-manipulation/iso-locale/package.json
@@ -49,11 +49,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -69,13 +64,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -107,10 +102,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -152,5 +148,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/object/package.json
+++ b/packages/data-manipulation/object/package.json
@@ -25,11 +25,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -45,13 +40,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -59,10 +54,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -110,5 +106,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/redact/package.json
+++ b/packages/data-manipulation/redact/package.json
@@ -28,11 +28,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -48,14 +43,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "browser": "./dist/index.js",
@@ -66,10 +60,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -115,5 +111,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/email/disposable-email-domains/package.json
+++ b/packages/email/disposable-email-domains/package.json
@@ -16,11 +16,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -36,13 +31,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -53,10 +48,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development && pnpm run generate:domains",
         "build:prod": "packem build --production && pnpm run generate:domains",
@@ -101,5 +97,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/email/email/package.json
+++ b/packages/email/email/package.json
@@ -52,11 +52,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -72,13 +67,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -262,10 +257,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -366,5 +362,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/dev-toolbar/examples/vite-tanstack-start-cloudflare/package.json
+++ b/packages/error-debugging/dev-toolbar/examples/vite-tanstack-start-cloudflare/package.json
@@ -2,8 +2,8 @@
     "name": "dev_toolbar_vite-tanstack-start-cloudflare",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
     "sideEffects": false,
+    "type": "module",
     "scripts": {
         "build": "vite build && tsc --noEmit",
         "cf:preview": "wrangler pages dev",

--- a/packages/error-debugging/dev-toolbar/examples/vite-tanstack-start/package.json
+++ b/packages/error-debugging/dev-toolbar/examples/vite-tanstack-start/package.json
@@ -2,8 +2,8 @@
     "name": "dev_toolbar_vite-tanstack-start",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
     "sideEffects": false,
+    "type": "module",
     "scripts": {
         "build": "vite build && tsc --noEmit",
         "dev": "vite dev",

--- a/packages/error-debugging/error-handler/package.json
+++ b/packages/error-debugging/error-handler/package.json
@@ -38,11 +38,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -58,13 +53,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -132,10 +127,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -188,5 +184,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/error/package.json
+++ b/packages/error-debugging/error/package.json
@@ -40,11 +40,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -60,19 +55,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -104,10 +93,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -160,5 +151,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/source-map/package.json
+++ b/packages/error-debugging/source-map/package.json
@@ -13,11 +13,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -33,13 +28,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -47,10 +42,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -97,5 +93,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/vite-overlay/examples/vite-tanstack-hydration/package.json
+++ b/packages/error-debugging/vite-overlay/examples/vite-tanstack-hydration/package.json
@@ -2,8 +2,8 @@
     "name": "vite_overlay_vite-tanstack-hydration",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
     "sideEffects": false,
+    "type": "module",
     "scripts": {
         "build": "vite build && tsc --noEmit",
         "dev": "vite dev",

--- a/packages/error-debugging/vite-overlay/package.json
+++ b/packages/error-debugging/vite-overlay/package.json
@@ -21,11 +21,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -41,13 +36,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -55,10 +50,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -134,5 +130,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/filesystem/fs/package.json
+++ b/packages/filesystem/fs/package.json
@@ -63,11 +63,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -83,19 +78,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -155,10 +144,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -246,5 +237,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/filesystem/path/package.json
+++ b/packages/filesystem/path/package.json
@@ -17,11 +17,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -37,19 +32,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -61,10 +50,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -108,5 +99,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/colorize/package.json
+++ b/packages/terminal/colorize/package.json
@@ -56,11 +56,6 @@
         "yellow"
     ],
     "homepage": "https://visulima.com/packages/colorize/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -76,42 +71,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
-    "sideEffects": false,
-    "main": "dist/index.server.cjs",
-    "module": "dist/index.server.mjs",
-    "types": "dist/index.server.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.server.d.ts",
-                "./dist/index.browser.d.ts"
-            ],
-            "browser": [
-                "./dist/index.browser.d.ts"
-            ],
-            "template": [
-                "./dist/template.d.ts"
-            ],
-            "gradient": [
-                "./dist/gradient.d.ts"
-            ],
-            "utils": [
-                "./dist/utils.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "edge-light": {
@@ -169,10 +135,35 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/index.server.cjs",
+    "module": "dist/index.server.mjs",
+    "types": "dist/index.server.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.server.d.ts",
+                "./dist/index.browser.d.ts"
+            ],
+            "browser": [
+                "./dist/index.browser.d.ts"
+            ],
+            "template": [
+                "./dist/template.d.ts"
+            ],
+            "gradient": [
+                "./dist/gradient.d.ts"
+            ],
+            "utils": [
+                "./dist/utils.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -220,5 +211,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/is-ansi-color-supported/package.json
+++ b/packages/terminal/is-ansi-color-supported/package.json
@@ -36,11 +36,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -56,38 +51,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
-    "sideEffects": false,
-    "main": "dist/is-color-supported.server.cjs",
-    "module": "dist/is-color-supported.server.mjs",
-    "browser": "dist/is-color-supported.browser.mjs",
-    "types": "dist/is-color-supported.server.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/is-color-supported.edge-light.d.ts",
-                "./dist/is-color-supported.browser.d.ts",
-                "./dist/is-color-supported.server.d.ts"
-            ],
-            "edge-light": [
-                "./dist/is-color-supported.edge-light.d.ts"
-            ],
-            "browser": [
-                "./dist/is-color-supported.browser.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "edge-light": {
@@ -129,10 +99,31 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/is-color-supported.server.cjs",
+    "module": "dist/is-color-supported.server.mjs",
+    "browser": "dist/is-color-supported.browser.mjs",
+    "types": "dist/is-color-supported.server.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/is-color-supported.edge-light.d.ts",
+                "./dist/is-color-supported.browser.d.ts",
+                "./dist/is-color-supported.server.d.ts"
+            ],
+            "edge-light": [
+                "./dist/is-color-supported.edge-light.d.ts"
+            ],
+            "browser": [
+                "./dist/is-color-supported.browser.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -174,5 +165,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/progress-bar/package.json
+++ b/packages/terminal/progress-bar/package.json
@@ -13,11 +13,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -33,13 +28,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -47,10 +42,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -95,5 +91,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/spinner/package.json
+++ b/packages/terminal/spinner/package.json
@@ -10,11 +10,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -30,13 +25,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -44,10 +39,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -93,5 +89,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/tui/npm/linux-arm64-gnu/package.json
+++ b/packages/terminal/tui/npm/linux-arm64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/terminal/tui/npm/linux-arm64-musl/package.json
+++ b/packages/terminal/tui/npm/linux-arm64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/terminal/tui/npm/linux-x64-gnu/package.json
+++ b/packages/terminal/tui/npm/linux-x64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/terminal/tui/npm/linux-x64-musl/package.json
+++ b/packages/terminal/tui/npm/linux-x64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/find-ai-runner/package.json
+++ b/packages/tooling/find-ai-runner/package.json
@@ -24,11 +24,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -44,6 +39,20 @@
             "url": "https://anolilab.com/support"
         }
     ],
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
+    "sideEffects": false,
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./package.json": "./package.json"
+    },
     "bin": {
         "find-ai-runner": "./dist/cli.js"
     },
@@ -53,19 +62,6 @@
         "CHANGELOG.md",
         "LICENSE.md"
     ],
-    "type": "module",
-    "sideEffects": false,
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        },
-        "./package.json": "./package.json"
-    },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -107,5 +103,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/tooling/package/package.json
+++ b/packages/tooling/package/package.json
@@ -36,11 +36,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -56,19 +51,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -104,10 +93,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -167,5 +158,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/tooling/prisma-dmmf-transformer/package.json
+++ b/packages/tooling/prisma-dmmf-transformer/package.json
@@ -15,11 +15,6 @@
         "visulima"
     ],
     "homepage": "https://visulima.com/packages/prisma-dmmf-transformer/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -35,29 +30,12 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "source": "src/index.ts",
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "sideEffects": false,
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
     "exports": {
         ".": {
             "import": {
@@ -71,10 +49,23 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "main": "dist/index.cjs",
+    "module": "dist/index.mjs",
+    "source": "src/index.ts",
+    "types": "dist/index.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -129,5 +120,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/tooling/secret-scanner/npm/linux-arm64-gnu/package.json
+++ b/packages/tooling/secret-scanner/npm/linux-arm64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/secret-scanner/npm/linux-arm64-musl/package.json
+++ b/packages/tooling/secret-scanner/npm/linux-arm64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/secret-scanner/npm/linux-x64-gnu/package.json
+++ b/packages/tooling/secret-scanner/npm/linux-x64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/secret-scanner/npm/linux-x64-musl/package.json
+++ b/packages/tooling/secret-scanner/npm/linux-x64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/task-runner/npm/linux-arm64-gnu/package.json
+++ b/packages/tooling/task-runner/npm/linux-arm64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/task-runner/npm/linux-arm64-musl/package.json
+++ b/packages/tooling/task-runner/npm/linux-arm64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/task-runner/npm/linux-x64-gnu/package.json
+++ b/packages/tooling/task-runner/npm/linux-x64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/task-runner/npm/linux-x64-musl/package.json
+++ b/packages/tooling/task-runner/npm/linux-x64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/tsconfig/package.json
+++ b/packages/tooling/tsconfig/package.json
@@ -15,11 +15,6 @@
     "bugs": {
         "url": "https://github.com/visulima/visulima/issues"
     },
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -35,13 +30,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -49,10 +44,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -107,5 +103,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/tooling/vis/npm/linux-arm64-gnu/package.json
+++ b/packages/tooling/vis/npm/linux-arm64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/vis/npm/linux-arm64-musl/package.json
+++ b/packages/tooling/vis/npm/linux-arm64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "arm64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }

--- a/packages/tooling/vis/npm/linux-x64-gnu/package.json
+++ b/packages/tooling/vis/npm/linux-x64-gnu/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "glibc"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "glibc"
+    ]
 }

--- a/packages/tooling/vis/npm/linux-x64-musl/package.json
+++ b/packages/tooling/vis/npm/linux-x64-musl/package.json
@@ -26,11 +26,11 @@
     "cpu": [
         "x64"
     ],
-    "libc": [
-        "musl"
-    ],
     "publishConfig": {
         "access": "public",
         "provenance": true
-    }
+    },
+    "libc": [
+        "musl"
+    ]
 }


### PR DESCRIPTION
## Summary

- Run `sort-package-json` on every `package.json` under `packages/` and `apps/`
- Pure key reordering, no value changes (48 files, 668 +/- balanced)

## Why

Drift had accumulated across packages because different pre-commit hook runs over time produced slightly different intermediate orders. This realigns everything to the canonical output of `sort-package-json`, the tool wired into lint-staged per CLAUDE.md.

## Test plan

- [ ] CI passes
- [ ] Spot-check `git diff` shows only key reordering, no value diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized package configuration metadata across multiple packages to improve consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/visulima/visulima/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->