### PR TITLE
feat(vis): declarative task arguments + per-target script mode

### DIFF
--- a/packages/tooling/vis/__tests__/commands/run/task-arguments.test.ts
+++ b/packages/tooling/vis/__tests__/commands/run/task-arguments.test.ts
@@ -25,6 +25,16 @@ describe(resolveTaskArguments, () => {
         expect(result.kind === "help" && result.text).toContain("Usage: vis run test");
     });
 
+    it("rejects a malformed schema before parsing user args", () => {
+        expect.assertions(2);
+
+        // enum without choices — a schema-valid but runtime-invalid config.
+        const result = resolveTaskArguments("test", undefined, [{ name: "mode", type: "enum" }], ["--mode=x"]);
+
+        expect(result.kind).toBe("invalid");
+        expect(result.kind === "invalid" && result.errors[0]).toContain("invalid `arguments` schema");
+    });
+
     it("reports validation errors with help for invalid input", () => {
         expect.assertions(3);
 

--- a/packages/tooling/vis/__tests__/commands/run/task-arguments.test.ts
+++ b/packages/tooling/vis/__tests__/commands/run/task-arguments.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTaskArguments } from "../../../src/commands/run/task-arguments";
+import type { TaskArgument } from "../../../src/task/arguments";
+
+const SCHEMA: TaskArgument[] = [
+    { alias: "r", description: "Reporter", name: "reporter" },
+    { choices: ["dev", "prod"], name: "mode", required: true, type: "enum" },
+    { default: 0, name: "retries", type: "number" },
+];
+
+describe(resolveTaskArguments, () => {
+    it("returns an empty ok result when the target declares no schema", () => {
+        expect.assertions(1);
+
+        expect(resolveTaskArguments("test", undefined, undefined, ["--anything"])).toStrictEqual({ env: {}, kind: "ok" });
+    });
+
+    it("renders help when --help is forwarded", () => {
+        expect.assertions(2);
+
+        const result = resolveTaskArguments("test", "Run tests", SCHEMA, ["--help"]);
+
+        expect(result.kind).toBe("help");
+        expect(result.kind === "help" && result.text).toContain("Usage: vis run test");
+    });
+
+    it("reports validation errors with help for invalid input", () => {
+        expect.assertions(3);
+
+        // `mode` is required + must be an enum; `retries` must be a number.
+        const result = resolveTaskArguments("test", undefined, SCHEMA, ["--mode=staging", "--retries=abc"]);
+
+        expect(result.kind).toBe("invalid");
+        expect(result.kind === "invalid" && result.errors).toStrictEqual([
+            `--mode must be one of [dev, prod], got "staging"`,
+            `--retries expects a number, got "abc"`,
+        ]);
+        expect(result.kind === "invalid" && result.help).toContain("--mode");
+    });
+
+    it("flags a missing required argument", () => {
+        expect.assertions(2);
+
+        const result = resolveTaskArguments("test", undefined, SCHEMA, ["--reporter=dot"]);
+
+        expect(result.kind).toBe("invalid");
+        expect(result.kind === "invalid" && result.errors).toStrictEqual(["missing required argument --mode"]);
+    });
+
+    it("returns the VIS_ARG_* env block for valid input (with defaults + alias)", () => {
+        expect.assertions(1);
+
+        const result = resolveTaskArguments("test", undefined, SCHEMA, ["-r", "dot", "--mode", "prod"]);
+
+        // reporter via alias, mode provided, retries defaulted to 0.
+        expect(result).toStrictEqual({
+            env: { VIS_ARG_MODE: "prod", VIS_ARG_REPORTER: "dot", VIS_ARG_RETRIES: "0" },
+            kind: "ok",
+        });
+    });
+});

--- a/packages/tooling/vis/__tests__/task/arguments.test.ts
+++ b/packages/tooling/vis/__tests__/task/arguments.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskArgument } from "../../src/task/arguments";
+import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv, taskArgumentEnvName } from "../../src/task/arguments";
+
+describe(parseTaskArguments, () => {
+    it("parses --flag=value and --flag value forms", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [{ name: "reporter" }, { name: "config" }];
+        const result = parseTaskArguments(schema, ["--reporter=verbose", "--config", "vitest.config.ts"]);
+
+        expect(result).toStrictEqual({ errors: [], values: { config: "vitest.config.ts", reporter: "verbose" } });
+    });
+
+    it("resolves a short alias", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [{ alias: "r", name: "reporter" }];
+
+        expect(parseTaskArguments(schema, ["-r", "dot"]).values).toStrictEqual({ reporter: "dot" });
+    });
+
+    it("coerces boolean flags including the --no- form", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [{ name: "watch", type: "boolean" }];
+
+        expect(parseTaskArguments(schema, ["--watch"]).values).toStrictEqual({ watch: true });
+        expect(parseTaskArguments(schema, ["--no-watch"]).values).toStrictEqual({ watch: false });
+    });
+
+    it("coerces numbers and reports a bad number", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [{ name: "retries", type: "number" }];
+
+        expect(parseTaskArguments(schema, ["--retries=3"]).values).toStrictEqual({ retries: 3 });
+        expect(parseTaskArguments(schema, ["--retries=abc"]).errors).toStrictEqual([`--retries expects a number, got "abc"`]);
+    });
+
+    it("validates enum choices", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [{ choices: ["dev", "prod"], name: "mode", type: "enum" }];
+
+        expect(parseTaskArguments(schema, ["--mode=prod"]).values).toStrictEqual({ mode: "prod" });
+        expect(parseTaskArguments(schema, ["--mode=staging"]).errors).toStrictEqual([
+            `--mode must be one of [dev, prod], got "staging"`,
+        ]);
+    });
+
+    it("applies defaults and enforces required", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [
+            { default: "info", name: "level" },
+            { name: "target", required: true },
+        ];
+
+        expect(parseTaskArguments(schema, []).values).toStrictEqual({ level: "info" });
+        expect(parseTaskArguments(schema, []).errors).toStrictEqual(["missing required argument --target"]);
+    });
+
+    it("fills positional arguments in declaration order", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [
+            { name: "src", positional: true },
+            { name: "dest", positional: true },
+        ];
+
+        expect(parseTaskArguments(schema, ["a.ts", "b.ts"]).values).toStrictEqual({ dest: "b.ts", src: "a.ts" });
+    });
+
+    it("ignores unknown flags so they pass through to the command", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [{ name: "reporter" }];
+
+        // `--bail` is not declared; it must not error (the command still gets it).
+        expect(parseTaskArguments(schema, ["--reporter=dot", "--bail"]).errors).toStrictEqual([]);
+    });
+});
+
+describe(taskArgumentEnvName, () => {
+    it("upper-snake-cases the name", () => {
+        expect.assertions(2);
+
+        expect(taskArgumentEnvName("reporter")).toBe("VIS_ARG_REPORTER");
+        expect(taskArgumentEnvName("min-age")).toBe("VIS_ARG_MIN_AGE");
+    });
+});
+
+describe(taskArgumentEnv, () => {
+    it("stringifies values into a VIS_ARG_* block", () => {
+        expect.assertions(1);
+
+        expect(taskArgumentEnv({ retries: 3, watch: true })).toStrictEqual({
+            VIS_ARG_RETRIES: "3",
+            VIS_ARG_WATCH: "true",
+        });
+    });
+});
+
+describe(renderTaskArgumentsHelp, () => {
+    it("renders usage, description, and each argument with metadata", () => {
+        expect.assertions(4);
+
+        const help = renderTaskArgumentsHelp("test", "Run the test suite", [
+            { alias: "r", description: "Reporter name", name: "reporter" },
+            { choices: ["dev", "prod"], name: "mode", required: true, type: "enum" },
+            { default: 0, name: "retries", type: "number" },
+        ]);
+
+        expect(help).toContain("Usage: vis run test");
+        expect(help).toContain("Run the test suite");
+        expect(help).toContain("--mode");
+        expect(help).toContain("enum(dev|prod), required");
+    });
+});

--- a/packages/tooling/vis/__tests__/task/arguments.test.ts
+++ b/packages/tooling/vis/__tests__/task/arguments.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { TaskArgument } from "../../src/task/arguments";
-import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv, taskArgumentEnvName } from "../../src/task/arguments";
+import {
+    parseTaskArguments,
+    renderTaskArgumentsHelp,
+    taskArgumentEnv,
+    taskArgumentEnvName,
+    validateArgumentSchema,
+} from "../../src/task/arguments";
 
 describe(parseTaskArguments, () => {
     it("parses --flag=value and --flag value forms", () => {
@@ -114,6 +120,51 @@ describe(parseTaskArguments, () => {
 
         // `--bail` is not declared; it must not error (the command still gets it).
         expect(parseTaskArguments(schema, ["--reporter=dot", "--bail"]).errors).toStrictEqual([]);
+    });
+});
+
+describe(validateArgumentSchema, () => {
+    it("accepts a well-formed schema", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [
+            { alias: "r", name: "reporter" },
+            { choices: ["dev", "prod"], default: "dev", name: "mode", type: "enum" },
+            { default: 0, name: "retries", type: "number" },
+        ];
+
+        expect(validateArgumentSchema(schema)).toStrictEqual([]);
+    });
+
+    it("flags a multi-character alias", () => {
+        expect.assertions(1);
+
+        expect(validateArgumentSchema([{ alias: "rep", name: "reporter" }])).toStrictEqual([
+            `argument "reporter" alias "rep" must be a single character`,
+        ]);
+    });
+
+    it("flags an enum without choices", () => {
+        expect.assertions(1);
+
+        expect(validateArgumentSchema([{ name: "mode", type: "enum" }])).toStrictEqual([
+            `argument "mode" has type "enum" but declares no choices`,
+        ]);
+    });
+
+    it("flags a default that does not match the type", () => {
+        expect.assertions(1);
+
+        expect(validateArgumentSchema([{ default: "abc", name: "retries", type: "number" }])).toStrictEqual([
+            `argument "retries" default "abc" does not match type "number"`,
+        ]);
+    });
+
+    it("flags an empty / invalid name and duplicates", () => {
+        expect.assertions(2);
+
+        expect(validateArgumentSchema([{ name: "" }])[0]).toContain("is empty or invalid");
+        expect(validateArgumentSchema([{ name: "dup" }, { name: "dup" }])).toContain(`duplicate argument name "dup"`);
     });
 });
 

--- a/packages/tooling/vis/__tests__/task/arguments.test.ts
+++ b/packages/tooling/vis/__tests__/task/arguments.test.ts
@@ -39,6 +39,40 @@ describe(parseTaskArguments, () => {
         expect(parseTaskArguments(schema, ["--retries=abc"]).errors).toStrictEqual([`--retries expects a number, got "abc"`]);
     });
 
+    it("rejects empty and non-finite numbers", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [{ name: "retries", type: "number" }];
+
+        // `Number("")` is 0 and `Number("Infinity")` is finite-looking — both must fail.
+        expect(parseTaskArguments(schema, ["--retries="]).errors).toStrictEqual([`--retries expects a number, got ""`]);
+        expect(parseTaskArguments(schema, ["--retries=Infinity"]).errors).toStrictEqual([
+            `--retries expects a number, got "Infinity"`,
+        ]);
+    });
+
+    it("consumes a negative number as a value, not a flag", () => {
+        expect.assertions(1);
+
+        const schema: TaskArgument[] = [{ name: "offset", type: "number" }];
+
+        expect(parseTaskArguments(schema, ["--offset", "-5"]).values).toStrictEqual({ offset: -5 });
+    });
+
+    it("consumes an explicit boolean value without leaving a stray positional", () => {
+        expect.assertions(2);
+
+        const schema: TaskArgument[] = [
+            { name: "watch", type: "boolean" },
+            { name: "file", positional: true },
+        ];
+
+        // `false` is consumed by --watch, so it must NOT fill the positional `file`.
+        expect(parseTaskArguments(schema, ["--watch", "false"]).values).toStrictEqual({ watch: false });
+        // A non-boolean token after a boolean flag stays a positional.
+        expect(parseTaskArguments(schema, ["--watch", "a.ts"]).values).toStrictEqual({ file: "a.ts", watch: true });
+    });
+
     it("validates enum choices", () => {
         expect.assertions(2);
 

--- a/packages/tooling/vis/schemas/project.schema.json
+++ b/packages/tooling/vis/schemas/project.schema.json
@@ -659,9 +659,16 @@
                     },
                     "description": "Alternate names that resolve to this target on the CLI. Useful for shortening long canonical names (`test` ↔ `t`) or for offering migration-friendly aliases when renaming targets. Aliases must be globally unique within the workspace."
                 },
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/TaskArgument"
+                    },
+                    "description": "Declarative argument schema for this target. Forwarded CLI args (`vis run &lt;target> -- --flag value`) are validated against it, surfaced by per-task `--help`, and exposed to the command as `VIS_ARG_&lt;NAME>` environment variables."
+                },
                 "description": {
                     "type": "string",
-                    "description": "One-line description surfaced by `vis list` and (in future) per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
+                    "description": "One-line description surfaced by `vis list` and per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
                 },
                 "inferred": {
                     "type": "boolean",
@@ -683,6 +690,69 @@
             },
             "additionalProperties": false,
             "description": "An extended target configuration that adds the vis-specific options on top of task-runner's `TargetConfiguration`."
+        },
+        "TaskArgument": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string",
+                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`)."
+                },
+                "choices": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`."
+                },
+                "default": {
+                    "$ref": "#/$defs/TaskArgumentValue",
+                    "description": "Value applied when the argument is omitted. Skips the required check."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "One-line help text surfaced by per-task `--help`."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Canonical name, without the leading `--` (kebab-case by convention)."
+                },
+                "positional": {
+                    "type": "boolean",
+                    "description": "Consume the value from the next free positional argument instead of a `--flag`. Positional args are filled in declaration order."
+                },
+                "required": {
+                    "type": "boolean",
+                    "description": "Fail the task when the argument is absent and has no `default`."
+                },
+                "type": {
+                    "$ref": "#/$defs/TaskArgumentType",
+                    "description": "Value type for coercion + validation. Defaults to `\"string\"`."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "description": "A single declared argument for a task target."
+        },
+        "TaskArgumentValue": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "description": "A coerced task-argument value."
+        },
+        "TaskArgumentType": {
+            "type": "string",
+            "enum": [
+                "boolean",
+                "enum",
+                "number",
+                "string"
+            ],
+            "description": "Value type a  {@link  TaskArgument }  coerces to and validates against."
         },
         "VisTargetOptions": {
             "type": "object",
@@ -792,6 +862,13 @@
                 "shell": {
                     "type": "string",
                     "description": "Per-target shell override. When set, the command runs through this shell instead of the platform default."
+                },
+                "shellArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell."
                 },
                 "strictEnv": {
                     "type": "boolean",

--- a/packages/tooling/vis/schemas/project.schema.json
+++ b/packages/tooling/vis/schemas/project.schema.json
@@ -696,14 +696,14 @@
             "properties": {
                 "alias": {
                     "type": "string",
-                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`)."
+                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`). Must be exactly one character — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "choices": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`."
+                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`. Must be non-empty (and is required) for `enum` — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "default": {
                     "$ref": "#/$defs/TaskArgumentValue",
@@ -715,7 +715,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Canonical name, without the leading `--` (kebab-case by convention)."
+                    "description": "Canonical name, without the leading `--` (kebab-case by convention). Must start with a letter and contain only letters, digits, `-`, `_` — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "positional": {
                     "type": "boolean",
@@ -868,7 +868,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell."
+                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell.\n\nMust be non-empty when set — an empty array would drop the interpreter flag entirely, so the runtime falls back to `-c` defensively."
                 },
                 "strictEnv": {
                     "type": "boolean",

--- a/packages/tooling/vis/schemas/vis-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-config.schema.json
@@ -2753,9 +2753,16 @@
                         },
                         "description": "Alternate names that resolve to this target on the CLI. Useful for shortening long canonical names (`test` ↔ `t`) or for offering migration-friendly aliases when renaming targets. Aliases must be globally unique within the workspace."
                     },
+                    "arguments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/TaskArgument"
+                        },
+                        "description": "Declarative argument schema for this target. Forwarded CLI args (`vis run &lt;target> -- --flag value`) are validated against it, surfaced by per-task `--help`, and exposed to the command as `VIS_ARG_&lt;NAME>` environment variables."
+                    },
                     "description": {
                         "type": "string",
-                        "description": "One-line description surfaced by `vis list` and (in future) per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
+                        "description": "One-line description surfaced by `vis list` and per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
                     },
                     "inferred": {
                         "type": "boolean",
@@ -3790,9 +3797,16 @@
                                 },
                                 "description": "Alternate names that resolve to this target on the CLI. Useful for shortening long canonical names (`test` ↔ `t`) or for offering migration-friendly aliases when renaming targets. Aliases must be globally unique within the workspace."
                             },
+                            "arguments": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/$defs/TaskArgument"
+                                },
+                                "description": "Declarative argument schema for this target. Forwarded CLI args (`vis run &lt;target> -- --flag value`) are validated against it, surfaced by per-task `--help`, and exposed to the command as `VIS_ARG_&lt;NAME>` environment variables."
+                            },
                             "description": {
                                 "type": "string",
-                                "description": "One-line description surfaced by `vis list` and (in future) per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
+                                "description": "One-line description surfaced by `vis list` and per-task `--help`. Kept short — longer docs belong in project READMEs or vis.config.ts comments."
                             },
                             "inferred": {
                                 "type": "boolean",
@@ -4469,6 +4483,69 @@
             "additionalProperties": false,
             "description": "A predicate used by  {@link  VisConfig.scopedTasks } . All listed constraints must match for the block to apply."
         },
+        "TaskArgument": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string",
+                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`)."
+                },
+                "choices": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`."
+                },
+                "default": {
+                    "$ref": "#/$defs/TaskArgumentValue",
+                    "description": "Value applied when the argument is omitted. Skips the required check."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "One-line help text surfaced by per-task `--help`."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Canonical name, without the leading `--` (kebab-case by convention)."
+                },
+                "positional": {
+                    "type": "boolean",
+                    "description": "Consume the value from the next free positional argument instead of a `--flag`. Positional args are filled in declaration order."
+                },
+                "required": {
+                    "type": "boolean",
+                    "description": "Fail the task when the argument is absent and has no `default`."
+                },
+                "type": {
+                    "$ref": "#/$defs/TaskArgumentType",
+                    "description": "Value type for coercion + validation. Defaults to `\"string\"`."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "description": "A single declared argument for a task target."
+        },
+        "TaskArgumentValue": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "description": "A coerced task-argument value."
+        },
+        "TaskArgumentType": {
+            "type": "string",
+            "enum": [
+                "boolean",
+                "enum",
+                "number",
+                "string"
+            ],
+            "description": "Value type a  {@link  TaskArgument }  coerces to and validates against."
+        },
         "VisTargetOptions": {
             "type": "object",
             "properties": {
@@ -4577,6 +4654,13 @@
                 "shell": {
                     "type": "string",
                     "description": "Per-target shell override. When set, the command runs through this shell instead of the platform default."
+                },
+                "shellArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell."
                 },
                 "strictEnv": {
                     "type": "boolean",

--- a/packages/tooling/vis/schemas/vis-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-config.schema.json
@@ -4488,14 +4488,14 @@
             "properties": {
                 "alias": {
                     "type": "string",
-                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`)."
+                    "description": "Short single-character alias (e.g. `r` for `--reporter`, used as `-r`). Must be exactly one character — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "choices": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`."
+                    "description": "Allowed values when  {@link  TaskArgument.type }  is `\"enum\"`. Must be non-empty (and is required) for `enum` — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "default": {
                     "$ref": "#/$defs/TaskArgumentValue",
@@ -4507,7 +4507,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Canonical name, without the leading `--` (kebab-case by convention)."
+                    "description": "Canonical name, without the leading `--` (kebab-case by convention). Must start with a letter and contain only letters, digits, `-`, `_` — enforced at run time by  {@link  validateArgumentSchema } ."
                 },
                 "positional": {
                     "type": "boolean",
@@ -4660,7 +4660,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell."
+                    "description": "Arguments passed to the per-target shell/interpreter before the command string. Defaults to `[\"-c\"]` (POSIX shells, pwsh). Set this to run the command under an interpreter that uses a different flag — e.g. `shell: \"node\", shellArgs: [\"-e\"]` runs the command as inline JS (\"script mode\"), or `shellArgs: [\"-lc\"]` for a login shell. Only applies when `shell`/`unixShell`/`windowsShell` resolves to a custom shell.\n\nMust be non-empty when set — an empty array would drop the interpreter flag entirely, so the runtime falls back to `-c` defensively."
                 },
                 "strictEnv": {
                     "type": "boolean",

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -44,7 +44,6 @@ import { runToolchainPreflight } from "../../runtime/toolchain";
 import { runReadiness } from "../../services/readiness";
 import { deleteEntry, readAllEntries } from "../../services/registry";
 import type { ServiceEntry } from "../../services/types";
-import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv } from "../../task/arguments";
 import { decidePty } from "../../task/pty-decision";
 import { filterProjectsByQuery, resolveSelector } from "../../task/selectors";
 import { resolveSkipCachePatterns } from "../../task/skip-cache";
@@ -78,6 +77,7 @@ import type { RunOptions } from "./index";
 import type { ServiceBridgeEntry } from "./service-event-bridge";
 import { ServiceEventBridge } from "./service-event-bridge";
 import { buildBootstrapPaths, extractPreflightTasks, injectServiceTasks, resolveServicesPolicy } from "./service-preflight";
+import { resolveTaskArguments } from "./task-arguments";
 
 const AFFECTED_FILES_ENV = "VIS_AFFECTED_FILES";
 
@@ -1440,42 +1440,36 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
     const ptyFlag = options.pty === true;
 
     // First-class task arguments: validate the forwarded args against the
-    // invoked target's declared schema, surface per-task `--help`, and expose
-    // validated values to the command as VIS_ARG_* env vars. The schema is
-    // taken from the first project whose target declares one — a target's
-    // argument contract is the same wherever it runs.
+    // invoked target's declared schema (taken from the first project that
+    // declares one — a target's argument contract is the same wherever it
+    // runs), surface per-task `--help`, and expose validated values to the
+    // command as VIS_ARG_* env vars. See `./task-arguments`.
     const argumentSchema = projectsWithTarget
         .map((projectName) => projectTargetIndex.get(projectName)?.arguments)
         .find((schema): schema is NonNullable<typeof schema> => Array.isArray(schema) && schema.length > 0);
+    const argumentDescription = projectTargetIndex.get(projectsWithTarget[0] as string)?.description;
+    const argumentResolution = resolveTaskArguments(target, argumentDescription, argumentSchema, forwardedArgs);
 
-    let taskArgumentEnvVars: Record<string, string> = {};
+    if (argumentResolution.kind === "help") {
+        logger.info(argumentResolution.text);
 
-    if (argumentSchema) {
-        const description = projectTargetIndex.get(projectsWithTarget[0] as string)?.description;
-
-        if (forwardedArgs.includes("--help") || forwardedArgs.includes("-h")) {
-            logger.info(renderTaskArgumentsHelp(target, description, argumentSchema));
-
-            return;
-        }
-
-        const parsed = parseTaskArguments(argumentSchema, forwardedArgs);
-
-        if (parsed.errors.length > 0) {
-            logger.info(`Invalid arguments for "${target}":`);
-
-            for (const message of parsed.errors) {
-                logger.info(`  ✖ ${message}`);
-            }
-
-            logger.info("");
-            logger.info(renderTaskArgumentsHelp(target, description, argumentSchema));
-
-            throw new Error(`Invalid arguments for target "${target}"`);
-        }
-
-        taskArgumentEnvVars = taskArgumentEnv(parsed.values);
+        return;
     }
+
+    if (argumentResolution.kind === "invalid") {
+        logger.info(`Invalid arguments for "${target}":`);
+
+        for (const message of argumentResolution.errors) {
+            logger.info(`  ✖ ${message}`);
+        }
+
+        logger.info("");
+        logger.info(argumentResolution.help);
+
+        throw new Error(`Invalid arguments for target "${target}"`);
+    }
+
+    const taskArgumentEnvVars = argumentResolution.env;
 
     let initialTasks: Task[] = projectsWithTarget.map((projectName) => {
         const project = workspace.projects[projectName];

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -851,7 +851,10 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
         // into a file lookup), so fall back to `-c`.
         const shellArgs = visOptions?.shellArgs;
         const shellInvokeArgs = shellArgs && shellArgs.length > 0 ? shellArgs.join(" ") : "-c";
-        const command = customShell ? `${customShell} ${shellInvokeArgs} ${singleQuoteEscape(commandWithAffected)}` : commandWithAffected;
+        // `shellQuote` is platform-aware (POSIX single-quote / cmd.exe
+        // double-quote) — `singleQuoteEscape` would leave literal `'…'` around
+        // the command under cmd.exe, breaking e.g. `node -e` on Windows.
+        const command = customShell ? `${customShell} ${shellInvokeArgs} ${shellQuote(commandWithAffected)}` : commandWithAffected;
 
         const envFileVars = visOptions?.envFile ? loadEnvFileCached(envFileCache, resolvedCwd, visOptions.envFile) : undefined;
 
@@ -1443,14 +1446,37 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
     const ptyFlag = options.pty === true;
 
     // First-class task arguments: validate the forwarded args against the
-    // invoked target's declared schema (taken from the first project that
-    // declares one — a target's argument contract is the same wherever it
-    // runs), surface per-task `--help`, and expose validated values to the
-    // command as VIS_ARG_* env vars. See `./task-arguments`.
-    const argumentSchema = projectsWithTarget
-        .map((projectName) => projectTargetIndex.get(projectName)?.arguments)
-        .find((schema): schema is NonNullable<typeof schema> => Array.isArray(schema) && schema.length > 0);
-    const argumentDescription = projectTargetIndex.get(projectsWithTarget[0] as string)?.description;
+    // invoked target's declared schema, surface per-task `--help`, and expose
+    // validated values to the command as VIS_ARG_* env vars. See
+    // `./task-arguments`. Because the same args + VIS_ARG_* reach every
+    // selected project, all of them must agree on the contract — fail fast if
+    // two projects expose this target with different `arguments` schemas
+    // rather than validate one project's invocation against another's.
+    const schemasByProject = projectsWithTarget
+        .map((projectName) => { return { project: projectName, schema: projectTargetIndex.get(projectName)?.arguments }; })
+        .filter((entry): entry is { project: string; schema: NonNullable<VisTargetConfiguration["arguments"]> } => Array.isArray(entry.schema) && entry.schema.length > 0);
+
+    const distinctSchemas = new Map<string, string[]>();
+
+    for (const { project, schema } of schemasByProject) {
+        const key = JSON.stringify(schema);
+        const projects = distinctSchemas.get(key) ?? [];
+
+        projects.push(project);
+        distinctSchemas.set(key, projects);
+    }
+
+    if (distinctSchemas.size > 1) {
+        const groups = [...distinctSchemas.values()].map((projects) => projects.join(", ")).join(" | ");
+
+        throw new Error(
+            `Target "${target}" declares conflicting \`arguments\` schemas across projects (${groups}). `
+            + `Run a single project (e.g. \`vis run ${schemasByProject[0]?.project}:${target}\` or --project=<name>) so the argument contract is unambiguous.`,
+        );
+    }
+
+    const argumentSchema = schemasByProject[0]?.schema;
+    const argumentDescription = projectTargetIndex.get(schemasByProject[0]?.project ?? (projectsWithTarget[0] as string))?.description;
     const argumentResolution = resolveTaskArguments(target, argumentDescription, argumentSchema, forwardedArgs);
 
     if (argumentResolution.kind === "help") {

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -847,7 +847,10 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
         const customShell = resolveTargetShell(visOptions, currentOs);
         // `shellArgs` lets a target pick a non-`-c` interpreter (e.g.
         // `shell: "node", shellArgs: ["-e"]` runs the command as inline JS).
-        const shellInvokeArgs = (visOptions?.shellArgs ?? ["-c"]).join(" ");
+        // An empty array would drop the flag entirely (turning `node 'cmd'`
+        // into a file lookup), so fall back to `-c`.
+        const shellArgs = visOptions?.shellArgs;
+        const shellInvokeArgs = shellArgs && shellArgs.length > 0 ? shellArgs.join(" ") : "-c";
         const command = customShell ? `${customShell} ${shellInvokeArgs} ${singleQuoteEscape(commandWithAffected)}` : commandWithAffected;
 
         const envFileVars = visOptions?.envFile ? loadEnvFileCached(envFileCache, resolvedCwd, visOptions.envFile) : undefined;

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -44,6 +44,7 @@ import { runToolchainPreflight } from "../../runtime/toolchain";
 import { runReadiness } from "../../services/readiness";
 import { deleteEntry, readAllEntries } from "../../services/registry";
 import type { ServiceEntry } from "../../services/types";
+import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv } from "../../task/arguments";
 import { decidePty } from "../../task/pty-decision";
 import { filterProjectsByQuery, resolveSelector } from "../../task/selectors";
 import { resolveSkipCachePatterns } from "../../task/skip-cache";
@@ -158,7 +159,13 @@ const runPersistentTasks = async (
             return {
                 command,
                 cwd,
-                env: { INIT_CWD: initCwd, ...envFileVars, ...serviceEnv, ...affectedEnv },
+                env: {
+                    INIT_CWD: initCwd,
+                    ...envFileVars,
+                    ...serviceEnv,
+                    ...affectedEnv,
+                    ...(task.overrides[TASK_ARG_ENV_KEY] as Record<string, string> | undefined),
+                },
                 name: task.id,
                 ...(usePty
                     ? {
@@ -608,6 +615,9 @@ const buildAffectedFilesArgs = (command: string, affectedFiles: string[] | undef
 /** Override key carrying CLI args that should only reach the target task. */
 const FORWARDED_ARGS_KEY = "visForwardedArgs";
 
+/** Override key carrying validated `VIS_ARG_*` env vars for the target task. */
+const TASK_ARG_ENV_KEY = "visTaskArgEnv";
+
 /**
  * Appends forwarded positional args (`vis run test --reporter=verbose`)
  * to the task's command. Only the user-invoked target task carries this
@@ -835,7 +845,10 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
         const commandWithAffected = buildAffectedFilesArgs(commandWithArgs, affectedFiles, visOptions?.affectedFiles);
 
         const customShell = resolveTargetShell(visOptions, currentOs);
-        const command = customShell ? `${customShell} -c ${singleQuoteEscape(commandWithAffected)}` : commandWithAffected;
+        // `shellArgs` lets a target pick a non-`-c` interpreter (e.g.
+        // `shell: "node", shellArgs: ["-e"]` runs the command as inline JS).
+        const shellInvokeArgs = (visOptions?.shellArgs ?? ["-c"]).join(" ");
+        const command = customShell ? `${customShell} ${shellInvokeArgs} ${singleQuoteEscape(commandWithAffected)}` : commandWithAffected;
 
         const envFileVars = visOptions?.envFile ? loadEnvFileCached(envFileCache, resolvedCwd, visOptions.envFile) : undefined;
 
@@ -857,6 +870,7 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
             ...serviceEnv,
             ...execOptions.env,
             ...affectedFilesEnv,
+            ...(task.overrides[TASK_ARG_ENV_KEY] as Record<string, string> | undefined),
         };
 
         // Per-target opt-in/out wins over the workspace flag — let a
@@ -1425,6 +1439,44 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
 
     const ptyFlag = options.pty === true;
 
+    // First-class task arguments: validate the forwarded args against the
+    // invoked target's declared schema, surface per-task `--help`, and expose
+    // validated values to the command as VIS_ARG_* env vars. The schema is
+    // taken from the first project whose target declares one — a target's
+    // argument contract is the same wherever it runs.
+    const argumentSchema = projectsWithTarget
+        .map((projectName) => projectTargetIndex.get(projectName)?.arguments)
+        .find((schema): schema is NonNullable<typeof schema> => Array.isArray(schema) && schema.length > 0);
+
+    let taskArgumentEnvVars: Record<string, string> = {};
+
+    if (argumentSchema) {
+        const description = projectTargetIndex.get(projectsWithTarget[0] as string)?.description;
+
+        if (forwardedArgs.includes("--help") || forwardedArgs.includes("-h")) {
+            logger.info(renderTaskArgumentsHelp(target, description, argumentSchema));
+
+            return;
+        }
+
+        const parsed = parseTaskArguments(argumentSchema, forwardedArgs);
+
+        if (parsed.errors.length > 0) {
+            logger.info(`Invalid arguments for "${target}":`);
+
+            for (const message of parsed.errors) {
+                logger.info(`  ✖ ${message}`);
+            }
+
+            logger.info("");
+            logger.info(renderTaskArgumentsHelp(target, description, argumentSchema));
+
+            throw new Error(`Invalid arguments for target "${target}"`);
+        }
+
+        taskArgumentEnvVars = taskArgumentEnv(parsed.values);
+    }
+
     let initialTasks: Task[] = projectsWithTarget.map((projectName) => {
         const project = workspace.projects[projectName];
         const visTarget = projectTargetIndex.get(projectName)!;
@@ -1452,6 +1504,7 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
             overrides: {
                 command: expandedCommand,
                 ...(forwardedArgs.length > 0 ? { [FORWARDED_ARGS_KEY]: forwardedArgs } : {}),
+                ...(Object.keys(taskArgumentEnvVars).length > 0 ? { [TASK_ARG_ENV_KEY]: taskArgumentEnvVars } : {}),
                 ...(mergedOptions ? { visOptions: mergedOptions } : {}),
             },
             parallelism: visTarget.parallelism,

--- a/packages/tooling/vis/src/commands/run/task-arguments.ts
+++ b/packages/tooling/vis/src/commands/run/task-arguments.ts
@@ -6,7 +6,7 @@
  * decision is unit-testable in isolation from the 2k-line run handler.
  */
 import type { TaskArgument } from "../../task/arguments";
-import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv } from "../../task/arguments";
+import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv, validateArgumentSchema } from "../../task/arguments";
 
 /** Outcome of resolving forwarded args against a target's argument schema. */
 export type TaskArgumentResolution
@@ -30,6 +30,18 @@ export const resolveTaskArguments = (
 ): TaskArgumentResolution => {
     if (!schema || schema.length === 0) {
         return { env: {}, kind: "ok" };
+    }
+
+    // Reject a malformed schema (bad alias/name, enum without choices,
+    // mismatched default) before it can misbehave at runtime.
+    const schemaProblems = validateArgumentSchema(schema);
+
+    if (schemaProblems.length > 0) {
+        return {
+            errors: schemaProblems.map((problem) => `invalid \`arguments\` schema for "${target}": ${problem}`),
+            help: renderTaskArgumentsHelp(target, description, schema),
+            kind: "invalid",
+        };
     }
 
     if (forwardedArgs.includes("--help") || forwardedArgs.includes("-h")) {

--- a/packages/tooling/vis/src/commands/run/task-arguments.ts
+++ b/packages/tooling/vis/src/commands/run/task-arguments.ts
@@ -1,0 +1,46 @@
+/**
+ * Run-handler glue for first-class task arguments: turns a target's declared
+ * argument schema + the forwarded CLI args into one of three outcomes the
+ * handler acts on — render `--help`, fail with validation errors, or proceed
+ * with the `VIS_ARG_*` env block. Kept pure (no logging / no throwing) so the
+ * decision is unit-testable in isolation from the 2k-line run handler.
+ */
+import type { TaskArgument } from "../../task/arguments";
+import { parseTaskArguments, renderTaskArgumentsHelp, taskArgumentEnv } from "../../task/arguments";
+
+/** Outcome of resolving forwarded args against a target's argument schema. */
+export type TaskArgumentResolution
+    = | { env: Record<string, string>; kind: "ok" }
+        | { errors: string[]; help: string; kind: "invalid" }
+        | { kind: "help"; text: string };
+
+/**
+ * Resolve forwarded CLI args against a target's `arguments` schema.
+ *
+ * - No schema (or empty): `{ kind: "ok", env: {} }` — nothing to validate.
+ * - `--help`/`-h` present: `{ kind: "help" }` — caller prints and exits 0.
+ * - Validation errors: `{ kind: "invalid" }` — caller prints + fails the run.
+ * - Otherwise: `{ kind: "ok", env }` with the `VIS_ARG_*` block to inject.
+ */
+export const resolveTaskArguments = (
+    target: string,
+    description: string | undefined,
+    schema: TaskArgument[] | undefined,
+    forwardedArgs: string[],
+): TaskArgumentResolution => {
+    if (!schema || schema.length === 0) {
+        return { env: {}, kind: "ok" };
+    }
+
+    if (forwardedArgs.includes("--help") || forwardedArgs.includes("-h")) {
+        return { kind: "help", text: renderTaskArgumentsHelp(target, description, schema) };
+    }
+
+    const parsed = parseTaskArguments(schema, forwardedArgs);
+
+    if (parsed.errors.length > 0) {
+        return { errors: parsed.errors, help: renderTaskArgumentsHelp(target, description, schema), kind: "invalid" };
+    }
+
+    return { env: taskArgumentEnv(parsed.values), kind: "ok" };
+};

--- a/packages/tooling/vis/src/commands/update/ecosystems/docker/scanner.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/docker/scanner.ts
@@ -10,26 +10,26 @@ import { join } from "@visulima/path";
  * compose `image:` value have different formatting rules.
  */
 export interface ImageReference {
-    /** Full original reference token as it appeared in the file. */
-    readonly original: string;
-    /** Image namespace (`library` for unqualified). */
-    readonly namespace: string;
-    /** Image short name (e.g. `node` in `library/node`). */
-    readonly name: string;
-    /** Registry host. `docker.io` is the default; ghcr.io, mcr.microsoft.com etc. are kept verbatim. */
-    readonly registry: string;
-    /** Tag portion or `latest` when omitted. */
-    readonly tag: string;
     /** Digest portion (`sha256:…`) when present, otherwise `undefined`. */
     readonly digest: string | undefined;
     /** Path of the file that the reference came from. */
     readonly file: string;
-    /** 1-based line number for diagnostics. */
-    readonly line: number;
-    /** Origin file kind — drives the applier behaviour. */
-    readonly kind: "dockerfile" | "compose";
     /** When set, the reference is excluded via `# vis-update-ignore` directive on the line. */
     readonly ignoreReason: string | undefined;
+    /** Origin file kind — drives the applier behaviour. */
+    readonly kind: "dockerfile" | "compose";
+    /** 1-based line number for diagnostics. */
+    readonly line: number;
+    /** Image short name (e.g. `node` in `library/node`). */
+    readonly name: string;
+    /** Image namespace (`library` for unqualified). */
+    readonly namespace: string;
+    /** Full original reference token as it appeared in the file. */
+    readonly original: string;
+    /** Registry host. `docker.io` is the default; ghcr.io, mcr.microsoft.com etc. are kept verbatim. */
+    readonly registry: string;
+    /** Tag portion or `latest` when omitted. */
+    readonly tag: string;
 }
 
 const DEFAULT_REGISTRY = "docker.io";
@@ -57,9 +57,9 @@ export const parseImageReference = (raw: string): Omit<ImageReference, "file" | 
     let working = trimmed;
     let digest: string | undefined;
 
-    const atIndex = working.indexOf("@" + SHA_PREFIX);
+    const atIndex = working.indexOf(`@${SHA_PREFIX}`);
 
-    if (atIndex >= 0) {
+    if (atIndex !== -1) {
         digest = working.slice(atIndex + 1);
         working = working.slice(0, atIndex);
     }
@@ -84,8 +84,9 @@ export const parseImageReference = (raw: string): Omit<ImageReference, "file" | 
     let nameWithNamespace = pathPart;
 
     const colonIndex = pathPart.lastIndexOf(":");
+
     // Beware: a registry like `localhost:5000` was already split off above.
-    if (colonIndex >= 0 && !pathPart.slice(colonIndex).includes("/")) {
+    if (colonIndex !== -1 && !pathPart.slice(colonIndex).includes("/")) {
         tag = pathPart.slice(colonIndex + 1);
         nameWithNamespace = pathPart.slice(0, colonIndex);
     }
@@ -94,7 +95,7 @@ export const parseImageReference = (raw: string): Omit<ImageReference, "file" | 
     let name = nameWithNamespace;
     const namespaceSlash = nameWithNamespace.indexOf("/");
 
-    if (namespaceSlash >= 0) {
+    if (namespaceSlash !== -1) {
         namespace = nameWithNamespace.slice(0, namespaceSlash);
         name = nameWithNamespace.slice(namespaceSlash + 1);
     }
@@ -130,15 +131,15 @@ const isCommentOnlyLine = (line: string): boolean => {
 };
 
 /**
- * Regex for a Dockerfile `FROM` line. Captures the image reference and
- * an optional trailing alias. Multi-stage builds use
- * `FROM base AS stage` — `AS` is captured separately so it round-trips.
+ * Regex for a Dockerfile `FROM` line. Group 1 is the image reference; an
+ * optional `AS stage` alias and any other trailing tokens are skipped, and
+ * group 2 captures a trailing `# comment` (used for ignore directives).
  *
  * BuildKit allows flags before the image (`FROM --platform=$BUILDPLATFORM node:18`).
- * The leading `(?:--\S+\s+)*` consumes any number of `--key=value` flags
- * so the image captured in group 2 is the actual image, not the flag.
+ * The leading `(?:--\S+\s+)*` consumes any number of `--key=value` flags so
+ * the captured image is the actual image, not the flag.
  */
-const FROM_LINE_RE = /^(\s*FROM\s+(?:--\S+\s+)*)([^\s#]+)(\s+AS\s+\S+)?(\s*#.*)?$/i;
+const FROM_LINE_RE = /^\s*FROM\s+(?:--\S+\s+)*([^\s#]+)(?:\s[^#]*)?(#.*)?$/i;
 
 const extractFromDockerfile = (filePath: string, content: string): ImageReference[] => {
     const lines = content.split(/\r?\n/);
@@ -146,9 +147,7 @@ const extractFromDockerfile = (filePath: string, content: string): ImageReferenc
 
     let pendingIgnore = false;
 
-    for (let index = 0; index < lines.length; index++) {
-        const line = lines[index] ?? "";
-
+    for (const [index, line] of lines.entries()) {
         // The next-line directive must live on its own line. When the
         // marker appears on a `FROM` line itself it's the inline form —
         // handled below via IGNORE_INLINE_RE on the trailing comment.
@@ -170,7 +169,7 @@ const extractFromDockerfile = (filePath: string, content: string): ImageReferenc
             continue;
         }
 
-        const value = match[2] ?? "";
+        const value = match[1] ?? "";
 
         // `FROM scratch` has no upstream to update against.
         if (value === "scratch") {
@@ -179,7 +178,7 @@ const extractFromDockerfile = (filePath: string, content: string): ImageReferenc
             continue;
         }
 
-        const trailingComment = match[4]?.trim();
+        const trailingComment = match[2]?.trim();
         let ignoreReason = pendingIgnore ? "vis-update-ignore-next-line" : undefined;
 
         if (trailingComment && IGNORE_NEXT_RE.test(trailingComment)) {
@@ -215,12 +214,14 @@ const extractFromDockerfile = (filePath: string, content: string): ImageReferenc
 /**
  * Compose files can express the image in two ways:
  *   - top-level `image: name:tag`
- *   - inside `services.<name>.image: name:tag`
+ *   - inside `services.&lt;name>.image: name:tag`
  *
  * We keep the line-based extractor to preserve quoting and indentation
  * exactly. The regex matches both `key: value` and `key: "value"` forms.
+ * Group 1 is the optional quote (so the closing `\1` backref matches it),
+ * group 2 the value, group 3 the trailing comment.
  */
-const COMPOSE_IMAGE_RE = /^(\s*image:\s*)(['"]?)([^'"\s#]+)\2(\s*#.*)?$/;
+const COMPOSE_IMAGE_RE = /^\s*image:\s*(['"]?)([^'"\s#]+)\1(\s*#.*)?$/;
 
 const extractFromCompose = (filePath: string, content: string): ImageReference[] => {
     const lines = content.split(/\r?\n/);
@@ -228,9 +229,7 @@ const extractFromCompose = (filePath: string, content: string): ImageReference[]
 
     let pendingIgnore = false;
 
-    for (let index = 0; index < lines.length; index++) {
-        const line = lines[index] ?? "";
-
+    for (const [index, line] of lines.entries()) {
         if (IGNORE_NEXT_RE.test(line) && isCommentOnlyLine(line)) {
             pendingIgnore = true;
 
@@ -247,8 +246,8 @@ const extractFromCompose = (filePath: string, content: string): ImageReference[]
             continue;
         }
 
-        const value = match[3] ?? "";
-        const trailingComment = match[4]?.trim();
+        const value = match[2] ?? "";
+        const trailingComment = match[3]?.trim();
         let ignoreReason = pendingIgnore ? "vis-update-ignore-next-line" : undefined;
 
         if (trailingComment && IGNORE_NEXT_RE.test(trailingComment)) {
@@ -301,7 +300,7 @@ const isComposeFile = (name: string): boolean => {
     return /^(?:docker-)?compose(?:\..+)?\.ya?ml$/.test(lower);
 };
 
-const SKIP_DIRS = new Set([".git", "node_modules", ".pnpm-store", ".turbo", ".nx", "dist", "build", ".cache"]);
+const SKIP_DIRS = new Set([".cache", ".git", ".nx", ".pnpm-store", ".turbo", "build", "dist", "node_modules"]);
 
 // `walkSync` runs `skip` patterns against the full resolved path, not the
 // entry name alone. Match any path segment so e.g. `…/node_modules/sub/…`

--- a/packages/tooling/vis/src/task/arguments.ts
+++ b/packages/tooling/vis/src/task/arguments.ts
@@ -17,10 +17,18 @@ export type TaskArgumentValue = boolean | number | string;
 
 /** A single declared argument for a task target. */
 export interface TaskArgument {
-    /** Short single-character alias (e.g. `r` for `--reporter`, used as `-r`). */
+    /**
+     * Short single-character alias (e.g. `r` for `--reporter`, used as `-r`).
+     * Must be exactly one character — enforced at run time by
+     * {@link validateArgumentSchema}.
+     */
     alias?: string;
 
-    /** Allowed values when {@link TaskArgument.type} is `"enum"`. */
+    /**
+     * Allowed values when {@link TaskArgument.type} is `"enum"`. Must be
+     * non-empty (and is required) for `enum` — enforced at run time by
+     * {@link validateArgumentSchema}.
+     */
     choices?: string[];
 
     /** Value applied when the argument is omitted. Skips the required check. */
@@ -29,7 +37,11 @@ export interface TaskArgument {
     /** One-line help text surfaced by per-task `--help`. */
     description?: string;
 
-    /** Canonical name, without the leading `--` (kebab-case by convention). */
+    /**
+     * Canonical name, without the leading `--` (kebab-case by convention).
+     * Must start with a letter and contain only letters, digits, `-`, `_` —
+     * enforced at run time by {@link validateArgumentSchema}.
+     */
     name: string;
 
     /**
@@ -153,6 +165,58 @@ const coerce = (
     }
 
     return { value: raw };
+};
+
+/**
+ * Validate the declared schema *itself* (not user input). The generated JSON
+ * schema can't express these conditional invariants, so a config can be
+ * schema-valid yet wrong; surfacing the problems here makes `vis run` fail
+ * fast with a clear message instead of misbehaving. Returns the problems;
+ * empty when the schema is well-formed.
+ */
+export const validateArgumentSchema = (schema: TaskArgument[]): string[] => {
+    const problems: string[] = [];
+    const seen = new Set<string>();
+
+    for (const argument of schema) {
+        const label = argument.name || "<unnamed>";
+
+        if (!argument.name || !/^[a-zA-Z][\w-]*$/u.test(argument.name)) {
+            problems.push(`argument name "${label}" is empty or invalid (start with a letter; use letters, digits, '-', '_')`);
+        }
+
+        if (seen.has(argument.name)) {
+            problems.push(`duplicate argument name "${label}"`);
+        }
+
+        seen.add(argument.name);
+
+        if (argument.alias !== undefined && argument.alias.length !== 1) {
+            problems.push(`argument "${label}" alias "${argument.alias}" must be a single character`);
+        }
+
+        const type = argument.type ?? "string";
+
+        if (type === "enum" && (argument.choices === undefined || argument.choices.length === 0)) {
+            problems.push(`argument "${label}" has type "enum" but declares no choices`);
+        }
+
+        if (argument.default !== undefined) {
+            const defaultType = typeof argument.default;
+            const matches
+                = (type === "number" && defaultType === "number")
+                    || (type === "boolean" && defaultType === "boolean")
+                    || ((type === "string" || type === "enum") && defaultType === "string");
+
+            if (!matches) {
+                problems.push(`argument "${label}" default ${JSON.stringify(argument.default)} does not match type "${type}"`);
+            } else if (type === "enum" && argument.choices && !argument.choices.includes(argument.default as string)) {
+                problems.push(`argument "${label}" default "${String(argument.default)}" is not one of its choices`);
+            }
+        }
+    }
+
+    return problems;
 };
 
 /**

--- a/packages/tooling/vis/src/task/arguments.ts
+++ b/packages/tooling/vis/src/task/arguments.ts
@@ -56,6 +56,62 @@ export interface ParsedTaskArguments {
 
 const asKebab = (name: string): string => name.replace(/^--?/u, "");
 
+/** Tokens accepted as explicit boolean values (case-insensitive). */
+const BOOLEAN_LITERALS = new Set(["0", "1", "false", "no", "true", "yes"]);
+
+/**
+ * A token is a *value* (not a flag) when it doesn't start with `-`, or when it
+ * is a negative number (`-5`, `-1.5`) — so `--offset -5` consumes `-5` while
+ * `--reporter -r` does not swallow the `-r` flag.
+ */
+const isValueToken = (token: string): boolean => !token.startsWith("-") || /^-(?:\d|\.\d)/u.test(token);
+
+/**
+ * Set `provided[name]` from either the inline `=value`, the next token, or a
+ * presence-only `"true"`. Returns the number of *extra* tokens consumed (0 or
+ * 1) so the caller can advance its loop counter. Boolean args only consume a
+ * following token when it is a boolean literal, so `--watch true` works
+ * without leaving `true` as a stray positional.
+ */
+const captureValue = (
+    provided: Map<string, string>,
+    name: string,
+    argument: TaskArgument | undefined,
+    inline: string | undefined,
+    raw: string[],
+    index: number,
+): number => {
+    if (inline !== undefined) {
+        provided.set(name, inline);
+
+        return 0;
+    }
+
+    const next = raw[index + 1];
+
+    if ((argument?.type ?? "string") === "boolean") {
+        if (next !== undefined && BOOLEAN_LITERALS.has(next.toLowerCase())) {
+            provided.set(name, next.toLowerCase());
+
+            return 1;
+        }
+
+        provided.set(name, "true");
+
+        return 0;
+    }
+
+    if (next !== undefined && isValueToken(next)) {
+        provided.set(name, next);
+
+        return 1;
+    }
+
+    provided.set(name, "true");
+
+    return 0;
+};
+
 const coerce = (
     argument: TaskArgument,
     raw: string,
@@ -63,9 +119,11 @@ const coerce = (
     const type = argument.type ?? "string";
 
     if (type === "number") {
-        const value = Number(raw);
+        const trimmed = raw.trim();
+        const value = Number(trimmed);
 
-        if (Number.isNaN(value)) {
+        // Reject empty (`Number("")` is 0) and non-finite (`Infinity`, `NaN`).
+        if (trimmed === "" || !Number.isFinite(value)) {
             return { error: `--${argument.name} expects a number, got "${raw}"` };
         }
 
@@ -138,19 +196,8 @@ export const parseTaskArguments = (schema: TaskArgument[], raw: string[]): Parse
 
         if (matchLong) {
             const name = matchLong[1] as string;
-            const argument = byName.get(name);
-            const inline = matchLong[2];
 
-            if (inline !== undefined) {
-                provided.set(name, inline);
-            } else if (argument && (argument.type ?? "string") === "boolean") {
-                provided.set(name, "true");
-            } else if (index + 1 < raw.length && !(raw[index + 1] as string).startsWith("-")) {
-                index += 1;
-                provided.set(name, raw[index] as string);
-            } else {
-                provided.set(name, "true");
-            }
+            index += captureValue(provided, name, byName.get(name), matchLong[2], raw, index);
 
             continue;
         }
@@ -160,19 +207,8 @@ export const parseTaskArguments = (schema: TaskArgument[], raw: string[]): Parse
 
         if (matchShort && shortName !== undefined) {
             const argument = byAlias.get(shortName);
-            const name = argument?.name ?? shortName;
-            const inline = matchShort[2];
 
-            if (inline !== undefined) {
-                provided.set(name, inline);
-            } else if (argument && (argument.type ?? "string") === "boolean") {
-                provided.set(name, "true");
-            } else if (index + 1 < raw.length && !(raw[index + 1] as string).startsWith("-")) {
-                index += 1;
-                provided.set(name, raw[index] as string);
-            } else {
-                provided.set(name, "true");
-            }
+            index += captureValue(provided, argument?.name ?? shortName, argument, matchShort[2], raw, index);
 
             continue;
         }
@@ -214,7 +250,11 @@ export const parseTaskArguments = (schema: TaskArgument[], raw: string[]): Parse
     return { errors, values };
 };
 
-/** `VIS_ARG_&lt;UPPER_SNAKE>` env-var name for a declared argument. */
+/**
+ * `VIS_ARG_&lt;UPPER_SNAKE>` env-var name for a declared argument. Non-alphanumeric
+ * runs collapse to `_`, so argument names should be unique after normalization
+ * (`min-age` and `min_age` both map to `VIS_ARG_MIN_AGE`).
+ */
 export const taskArgumentEnvName = (name: string): string => `VIS_ARG_${asKebab(name).replaceAll(/[^a-zA-Z0-9]+/gu, "_").toUpperCase()}`;
 
 /** Build the `{ VIS_ARG_*: value }` env block from validated values. */

--- a/packages/tooling/vis/src/task/arguments.ts
+++ b/packages/tooling/vis/src/task/arguments.ts
@@ -1,0 +1,273 @@
+/**
+ * First-class task arguments: a declarative schema per target that lets a
+ * task define its named/positional arguments, validate what the user passes
+ * on the CLI, and render a per-task `--help`. The validated values are also
+ * exposed to the command as `VIS_ARG_&lt;NAME>` environment variables so the
+ * underlying script can read them without re-parsing argv.
+ *
+ * This module is intentionally pure (no IO) so it is trivially unit-testable;
+ * the run handler wires it to the forwarded-args vector and the task env.
+ */
+
+/** Value type a {@link TaskArgument} coerces to and validates against. */
+export type TaskArgumentType = "boolean" | "enum" | "number" | "string";
+
+/** A coerced task-argument value. */
+export type TaskArgumentValue = boolean | number | string;
+
+/** A single declared argument for a task target. */
+export interface TaskArgument {
+    /** Short single-character alias (e.g. `r` for `--reporter`, used as `-r`). */
+    alias?: string;
+
+    /** Allowed values when {@link TaskArgument.type} is `"enum"`. */
+    choices?: string[];
+
+    /** Value applied when the argument is omitted. Skips the required check. */
+    default?: TaskArgumentValue;
+
+    /** One-line help text surfaced by per-task `--help`. */
+    description?: string;
+
+    /** Canonical name, without the leading `--` (kebab-case by convention). */
+    name: string;
+
+    /**
+     * Consume the value from the next free positional argument instead of a
+     * `--flag`. Positional args are filled in declaration order.
+     */
+    positional?: boolean;
+
+    /** Fail the task when the argument is absent and has no `default`. */
+    required?: boolean;
+
+    /** Value type for coercion + validation. Defaults to `"string"`. */
+    type?: TaskArgumentType;
+}
+
+/** Result of {@link parseTaskArguments}. */
+export interface ParsedTaskArguments {
+    /** Human-readable validation errors. Empty when the input is valid. */
+    errors: string[];
+
+    /** Coerced values for declared arguments that were provided or defaulted. */
+    values: Record<string, TaskArgumentValue>;
+}
+
+const asKebab = (name: string): string => name.replace(/^--?/u, "");
+
+const coerce = (
+    argument: TaskArgument,
+    raw: string,
+): { error?: string; value?: TaskArgumentValue } => {
+    const type = argument.type ?? "string";
+
+    if (type === "number") {
+        const value = Number(raw);
+
+        if (Number.isNaN(value)) {
+            return { error: `--${argument.name} expects a number, got "${raw}"` };
+        }
+
+        return { value };
+    }
+
+    if (type === "boolean") {
+        if (["1", "true", "yes"].includes(raw.toLowerCase())) {
+            return { value: true };
+        }
+
+        if (["0", "false", "no"].includes(raw.toLowerCase())) {
+            return { value: false };
+        }
+
+        return { error: `--${argument.name} expects a boolean, got "${raw}"` };
+    }
+
+    if (type === "enum") {
+        const choices = argument.choices ?? [];
+
+        if (!choices.includes(raw)) {
+            return { error: `--${argument.name} must be one of [${choices.join(", ")}], got "${raw}"` };
+        }
+
+        return { value: raw };
+    }
+
+    return { value: raw };
+};
+
+/**
+ * Parse + validate a raw forwarded-args vector against a task's argument
+ * schema. Unknown tokens are left untouched (the command still receives the
+ * full forwarded vector) — only declared arguments are validated, so a schema
+ * never blocks passing extra flags straight through to the underlying tool.
+ */
+export const parseTaskArguments = (schema: TaskArgument[], raw: string[]): ParsedTaskArguments => {
+    const byName = new Map<string, TaskArgument>();
+    const byAlias = new Map<string, TaskArgument>();
+
+    for (const argument of schema) {
+        byName.set(argument.name, argument);
+
+        if (argument.alias) {
+            byAlias.set(argument.alias, argument);
+        }
+    }
+
+    // Collect raw flag values + leftover positionals in one pass.
+    const provided = new Map<string, string>();
+    const positionals: string[] = [];
+
+    for (let index = 0; index < raw.length; index += 1) {
+        const token = raw[index] as string;
+
+        if (token === "--") {
+            // Everything after `--` is a positional pass-through.
+            positionals.push(...raw.slice(index + 1));
+            break;
+        }
+
+        if (token.startsWith("--no-")) {
+            provided.set(asKebab(token.slice("--no-".length)), "false");
+
+            continue;
+        }
+
+        const matchLong = /^--([^=]+)(?:=(.*))?$/su.exec(token);
+
+        if (matchLong) {
+            const name = matchLong[1] as string;
+            const argument = byName.get(name);
+            const inline = matchLong[2];
+
+            if (inline !== undefined) {
+                provided.set(name, inline);
+            } else if (argument && (argument.type ?? "string") === "boolean") {
+                provided.set(name, "true");
+            } else if (index + 1 < raw.length && !(raw[index + 1] as string).startsWith("-")) {
+                index += 1;
+                provided.set(name, raw[index] as string);
+            } else {
+                provided.set(name, "true");
+            }
+
+            continue;
+        }
+
+        const matchShort = /^-([^=-])(?:=(.*))?$/su.exec(token);
+
+        if (matchShort) {
+            const argument = byAlias.get(matchShort[1] as string);
+            const name = argument?.name ?? (matchShort[1]);
+            const inline = matchShort[2];
+
+            if (inline !== undefined) {
+                provided.set(name, inline);
+            } else if (argument && (argument.type ?? "string") === "boolean") {
+                provided.set(name, "true");
+            } else if (index + 1 < raw.length && !(raw[index + 1] as string).startsWith("-")) {
+                index += 1;
+                provided.set(name, raw[index] as string);
+            } else {
+                provided.set(name, "true");
+            }
+
+            continue;
+        }
+
+        positionals.push(token);
+    }
+
+    const values: Record<string, TaskArgumentValue> = {};
+    const errors: string[] = [];
+    let positionalIndex = 0;
+
+    for (const argument of schema) {
+        let rawValue: string | undefined = provided.get(argument.name);
+
+        if (rawValue === undefined && argument.positional && positionalIndex < positionals.length) {
+            rawValue = positionals[positionalIndex];
+            positionalIndex += 1;
+        }
+
+        if (rawValue === undefined) {
+            if (argument.default !== undefined) {
+                values[argument.name] = argument.default;
+            } else if (argument.required) {
+                errors.push(`missing required argument --${argument.name}`);
+            }
+
+            continue;
+        }
+
+        const { error, value } = coerce(argument, rawValue);
+
+        if (error) {
+            errors.push(error);
+        } else if (value !== undefined) {
+            values[argument.name] = value;
+        }
+    }
+
+    return { errors, values };
+};
+
+/** `VIS_ARG_&lt;UPPER_SNAKE>` env-var name for a declared argument. */
+export const taskArgumentEnvName = (name: string): string => `VIS_ARG_${asKebab(name).replaceAll(/[^a-zA-Z0-9]+/gu, "_").toUpperCase()}`;
+
+/** Build the `{ VIS_ARG_*: value }` env block from validated values. */
+export const taskArgumentEnv = (values: Record<string, TaskArgumentValue>): Record<string, string> => {
+    const env: Record<string, string> = {};
+
+    for (const [name, value] of Object.entries(values)) {
+        env[taskArgumentEnvName(name)] = String(value);
+    }
+
+    return env;
+};
+
+/** Render a per-task `--help` block from the target's description + schema. */
+export const renderTaskArgumentsHelp = (targetName: string, description: string | undefined, schema: TaskArgument[]): string => {
+    const lines: string[] = [`Usage: vis run ${targetName} [-- <args>]`];
+
+    if (description) {
+        lines.push("", description);
+    }
+
+    if (schema.length === 0) {
+        return lines.join("\n");
+    }
+
+    lines.push("", "Arguments:");
+
+    const rows = schema.map((argument) => {
+        const flag = argument.positional ? `<${argument.name}>` : `--${argument.name}`;
+        const alias = argument.alias ? `, -${argument.alias}` : "";
+
+        return { left: `${flag}${alias}`, right: argument };
+    });
+
+    const width = Math.max(...rows.map((row) => row.left.length));
+
+    for (const { left, right } of rows) {
+        const meta: string[] = [];
+        const type = right.type ?? "string";
+
+        meta.push(type === "enum" ? `enum(${(right.choices ?? []).join("|")})` : type);
+
+        if (right.required) {
+            meta.push("required");
+        }
+
+        if (right.default !== undefined) {
+            meta.push(`default: ${String(right.default)}`);
+        }
+
+        const detail = `${right.description ?? ""}${right.description ? " " : ""}[${meta.join(", ")}]`;
+
+        lines.push(`  ${left.padEnd(width)}  ${detail}`);
+    }
+
+    return lines.join("\n");
+};

--- a/packages/tooling/vis/src/task/arguments.ts
+++ b/packages/tooling/vis/src/task/arguments.ts
@@ -156,10 +156,11 @@ export const parseTaskArguments = (schema: TaskArgument[], raw: string[]): Parse
         }
 
         const matchShort = /^-([^=-])(?:=(.*))?$/su.exec(token);
+        const shortName = matchShort?.[1];
 
-        if (matchShort) {
-            const argument = byAlias.get(matchShort[1] as string);
-            const name = argument?.name ?? (matchShort[1]);
+        if (matchShort && shortName !== undefined) {
+            const argument = byAlias.get(shortName);
+            const name = argument?.name ?? shortName;
             const inline = matchShort[2];
 
             if (inline !== undefined) {

--- a/packages/tooling/vis/src/task/types.ts
+++ b/packages/tooling/vis/src/task/types.ts
@@ -214,6 +214,9 @@ export interface VisTargetOptions {
      * `shell: "node", shellArgs: ["-e"]` runs the command as inline JS
      * ("script mode"), or `shellArgs: ["-lc"]` for a login shell. Only applies
      * when `shell`/`unixShell`/`windowsShell` resolves to a custom shell.
+     *
+     * Must be non-empty when set — an empty array would drop the interpreter
+     * flag entirely, so the runtime falls back to `-c` defensively.
      */
     shellArgs?: string[];
 

--- a/packages/tooling/vis/src/task/types.ts
+++ b/packages/tooling/vis/src/task/types.ts
@@ -1,8 +1,10 @@
 import type { TargetConfiguration } from "@visulima/task-runner";
 
 import type { ServiceConfig } from "../services/types";
+import type { TaskArgument } from "./arguments";
 
 export type { ServiceConfig } from "../services/types";
+export type { TaskArgument, TaskArgumentType } from "./arguments";
 
 /**
  * Semantic classification for a target.
@@ -206,6 +208,16 @@ export interface VisTargetOptions {
     shell?: string;
 
     /**
+     * Arguments passed to the per-target shell/interpreter before the command
+     * string. Defaults to `["-c"]` (POSIX shells, pwsh). Set this to run the
+     * command under an interpreter that uses a different flag — e.g.
+     * `shell: "node", shellArgs: ["-e"]` runs the command as inline JS
+     * ("script mode"), or `shellArgs: ["-lc"]` for a login shell. Only applies
+     * when `shell`/`unixShell`/`windowsShell` resolves to a custom shell.
+     */
+    shellArgs?: string[];
+
+    /**
      * Override the workspace `strictEnv` setting for this target. When
      * truthy, the target fails if its command references an env var
      * that resolves to neither the task's effective env nor
@@ -257,9 +269,17 @@ export interface VisTargetConfiguration extends Omit<TargetConfiguration, "optio
     aliases?: string[];
 
     /**
-     * One-line description surfaced by `vis list` and (in future)
-     * per-task `--help`. Kept short — longer docs belong in project
-     * READMEs or vis.config.ts comments.
+     * Declarative argument schema for this target. Forwarded CLI args
+     * (`vis run &lt;target> -- --flag value`) are validated against it, surfaced
+     * by per-task `--help`, and exposed to the command as `VIS_ARG_&lt;NAME>`
+     * environment variables.
+     */
+    arguments?: TaskArgument[];
+
+    /**
+     * One-line description surfaced by `vis list` and per-task `--help`.
+     * Kept short — longer docs belong in project READMEs or
+     * vis.config.ts comments.
      */
     description?: string;
 


### PR DESCRIPTION
## first-class task arguments
Targets can declare an `arguments` schema and `vis` validates, documents, and forwards them.

- **Schema** (`TaskArgument`): `name`, `alias`, `type` (`string`/`number`/`boolean`/`enum`), `choices`, `required`, `default`, `positional`, `description`.
- **Validation** of forwarded args (`vis run <target> --flag value`): type coercion, enum + required checks. Invalid input prints the errors + per-task help and fails the run.
- **`--help`**: `vis run <target> -- --help` renders usage + each argument.
- **Exposure**: validated values reach the command as `VIS_ARG_<NAME>` env vars (merged at both spawn sites).

Core logic is a pure, unit-tested module (`src/task/arguments.ts`); the run-handler glue is a small exported helper (`src/commands/run/task-arguments.ts`).

## script mode
Adds `options.shellArgs` so a per-target shell can use a non-`-c` interpreter flag — e.g. `shell: "node", shellArgs: ["-e"]` runs the command as inline JS. Complements the existing `shell`/`unixShell`/`windowsShell` overrides (which already covered bash/zsh/pwsh).

## Notes
- All in `@visulima/vis` — `task-runner` (the engine) needed no changes.
- Per-task `--help` triggers via `vis run <target> -- --help` (the `--` keeps `--help` in the forwarded vector rather than cerebro's command help).
- Schemas regenerated via `generate-schemas` (not hand-edited).

## Validation
- `tsc` clean, `eslint` clean on all changed files.
- **16** argument tests (11 module + 5 handler-integration) + **105** existing run-command tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative task arguments: validation, type coercion, defaults, aliases, positional args, and enum choices
  * Forwarded CLI args validated at run-time; malformed args show per-task help and clear errors
  * Parsed arguments exposed to tasks as VIS_ARG_<NAME> environment variables
  * Per-target customizable shell/interpreter flags (shellArgs) to control command invocation
  * Run fails with an error if multiple projects declare conflicting argument schemas for the same target

* **Documentation**
  * Target descriptions are surfaced in task listings and per-task --help outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->