### PR TITLE
fix(vis): correct flag name in conflicting-schema error message

### DIFF
--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -1471,7 +1471,7 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
 
         throw new Error(
             `Target "${target}" declares conflicting \`arguments\` schemas across projects (${groups}). `
-            + `Run a single project (e.g. \`vis run ${schemasByProject[0]?.project}:${target}\` or --project=<name>) so the argument contract is unambiguous.`,
+            + `Run a single project (e.g. \`vis run ${schemasByProject[0]?.project}:${target}\` or --projects=<name>) so the argument contract is unambiguous.`,
         );
     }
 


### PR DESCRIPTION
CodeRabbit follow-up on #662 (the one unresolved thread). The error raised when multiple selected projects declare conflicting `arguments` schemas suggested `--project=<name>`, but the actual CLI flag is `--projects` (plural — see `options.projects`). One-word message fix so the suggestion is runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messaging for conflicting `arguments` schemas to reference the correct flag name (`--projects=<name>`) in `vis run` command guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->