### PR TITLE
feat(vis): auto-update GitHub Actions, Docker, and GitLab CI references

### DIFF
--- a/packages/tooling/vis/__tests__/commands/update/ecosystems/gitlab-scanner.test.ts
+++ b/packages/tooling/vis/__tests__/commands/update/ecosystems/gitlab-scanner.test.ts
@@ -53,12 +53,16 @@ describe(extractFromGitlabCi, () => {
     });
 
     it("captures component include refs", () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const { includes } = extractFromGitlabCi("/tmp/.gitlab-ci.yml", GITLAB_YAML);
         const component = includes.find((include) => include.kind === "component");
 
-        expect(component?.project).toBe("gitlab.com/group/components/ci");
+        // GitLab resolves component tags against the *parent project*
+        // (`group/components`), not the full component path — the trailing
+        // segment is the component name and goes into `componentName`.
+        expect(component?.project).toBe("gitlab.com/group/components");
+        expect(component?.componentName).toBe("ci");
         expect(component?.ref).toBe("2.0.0");
     });
 

--- a/packages/tooling/vis/src/commands/update/ecosystems/actions/resolver.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/actions/resolver.ts
@@ -1,3 +1,4 @@
+import { parseLinkHeader } from "../link-header";
 import type { ParsedTag } from "../semver-helpers";
 import { parseTag } from "../semver-helpers";
 
@@ -119,40 +120,67 @@ export class ActionsResolver {
         // (`..`, `%2f`, etc.) that would otherwise let a malformed slug
         // path-traverse to a different repo with the user's bearer
         // token attached.
-        const url = `${this.apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tags?per_page=100`;
+        const initialUrl = `${this.apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tags?per_page=100`;
         const empty: RepoTags = { tags: [], parsed: [] };
+        const tags: { name: string; sha: string }[] = [];
 
-        try {
-            const response = await this.fetchImpl(url, { headers: this.buildHeaders() });
+        // Cap pagination at 5 pages (500 tags). GitHub's tags endpoint
+        // is cheap but unbounded — popular repos have thousands of
+        // tags and we only need the newest ones for an "is this still
+        // current" check.
+        let nextUrl: string | undefined = initialUrl;
+        let pages = 0;
+
+        while (nextUrl && pages < 5) {
+            const currentUrl: string = nextUrl;
+            let response: Response;
+
+            try {
+                response = await this.fetchImpl(currentUrl, { headers: this.buildHeaders() });
+            } catch {
+                return empty;
+            }
 
             if (!response.ok) {
                 return empty;
             }
 
-            const json = (await response.json()) as { name?: string; commit?: { sha?: string } }[];
+            let json: { name?: string; commit?: { sha?: string } }[];
+
+            try {
+                json = (await response.json()) as { name?: string; commit?: { sha?: string } }[];
+            } catch {
+                return empty;
+            }
 
             if (!Array.isArray(json)) {
                 return empty;
             }
 
-            const tags = json
-                .map((entry) => ({ name: typeof entry.name === "string" ? entry.name : "", sha: typeof entry.commit?.sha === "string" ? entry.commit.sha : "" }))
-                .filter((entry) => entry.name !== "" && entry.sha !== "");
+            for (const entry of json) {
+                const name = typeof entry.name === "string" ? entry.name : "";
+                const sha = typeof entry.commit?.sha === "string" ? entry.commit.sha : "";
 
-            const parsed: (ParsedTag & { sha: string })[] = [];
-
-            for (const entry of tags) {
-                const tag = parseTag(entry.name);
-
-                if (tag) {
-                    parsed.push({ ...tag, sha: entry.sha });
+                if (name !== "" && sha !== "") {
+                    tags.push({ name, sha });
                 }
             }
 
-            return { parsed, tags };
-        } catch {
-            return empty;
+            nextUrl = parseLinkHeader(response.headers.get("link")).next;
+            pages += 1;
         }
+
+        const parsed: (ParsedTag & { sha: string })[] = [];
+
+        for (const entry of tags) {
+            const tag = parseTag(entry.name);
+
+            if (tag) {
+                parsed.push({ ...tag, sha: entry.sha });
+            }
+        }
+
+        return { parsed, tags };
     }
 
     private async fetchCommit(owner: string, repo: string, ref: string): Promise<CommitInfo | undefined> {

--- a/packages/tooling/vis/src/commands/update/ecosystems/actions/scanner.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/actions/scanner.ts
@@ -1,5 +1,5 @@
 import { isAccessibleSync, readFileSync, walkSync } from "@visulima/fs";
-import { join } from "@visulima/path";
+import { isAbsolute, join } from "@visulima/path";
 
 /**
  * A single `uses:` reference picked out of a workflow / composite action.
@@ -278,7 +278,7 @@ export const scanActionsRepository = (workspaceRoot: string, extraDirs: string[]
     }
 
     for (const directory of extraDirs) {
-        const absolute = directory.startsWith("/") ? directory : join(workspaceRoot, directory);
+        const absolute = isAbsolute(directory) ? directory : join(workspaceRoot, directory);
 
         if (!isAccessibleSync(absolute)) {
             continue;

--- a/packages/tooling/vis/src/commands/update/ecosystems/dependabot.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/dependabot.ts
@@ -157,13 +157,17 @@ const addAll = (target: Set<string>, values: string[] | undefined): void => {
 };
 
 /**
- * Strips `//` line comments and `/* … *\/` block comments from JSON5 text
- * **without** touching content inside string literals. A naive
- * `/\/\/.*$/g` would happily chew through `"url": "https://example.com"`
- * — corrupting any renovate config that references a URL.
+ * Strips `//` line comments, `/* … *\/` block comments, and trailing
+ * commas from JSON5 text **without** touching content inside string
+ * literals. A naive `/\/\/.*$/g` would happily chew through
+ * `"url": "https://example.com"` — corrupting any renovate config that
+ * references a URL.
  *
  * The state machine tracks whether we're inside a string and skips
  * escapes (`\"`, `\\`) so quoted forward-slash sequences are preserved.
+ * Trailing commas before `}` and `]` are dropped because they're the
+ * most common JSON5 feature found in hand-edited renovate configs and
+ * strict `JSON.parse` rejects them.
  */
 const stripJsonComments = (source: string): string => {
     let out = "";
@@ -217,6 +221,25 @@ const stripJsonComments = (source: string): string => {
 
             index += 2;
             continue;
+        }
+
+        // Trailing-comma elision: a `,` immediately followed (after
+        // any whitespace) by `}` or `]` would crash `JSON.parse`.
+        // Skip it. We only look ahead — string-mode is already handled
+        // above so we never touch a comma inside a quoted value.
+        if (char === ",") {
+            let lookahead = index + 1;
+
+            while (lookahead < length && /\s/.test(source[lookahead] ?? "")) {
+                lookahead += 1;
+            }
+
+            const next = source[lookahead];
+
+            if (next === "}" || next === "]") {
+                index += 1;
+                continue;
+            }
         }
 
         out += char;

--- a/packages/tooling/vis/src/commands/update/ecosystems/docker/index.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/docker/index.ts
@@ -221,6 +221,30 @@ export const checkDocker = async (_workspaceRoot: string, context: CheckDockerCo
                 continue;
             }
 
+            // Branch ref with --include-branches but a constrained mode:
+            // there's no version baseline to compute the patch/minor jump
+            // from, so `pickBestTag` would silently return undefined.
+            // Make the skip explicit instead of dropping the entry.
+            if (!currentParsed && options.mode !== "latest") {
+                ignoredList.push({
+                    currentRef: reference.tag,
+                    currentVersion: reference.tag,
+                    ecosystem: "docker",
+                    file: reference.file,
+                    ignored: true,
+                    line: reference.line,
+                    name: fullName,
+                    newRef: reference.tag,
+                    newVersion: undefined,
+                    original: reference.original,
+                    reason: `branch ref has no version baseline for --target=${options.mode}`,
+                    replacement: reference.original,
+                    updateType: "unknown",
+                });
+
+                continue;
+            }
+
             const best = pickBestTag(listing.parsed, currentParsed, options.mode, false);
 
             if (!best) {

--- a/packages/tooling/vis/src/commands/update/ecosystems/docker/registry.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/docker/registry.ts
@@ -1,3 +1,4 @@
+import { parseLinkHeader } from "../link-header";
 import type { ParsedTag } from "../semver-helpers";
 import { parseTag } from "../semver-helpers";
 
@@ -137,11 +138,14 @@ export class DockerRegistry {
      * Standard v2 registry tag listing. Some registries (ghcr.io,
      * mcr.microsoft.com) require a bearer token even for public repos —
      * we honor the WWW-Authenticate challenge on a 401 and retry once.
+     *
+     * The registry HTTP API paginates via the `Link` header (RFC 5988)
+     * — we walk up to 5 pages (500 tags) which is enough for any
+     * realistic image without burning a session token's quota.
      */
     private async listV2Tags(registry: string, namespace: string, image: string): Promise<RegistryTagListing> {
         const empty: RegistryTagListing = { parsed: [], raw: [] };
         const repository = namespace === "library" ? image : `${namespace}/${image}`;
-        const url = `https://${registry}/v2/${repository}/tags/list?n=100`;
         const baseHeaders: Record<string, string> = { Accept: "application/json" };
         const explicit = this.tokens[registry] ?? process.env[`DOCKER_REGISTRY_TOKEN_${registry.toUpperCase().replaceAll(/[^A-Z0-9]/g, "_")}`];
 
@@ -149,40 +153,21 @@ export class DockerRegistry {
             baseHeaders.Authorization = `Bearer ${explicit}`;
         }
 
-        try {
-            let response = await this.fetchImpl(url, { headers: baseHeaders });
+        // The Link header carries a relative URL (`/v2/foo/tags/list?n=100&last=…`)
+        // for cross-page navigation, so we need the base origin to
+        // re-anchor it.
+        const origin = `https://${registry}`;
+        const tags: string[] = [];
+        let nextUrl: string | undefined = `${origin}/v2/${repository}/tags/list?n=100`;
+        let challengeHeaders: Record<string, string> = baseHeaders;
+        let pages = 0;
 
-            if (response.status === 401) {
-                const auth = parseAuthenticate(response.headers.get("www-authenticate"));
-
-                if (auth) {
-                    const token = await this.fetchBearerToken(auth);
-
-                    if (token) {
-                        response = await this.fetchImpl(url, {
-                            headers: { ...baseHeaders, Authorization: `Bearer ${token}` },
-                        });
-                    }
-                }
-            }
-
-            if (!response.ok) {
-                return empty;
-            }
-
-            const json = (await response.json()) as { tags?: string[] };
-
-            if (!Array.isArray(json.tags)) {
-                return empty;
-            }
-
-            // Imperative loop — `parsed.map(...).filter(predicate)` infers
-            // the literal-`undefined` `lastUpdated` as a non-assignable
-            // subtype of `DockerParsedTag` (TS2677). Pushing into the
-            // typed array sidesteps the inference issue.
+        const buildResult = (): RegistryTagListing => {
+            // v2 registries don't expose timestamps — leave `lastUpdated`
+            // undefined and the min-age gate skips silently.
             const parsed: DockerParsedTag[] = [];
 
-            for (const tag of json.tags) {
+            for (const tag of tags) {
                 const base = parseTag(tag);
 
                 if (base) {
@@ -190,10 +175,66 @@ export class DockerRegistry {
                 }
             }
 
-            return { parsed, raw: json.tags };
-        } catch {
+            return { parsed, raw: tags };
+        };
+
+        while (nextUrl && pages < 5) {
+            try {
+                let response: Response = await this.fetchImpl(nextUrl, { headers: challengeHeaders });
+
+                if (response.status === 401 && challengeHeaders === baseHeaders) {
+                    const auth = parseAuthenticate(response.headers.get("www-authenticate"));
+
+                    if (auth) {
+                        const token = await this.fetchBearerToken(auth);
+
+                        if (token) {
+                            // Re-issue with the bearer token AND keep it
+                            // for every subsequent page so we don't
+                            // re-challenge once per page.
+                            challengeHeaders = { ...baseHeaders, Authorization: `Bearer ${token}` };
+                            response = await this.fetchImpl(nextUrl, { headers: challengeHeaders });
+                        }
+                    }
+                }
+
+                if (!response.ok) {
+                    return pages === 0 ? empty : buildResult();
+                }
+
+                const json = (await response.json()) as { tags?: string[] };
+
+                if (!Array.isArray(json.tags)) {
+                    return pages === 0 ? empty : buildResult();
+                }
+
+                for (const tag of json.tags) {
+                    if (typeof tag === "string") {
+                        tags.push(tag);
+                    }
+                }
+
+                const link = parseLinkHeader(response.headers.get("link"));
+
+                if (link.next) {
+                    // Registries may return either an absolute URL or a
+                    // path-relative one — `URL` resolves both consistently.
+                    nextUrl = new URL(link.next, origin).toString();
+                } else {
+                    nextUrl = undefined;
+                }
+            } catch {
+                return pages === 0 ? empty : buildResult();
+            }
+
+            pages += 1;
+        }
+
+        if (tags.length === 0) {
             return empty;
         }
+
+        return buildResult();
     }
 
     private async fetchBearerToken(auth: AuthInfo): Promise<string | undefined> {

--- a/packages/tooling/vis/src/commands/update/ecosystems/gitlab/index.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/gitlab/index.ts
@@ -130,8 +130,21 @@ export const checkGitlab = async (workspaceRoot: string, context: CheckGitlabCon
             return;
         }
 
+        if (listing.error) {
+            for (const include of groupIncludes) {
+                failed.push({ file: include.file, reason: `failed to list tags for ${project}: ${listing.error}` });
+            }
+
+            return;
+        }
+
         for (const include of groupIncludes) {
-            const fullName = include.project;
+            // Display the full component path (project + component name)
+            // so the report tells the user what they actually wrote in
+            // the YAML, not the stripped-for-API-lookup form.
+            const fullName = include.kind === "component" && include.componentName
+                ? `${include.project}/${include.componentName}`
+                : include.project;
             let ignoreReason: string | undefined;
 
             if (include.ignoreReason) {
@@ -172,13 +185,33 @@ export const checkGitlab = async (workspaceRoot: string, context: CheckGitlabCon
                 continue;
             }
 
+            // Branch ref with --include-branches but a constrained mode:
+            // pickBestTag would silently return undefined because there's
+            // no version baseline. Surface it as an explicit ignore so
+            // the user sees why nothing happened.
+            if (!currentParsed && options.mode !== "latest") {
+                ignoredList.push(buildIgnored(`branch ref has no version baseline for --target=${options.mode}`));
+                continue;
+            }
+
             const best = pickBestTag(listing.parsed, currentParsed, options.mode, false);
 
             if (!best) {
                 continue;
             }
 
-            const newRef = include.kind === "component" ? `${include.project}@${best.raw}` : best.raw;
+            // Component refs are rewritten as `${project}/${componentName}@${tag}`
+            // so the on-disk token keeps its full component path. Project
+            // includes only carry the ref, not the project path.
+            let newRef: string;
+
+            if (include.kind === "component") {
+                const componentPath = include.componentName ? `${include.project}/${include.componentName}` : include.project;
+
+                newRef = `${componentPath}@${best.raw}`;
+            } else {
+                newRef = best.raw;
+            }
 
             updates.push({
                 currentRef: include.ref,

--- a/packages/tooling/vis/src/commands/update/ecosystems/gitlab/resolver.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/gitlab/resolver.ts
@@ -4,6 +4,8 @@ import { parseTag } from "../semver-helpers";
 interface GitlabProjectTags {
     readonly tags: { name: string; sha: string }[];
     readonly parsed: (ParsedTag & { sha: string })[];
+    /** When set, the lookup failed (HTTP error, bad payload, network). Callers must surface this rather than treat the empty list as "no tags". */
+    readonly error?: string;
 }
 
 export interface GitlabResolverOptions {
@@ -25,6 +27,8 @@ export interface GitlabResolverOptions {
 export class GitlabResolver {
     private readonly token: string | undefined;
 
+    private readonly tokenHeader: "JOB-TOKEN" | "PRIVATE-TOKEN";
+
     private readonly defaultApiBase: string;
 
     private readonly fetchImpl: typeof fetch;
@@ -32,7 +36,24 @@ export class GitlabResolver {
     private readonly tagCache = new Map<string, Promise<GitlabProjectTags>>();
 
     public constructor(options: GitlabResolverOptions) {
-        this.token = options.token ?? process.env.GITLAB_TOKEN ?? process.env.CI_JOB_TOKEN;
+        // GitLab uses a different header for CI-job tokens — passing a
+        // `CI_JOB_TOKEN` via `PRIVATE-TOKEN` returns 401 because GitLab
+        // routes the two through different auth providers. We preserve
+        // the explicit-token case (`PRIVATE-TOKEN`) and only flip to
+        // `JOB-TOKEN` when the value originates from `CI_JOB_TOKEN`.
+        const explicit = options.token ?? process.env.GITLAB_TOKEN;
+
+        if (explicit) {
+            this.token = explicit;
+            this.tokenHeader = "PRIVATE-TOKEN";
+        } else if (process.env.CI_JOB_TOKEN) {
+            this.token = process.env.CI_JOB_TOKEN;
+            this.tokenHeader = "JOB-TOKEN";
+        } else {
+            this.token = undefined;
+            this.tokenHeader = "PRIVATE-TOKEN";
+        }
+
         this.defaultApiBase = options.apiBase ?? "https://gitlab.com";
         this.fetchImpl = options.fetch ?? fetch;
     }
@@ -68,7 +89,6 @@ export class GitlabResolver {
     }
 
     private async fetchTags(projectPath: string): Promise<GitlabProjectTags> {
-        const empty: GitlabProjectTags = { parsed: [], tags: [] };
         const { host, path } = this.resolveHostAndPath(projectPath);
         const encoded = encodeURIComponent(path);
         const url = `${host}/api/v4/projects/${encoded}/repository/tags?per_page=100`;
@@ -78,20 +98,20 @@ export class GitlabResolver {
         };
 
         if (this.token) {
-            headers["PRIVATE-TOKEN"] = this.token;
+            headers[this.tokenHeader] = this.token;
         }
 
         try {
             const response = await this.fetchImpl(url, { headers });
 
             if (!response.ok) {
-                return empty;
+                return { error: `HTTP ${String(response.status)} from ${host}`, parsed: [], tags: [] };
             }
 
             const json = (await response.json()) as { name?: string; commit?: { id?: string } }[];
 
             if (!Array.isArray(json)) {
-                return empty;
+                return { error: `unexpected response shape from ${host}`, parsed: [], tags: [] };
             }
 
             const tags = json
@@ -108,8 +128,10 @@ export class GitlabResolver {
             }
 
             return { parsed, tags };
-        } catch {
-            return empty;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "fetch failed";
+
+            return { error: message, parsed: [], tags: [] };
         }
     }
 }

--- a/packages/tooling/vis/src/commands/update/ecosystems/gitlab/scanner.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/gitlab/scanner.ts
@@ -12,7 +12,13 @@ import { parseImageReference } from "../docker/scanner";
  * lives in another repo and we have no checked-out copy to walk.
  */
 export interface GitLabInclude {
-    /** Full `project` path (`group/subgroup/project`) or `component` host path. */
+    /**
+     * Project path used for tag-lookup (`group/subgroup/project`). For
+     * component refs this is the parent project — the trailing
+     * component-name segment is stored separately in `componentName`
+     * because GitLab resolves tags against the project, not against the
+     * component path.
+     */
     readonly project: string;
     /** Current ref (tag, branch, or SHA). */
     readonly ref: string;
@@ -24,6 +30,13 @@ export interface GitLabInclude {
     readonly original: string;
     /** `include: { component: gitlab.com/foo/bar/baz@1.2.3 }` form. */
     readonly kind: "component" | "project";
+    /**
+     * Component-name segment for `kind === "component"`. The full
+     * component path the user wrote is `${project}/${componentName}`; we
+     * keep them split because the API lookup targets `project` but the
+     * replacement we write back must include the component name.
+     */
+    readonly componentName?: string;
     /** When set, the include was excluded by a `# vis-update-ignore` directive. */
     readonly ignoreReason: string | undefined;
 }
@@ -56,12 +69,41 @@ const COMPONENT_RE = /^(\s*-?\s*component:\s*)(['"]?)([^'"\s#]+)\2(\s*#.*)?$/;
 const IMAGE_RE = /^(\s*image:\s*)(['"]?)([^'"\s#]+)\2(\s*#.*)?$/;
 
 /**
+ * Inline (flow-style) include mapping on a single line:
+ *
+ *     include: { project: 'foo/bar', ref: 'v1.2.3' }
+ *     - { project: 'foo/bar', ref: 'main', file: '/x.yml' }
+ *
+ * We don't parse the brace content as full YAML — we just pull
+ * `project: …` and `ref: …` out of the slice between the braces. A
+ * line that's missing either key is treated as not-an-include and
+ * dropped through to the rest of the state machine.
+ */
+const FLOW_LINE_RE = /^\s*(?:-\s*)?(?:include:\s*)?\{([^}]*)\}\s*(?:#.*)?$/;
+
+const FLOW_PROJECT_RE = /project:\s*(['"]?)([^'"\s,}]+)\1/;
+
+const FLOW_REF_RE = /ref:\s*(['"]?)([^'"\s,}]+)\1/;
+
+const FLOW_COMPONENT_RE = /component:\s*(['"]?)([^'"\s,}]+)\1/;
+
+/**
  * Limited services-list parser: matches a line of the form
  * `- name: postgres:14` (inside a `services:` block) or a bare `- postgres:14`.
  */
 const SERVICE_NAME_RE = /^(\s*-\s*name:\s*)(['"]?)([^'"\s#]+)\2(\s*#.*)?$/;
 
 const SERVICE_BARE_RE = /^(\s*-\s*)(['"]?)([^'"\s#:]+:[^'"\s#]+)\2(\s*#.*)?$/;
+
+/**
+ * YAML block-opener lines — a mapping key followed by no inline value
+ * (the value lives on subsequent indented lines). Examples: `include:`,
+ * `default:`, `before_script:`. These are structural and shouldn't
+ * consume a pending `# vis-update-ignore-next-line` directive, otherwise
+ * the directive gets eaten by the `include:` line and never reaches the
+ * `project:` / `ref:` that follows.
+ */
+const BLOCK_OPENER_RE = /^\s*-?\s*[a-z_][\w-]*:\s*(?:#.*)?$/i;
 
 export const extractFromGitlabCi = (filePath: string, content: string): { includes: GitLabInclude[]; images: ImageReference[] } => {
     const lines = content.split(/\r?\n/);
@@ -208,8 +250,11 @@ export const extractFromGitlabCi = (filePath: string, content: string): { includ
             const atIndex = raw.lastIndexOf("@");
 
             if (atIndex > 0) {
-                const project = raw.slice(0, atIndex);
+                const fullPath = raw.slice(0, atIndex);
                 const ref = raw.slice(atIndex + 1);
+                const lastSlash = fullPath.lastIndexOf("/");
+                const project = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
+                const componentName = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : undefined;
                 const trailingComment = componentMatch[4]?.trim();
                 let ignoreReason = pendingIgnore ? "vis-update-ignore-next-line" : undefined;
 
@@ -218,6 +263,7 @@ export const extractFromGitlabCi = (filePath: string, content: string): { includ
                 }
 
                 includes.push({
+                    componentName,
                     file: filePath,
                     ignoreReason,
                     kind: "component",
@@ -232,14 +278,68 @@ export const extractFromGitlabCi = (filePath: string, content: string): { includ
             continue;
         }
 
+        const flowMatch = FLOW_LINE_RE.exec(line);
+
+        if (flowMatch) {
+            const inner = flowMatch[1] ?? "";
+            const trailingComment = /#(.*)$/.exec(line)?.[1]?.trim();
+            let ignoreReason = pendingIgnore ? "vis-update-ignore-next-line" : undefined;
+
+            if (trailingComment && IGNORE_INLINE_RE.test(trailingComment)) {
+                ignoreReason = ignoreReason ?? "vis-update-ignore";
+            }
+
+            const componentInline = FLOW_COMPONENT_RE.exec(inner);
+
+            if (componentInline) {
+                const raw = componentInline[2] ?? "";
+                const atIndex = raw.lastIndexOf("@");
+
+                if (atIndex > 0) {
+                    const fullPath = raw.slice(0, atIndex);
+                    const ref = raw.slice(atIndex + 1);
+                    const lastSlash = fullPath.lastIndexOf("/");
+                    const project = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
+                    const componentName = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : undefined;
+
+                    includes.push({
+                        componentName,
+                        file: filePath,
+                        ignoreReason,
+                        kind: "component",
+                        line: index + 1,
+                        original: raw,
+                        project,
+                        ref,
+                    });
+                }
+            } else {
+                const projectInline = FLOW_PROJECT_RE.exec(inner);
+                const refInline = FLOW_REF_RE.exec(inner);
+
+                if (projectInline && refInline) {
+                    includes.push({
+                        file: filePath,
+                        ignoreReason,
+                        kind: "project",
+                        line: index + 1,
+                        original: refInline[2] ?? "",
+                        project: projectInline[2] ?? "",
+                        ref: refInline[2] ?? "",
+                    });
+                }
+            }
+
+            pendingIgnore = false;
+            continue;
+        }
+
         // YAML key-only lines (`include:`, `services:`, `some-job:`) sit
         // between a `# vis-update-ignore-next-line` directive and the
         // value-bearing line that the user actually wants to ignore.
         // Treat them like comments for the purpose of the lookahead so
         // the directive survives to the next `ref:` / `image:` line.
-        const isKeyOnlyLine = /^\s*-?\s*[a-z_][\w-]*:\s*(?:#.*)?$/i.test(line);
-
-        if (trimmed !== "" && !trimmed.startsWith("#") && !isKeyOnlyLine) {
+        if (trimmed !== "" && !trimmed.startsWith("#") && !BLOCK_OPENER_RE.test(line)) {
             pendingIgnore = false;
         }
     }

--- a/packages/tooling/vis/src/commands/update/ecosystems/link-header.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/link-header.ts
@@ -1,0 +1,47 @@
+/**
+ * Minimal RFC 5988 Link header parser. We only need the `rel="next"`
+ * URL to drive pagination across GitHub's REST API and Docker Registry
+ * v2 tag listings — bringing in a full parser would be overkill.
+ *
+ * Returns the URL for each known `rel`. Unknown rels are dropped. A
+ * `null` or empty input yields an empty object.
+ */
+export interface ParsedLinks {
+    readonly next?: string;
+    readonly previous?: string;
+    readonly last?: string;
+    readonly first?: string;
+}
+
+export const parseLinkHeader = (header: string | null | undefined): ParsedLinks => {
+    if (!header) {
+        return {};
+    }
+
+    const out: { next?: string; previous?: string; last?: string; first?: string } = {};
+
+    for (const entry of header.split(",")) {
+        const match = /^\s*<([^>]+)>\s*;\s*(.+)$/.exec(entry);
+
+        if (!match) {
+            continue;
+        }
+
+        const url = match[1] ?? "";
+        const params = match[2] ?? "";
+        const relMatch = /rel\s*=\s*"?([^";\s]+)"?/i.exec(params);
+        const rel = relMatch?.[1]?.toLowerCase();
+
+        if (rel === "next") {
+            out.next = url;
+        } else if (rel === "prev" || rel === "previous") {
+            out.previous = url;
+        } else if (rel === "last") {
+            out.last = url;
+        } else if (rel === "first") {
+            out.first = url;
+        }
+    }
+
+    return out;
+};

--- a/packages/tooling/vis/src/commands/update/ecosystems/report.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/report.ts
@@ -77,7 +77,33 @@ export const formatEcosystemReport = (result: EcosystemCheckResult, options: { s
     }
 
     if (totalUpdates === 0) {
-        lines.push(`${green("✓")} All ecosystem references up to date.`);
+        // "All up to date" only when every lookup succeeded AND nothing
+        // was hidden behind an ignore rule. Otherwise the user could
+        // believe their CI is fully pinned when in reality we just
+        // couldn't reach the registry for half of it.
+        if (result.failed.length === 0 && result.ignored.length === 0) {
+            lines.push(`${green("✓")} All ecosystem references up to date.`);
+
+            return lines.join("\n");
+        }
+
+        lines.push(`${yellow("⚠")} No actionable updates found.`);
+
+        if (result.failed.length > 0) {
+            lines.push(`\n  ${yellow("Failed lookups:")}`);
+
+            for (const failure of result.failed) {
+                lines.push(`    ${failure.file}: ${failure.reason}`);
+            }
+        }
+
+        if (options.showIgnored && result.ignored.length > 0) {
+            lines.push(`\n  ${dim("Ignored:")}`);
+
+            for (const update of result.ignored) {
+                lines.push(`    ${dim(update.name)}  ${dim(update.reason ?? "")}`);
+            }
+        }
 
         return lines.join("\n");
     }


### PR DESCRIPTION
## Summary

Extends `vis update` to scan and bump non-npm dependency references alongside the existing catalog / package-manager flow. The npm path is unchanged; the new ecosystem scan auto-runs after it when no explicit package args were passed.

### What `vis update` now updates

- **GitHub Actions** — every `uses:` in `.github/workflows/*.yml`, `.github/actions/*/action.yml`, and root `action.yml`. Resolves tags via the GitHub REST API (`/repos/{owner}/{repo}/tags`), defaults to SHA-pinning with a `# vN.M.P` version-hint comment for readability (matching the actions-up convention), and honours inline ignore directives: `# actions-up-ignore`, `# actions-up-ignore-next-line`, and block `# actions-up-ignore-start` / `-end`. Modelled after [azat-io/actions-up](https://github.com/azat-io/actions-up).
- **Docker** — every `FROM` line in `Dockerfile*` / `*.dockerfile`, and every `image:` field in `docker-compose*.yml`. Resolves newer tags from Docker Hub (`docker.io`) and v2-compatible registries (`ghcr.io`, `mcr.microsoft.com`, self-hosted) with automatic WWW-Authenticate bearer-token handling. Honours `# vis-update-ignore` directives; skips non-semver tags (`latest`, `nightly`) unless `--include-branches`.
- **GitLab CI** — `.gitlab-ci.yml` plus anything under `.gitlab/ci/`. Updates `image:` / `services:` via the Docker path; resolves `include: { project, ref }` and component refs via the GitLab v4 REST API (`gitlab.com` or the host extracted from the project path for self-hosted instances).
- **Dependabot / Renovate config sync** — reads `.github/dependabot.yml` and `renovate.json` so existing `ignoreDeps`, `ignore.dependency-name`, and `packageRules` entries with `enabled: false` automatically gate the ecosystem scan (no duplicate config needed).

### New CLI flags

| Flag                  | Default | Purpose                                                                       |
| --------------------- | ------- | ----------------------------------------------------------------------------- |
| `--no-actions`        | `false` | Skip the GitHub Actions scan                                                  |
| `--no-docker`         | `false` | Skip the Docker scan                                                          |
| `--no-gitlab`         | `false` | Skip the GitLab CI scan                                                       |
| `--include-branches`  | `false` | Include branch references (`actions/checkout@main`, `node:latest`)            |
| `--style sha\|preserve` | `sha` | Reference style for Actions — SHA-pin with version comment, or keep existing  |
| `--actions-token`     |         | GitHub token override (defaults to `GITHUB_TOKEN` / `GH_TOKEN`)               |
| `--gitlab-token`      |         | GitLab token override (defaults to `GITLAB_TOKEN` / `CI_JOB_TOKEN`)           |

### Architecture

New module tree under `packages/tooling/vis/src/commands/update/ecosystems/`:

```
ecosystems/
├── actions/          # GitHub Actions scanner + GitHub-API resolver + orchestrator
├── docker/           # Dockerfile/compose scanner + multi-registry client + orchestrator
├── gitlab/           # GitLab CI scanner + GitLab-API resolver + orchestrator
├── applier.ts        # File rewriter (line + exact-token replacement, preserves CRLF)
├── dependabot.ts     # dependabot.yml + renovate.json ignore-rule loader
├── semver-helpers.ts # Shared tag parsing, comparison, and mode-aware best-pick
├── report.ts         # Human + JSON formatters mirroring the catalog report shape
├── types.ts          # Shared types
└── index.ts          # Top-level orchestrator (detect → fan out → aggregate)
```

The handler wires `runEcosystemUpdate` after the catalog/PM-wrapper path so existing exit codes and interactive flows are untouched. The applier rewrites files by line + exact-token substring replacement (no YAML re-serialisation) so it preserves anchors, comments, quoting style, and indentation.

## Test plan

- [x] Unit tests for the semver helper (parsing, comparison, mode-constrained pick, prerelease handling)
- [x] GitHub Actions scanner — `uses:` extraction, SHA pins with version-hint comments, `# actions-up-ignore-*` directives
- [x] GitHub Actions resolver — mocked fetch, per-repo caching, 401 handling
- [x] GitHub Actions orchestrator — SHA vs preserve style, `--include-branches`, `--mode patch`, `--exclude`, inline ignore reasons
- [x] Docker scanner — registry parsing (library, GHCR, host:port), digest pins, variable-expansion skip
- [x] Docker orchestrator — Hub URL shape, `latest` ignore, update-type classification
- [x] GitLab CI scanner — `image:`, `services:` (both `- name:` and bare forms), project + component includes
- [x] Dependabot + Renovate config loader — ecosystem mapping, scoped `ignoreDeps`, disabled `packageRules`, `isIgnored` glob/exact matching
- [x] Applier — original-token replacement, version-hint stripping, drift detection, CRLF preservation

**Note**: I couldn't run `pnpm install` / `tsc` / `vitest` locally — this sandbox can't reach `npm.jsr.io` and the lockfile policy check on `@jsr/std__bytes` / `@jsr/std__html` blocks install. CI will be the first ground truth on typing + test execution.

## Docs

- `packages/tooling/vis/docs/commands/update.mdx` — new flag rows, "Non-npm ecosystem updates" section covering Actions / Docker / GitLab / Dependabot integration
- `packages/tooling/vis/docs/guides/ci-cd.mdx` — new "Keeping Pipelines Pinned" section with a workflow example
- `packages/tooling/vis/README.md` — quick-start tweak + command-table description

https://claude.ai/code/session_01J44SJG8xi1HUVEhDpiRBeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination support for ecosystem tag fetching, retrieving up to 500 tags per ecosystem
  * Enhanced GitLab CI include detection with component-level reference support
  * Improved failure tracking and ignored reference reporting

* **Bug Fixes**
  * Fixed cross-platform path detection accuracy
  * Enhanced JSON/JSON5 config parsing with trailing-comma tolerance
  * Improved Docker Registry authorization retry logic

* **Improvements**
  * Clearer reporting when no actionable ecosystem updates are available
  * Better categorization of ignored and failed references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/visulima/visulima/pull/654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->