### PR TITLE
fix(task-runner): vite-task#396 lingering-child hang + #411 cycle guard

### DIFF
--- a/packages/tooling/task-runner/__tests__/unit/task-graph.test.ts
+++ b/packages/tooling/task-runner/__tests__/unit/task-graph.test.ts
@@ -125,6 +125,49 @@ describe(createTaskGraph, () => {
         expect(graph.dependencies["app:build"]).toContain("lib-b:build");
     });
 
+    it("does not create a build-order cycle from a peer-dependency back-edge (vite-task#411)", () => {
+        expect.assertions(3);
+
+        // app → builder via dependencies; builder → app via peerDependencies.
+        // The peer back-edge must NOT become a build-order edge, else the two
+        // `^build` targets would form a false cycle (app→builder→app), which
+        // is exactly what vite-task#411 reported. pnpm/turbo exclude peer deps
+        // from build order; so do we.
+        const peerWorkspace: WorkspaceConfiguration = {
+            projects: {
+                app: { root: "packages/app", targets: { build: { command: "tsc", dependsOn: ["^build"] } } },
+                builder: { root: "packages/builder", targets: { build: { command: "tsc", dependsOn: ["^build"] } } },
+            },
+        };
+
+        const peerGraph: ProjectGraph = {
+            dependencies: {
+                app: [{ source: "app", target: "builder", type: "static" }],
+                builder: [{ source: "builder", target: "app", type: "peerDependency" }],
+            },
+            nodes: {
+                app: { data: peerWorkspace.projects["app"]!, name: "app", type: "library" },
+                builder: { data: peerWorkspace.projects["builder"]!, name: "builder", type: "library" },
+            },
+        };
+
+        const appBuild: Task = {
+            id: "app:build",
+            outputs: [],
+            overrides: {},
+            target: { project: "app", target: "build" },
+        };
+
+        const graph = createTaskGraph([appBuild], { projectGraph: peerGraph, workspace: peerWorkspace });
+
+        // app:build pulls in builder:build (the real dependencies edge)…
+        expect(graph.dependencies["app:build"]).toContain("builder:build");
+        // …but builder:build must NOT depend back on app:build (peer skipped)…
+        expect(graph.dependencies["builder:build"] ?? []).not.toContain("app:build");
+        // …so app:build is not its own transitive dependency — no cycle.
+        expect(graph.dependencies["app:build"]).not.toContain("app:build");
+    });
+
     it("should handle same-project dependencies", () => {
         expect.assertions(1);
 


### PR DESCRIPTION
From auditing the [vite-task](https://github.com/voidzero-dev/vite-task) open-issue backlog against our subsystems — verifying whether vis shares the bugs, fixing where it does.

## vite-task#396 — run hangs under cache (lingering descendant) — **FIXED (all paths)**
**vis was affected.** Reproduced directly through the seccomp binding: a tracked command that backgrounds a long-lived child (`sleep 20 &`) and exits hung instead of returning. The tracking machinery waits for the *whole process tree* / inherited-fd EOF, so a lingering descendant (an orphaned Playwright/Chromium from a vitest-browser-mode test) pins it open forever.

Found **two vectors per native path** + the fallback, all now bounded by a shared cancel signal + a 2 s post-main-exit grace:

1. **Linux seccomp — supervisor:** `SECCOMP_IOCTL_NOTIF_RECV` blocked until the whole tree exited → now `poll()`s a cancel pipe.
2. **Linux seccomp — stdout/stderr:** `read_to_end` blocked on pipe EOF held by an orphan → now a poll-based `drain_bounded`.
3. **macOS interpose:** the same two (datagram `recv` until socket EOF + stdio `read_to_end`) → ported the cancel pattern.
4. **Node preload fallback (cross-platform):** `exec()` resolved on stdio `close` → now resolves on process `exit` + grace.

Verified (Linux, helper built): normal command **~4 ms** (no grace penalty), the `sleep 20 &` cases (with and without the orphan holding stdout) return in **~2 s** instead of hanging, `fspy_seccomp` tests pass, rustfmt clean. macOS compile-checked (`aarch64-apple-darwin`); runtime-validated on the macOS CI runner.

**Not affected:** Windows IAT (no stdout/stderr capture yet, `WaitForSingleObject` waits for the main child only, grandchildren aren't injected so they don't hold the pipe — revisit when recursive injection lands).

## vite-task#411 — false build-order cycle from peer-linked siblings — **not affected (guard added)**
`task-graph.ts` already skips `peerDependency` edges for build ordering. Added a regression test reproducing the exact `app ⇄ builder` shape.

## Also audited (no change)
- **#353** (vitest SIGBUS on 64 MiB /dev/shm): not applicable — our fspy IPC is AF_UNIX sockets + named pipes, not a 4 GiB shm mapping.
- **#364** (compound-command cache replay): not applicable — `vis exec` isn't cache-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)