### PR TITLE
fix(task-runner): tolerate dev-only dependency cycles (#411)

### DIFF
--- a/packages/tooling/task-runner/__tests__/unit/deadlock-repro.test.ts
+++ b/packages/tooling/task-runner/__tests__/unit/deadlock-repro.test.ts
@@ -6,10 +6,12 @@ import { describe, expect, it } from "vitest";
 
 import { Cache } from "../../src/cache";
 import { EmptyLifeCycle } from "../../src/life-cycle";
+import { createTaskGraph } from "../../src/task-graph";
+import { findCycle } from "../../src/task-graph-utils";
 import { InProcessTaskHasher } from "../../src/task-hasher";
 import { TaskOrchestrator } from "../../src/task-orchestrator";
 import { TaskScheduler } from "../../src/task-scheduler";
-import type { ProjectGraph, Task, TaskExecutor, TaskGraph } from "../../src/types";
+import type { DependencyType, ProjectGraph, Task, TaskExecutor, TaskGraph, WorkspaceConfiguration } from "../../src/types";
 
 const createTemporaryDirectory = async (): Promise<string> => {
     // eslint-disable-next-line sonarjs/pseudo-random
@@ -190,6 +192,116 @@ describe("orphan-dep tolerance + deadlock diagnostics", () => {
         } finally {
             await rm(workspaceRoot, { force: true, recursive: true });
         }
+    });
+});
+
+describe("dev-dependency cycles via --filter (#411)", () => {
+    const makeWorkspace = (): WorkspaceConfiguration => {
+        return {
+            projects: {
+                "pkg-a": { root: "packages/pkg-a", targets: { build: { command: "tsc", dependsOn: ["^build"] } } },
+                "pkg-b": { root: "packages/pkg-b", targets: { build: { command: "tsc", dependsOn: ["^build"] } } },
+            },
+        };
+    };
+
+    // Two siblings that depend on each other in the project graph, with the
+    // edge kinds under test. Mirrors `--filter pkg-a pkg-b` narrowing the run
+    // to exactly the two packages that form the cycle.
+    const makeProjectGraph = (aToB: DependencyType, bToA: DependencyType): ProjectGraph => {
+        return {
+            dependencies: {
+                "pkg-a": [{ source: "pkg-a", target: "pkg-b", type: aToB }],
+                "pkg-b": [{ source: "pkg-b", target: "pkg-a", type: bToA }],
+            },
+            nodes: {
+                "pkg-a": { data: { root: "packages/pkg-a" }, name: "pkg-a", type: "library" },
+                "pkg-b": { data: { root: "packages/pkg-b" }, name: "pkg-b", type: "library" },
+            },
+        };
+    };
+
+    const runGraph = async (taskGraph: TaskGraph, projectGraph: ProjectGraph) => {
+        const workspaceRoot = await createTemporaryDirectory();
+
+        try {
+            const projects = { "pkg-a": { root: "packages/pkg-a" }, "pkg-b": { root: "packages/pkg-b" } };
+            const executor: TaskExecutor = async () => {
+                return { code: 0, terminalOutput: "ok" };
+            };
+            const orchestrator = new TaskOrchestrator({
+                cache: new Cache({ workspaceRoot }),
+                lifeCycle: new EmptyLifeCycle(),
+                scheduler: new TaskScheduler(taskGraph, projectGraph, 2),
+                skipCache: true,
+                taskExecutor: executor,
+                taskGraph,
+                taskHasher: new InProcessTaskHasher({ projects, workspaceRoot }),
+                workspaceRoot,
+            });
+
+            return await orchestrator.run();
+        } finally {
+            await rm(workspaceRoot, { force: true, recursive: true });
+        }
+    };
+
+    it("breaks a dev-only cycle between filtered siblings instead of deadlocking", async () => {
+        expect.assertions(4);
+
+        const projectGraph = makeProjectGraph("devDependency", "devDependency");
+        const broken: string[][] = [];
+
+        const taskGraph = createTaskGraph([makeTask("pkg-a"), makeTask("pkg-b")], {
+            onCycleBroken: (cycle) => broken.push(cycle),
+            projectGraph,
+            workspace: makeWorkspace(),
+        });
+
+        // The dev-only cycle is broken at graph-construction time...
+        expect(findCycle(taskGraph)).toBeUndefined();
+        expect(broken).toHaveLength(1);
+
+        // ...so the orchestrator runs both tasks to completion rather than
+        // throwing "Circular dependency found".
+        const results = await runGraph(taskGraph, projectGraph);
+
+        expect(results.get("pkg-a:build")?.status).toBe("success");
+        expect(results.get("pkg-b:build")?.status).toBe("success");
+    });
+
+    it("leaves a static cycle intact so the orchestrator still reports it fatally", async () => {
+        expect.assertions(3);
+
+        const projectGraph = makeProjectGraph("static", "static");
+        const broken: string[][] = [];
+
+        const taskGraph = createTaskGraph([makeTask("pkg-a"), makeTask("pkg-b")], {
+            onCycleBroken: (cycle) => broken.push(cycle),
+            projectGraph,
+            workspace: makeWorkspace(),
+        });
+
+        // A real (static) cycle must not be silently broken.
+        expect(broken).toHaveLength(0);
+        expect(findCycle(taskGraph)).toBeDefined();
+
+        await expect(runGraph(taskGraph, projectGraph)).rejects.toThrow(/Circular dependency found/);
+    });
+
+    it("keeps a cycle fatal when at least one edge is a static dependency", () => {
+        expect.assertions(2);
+
+        const broken: string[][] = [];
+
+        const taskGraph = createTaskGraph([makeTask("pkg-a"), makeTask("pkg-b")], {
+            onCycleBroken: (cycle) => broken.push(cycle),
+            projectGraph: makeProjectGraph("devDependency", "static"),
+            workspace: makeWorkspace(),
+        });
+
+        expect(broken).toHaveLength(0);
+        expect(findCycle(taskGraph)).toBeDefined();
     });
 });
 

--- a/packages/tooling/task-runner/src/task-graph.ts
+++ b/packages/tooling/task-runner/src/task-graph.ts
@@ -1,12 +1,40 @@
+import { findCycle } from "./task-graph-utils";
 import type { OutputSpec, ProjectGraph, TargetConfiguration, TargetDependencyConfig, Task, TaskGraph, TaskTarget, WorkspaceConfiguration } from "./types";
 
 interface CreateTaskGraphOptions {
+    /**
+     * Invoked once per dependency cycle that {@link createTaskGraph}
+     * breaks because it runs *solely* through soft (devDependency)
+     * edges. The argument is the cycle as a closed path of task ids
+     * (`[a, b, …, a]`). Consumers can surface this as a warning; cycles
+     * that contain a hard (static) edge are left intact and never
+     * reported here.
+     */
+    onCycleBroken?: (cycle: string[]) => void;
     /** The project graph */
     projectGraph: ProjectGraph;
     /** Target default configurations */
     targetDefaults?: Record<string, Partial<TargetConfiguration>>;
     /** The workspace configuration */
     workspace: WorkspaceConfiguration;
+}
+
+/**
+ * A dependency task plus the provenance of the edge that produced it.
+ */
+interface ResolvedDependency {
+    /**
+     * `true` when the edge originates from a `devDependency` project-graph
+     * edge. Soft edges are honoured for build ordering like any other, but
+     * a cycle composed *entirely* of soft edges is broken (with a warning)
+     * rather than treated as a fatal deadlock — matching pnpm, which
+     * tolerates cycles that run only through devDependencies. Peer-dependency
+     * edges never reach here (they are dropped from build ordering entirely;
+     * see {@link getDependencyProjectTasks}).
+     */
+    soft: boolean;
+    /** The resolved dependency task. */
+    task: Task;
 }
 
 /**
@@ -132,8 +160,8 @@ const getDependencyProjectTasks = (
     workspace: WorkspaceConfiguration,
     projectGraph: ProjectGraph,
     targetDefaults?: Record<string, Partial<TargetConfiguration>>,
-): Task[] => {
-    const tasks: Task[] = [];
+): ResolvedDependency[] => {
+    const tasks: ResolvedDependency[] = [];
     const deps = projectGraph.dependencies[projectName] ?? [];
 
     for (const dep of deps) {
@@ -175,29 +203,44 @@ const getDependencyProjectTasks = (
             };
 
             tasks.push({
-                always: depProject.targets?.[targetName]?.always ?? targetDefaults?.[targetName]?.always,
-                cache: depProject.targets?.[targetName]?.cache ?? targetDefaults?.[targetName]?.cache,
-                cacheOnWarning: depProject.targets?.[targetName]?.cacheOnWarning ?? targetDefaults?.[targetName]?.cacheOnWarning,
-                cacheRestore: depProject.targets?.[targetName]?.cacheRestore ?? targetDefaults?.[targetName]?.cacheRestore,
-                concurrencyGroup: depProject.targets?.[targetName]?.concurrencyGroup ?? targetDefaults?.[targetName]?.concurrencyGroup,
-                concurrencyWeight: depProject.targets?.[targetName]?.concurrencyWeight ?? targetDefaults?.[targetName]?.concurrencyWeight,
-                hashMode: depProject.targets?.[targetName]?.hashMode ?? targetDefaults?.[targetName]?.hashMode,
-                id: getTaskId(target),
-                maxConcurrent: depProject.targets?.[targetName]?.maxConcurrent ?? targetDefaults?.[targetName]?.maxConcurrent,
-                outputs: getTaskOutputs(dep.target, targetName, workspace, targetDefaults),
-                overrides,
-                parallelism: depProject.targets?.[targetName]?.parallelism ?? targetDefaults?.[targetName]?.parallelism,
-                projectRoot: depProject.root,
-                pty: depProject.targets?.[targetName]?.pty ?? targetDefaults?.[targetName]?.pty,
-                target,
-                warningPattern: normalizeWarningPattern(depProject.targets?.[targetName]?.warningPattern ?? targetDefaults?.[targetName]?.warningPattern),
-                when: depProject.targets?.[targetName]?.when ?? targetDefaults?.[targetName]?.when,
+                // devDependency edges are real build-order constraints, but
+                // a cycle made up only of them is broken instead of fatal.
+                soft: dep.type === "devDependency",
+                task: {
+                    always: depProject.targets?.[targetName]?.always ?? targetDefaults?.[targetName]?.always,
+                    cache: depProject.targets?.[targetName]?.cache ?? targetDefaults?.[targetName]?.cache,
+                    cacheOnWarning: depProject.targets?.[targetName]?.cacheOnWarning ?? targetDefaults?.[targetName]?.cacheOnWarning,
+                    cacheRestore: depProject.targets?.[targetName]?.cacheRestore ?? targetDefaults?.[targetName]?.cacheRestore,
+                    concurrencyGroup: depProject.targets?.[targetName]?.concurrencyGroup ?? targetDefaults?.[targetName]?.concurrencyGroup,
+                    concurrencyWeight: depProject.targets?.[targetName]?.concurrencyWeight ?? targetDefaults?.[targetName]?.concurrencyWeight,
+                    hashMode: depProject.targets?.[targetName]?.hashMode ?? targetDefaults?.[targetName]?.hashMode,
+                    id: getTaskId(target),
+                    maxConcurrent: depProject.targets?.[targetName]?.maxConcurrent ?? targetDefaults?.[targetName]?.maxConcurrent,
+                    outputs: getTaskOutputs(dep.target, targetName, workspace, targetDefaults),
+                    overrides,
+                    parallelism: depProject.targets?.[targetName]?.parallelism ?? targetDefaults?.[targetName]?.parallelism,
+                    projectRoot: depProject.root,
+                    pty: depProject.targets?.[targetName]?.pty ?? targetDefaults?.[targetName]?.pty,
+                    target,
+                    warningPattern: normalizeWarningPattern(depProject.targets?.[targetName]?.warningPattern ?? targetDefaults?.[targetName]?.warningPattern),
+                    when: depProject.targets?.[targetName]?.when ?? targetDefaults?.[targetName]?.when,
+                },
             });
         }
     }
 
     return tasks;
 };
+
+/**
+ * Wraps plain dependency tasks as hard edges. Used for same-project and
+ * explicitly-listed (`projects`) dependencies, which always impose a real
+ * ordering constraint regardless of the package.json dependency kind.
+ */
+const asHardDependencies = (tasks: Task[]): ResolvedDependency[] =>
+    tasks.map((task) => {
+        return { soft: false, task };
+    });
 
 /**
  * Resolves a string-format dependency like "build" or "^build".
@@ -213,7 +256,7 @@ const resolveStringDependency = (
     workspace: WorkspaceConfiguration,
     projectGraph: ProjectGraph,
     targetDefaults?: Record<string, Partial<TargetConfiguration>>,
-): Task[] => {
+): ResolvedDependency[] => {
     // "^targetName" means the target on dependency projects
     if (dep.startsWith("^")) {
         const targetName = dep.slice(1);
@@ -221,8 +264,9 @@ const resolveStringDependency = (
         return getDependencyProjectTasks(task.target.project, targetName, {}, workspace, projectGraph, targetDefaults);
     }
 
-    // "targetName" means the target on the same project
-    return getSameProjectTask(task.target.project, dep, {}, workspace, targetDefaults);
+    // "targetName" means the target on the same project — same-project
+    // ordering is always a hard edge.
+    return asHardDependencies(getSameProjectTask(task.target.project, dep, {}, workspace, targetDefaults));
 };
 
 /**
@@ -234,8 +278,8 @@ const resolveConfigDependency = (
     workspace: WorkspaceConfiguration,
     projectGraph: ProjectGraph,
     targetDefaults?: Record<string, Partial<TargetConfiguration>>,
-): Task[] => {
-    const tasks: Task[] = [];
+): ResolvedDependency[] => {
+    const tasks: ResolvedDependency[] = [];
 
     if (dep.dependencies) {
         tasks.push(
@@ -252,10 +296,10 @@ const resolveConfigDependency = (
         const projects = Array.isArray(dep.projects) ? dep.projects : [dep.projects];
 
         for (const projectName of projects) {
-            tasks.push(...getSameProjectTask(projectName, dep.target, dep.params === "forward" ? task.overrides : {}, workspace, targetDefaults));
+            tasks.push(...asHardDependencies(getSameProjectTask(projectName, dep.target, dep.params === "forward" ? task.overrides : {}, workspace, targetDefaults)));
         }
     } else {
-        tasks.push(...getSameProjectTask(task.target.project, dep.target, dep.params === "forward" ? task.overrides : {}, workspace, targetDefaults));
+        tasks.push(...asHardDependencies(getSameProjectTask(task.target.project, dep.target, dep.params === "forward" ? task.overrides : {}, workspace, targetDefaults)));
     }
 
     return tasks;
@@ -270,7 +314,7 @@ const resolveDependency = (
     workspace: WorkspaceConfiguration,
     projectGraph: ProjectGraph,
     targetDefaults?: Record<string, Partial<TargetConfiguration>>,
-): Task[] => {
+): ResolvedDependency[] => {
     if (typeof dep === "string") {
         return resolveStringDependency(task, dep, workspace, projectGraph, targetDefaults);
     }
@@ -281,7 +325,7 @@ const resolveDependency = (
 /**
  * Resolves the dependencies of a task based on target configuration.
  */
-const resolveTaskDependencies = (task: Task, options: CreateTaskGraphOptions): Task[] => {
+const resolveTaskDependencies = (task: Task, options: CreateTaskGraphOptions): ResolvedDependency[] => {
     const { projectGraph, targetDefaults, workspace } = options;
     const project = workspace.projects[task.target.project];
 
@@ -293,7 +337,7 @@ const resolveTaskDependencies = (task: Task, options: CreateTaskGraphOptions): T
     const defaultConfig = targetDefaults?.[task.target.target];
     const dependsOn = targetConfig?.dependsOn ?? defaultConfig?.dependsOn ?? [];
 
-    const depTasks: Task[] = [];
+    const depTasks: ResolvedDependency[] = [];
 
     for (const dep of dependsOn) {
         const resolved = resolveDependency(task, dep, workspace, projectGraph, targetDefaults);
@@ -304,12 +348,89 @@ const resolveTaskDependencies = (task: Task, options: CreateTaskGraphOptions): T
     return depTasks;
 };
 
+// Task ids are `project:target[:config]` and never contain whitespace,
+// so a space is a safe separator for a `from`-`to` edge key.
+const EDGE_SEPARATOR = " ";
+
+const edgeKey = (from: string, to: string): string => `${from}${EDGE_SEPARATOR}${to}`;
+
+/**
+ * Breaks dependency cycles that run *solely* through soft (devDependency)
+ * edges, mutating `dependencies` in place. This mirrors pnpm: a dev-only
+ * cycle between sibling packages is a tolerable ordering ambiguity, not a
+ * fatal deadlock. A cycle that contains at least one hard (static) edge —
+ * or any soft edge that is *also* backed by a hard edge — is left intact so
+ * the orchestrator still surfaces it as a real circular dependency.
+ */
+const breakSoftOnlyCycles = (
+    tasks: Record<string, Task>,
+    dependencies: Record<string, string[]>,
+    softEdges: Set<string>,
+    hardEdges: Set<string>,
+    onCycleBroken?: (cycle: string[]) => void,
+): void => {
+    // No soft edges means nothing is breakable; skip the cycle scan entirely
+    // so a pure-static graph keeps its original, untouched code path. Any real
+    // cycle is then reported by the orchestrator's deadlock detector as before.
+    if (softEdges.size === 0) {
+        return;
+    }
+
+    const isSoftEdge = (from: string, to: string): boolean => {
+        const key = edgeKey(from, to);
+
+        // A hard contributor anywhere on the same edge makes the ordering
+        // mandatory, so the edge is never eligible for breaking.
+        return softEdges.has(key) && !hardEdges.has(key);
+    };
+
+    // Each iteration removes at most one edge, so the soft-edge count is a
+    // safe upper bound that also terminates if findCycle keeps surfacing
+    // fresh soft cycles.
+    for (let guard = softEdges.size; guard >= 0; guard -= 1) {
+        const cycle = findCycle({ dependencies, roots: [], tasks });
+
+        if (!cycle || cycle.length < 2) {
+            return;
+        }
+
+        // findCycle returns a closed path `[a, …, a]`; its edges are the
+        // consecutive pairs. Only break it when every edge is purely soft.
+        let allSoft = true;
+
+        for (let index = 0; index < cycle.length - 1; index += 1) {
+            if (!isSoftEdge(cycle[index] as string, cycle[index + 1] as string)) {
+                allSoft = false;
+
+                break;
+            }
+        }
+
+        if (!allSoft) {
+            // A hard edge is involved — leave the cycle for the
+            // orchestrator's deadlock reporter to surface fatally.
+            return;
+        }
+
+        // Drop the closing edge to break this cycle, then re-scan for more.
+        const from = cycle.at(-2) as string;
+        const to = cycle.at(-1) as string;
+
+        dependencies[from] = (dependencies[from] ?? []).filter((dep) => dep !== to);
+        softEdges.delete(edgeKey(from, to));
+
+        onCycleBroken?.(cycle);
+    }
+};
+
 /**
  * Creates a task graph from a list of tasks, resolving all dependencies.
  */
 const createTaskGraph = (initialTasks: Task[], options: CreateTaskGraphOptions): TaskGraph => {
     const tasks: Record<string, Task> = {};
     const dependencies: Record<string, string[]> = {};
+    const softEdges = new Set<string>();
+    const hardEdges = new Set<string>();
     const visited = new Set<string>();
     const queued = new Set<string>(initialTasks.map((task) => task.id));
     const queue: Task[] = [...initialTasks];
@@ -331,8 +452,14 @@ const createTaskGraph = (initialTasks: Task[], options: CreateTaskGraphOptions):
 
         const deps = resolveTaskDependencies(task, options);
 
-        for (const depTask of deps) {
+        for (const { soft, task: depTask } of deps) {
             dependencies[task.id]?.push(depTask.id);
+
+            // Record edge provenance for soft-cycle breaking below. An edge
+            // can be reached as both soft and hard (e.g. a devDependency that
+            // is *also* an explicit dependsOn); the hard contributor wins,
+            // so we track both sets and let the cycle-breaking pass decide.
+            (soft ? softEdges : hardEdges).add(edgeKey(task.id, depTask.id));
 
             // Dedup at queue-time, not just at dequeue-time. Diamond
             // graphs (multiple parents sharing a dep) used to push the
@@ -347,6 +474,13 @@ const createTaskGraph = (initialTasks: Task[], options: CreateTaskGraphOptions):
             }
         }
     }
+
+    // Tolerate cycles that run only through devDependency edges (pnpm does
+    // the same): break them with a warning instead of letting the scheduler
+    // deadlock. Cycles with any hard edge are left for the orchestrator to
+    // report fatally. Runs before root computation so roots reflect the
+    // post-break graph.
+    breakSoftOnlyCycles(tasks, dependencies, softEdges, hardEdges, options.onCycleBroken);
 
     const allDeps = new Set<string>();
 

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -1574,6 +1574,12 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
     // stripped from the graph again after preflight injection so the
     // regular runner doesn't execute them — they run via `runPersistentTasks`.
     let taskGraph = createTaskGraph([...initialTasks, ...persistentTasks], {
+        onCycleBroken: (cycle) => {
+            // A dependency cycle that runs only through devDependency edges
+            // is tolerated (pnpm does the same) — we break it and warn rather
+            // than deadlocking. Cycles with a real (static) edge stay fatal.
+            logger.warn(`Ignoring dev-only dependency cycle (build order is ambiguous): ${cycle.join(" → ")}`);
+        },
         projectGraph,
         targetDefaults: config.tasks as unknown as Record<string, Partial<TargetConfiguration>>,
         workspace,


### PR DESCRIPTION
## Problem

A dependency cycle formed **solely** by `devDependency` edges between sibling packages — common when scoping a run with `--filter` to two packages that dev-depend on each other — was reported as a fatal `Circular dependency found` deadlock. Only `peerDependency` edges were excluded from build ordering (`task-graph.ts`); `devDependency` edges became hard edges identical to `static` ones.

This contradicts pnpm, which tolerates cycles that run only through devDependencies (warns rather than errors).

## Fix

- Plumb **edge provenance** through task-graph construction: a `devDependency`-originated `^target` edge is marked *soft*; same-project and explicit `projects:` deps are always *hard*. Peer edges are still dropped entirely, as before.
- After building the graph, `breakSoftOnlyCycles` breaks any cycle whose edges are **all** soft (dropping the closing edge + firing an `onCycleBroken` callback). A cycle containing at least one hard edge — or a soft edge also backed by a hard contributor — is left intact and still surfaced fatally by the orchestrator.
- Pure-static graphs skip the new scan entirely (early return when there are no soft edges).
- The `vis` run handler wires `onCycleBroken` to `logger.warn`, so a tolerated dev-only cycle is reported as a warning instead of deadlocking.

The fix is deliberately *not* "drop devDeps like peers" — a devDependency can be a genuine build-order requirement (e.g. a sibling build plugin), so dev edges are kept as ordering constraints and only broken when they actually form an all-soft cycle.

## Tests

New `dev-dependency cycles via --filter (#411)` block in `deadlock-repro.test.ts`:
- dev-only cycle → broken at construction, `onCycleBroken` fires once, orchestrator runs both tasks to success;
- static cycle → not broken, orchestrator still throws `Circular dependency found`;
- mixed (dev + static) cycle → stays fatal.

These are genuinely red without the fix.

## Verification

- task-runner full suite: **729 passed**, `tsc` clean, ESLint clean on changed files.
- vis: `tsc` clean, ESLint clean.
- CodeRabbit review (high effort): **no findings**.

Refs #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `vis run` now better handles task-graph cycles: ambiguities related to build order produce a warning and are ignored so the run can continue, while true dependency cycles still halt execution as errors. This reduces false-positive failures during runs and surfaces non-fatal build-order issues to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->