### PR TITLE
fix(vis): require explicit opt-in to apply ecosystem updates

### DIFF
--- a/packages/tooling/vis/__tests__/commands/update/ecosystem-apply-gate.test.ts
+++ b/packages/tooling/vis/__tests__/commands/update/ecosystem-apply-gate.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { shouldApplyEcosystem } from "../../../src/commands/update/handler";
+
+vi.mock(import("is-in-ci"), () => {
+    return { default: false };
+});
+
+interface UpdatePathResult {
+    readonly applied: boolean;
+    readonly canceled: boolean;
+    readonly jsonEmitted: boolean;
+}
+
+const catalogResult = (overrides: Partial<UpdatePathResult> = {}): UpdatePathResult => {
+    return {
+        applied: false,
+        canceled: false,
+        jsonEmitted: false,
+        ...overrides,
+    };
+};
+
+describe(shouldApplyEcosystem, () => {
+    let originalTTY: boolean | undefined;
+    let originalExitCode: number | string | undefined;
+
+    beforeEach(() => {
+        originalTTY = process.stdout.isTTY;
+        originalExitCode = process.exitCode;
+        // Default to an interactive-capable TTY; individual tests override.
+        process.stdout.isTTY = true;
+        process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+        if (originalTTY === undefined) {
+            delete (process.stdout as { isTTY?: boolean }).isTTY;
+        } else {
+            process.stdout.isTTY = originalTTY;
+        }
+
+        process.exitCode = originalExitCode;
+    });
+
+    it("applies when --yes is passed", () => {
+        expect.assertions(1);
+
+        expect(shouldApplyEcosystem({ yes: true }, catalogResult())).toBe(true);
+    });
+
+    it("applies when --interactive is passed in a TTY", () => {
+        expect.assertions(1);
+
+        expect(shouldApplyEcosystem({ interactive: true }, catalogResult())).toBe(true);
+    });
+
+    it("does NOT apply --interactive when stdout is not a TTY", () => {
+        expect.assertions(1);
+
+        process.stdout.isTTY = false;
+
+        expect(shouldApplyEcosystem({ interactive: true }, catalogResult())).toBe(false);
+    });
+
+    it("does NOT auto-apply just because the catalog/npm path applied (the piggyback path is gone)", () => {
+        expect.assertions(1);
+
+        // Plain `vis update` in a TTY that bumped npm deps must still leave
+        // ecosystem references in preview-only mode.
+        expect(shouldApplyEcosystem({}, catalogResult({ applied: true }))).toBe(false);
+    });
+
+    it("does NOT apply on plain invocation with no opt-in flags", () => {
+        expect.assertions(1);
+
+        expect(shouldApplyEcosystem({}, catalogResult())).toBe(false);
+    });
+
+    it("refuses on --dry-run even with --yes", () => {
+        expect.assertions(1);
+
+        expect(shouldApplyEcosystem({ dryRun: true, yes: true }, catalogResult())).toBe(false);
+    });
+
+    it("refuses when a prior stage set a non-zero exit code", () => {
+        expect.assertions(1);
+
+        process.exitCode = 1;
+
+        expect(shouldApplyEcosystem({ yes: true }, catalogResult())).toBe(false);
+    });
+
+    it("refuses when the catalog TUI was canceled", () => {
+        expect.assertions(1);
+
+        expect(shouldApplyEcosystem({ yes: true }, catalogResult({ canceled: true }))).toBe(false);
+    });
+});

--- a/packages/tooling/vis/__tests__/commands/update/ecosystem-apply-gate.test.ts
+++ b/packages/tooling/vis/__tests__/commands/update/ecosystem-apply-gate.test.ts
@@ -2,8 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { shouldApplyEcosystem } from "../../../src/commands/update/handler";
 
+// `is-in-ci` exports a boolean default. We back it with a mutable holder so
+// individual tests can flip the CI state — `import isInCi from "is-in-ci"` is a
+// live binding, so reading it re-evaluates the getter each time.
+const ciState = vi.hoisted(() => {
+    return { value: false };
+});
+
 vi.mock(import("is-in-ci"), () => {
-    return { default: false };
+    return {
+        get default() {
+            return ciState.value;
+        },
+    };
 });
 
 interface UpdatePathResult {
@@ -41,6 +52,7 @@ describe(shouldApplyEcosystem, () => {
         }
 
         process.exitCode = originalExitCode;
+        ciState.value = false;
     });
 
     it("applies when --yes is passed", () => {
@@ -59,6 +71,16 @@ describe(shouldApplyEcosystem, () => {
         expect.assertions(1);
 
         process.stdout.isTTY = false;
+
+        expect(shouldApplyEcosystem({ interactive: true }, catalogResult())).toBe(false);
+    });
+
+    it("does NOT apply --interactive when running in CI (even on a TTY)", () => {
+        expect.assertions(1);
+
+        // CI runners can report a TTY, so the interactive picker must still be
+        // refused — there is no human to drive it.
+        ciState.value = true;
 
         expect(shouldApplyEcosystem({ interactive: true }, catalogResult())).toBe(false);
     });

--- a/packages/tooling/vis/__tests__/commands/update/ecosystems/report.test.ts
+++ b/packages/tooling/vis/__tests__/commands/update/ecosystems/report.test.ts
@@ -118,6 +118,30 @@ describe(formatEcosystemReport, () => {
         expect(report).toContain("Arbitrary code execution via crafted ref");
     });
 
+    it("appends a preview-only footer when previewOnly is set and updates exist", () => {
+        expect.assertions(2);
+
+        const updates = [makeUpdate({ ecosystem: "actions", name: "actions/checkout", updateType: "minor" })];
+        const report = stripAnsi(formatEcosystemReport(buildResult(updates), { previewOnly: true, showIgnored: false }));
+
+        expect(report).toContain("Not applied automatically");
+        expect(report).toContain("--interactive");
+    });
+
+    it("omits the preview-only footer when previewOnly is not set (apply path)", () => {
+        expect.assertions(1);
+
+        const updates = [makeUpdate({ ecosystem: "actions", name: "actions/checkout", updateType: "minor" })];
+
+        expect(stripAnsi(formatEcosystemReport(buildResult(updates), { showIgnored: false }))).not.toContain("Not applied automatically");
+    });
+
+    it("does not render the preview-only footer when everything is up to date", () => {
+        expect.assertions(1);
+
+        expect(stripAnsi(formatEcosystemReport(buildResult([]), { previewOnly: true, showIgnored: false }))).not.toContain("Not applied automatically");
+    });
+
     it("appends the changelog/release URL when the update carries one", () => {
         expect.assertions(2);
 

--- a/packages/tooling/vis/src/commands/update/ecosystems/report.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/report.ts
@@ -71,7 +71,7 @@ const formatAdvisoryLines = (update: EcosystemUpdate): string[] => {
  * matches the catalog reporter's tone. Used by `vis update`'s non-TUI
  * paths (CI, --format=table on a non-TTY, etc.).
  */
-export const formatEcosystemReport = (result: EcosystemCheckResult, options: { showIgnored: boolean }): string => {
+export const formatEcosystemReport = (result: EcosystemCheckResult, options: { previewOnly?: boolean; showIgnored: boolean }): string => {
     const lines: string[] = [];
     const totalUpdates = result.updates.length;
 
@@ -157,6 +157,15 @@ export const formatEcosystemReport = (result: EcosystemCheckResult, options: { s
         for (const failure of result.failed) {
             lines.push(`    ${failure.file}: ${failure.reason}`);
         }
+    }
+
+    if (options.previewOnly) {
+        // Make it unmistakable that these CI / Docker / GitLab references
+        // are NOT rewritten on the back of an npm bump — the user has to
+        // opt in. Mirrors the actionable hint emitted for minimal/json.
+        lines.push(
+            `\n  ${yellow("ℹ")} ${dim("Not applied automatically — re-run with `--interactive` to choose which to apply, or `--yes` to apply all.")}`,
+        );
     }
 
     return lines.join("\n");

--- a/packages/tooling/vis/src/commands/update/handler.ts
+++ b/packages/tooling/vis/src/commands/update/handler.ts
@@ -1053,23 +1053,25 @@ const buildEcosystemOptions = (options: Record<string, unknown>, visConfig: VisC
 /**
  * Decides whether the ecosystem stage should apply updates to disk.
  *
- * Plain `vis update` (no args, no `--yes`, no `--interactive`) defaults
- * to **preview only** — it must never silently mutate CI files when the
- * user didn't opt in. The user can apply by re-running with `--yes`.
+ * Ecosystem edits rewrite CI workflow files, Dockerfiles, and GitLab CI
+ * config — they must never be written unless the user explicitly opted
+ * in. Critically, the catalog/npm path applying does NOT carry over: a
+ * plain `vis update` that bumps npm deps still leaves GitHub Actions,
+ * Docker, and GitLab references in **preview only** mode. Auto-applying
+ * them on the back of an npm bump silently mutates files the user never
+ * selected.
  *
- * Apply is permitted when:
- *   - `--yes` was passed (explicit opt-in)
- *   - `--interactive` was passed AND catalog committed updates (the user
- *     has already engaged with the apply flow once this run)
- *   - The catalog path itself applied updates AND we're in a TTY
- *     (a non-CI session where the user can see the report)
+ * Apply is permitted only when:
+ *   - `--yes` was passed (explicit "apply all" opt-in), or
+ *   - `--interactive` was passed in a TTY (the picker lets the user
+ *     choose which references to apply).
  *
  * Apply is refused outright when:
  *   - `--dry-run` was passed
  *   - The catalog/PM stage failed (`process.exitCode` is non-zero)
  *   - The catalog TUI was canceled (user said no).
  */
-const shouldApplyEcosystem = (options: Record<string, unknown>, catalogResult: UpdatePathResult): boolean => {
+export const shouldApplyEcosystem = (options: Record<string, unknown>, catalogResult: UpdatePathResult): boolean => {
     if (options.dryRun === true) {
         return false;
     }
@@ -1086,15 +1088,9 @@ const shouldApplyEcosystem = (options: Record<string, unknown>, catalogResult: U
         return true;
     }
 
-    if (options.interactive === true && catalogResult.applied) {
-        return true;
-    }
-
-    if (catalogResult.applied && Boolean(process.stdout.isTTY) && !isInCi) {
-        return true;
-    }
-
-    return false;
+    // The npm/catalog path applying does NOT authorise ecosystem writes —
+    // only an explicit `--interactive` selection (in a TTY) does.
+    return options.interactive === true && Boolean(process.stdout.isTTY) && !isInCi;
 };
 
 /**
@@ -1137,6 +1133,10 @@ export const runEcosystemUpdate = async (
 
     const format = (options.format as string | undefined) ?? "table";
     const isDryRun = Boolean(options.dryRun);
+    // Decide up-front whether we'll write anything, so the report can tell
+    // the user these references are preview-only (not auto-applied) when
+    // they didn't opt in via `--yes` / `--interactive`.
+    const willApply = shouldApplyEcosystem(options, catalogResult);
 
     if (format === "json") {
         // The catalog path may have already written a JSON document to
@@ -1154,7 +1154,10 @@ export const runEcosystemUpdate = async (
             process.stdout.write(`${formatEcosystemJson(result)}\n`);
         }
     } else if (format !== "minimal") {
-        const report = formatEcosystemReport(result, { showIgnored: options.interactive === true });
+        const report = formatEcosystemReport(result, {
+            previewOnly: !willApply,
+            showIgnored: options.interactive === true,
+        });
 
         if (report) {
             logger.info(report);
@@ -1165,14 +1168,21 @@ export const runEcosystemUpdate = async (
         return result;
     }
 
-    if (!shouldApplyEcosystem(options, catalogResult)) {
-        // Show a clear hint so users know how to opt in. We intentionally
-        // do NOT exit non-zero here — having outdated CI references is
-        // not a failure, it's information.
-        logger.info(
-            `\n${yellow("ℹ")} ${String(result.updates.length)} ecosystem reference${result.updates.length === 1 ? "" : "s"} can be bumped. `
-            + "Re-run with `--yes` to apply (or `--no-actions` / `--no-docker` / `--no-gitlab` to silence by ecosystem).",
-        );
+    if (!willApply) {
+        // The table report already carries the preview note via
+        // `previewOnly`; `minimal` renders no report, so emit the
+        // actionable hint here instead. `json` is deliberately excluded —
+        // its document is written to stdout and a trailing prose line
+        // would corrupt it for `jq`/parser consumers. We intentionally do
+        // NOT exit non-zero — outdated CI references are information, not
+        // a failure.
+        if (format === "minimal") {
+            logger.info(
+                `\n${yellow("ℹ")} ${String(result.updates.length)} ecosystem reference${result.updates.length === 1 ? "" : "s"} can be bumped — not applied automatically. `
+                + "Re-run with `--interactive` to choose, or `--yes` to apply all "
+                + "(or `--no-actions` / `--no-docker` / `--no-gitlab` to silence by ecosystem).",
+            );
+        }
 
         return result;
     }

--- a/packages/tooling/vis/src/commands/update/handler.ts
+++ b/packages/tooling/vis/src/commands/update/handler.ts
@@ -1155,7 +1155,11 @@ export const runEcosystemUpdate = async (
         }
     } else if (format !== "minimal") {
         const report = formatEcosystemReport(result, {
-            previewOnly: !willApply,
+            // On `--dry-run` the user already knows nothing is written, so the
+            // "re-run with `--interactive`" footer is misleading (it implies
+            // dropping `--dry-run` alone would apply). Only surface the
+            // preview-only note when we genuinely declined to apply.
+            previewOnly: !willApply && !isDryRun,
             showIgnored: options.interactive === true,
         });
 
@@ -1164,7 +1168,22 @@ export const runEcosystemUpdate = async (
         }
     }
 
-    if (isDryRun || result.updates.length === 0) {
+    if (result.updates.length === 0) {
+        return result;
+    }
+
+    if (isDryRun) {
+        // `table`/`json` already surfaced the available updates above. For
+        // `minimal` (which renders no report) emit the actionable hint here
+        // too — otherwise `--dry-run --format=minimal` would print nothing
+        // at all and the user would never learn updates are available.
+        if (format === "minimal") {
+            logger.info(
+                `\n${yellow("ℹ")} ${String(result.updates.length)} ecosystem reference${result.updates.length === 1 ? "" : "s"} can be bumped — not applied (--dry-run). `
+                + "Re-run without --dry-run and with `--interactive` or `--yes` to apply.",
+            );
+        }
+
         return result;
     }
 


### PR DESCRIPTION
## Problem

Plain `vis update` auto-applied **GitHub Actions**, **Docker**, and **GitLab CI** reference bumps whenever the npm/catalog stage committed in a TTY (outside CI). This silently rewrote workflow files, Dockerfiles, and GitLab CI config the user never selected in any UI.

## Change

Ecosystem edits now apply **only on explicit opt-in**:

- `vis update` → preview only (no writes); report shows how to opt in
- `vis update --interactive` → picker, user chooses which to apply
- `vis update --yes` → applies all ecosystems (explicit "apply all")

`--dry-run`, non-TTY/CI, a canceled catalog TUI, or a failed prior stage all refuse to apply, as before.

### Details

- **`shouldApplyEcosystem` (`handler.ts`)** — removed the catalog-piggyback path (`catalogResult.applied && TTY && !CI`). Apply is now gated on `--yes` or `--interactive`+TTY. Exported for testing.
- **`runEcosystemUpdate` (`handler.ts`)** — computes `willApply` up front; passes `previewOnly` to the report; the standalone hint now only fires for `minimal`/`json` formats (which render no table) and names both `--interactive` and `--yes`.
- **`formatEcosystemReport` (`report.ts`)** — new `previewOnly` option appends a footer under the listed references:
  > ℹ Not applied automatically — re-run with `--interactive` to choose which to apply, or `--yes` to apply all.

## Tests

- `ecosystem-apply-gate.test.ts` (new, 8 cases) — covers `--yes`/`--interactive`+TTY apply, the removed piggyback path no longer applying, and all the refusal conditions.
- `report.test.ts` — 3 cases for the preview-only footer (shown with updates, absent on apply path, absent when up-to-date).

All touched-file tests pass; `tsc --noEmit` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ecosystem reports now mark references as "preview-only" when they won't be applied automatically and point users to re-run with interactive or confirmation options.

* **Changes**
  * Ecosystem edits are applied only when explicit confirmation is provided (interactive session or explicit yes), not automatically from prior path success.
  * Messaging adjusted: minimal/--dry-run emits actionable notes; JSON and other formats rely on the report’s preview note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->