### PR TITLE
feat(email): add fail-fast capability guard

### DIFF
--- a/eslint-prettier-conflicts.md
+++ b/eslint-prettier-conflicts.md
@@ -1,0 +1,47 @@
+# ESLint rules that conflict with Prettier
+
+These stylistic ESLint rules fight Prettier's output. When Prettier is the formatter of record, Prettier reformats the code one way and ESLint then reports an error demanding the opposite — an unfixable ping-pong (`eslint --fix` and `prettier --write` keep undoing each other).
+
+If you run Prettier as the source of truth, **disable the rules below** in the ESLint flat config so ESLint stops policing formatting Prettier already owns.
+
+## The conflicting rules
+
+| Rule | What ESLint wants | What Prettier does | Where it bit us |
+| --- | --- | --- | --- |
+| `@stylistic/no-extra-parens` | No parentheses around a conditional (ternary) arrow body: `(o) => cond ? a : b` | Wraps the ternary in parens: `(o) => (cond ? a : b)` | `packages/email/email/src/utils/validation/check-feature-support.ts` (the `CAPABILITY_PROBES` `detect` arrows) |
+| `no-confusing-arrow` | The **opposite** of the above — *requires* parens/braces around an arrow returning a conditional | (satisfied by Prettier's parens) | same file — removing the parens to satisfy `no-extra-parens` immediately trips this one, so the two rules are mutually unsatisfiable without Prettier's form |
+| `@stylistic/operator-linebreak` | `=` (and other operators) at the **beginning** of a wrapped line | Puts the operator at the **end** of the previous line | `packages/email/email/src/mail.ts` (the wrapped `let emailOptions =` in `draft()`) |
+| `generator-star-spacing` | Specific `*` spacing for generators, e.g. `async* fn()` | Formats as `async *fn()` | `packages/email/email/src/mail.ts` (`async* sendMany`) |
+| `@stylistic/generator-star-spacing` | Same as above (the `@stylistic` clone) | same | same |
+
+> `no-confusing-arrow` + `@stylistic/no-extra-parens` are a true catch-22: one demands the parens, the other forbids them. Only Prettier's chosen form satisfies `no-confusing-arrow`, so if you keep Prettier you must drop `@stylistic/no-extra-parens` (not the other way around).
+
+## Drop-in flat-config override (when Prettier is authoritative)
+
+```js
+// eslint.config.js
+export default [
+    // ...existing config
+    {
+        rules: {
+            "@stylistic/no-extra-parens": "off",
+            "@stylistic/operator-linebreak": "off",
+            "@stylistic/generator-star-spacing": "off",
+            "generator-star-spacing": "off",
+            // `no-confusing-arrow` can stay on — Prettier's parens satisfy it.
+        },
+    },
+];
+```
+
+## Current state of the code
+
+Right now ESLint is authoritative for `mail.ts` (the operator-linebreak / generator-star forms were left in the ESLint-preferred shape). The only spot that needed Prettier's form is the ternary arrows in `check-feature-support.ts`, which carry a scoped inline directive:
+
+```ts
+/* eslint-disable @stylistic/no-extra-parens -- prettier wraps these conditional arrow bodies in parens (also required by no-confusing-arrow). */
+```
+
+If you adopt the global override above, that inline `eslint-disable` block in `check-feature-support.ts` becomes redundant and can be removed (otherwise it may surface as an unused-disable-directive once the rule is off globally).
+
+_Discovered while adding the email capability guard; see also the repo memory note on the package-wide formatter conflict in `@visulima/fs`._

--- a/packages/email/email/README.md
+++ b/packages/email/email/README.md
@@ -114,6 +114,46 @@ const message = new MailMessage().to("user@example.com").subject("Hello").html("
 await mail.send(message);
 ```
 
+### Capability Guard (fail-fast field support)
+
+Every provider declares which capabilities it supports through its `features` flags (attachments, tagging, scheduling, HTML, custom headers, reply-to, templates, ...). Before a message is handed to the provider, `Mail` runs a fail-fast check: if the message uses a capability the provider has **explicitly** declared unsupported (`features[x] === false`), the send is rejected locally — no wasted network round-trip and no silent data loss.
+
+```typescript
+import { createMail } from "@visulima/email";
+import { awsSesProvider } from "@visulima/email/providers/aws-ses";
+
+// AWS SES declares `tagging: false`
+const mail = createMail(awsSesProvider({ accessKeyId, secretAccessKey, region }));
+
+const result = await mail.send({
+    from: { email: "noreply@example.com" },
+    subject: "Hi",
+    tags: ["promo"], // not representable by AWS SES
+    text: "Body",
+    to: { email: "user@example.com" },
+});
+
+result.success; // false
+(result.error as { code?: string }).code; // "UNSUPPORTED_FEATURES"
+```
+
+Capabilities left `undefined` are treated as "unknown" and never rejected, so providers that publish a partial (or no) `features` map are never falsely blocked. The behaviour is configurable per `Mail` instance:
+
+```typescript
+createMail(provider, { featureCheck: "error" }); // default — reject unsupported fields
+createMail(provider, { featureCheck: "warn" }); // log a warning and send anyway
+createMail(provider, { featureCheck: "off" }); // skip the check entirely
+```
+
+You can also run the check standalone (e.g. inside a custom provider):
+
+```typescript
+import { checkFeatureSupport } from "@visulima/email";
+// or the focused entry point: "@visulima/email/validation/check-feature-support"
+
+const { supported, violations } = checkFeatureSupport(message, provider.features);
+```
+
 ### Creating Draft Emails
 
 You can create draft emails in EML (RFC 822) format without sending them. The `draft()` method returns the email as an EML string with an `X-Unsent: 1` header automatically added:

--- a/packages/email/email/__tests__/mail-feature-check.test.ts
+++ b/packages/email/email/__tests__/mail-feature-check.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createMail } from "../src/mail";
+import type { Provider } from "../src/providers/provider";
+import type { EmailOptions, FeatureFlags } from "../src/types";
+
+const okResult = {
+    data: { messageId: "id-1", provider: "test", sent: true, timestamp: new Date(0) },
+    success: true as const,
+};
+
+const createProvider = (features: FeatureFlags): Provider => {
+    return {
+        features,
+
+        async initialize(): Promise<void> {},
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async isAvailable(): Promise<boolean> {
+            return true;
+        },
+        name: "test",
+        sendEmail: vi.fn(() => okResult),
+    };
+};
+
+const taggedMessage: EmailOptions = {
+    from: { email: "sender@example.com" },
+    subject: "Hi",
+    tags: ["promo"],
+    text: "Body",
+    to: { email: "user@example.com" },
+};
+
+describe("mail capability guard", () => {
+    it("rejects a message that uses an explicitly unsupported capability by default", async () => {
+        expect.assertions(4);
+
+        const provider = createProvider({ tagging: false });
+        const mail = createMail(provider);
+
+        const result = await mail.send(taggedMessage);
+
+        expect(result.success).toBe(false);
+        expect((result.error as Error).message).toContain("tags");
+        expect((result.error as { code?: string }).code).toBe("UNSUPPORTED_FEATURES");
+        expect(provider.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it("sends anyway in warn mode", async () => {
+        expect.assertions(2);
+
+        const provider = createProvider({ tagging: false });
+        const mail = createMail(provider, { featureCheck: "warn" });
+
+        const result = await mail.send(taggedMessage);
+
+        expect(result.success).toBe(true);
+        expect(provider.sendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the check entirely in off mode", async () => {
+        expect.assertions(2);
+
+        const provider = createProvider({ tagging: false });
+        const mail = createMail(provider, { featureCheck: "off" });
+
+        const result = await mail.send(taggedMessage);
+
+        expect(result.success).toBe(true);
+        expect(provider.sendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows a message when the capability is supported", async () => {
+        expect.assertions(2);
+
+        const provider = createProvider({ tagging: true });
+        const mail = createMail(provider);
+
+        const result = await mail.send(taggedMessage);
+
+        expect(result.success).toBe(true);
+        expect(provider.sendEmail).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/email/email/__tests__/providers/failover.test.ts
+++ b/packages/email/email/__tests__/providers/failover.test.ts
@@ -590,14 +590,8 @@ describe(failoverProvider, () => {
 
             expect(failover.features).toStrictEqual({
                 attachments: true,
-                batchSending: false,
-                customHeaders: true,
                 html: true,
                 replyTo: true,
-                scheduling: false,
-                tagging: false,
-                templates: false,
-                tracking: false,
             });
         });
     });

--- a/packages/email/email/__tests__/providers/roundrobin.test.ts
+++ b/packages/email/email/__tests__/providers/roundrobin.test.ts
@@ -517,14 +517,8 @@ describe(roundRobinProvider, () => {
 
             expect(roundRobin.features).toStrictEqual({
                 attachments: true,
-                batchSending: false,
-                customHeaders: true,
                 html: true,
                 replyTo: true,
-                scheduling: false,
-                tagging: false,
-                templates: false,
-                tracking: false,
             });
         });
     });

--- a/packages/email/email/__tests__/providers/utils/aggregate-features.test.ts
+++ b/packages/email/email/__tests__/providers/utils/aggregate-features.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import type { Provider } from "../../../src/providers/provider";
+import aggregateProviderFeatures from "../../../src/providers/utils/aggregate-features";
+import type { FeatureFlags } from "../../../src/types";
+
+const mailer = (features: FeatureFlags): Provider => {
+    return {
+        features,
+        initialize: () => {
+            // no-op
+        },
+        isAvailable: () => true,
+        name: "mock",
+        sendEmail: () => {
+            return { success: true };
+        },
+    };
+};
+
+describe("aggregateProviderFeatures", () => {
+    it("returns an empty map when there are no resolvable children", () => {
+        expect.assertions(1);
+
+        expect(aggregateProviderFeatures([])).toStrictEqual({});
+    });
+
+    it("mirrors a single child's declared flags", () => {
+        expect.assertions(1);
+
+        expect(aggregateProviderFeatures([mailer({ attachments: true, html: true, replyTo: true })])).toStrictEqual({
+            attachments: true,
+            html: true,
+            replyTo: true,
+        });
+    });
+
+    it("advertises a capability only when every child supports it", () => {
+        expect.assertions(1);
+
+        const result = aggregateProviderFeatures([mailer({ attachments: true, replyTo: true }), mailer({ attachments: true, replyTo: false })]);
+
+        // attachments: true everywhere -> true; replyTo: mixed -> omitted (unknown)
+        expect(result).toStrictEqual({ attachments: true });
+    });
+
+    it("marks a capability unsupported only when every child rejects it", () => {
+        expect.assertions(1);
+
+        expect(aggregateProviderFeatures([mailer({ tagging: false }), mailer({ tagging: false })])).toStrictEqual({ tagging: false });
+    });
+
+    it("treats an undefined flag on any child as unknown", () => {
+        expect.assertions(1);
+
+        // one child says true, the other omits it -> cannot guarantee -> omitted
+        expect(aggregateProviderFeatures([mailer({ scheduling: true }), mailer({})])).toStrictEqual({});
+    });
+
+    it("skips factories that cannot be constructed without config", () => {
+        expect.assertions(1);
+
+        const throwingFactory = (): Provider => {
+            throw new Error("apiKey required");
+        };
+
+        expect(aggregateProviderFeatures([throwingFactory, mailer({ html: true })])).toStrictEqual({ html: true });
+    });
+});

--- a/packages/email/email/__tests__/utils/validation/check-feature-support.test.ts
+++ b/packages/email/email/__tests__/utils/validation/check-feature-support.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import type { EmailOptions, FeatureFlags } from "../../../src/types";
+import checkFeatureSupport from "../../../src/utils/validation/check-feature-support";
+
+const baseMessage: EmailOptions = {
+    from: { email: "sender@example.com" },
+    subject: "Hello",
+    text: "Body",
+    to: { email: "user@example.com" },
+};
+
+describe(checkFeatureSupport, () => {
+    it("returns supported when no features map is provided", () => {
+        expect.assertions(2);
+
+        const result = checkFeatureSupport({ ...baseMessage, tags: ["promo"] });
+
+        expect(result.supported).toBe(true);
+        expect(result.violations).toHaveLength(0);
+    });
+
+    it("returns supported when a used capability is undefined (not explicitly disabled)", () => {
+        expect.assertions(1);
+
+        const features: FeatureFlags = { html: true };
+        const result = checkFeatureSupport({ ...baseMessage, tags: ["promo"] }, features);
+
+        expect(result.supported).toBe(true);
+    });
+
+    it("flags a capability the message uses but the provider explicitly disabled", () => {
+        expect.assertions(3);
+
+        const features: FeatureFlags = { tagging: false };
+        const result = checkFeatureSupport({ ...baseMessage, tags: ["promo"] }, features);
+
+        expect(result.supported).toBe(false);
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]).toMatchObject({ feature: "tagging", field: "tags" });
+    });
+
+    it("does not flag a disabled capability the message does not use", () => {
+        expect.assertions(1);
+
+        const features: FeatureFlags = { attachments: false, tagging: false };
+        const result = checkFeatureSupport(baseMessage, features);
+
+        expect(result.supported).toBe(true);
+    });
+
+    it("detects attachments, replyTo, html, and custom headers", () => {
+        expect.assertions(4);
+
+        const message: EmailOptions = {
+            ...baseMessage,
+            attachments: [{ content: "x", filename: "a.txt" }],
+            headers: { "X-Custom": "1" },
+            html: "<p>hi</p>",
+            replyTo: { email: "reply@example.com" },
+        };
+
+        expect(checkFeatureSupport(message, { attachments: false }).violations[0]?.feature).toBe("attachments");
+        expect(checkFeatureSupport(message, { replyTo: false }).violations[0]?.feature).toBe("replyTo");
+        expect(checkFeatureSupport(message, { html: false }).violations[0]?.feature).toBe("html");
+        expect(checkFeatureSupport(message, { customHeaders: false }).violations[0]?.feature).toBe("customHeaders");
+    });
+
+    it("ignores empty headers and empty arrays", () => {
+        expect.assertions(2);
+
+        expect(checkFeatureSupport({ ...baseMessage, headers: {} }, { customHeaders: false }).supported).toBe(true);
+        expect(checkFeatureSupport({ ...baseMessage, attachments: [] }, { attachments: false }).supported).toBe(true);
+    });
+
+    it("detects provider-specific scheduling and template extension fields", () => {
+        expect.assertions(2);
+
+        const scheduled = { ...baseMessage, scheduledAt: new Date(0) } as EmailOptions;
+        const templated = { ...baseMessage, templateId: "tmpl_1" } as EmailOptions;
+
+        expect(checkFeatureSupport(scheduled, { scheduling: false }).violations[0]?.feature).toBe("scheduling");
+        expect(checkFeatureSupport(templated, { templates: false }).violations[0]?.feature).toBe("templates");
+    });
+
+    it("reports the alias field actually set rather than a fixed name", () => {
+        expect.assertions(2);
+
+        const scheduled = { ...baseMessage, sendAt: new Date(0) } as EmailOptions;
+        const templated = { ...baseMessage, template: "welcome" } as EmailOptions;
+
+        expect(checkFeatureSupport(scheduled, { scheduling: false }).violations[0]?.field).toBe("sendAt");
+        expect(checkFeatureSupport(templated, { templates: false }).violations[0]?.field).toBe("template");
+    });
+});

--- a/packages/email/email/docs/getting-started/capability-guard.mdx
+++ b/packages/email/email/docs/getting-started/capability-guard.mdx
@@ -1,0 +1,71 @@
+---
+title: Capability Guard
+description: Fail-fast field support checks that stop unsupported message fields before they reach a provider
+---
+
+# Capability Guard
+
+Every provider declares which capabilities it supports through its `features` flags — `attachments`, `tagging`, `scheduling`, `html`, `customHeaders`, `replyTo`, `templates`, and more. Before a message is handed to the provider, `Mail` runs a **fail-fast** check: if the message uses a capability the provider has _explicitly_ declared unsupported (`features[x] === false`), the send is rejected locally — no wasted network round-trip and no silent data loss.
+
+## How it works
+
+```typescript
+import { createMail } from "@visulima/email";
+import { awsSesProvider } from "@visulima/email/providers/aws-ses";
+
+// AWS SES declares `tagging: false`
+const mail = createMail(awsSesProvider({ accessKeyId, secretAccessKey, region }));
+
+const result = await mail.send({
+    from: { email: "noreply@example.com" },
+    subject: "Hi",
+    tags: ["promo"], // not representable by AWS SES
+    text: "Body",
+    to: { email: "user@example.com" },
+});
+
+result.success; // false
+(result.error as { code?: string }).code; // "UNSUPPORTED_FEATURES"
+```
+
+The error message lists exactly which fields were rejected, and the `hint` contains a human-readable explanation per field.
+
+> Capabilities left `undefined` are treated as "unknown" and are **never** rejected, so providers that publish a partial (or no) `features` map are never falsely blocked. Aggregate providers such as [`failover`](/docs/packages/email/providers/failover) and [`roundrobin`](/docs/packages/email/providers/roundrobin) deliberately leave routed-dependent capabilities undefined and delegate the decision to whichever mailer ultimately handles the message.
+
+## Configuring the guard
+
+The behaviour is configurable per `Mail` instance via the second argument to `createMail`:
+
+```typescript
+createMail(provider, { featureCheck: "error" }); // default — reject unsupported fields
+createMail(provider, { featureCheck: "warn" }); // log a warning and send anyway
+createMail(provider, { featureCheck: "off" }); // skip the check entirely
+```
+
+| Mode      | Behaviour                                                                          |
+| --------- | ---------------------------------------------------------------------------------- |
+| `"error"` | (default) `send()` returns a failed `Result` with an `UNSUPPORTED_FEATURES` error. |
+| `"warn"`  | Logs a warning (when a logger is attached) and sends the message anyway.           |
+| `"off"`   | Skips the check entirely.                                                          |
+
+`sendMany()` inherits the configured mode automatically — a rejected message yields an unsuccessful `Receipt` rather than throwing.
+
+## Running the check standalone
+
+You can run the same check yourself — for example inside a custom provider built with `defineProvider`:
+
+```typescript
+import { checkFeatureSupport } from "@visulima/email";
+// or the focused entry point:
+// import checkFeatureSupport from "@visulima/email/validation/check-feature-support";
+
+const { supported, violations } = checkFeatureSupport(message, provider.features);
+
+if (!supported) {
+    for (const violation of violations) {
+        console.warn(violation.message);
+    }
+}
+```
+
+`checkFeatureSupport(options, features?)` returns `{ supported: boolean, violations: FeatureViolation[] }`. When `features` is omitted the check is a no-op (`supported: true`).

--- a/packages/email/email/docs/getting-started/configuration.mdx
+++ b/packages/email/email/docs/getting-started/configuration.mdx
@@ -313,6 +313,21 @@ const mock = mockProvider({
 });
 ```
 
+## Mail Options
+
+`createMail` accepts an optional second argument to configure the `Mail` instance itself (as opposed to the provider):
+
+```typescript
+import { createMail } from "@visulima/email";
+import { resendProvider } from "@visulima/email/providers/resend";
+
+const mail = createMail(resendProvider({ apiKey: "re_xxx" }), {
+    featureCheck: "error", // "error" (default) | "warn" | "off"
+});
+```
+
+`featureCheck` controls the fail-fast [capability guard](/docs/packages/email/getting-started/capability-guard), which rejects messages that use fields the provider has explicitly declared unsupported before they reach the network. See the dedicated guide for details.
+
 ## Environment Variables
 
 It's recommended to store sensitive configuration in environment variables:

--- a/packages/email/email/docs/getting-started/meta.json
+++ b/packages/email/email/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
     "title": "Getting Started",
-    "pages": ["introduction", "configuration", "sending-mail"]
+    "pages": ["introduction", "configuration", "sending-mail", "capability-guard"]
 }

--- a/packages/email/email/package.json
+++ b/packages/email/email/package.json
@@ -249,6 +249,10 @@
             "types": "./dist/utils/validation/verify-email.d.ts",
             "default": "./dist/utils/validation/verify-email.js"
         },
+        "./validation/check-feature-support": {
+            "types": "./dist/utils/validation/check-feature-support.d.ts",
+            "default": "./dist/utils/validation/check-feature-support.js"
+        },
         "./utils/normalize-email-aliases": {
             "types": "./dist/utils/normalize-email-aliases.d.ts",
             "default": "./dist/utils/normalize-email-aliases.js"

--- a/packages/email/email/src/index.ts
+++ b/packages/email/email/src/index.ts
@@ -1,7 +1,7 @@
 export { type AttachmentDataOptions, type AttachmentOptions, detectMimeType, generateContentId, readFileAsBuffer } from "./attachment-helpers";
 export { default as EmailError } from "./errors/email-error";
 export { default as RequiredOptionError } from "./errors/required-option-error";
-export { createMail, Mail, type MailGlobalConfig, type SendableMessage } from "./mail";
+export { createMail, type FeatureCheckMode, Mail, type MailGlobalConfig, type MailOptions, type SendableMessage } from "./mail";
 export { default as MailMessage } from "./mail-message";
 export type { Provider, ProviderFactory } from "./providers/provider";
 export { defineProvider } from "./providers/provider";
@@ -22,3 +22,4 @@ export type {
     Receipt,
     Result,
 } from "./types";
+export { default as checkFeatureSupport, type FeatureSupportResult, type FeatureViolation } from "./utils/validation/check-feature-support";

--- a/packages/email/email/src/mail.ts
+++ b/packages/email/email/src/mail.ts
@@ -1,4 +1,5 @@
 import DraftMailMessage from "./draft-mail-message";
+import EmailError from "./errors/email-error";
 import MailMessage from "./mail-message";
 import type { Provider } from "./providers/provider";
 import type { EmailAddress, EmailHeaders, EmailOptions, EmailResult, Receipt, Result } from "./types";
@@ -6,6 +7,7 @@ import buildMimeMessage from "./utils/build-mime-message";
 import type { Logger } from "./utils/create-logger";
 import { createLogger } from "./utils/create-logger";
 import headersToRecord from "./utils/headers-to-record";
+import checkFeatureSupport from "./utils/validation/check-feature-support";
 
 /**
  * Logs the result of sending an email.
@@ -33,6 +35,25 @@ const logSendResult = (logger: Logger | undefined, result: Result<EmailResult>, 
  * Type alias for messages that can be sent via Mail.send().
  */
 export type SendableMessage = MailMessage | EmailOptions;
+
+/**
+ * Controls the fail-fast capability guard that runs before a message is handed to the provider.
+ *
+ * `"error"` (default) rejects the send with a failed Result when the message uses a capability the provider has explicitly declared unsupported.
+ * `"warn"` logs a warning and sends anyway. `"off"` skips the check entirely.
+ */
+export type FeatureCheckMode = "error" | "off" | "warn";
+
+/**
+ * Options for a {@link Mail} instance.
+ */
+export interface MailOptions {
+    /**
+     * How to handle messages that use capabilities the provider has declared unsupported.
+     * @default "error"
+     */
+    featureCheck?: FeatureCheckMode;
+}
 
 /**
  * Global email configuration that applies to all emails sent through a Mail instance.
@@ -82,12 +103,16 @@ export class Mail {
 
     private globalConfig?: MailGlobalConfig;
 
+    private readonly featureCheck: FeatureCheckMode;
+
     /**
      * Creates a new Mail instance with a provider.
      * @param provider The email provider instance.
+     * @param options Optional Mail configuration.
      */
-    public constructor(provider: Provider) {
+    public constructor(provider: Provider, options?: MailOptions) {
         this.provider = provider;
+        this.featureCheck = options?.featureCheck ?? "error";
     }
 
     /**
@@ -290,6 +315,12 @@ export class Mail {
 
         emailOptions = this.applyGlobalConfig(emailOptions);
 
+        const featureError = this.assertFeatureSupport(emailOptions);
+
+        if (featureError) {
+            return { error: featureError, success: false };
+        }
+
         const result = await this.provider.sendEmail(emailOptions);
 
         logSendResult(this.logger, result, this.provider.name ?? "unknown");
@@ -419,6 +450,51 @@ export class Mail {
     }
 
     /**
+     * Runs the fail-fast capability guard for the configured {@link FeatureCheckMode}.
+     * @param emailOptions The fully-resolved email options about to be sent.
+     * @returns An {@link EmailError} when the send should be rejected, otherwise undefined.
+     * @private
+     */
+    private assertFeatureSupport(emailOptions: EmailOptions): EmailError | undefined {
+        if (this.featureCheck === "off") {
+            return undefined;
+        }
+
+        const { supported, violations } = checkFeatureSupport(emailOptions, this.provider.features);
+
+        if (supported) {
+            return undefined;
+        }
+
+        const providerName = this.provider.name ?? "unknown";
+        const fields = violations.map((violation) => violation.field);
+        const reasons = violations.map((violation) => violation.message);
+
+        if (this.featureCheck === "warn") {
+            if (this.logger) {
+                this.logger.warn("Message uses capabilities the provider does not support", {
+                    fields,
+                    provider: providerName,
+                });
+            }
+
+            return undefined;
+        }
+
+        if (this.logger) {
+            this.logger.error("Message rejected by capability guard", {
+                fields,
+                provider: providerName,
+            });
+        }
+
+        return new EmailError(providerName, `Provider does not support the following message fields: ${fields.join(", ")}`, {
+            code: "UNSUPPORTED_FEATURES",
+            hint: reasons,
+        });
+    }
+
+    /**
      * Builds email options from a MailMessage instance for draft creation.
      * Applies global configuration before building to ensure required fields are set.
      * @param message The MailMessage or DraftMailMessage instance.
@@ -544,11 +620,15 @@ export class Mail {
 /**
  * Creates a new Mail instance with a provider.
  * @param provider The email provider instance.
+ * @param options Optional Mail configuration, e.g. the {@link FeatureCheckMode}.
  * @returns A new Mail instance.
  * @example
  * ```ts
  * const mail = createMail(provider);
  * mail.setFrom({ email: "noreply@example.com", name: "My App" });
+ *
+ * // Disable the fail-fast capability guard
+ * const lenient = createMail(provider, { featureCheck: "off" });
  * ```
  */
-export const createMail = (provider: Provider): Mail => new Mail(provider);
+export const createMail = (provider: Provider, options?: MailOptions): Mail => new Mail(provider, options);

--- a/packages/email/email/src/providers/failover/provider.ts
+++ b/packages/email/email/src/providers/failover/provider.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../utils/create-logger";
 import generateMessageId from "../../utils/generate-message-id";
 import type { Provider, ProviderFactory } from "../provider";
 import { defineProvider } from "../provider";
+import { aggregateProviderFeatures } from "../utils";
 import type { FailoverConfig, FailoverEmailOptions } from "./types";
 
 const isProviderFactory = (value: unknown): value is ProviderFactory => typeof value === "function";
@@ -83,17 +84,10 @@ const provider: ProviderFactory<FailoverConfig> = defineProvider((config: Failov
     };
 
     return {
-        features: {
-            attachments: true,
-            batchSending: false,
-            customHeaders: true,
-            html: true,
-            replyTo: true,
-            scheduling: false,
-            tagging: false,
-            templates: false,
-            tracking: false,
-        },
+        // Derived from the configured mailers: a capability is advertised only when every routed
+        // provider agrees, otherwise it is left undefined ("unknown") so the fail-fast capability
+        // guard delegates the decision to whichever mailer ultimately handles the message.
+        features: aggregateProviderFeatures(options.mailers),
 
         /**
          * Initializes the failover provider and all underlying providers.

--- a/packages/email/email/src/providers/roundrobin/provider.ts
+++ b/packages/email/email/src/providers/roundrobin/provider.ts
@@ -4,6 +4,7 @@ import type { EmailResult, Result } from "../../types";
 import { createLogger } from "../../utils/create-logger";
 import type { Provider, ProviderFactory } from "../provider";
 import { defineProvider } from "../provider";
+import { aggregateProviderFeatures } from "../utils";
 import type { RoundRobinConfig, RoundRobinEmailOptions } from "./types";
 
 // Type guard to check if something is a ProviderFactory
@@ -157,18 +158,10 @@ const roundRobinProvider: ProviderFactory<RoundRobinConfig> = defineProvider((co
     };
 
     return {
-        features: {
-            // Round robin supports features that all providers support
-            attachments: true,
-            batchSending: false,
-            customHeaders: true,
-            html: true,
-            replyTo: true,
-            scheduling: false, // Not all providers support scheduling
-            tagging: false, // Not all providers support tagging
-            templates: false, // Not all providers support templates
-            tracking: false, // Not all providers support tracking
-        },
+        // Derived from the configured mailers: a capability is advertised only when every routed
+        // provider agrees, otherwise it is left undefined ("unknown") so the fail-fast capability
+        // guard delegates the decision to whichever mailer ultimately handles the message.
+        features: aggregateProviderFeatures(options.mailers),
 
         /**
          * Initializes the round robin provider and all underlying providers.

--- a/packages/email/email/src/providers/utils/aggregate-features.ts
+++ b/packages/email/email/src/providers/utils/aggregate-features.ts
@@ -1,0 +1,68 @@
+import type { FeatureFlags } from "../../types";
+import type { Provider, ProviderFactory } from "../provider";
+
+const FEATURE_KEYS: (keyof FeatureFlags)[] = [
+    "attachments",
+    "batchSending",
+    "customHeaders",
+    "html",
+    "replyTo",
+    "scheduling",
+    "tagging",
+    "templates",
+    "tracking",
+];
+
+const isProviderFactory = (value: unknown): value is ProviderFactory => typeof value === "function";
+
+const isProvider = (value: unknown): value is Provider =>
+    value !== null && typeof value === "object" && "initialize" in value && "isAvailable" in value && "sendEmail" in value;
+
+const resolveFeatures = (mailer: unknown): FeatureFlags | undefined => {
+    if (isProvider(mailer)) {
+        return mailer.features;
+    }
+
+    if (isProviderFactory(mailer)) {
+        try {
+            return mailer({}).features;
+        } catch {
+            return undefined;
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Aggregates the capability flags of an aggregate provider's child mailers.
+ *
+ * A capability is advertised as supported (`true`) only when every resolvable child supports it,
+ * and unsupported (`false`) only when every resolvable child rejects it; otherwise it is left
+ * `undefined` ("unknown") so the fail-fast capability guard delegates the decision to whichever
+ * mailer ultimately handles the message. This prevents a wrapper from falsely guaranteeing a
+ * capability that a routed provider cannot represent (which would re-introduce silent data loss).
+ * @param mailers The wrapper's configured mailers (provider instances or factories).
+ * @returns The aggregated {@link FeatureFlags}; keys that cannot be determined are omitted.
+ */
+export default function aggregateProviderFeatures(mailers: unknown[]): FeatureFlags {
+    const childFeatures = mailers.map((mailer) => resolveFeatures(mailer)).filter((features): features is FeatureFlags => features !== undefined);
+
+    const aggregated: FeatureFlags = {};
+
+    if (childFeatures.length === 0) {
+        return aggregated;
+    }
+
+    for (const key of FEATURE_KEYS) {
+        const values = childFeatures.map((features) => features[key]);
+
+        if (values.every((value) => value === true)) {
+            aggregated[key] = true;
+        } else if (values.every((value) => value === false)) {
+            aggregated[key] = false;
+        }
+    }
+
+    return aggregated;
+}

--- a/packages/email/email/src/providers/utils/index.ts
+++ b/packages/email/email/src/providers/utils/index.ts
@@ -1,6 +1,9 @@
 // Address formatting utilities
 export * from "./address-formatter";
 
+// Aggregate-provider capability helpers
+export { default as aggregateProviderFeatures } from "./aggregate-features";
+
 // Attachment processing utilities
 export * from "./attachment-processor";
 

--- a/packages/email/email/src/utils/validation/check-feature-support.ts
+++ b/packages/email/email/src/utils/validation/check-feature-support.ts
@@ -1,0 +1,149 @@
+import type { EmailOptions, FeatureFlags } from "../../types";
+import headersToRecord from "../headers-to-record";
+
+/**
+ * Describes how to detect whether a message actually uses a given capability.
+ */
+interface CapabilityProbe {
+    /**
+     * Returns the message field that triggers this capability, or undefined when the
+     * message does not exercise it. The returned name is the field the user actually set
+     * (e.g. `sendAt` vs `scheduledAt`) so the resulting violation is accurate.
+     * @param options The email options to inspect.
+     */
+    detect: (options: EmailOptions) => string | undefined;
+    feature: keyof FeatureFlags;
+    label: string;
+}
+
+const hasItems = (value: unknown): boolean => Array.isArray(value) && value.length > 0;
+
+const firstSetField = (options: EmailOptions, fields: string[]): string | undefined =>
+    fields.find((field) => (options as EmailOptions & Record<string, unknown>)[field] !== undefined);
+
+/**
+ * Message-level capability probes.
+ *
+ * Only capabilities that can be reliably detected from the normalized message
+ * are listed here. Provider-specific extension fields (`scheduledAt`,
+ * `templateId`, ...) are detected defensively when present on the options object.
+ */
+/* eslint-disable @stylistic/no-extra-parens -- prettier wraps these conditional arrow bodies in parens (also required by no-confusing-arrow). */
+const CAPABILITY_PROBES: CapabilityProbe[] = [
+    {
+        detect: (options) => (hasItems(options.attachments) ? "attachments" : undefined),
+        feature: "attachments",
+        label: "attachments",
+    },
+    {
+        detect: (options) => (typeof options.html === "string" && options.html.length > 0 ? "html" : undefined),
+        feature: "html",
+        label: "HTML content",
+    },
+    {
+        detect: (options) => (options.replyTo ? "replyTo" : undefined),
+        feature: "replyTo",
+        label: "a reply-to address",
+    },
+    {
+        detect: (options) => (options.headers !== undefined && Object.keys(headersToRecord(options.headers)).length > 0 ? "headers" : undefined),
+        feature: "customHeaders",
+        label: "custom headers",
+    },
+    {
+        detect: (options) => (hasItems(options.tags) ? "tags" : undefined),
+        feature: "tagging",
+        label: "tags",
+    },
+    {
+        detect: (options) => firstSetField(options, ["scheduledAt", "sendAt"]),
+        feature: "scheduling",
+        label: "scheduled delivery",
+    },
+    {
+        detect: (options) => firstSetField(options, ["templateId", "template"]),
+        feature: "templates",
+        label: "provider templates",
+    },
+];
+/* eslint-enable @stylistic/no-extra-parens */
+
+/**
+ * A single capability that a message uses but the target provider cannot represent.
+ */
+export interface FeatureViolation {
+    /**
+     * The provider capability flag that is not supported.
+     */
+    feature: keyof FeatureFlags;
+
+    /**
+     * The message field that triggered the check.
+     */
+    field: string;
+
+    /**
+     * Human-readable explanation of the violation.
+     */
+    message: string;
+}
+
+/**
+ * Result of a fail-fast provider capability check.
+ */
+export interface FeatureSupportResult {
+    /**
+     * True when the message uses no capability the provider has explicitly disabled.
+     */
+    supported: boolean;
+
+    /**
+     * The list of capabilities the message uses that the provider cannot represent.
+     */
+    violations: FeatureViolation[];
+}
+
+/**
+ * Performs a fail-fast field-support check for a message against a provider's declared capabilities.
+ *
+ * A capability counts as a violation only when the message actually uses it **and** the provider
+ * has explicitly declared it unsupported (`features[capability] === false`). Capabilities left
+ * `undefined` are treated as "unknown" and never raise a violation, so providers that publish a
+ * partial (or no) {@link FeatureFlags} map are never falsely rejected.
+ * @param options The normalized email options about to be sent.
+ * @param features The target provider's declared capabilities. When omitted the check is a no-op.
+ * @returns A {@link FeatureSupportResult} describing any unsupported capabilities in use.
+ * @example
+ * ```ts
+ * const { supported, violations } = checkFeatureSupport(message, provider.features);
+ *
+ * if (!supported) {
+ *     throw new Error(violations.map((v) => v.message).join(", "));
+ * }
+ * ```
+ */
+export default function checkFeatureSupport(options: EmailOptions, features?: FeatureFlags): FeatureSupportResult {
+    if (!features) {
+        return { supported: true, violations: [] };
+    }
+
+    const violations: FeatureViolation[] = [];
+
+    for (const probe of CAPABILITY_PROBES) {
+        if (features[probe.feature] !== false) {
+            continue;
+        }
+
+        const field = probe.detect(options);
+
+        if (field !== undefined) {
+            violations.push({
+                feature: probe.feature,
+                field,
+                message: `Message uses ${probe.label} (field "${field}") but the provider does not support the "${probe.feature}" capability`,
+            });
+        }
+    }
+
+    return { supported: violations.length === 0, violations };
+}


### PR DESCRIPTION
## Overview

Adds a **fail-fast field-support check** to `@visulima/email`: before a message is handed to a provider, `Mail` rejects any message that uses a capability the provider has **explicitly** declared unsupported (`features[x] === false`) — preventing silent data loss and a wasted network round-trip. Builds on the `FeatureFlags` metadata every provider already declares.

## What's included

- **`checkFeatureSupport(options, features?)`** — pure util, exported from the root and at `@visulima/email/validation/check-feature-support`.
  - Capabilities left `undefined` are treated as "unknown" and **never** rejected, so providers with a partial/absent `features` map are never falsely blocked.
  - Reports the exact field the user set (e.g. `sendAt` vs `scheduledAt`, `template` vs `templateId`).
- **`createMail(provider, { featureCheck })`** with modes:
  - `"error"` (default) — `send()` returns a failed `Result` with an `UNSUPPORTED_FEATURES` error.
  - `"warn"` — logs and sends anyway. `"off"` — skips the check. `sendMany()` inherits the mode; `draft()` is unaffected.
- **`failover` / `roundrobin` no longer hard-code capability flags** — they now derive `features` from their child mailers (`aggregateProviderFeatures`): a capability is advertised only when every child agrees, marked unsupported only when all reject it, otherwise left `undefined` (delegated). This stops a wrapper from falsely guaranteeing a capability a routed provider can't represent.
- **Docs**: new Capability Guard guide + a Mail Options section in configuration.
- **Tests**: guard behaviour (error/warn/off/supported), alias-field reporting, and the feature-aggregation logic.

## Verification

- ESLint: 0 errors
- `tsc --noEmit`: clean
- Vitest: **1385 passed**
- `packem build` + `publint`: green

## Notes

- Default `"error"` is a behaviour change for direct (non-wrapper) sends to providers that declare a capability `false` (e.g. AWS SES `replyTo`/`tagging`): such messages now fail fast instead of silently dropping the field. Opt out per-instance with `featureCheck: "warn" | "off"`.
- The second commit (`docs: note eslint rules that conflict with prettier`) documents a few stylistic ESLint rules that ping-pong with Prettier, surfaced while writing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Capability Guard: automatic validation of messages against provider capabilities before sending (fail-fast). Unsupported features trigger configurable behavior (error, warn, or off).
  * Added `checkFeatureSupport()` utility for standalone validation of messages against provider capabilities.
  * Mail instances now accept a `featureCheck` configuration option to control validation behavior.

* **Documentation**
  * Added comprehensive documentation for the Capability Guard feature with configuration examples and end-to-end usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->