### PR TITLE
ci: raise native-build gate deadline to ride out runner-queue spikes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -29,7 +29,7 @@ jobs:
         # Wait-for-Build-Native can burn up to 55 min when runner queues
         # back up; the discover work itself is fast (~2 min). 65 absorbs
         # both with cushion.
-        timeout-minutes: 65
+        timeout-minutes: 105
         outputs:
             matrix: "${{ steps.affected.outputs.matrix }}"
             has-benches: "${{ steps.affected.outputs.has-benches }}"
@@ -45,9 +45,13 @@ jobs:
               # Plain shell + gh api works on every runner without Ruby.
               # GitHub-hosted runner queue depth occasionally pushes the
               # gate job's start time 30+ minutes past the last build
-              # completion. 55-min step ceiling + 50-min internal deadline
-              # gives enough slack to ride that out.
-              timeout-minutes: 55
+              # completion — and on bad days the build matrix itself stays
+              # queued long enough that the old 50-min deadline timed out
+              # mid-build (check still in_progress). 85-min step ceiling +
+              # 80-min internal deadline rides out those spikes; the gate
+              # still exits in ~minutes in the common case, so the higher
+              # ceiling only costs wall-clock when the runner pool is saturated.
+              timeout-minutes: 85
               shell: "bash"
               env:
                   GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -56,7 +60,7 @@ jobs:
               run: |
                   set -euo pipefail
                   check_name="Check Native Build"
-                  deadline=$(( $(date +%s) + 3000 ))
+                  deadline=$(( $(date +%s) + 4800 ))
                   while :; do
                       # Transient HTTP 401s on secrets.GITHUB_TOKEN happen
                       # mid-poll (the token gets briefly rotated by Actions).
@@ -87,7 +91,7 @@ jobs:
                           echo "Check '$check_name' not yet registered, waiting 15s..."
                       fi
                       if [ "$(date +%s)" -ge "$deadline" ]; then
-                          echo "Timed out waiting for '$check_name' after 50 minutes"
+                          echo "Timed out waiting for '$check_name' after 80 minutes"
                           exit 1
                       fi
                       sleep 15

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -25,7 +25,7 @@ jobs:
         # Wait-for-Build-Native can burn up to 55 min when runner queues
         # back up; the publish step is fast (~3 min). 75 absorbs both
         # with cushion.
-        timeout-minutes: 75
+        timeout-minutes: 115
         permissions:
             # pkg-pr-new publish only writes a PR comment — it does not push commits.
             contents: "read"
@@ -72,9 +72,13 @@ jobs:
               # Plain shell + gh api works on every runner without Ruby.
               # GitHub-hosted runner queue depth occasionally pushes the
               # gate job's start time 30+ minutes past the last build
-              # completion. 55-min step ceiling + 50-min internal deadline
-              # gives enough slack to ride that out.
-              timeout-minutes: 55
+              # completion — and on bad days the build matrix itself stays
+              # queued long enough that the old 50-min deadline timed out
+              # mid-build (check still in_progress). 85-min step ceiling +
+              # 80-min internal deadline rides out those spikes; the gate
+              # still exits in ~minutes in the common case, so the higher
+              # ceiling only costs wall-clock when the runner pool is saturated.
+              timeout-minutes: 85
               shell: "bash"
               env:
                   GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -83,7 +87,7 @@ jobs:
               run: |
                   set -euo pipefail
                   check_name="Check Native Build"
-                  deadline=$(( $(date +%s) + 3000 ))
+                  deadline=$(( $(date +%s) + 4800 ))
                   while :; do
                       # Transient HTTP 401s on secrets.GITHUB_TOKEN happen
                       # mid-poll (the token gets briefly rotated by Actions).
@@ -114,7 +118,7 @@ jobs:
                           echo "Check '$check_name' not yet registered, waiting 15s..."
                       fi
                       if [ "$(date +%s)" -ge "$deadline" ]; then
-                          echo "Timed out waiting for '$check_name' after 50 minutes"
+                          echo "Timed out waiting for '$check_name' after 80 minutes"
                           exit 1
                       fi
                       sleep 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,9 +76,10 @@ jobs:
         needs: "files-changed"
         # "Wait for Build Native workflow" routinely burns 17-22 min on this
         # job before tests even start; runner-queue spikes have pushed that
-        # past 30. 90 min absorbs a 50-min wait (with cushion) plus the
-        # ~20-min test phase, without cancelling the matrix mid-tests.
-        timeout-minutes: 90
+        # past 30 and, on saturated days, past the old 50-min cap. 130 min
+        # absorbs an 80-min wait (with cushion) plus the ~20-min test phase,
+        # without cancelling the matrix mid-tests.
+        timeout-minutes: 130
         strategy:
             matrix:
                 include:
@@ -182,9 +183,13 @@ jobs:
               # Plain shell + gh api works on every runner without Ruby.
               # GitHub-hosted runner queue depth occasionally pushes the
               # gate job's start time 30+ minutes past the last build
-              # completion. 55-min step ceiling + 50-min internal deadline
-              # gives enough slack to ride that out.
-              timeout-minutes: 55
+              # completion — and on bad days the build matrix itself stays
+              # queued long enough that the old 50-min deadline timed out
+              # mid-build (check still in_progress). 85-min step ceiling +
+              # 80-min internal deadline rides out those spikes; the gate
+              # still exits in ~minutes in the common case, so the higher
+              # ceiling only costs wall-clock when the runner pool is saturated.
+              timeout-minutes: 85
               shell: "bash"
               env:
                   GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -193,7 +198,7 @@ jobs:
               run: |
                   set -euo pipefail
                   check_name="Check Native Build"
-                  deadline=$(( $(date +%s) + 3000 ))
+                  deadline=$(( $(date +%s) + 4800 ))
                   while :; do
                       # Transient HTTP 401s on secrets.GITHUB_TOKEN happen
                       # mid-poll (the token gets briefly rotated by Actions).
@@ -224,7 +229,7 @@ jobs:
                           echo "Check '$check_name' not yet registered or token blip, waiting 15s..."
                       fi
                       if [ "$(date +%s)" -ge "$deadline" ]; then
-                          echo "Timed out waiting for '$check_name' after 50 minutes"
+                          echo "Timed out waiting for '$check_name' after 80 minutes"
                           exit 1
                       fi
                       sleep 15
@@ -405,7 +410,7 @@ jobs:
         # Mirrors the `test` job ceiling: Build Native wait may eat up to
         # 55 min when runner queues back up; browser tests + install need
         # the remaining buffer. 90 min absorbs both without cancelling.
-        timeout-minutes: 90
+        timeout-minutes: 130
         env:
             NODE: "22"
         steps:
@@ -470,9 +475,13 @@ jobs:
               # Plain shell + gh api works on every runner without Ruby.
               # GitHub-hosted runner queue depth occasionally pushes the
               # gate job's start time 30+ minutes past the last build
-              # completion. 55-min step ceiling + 50-min internal deadline
-              # gives enough slack to ride that out.
-              timeout-minutes: 55
+              # completion — and on bad days the build matrix itself stays
+              # queued long enough that the old 50-min deadline timed out
+              # mid-build (check still in_progress). 85-min step ceiling +
+              # 80-min internal deadline rides out those spikes; the gate
+              # still exits in ~minutes in the common case, so the higher
+              # ceiling only costs wall-clock when the runner pool is saturated.
+              timeout-minutes: 85
               shell: "bash"
               env:
                   GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -481,7 +490,7 @@ jobs:
               run: |
                   set -euo pipefail
                   check_name="Check Native Build"
-                  deadline=$(( $(date +%s) + 3000 ))
+                  deadline=$(( $(date +%s) + 4800 ))
                   while :; do
                       # Transient HTTP 401s on secrets.GITHUB_TOKEN happen
                       # mid-poll (the token gets briefly rotated by Actions).
@@ -512,7 +521,7 @@ jobs:
                           echo "Check '$check_name' not yet registered or token blip, waiting 15s..."
                       fi
                       if [ "$(date +%s)" -ge "$deadline" ]; then
-                          echo "Timed out waiting for '$check_name' after 50 minutes"
+                          echo "Timed out waiting for '$check_name' after 80 minutes"
                           exit 1
                       fi
                       sleep 15


### PR DESCRIPTION
## Problem

The `Wait for Build Native workflow` gate (in `test.yml`, `codspeed.yml`, `preview-release.yaml`) polls the aggregate `Check Native Build` run via `gh api` and blocks tests until the native `.node` artifacts exist. It repeatedly failed task-runner-affected PRs (#663, #664, #666, #667 all hit it) at its **50-min internal deadline** — with the check still `in_progress`, e.g.:

```
Check 'Check Native Build' status=in_progress, waiting 15s...
Timed out waiting for 'Check Native Build' after 50 minutes
##[error]Process completed with exit code 1.
```

This is **not** a build failure — the build matrix itself was still queued/running. GitHub-hosted runner-pool saturation pushes both the gate job's start *and* the build matrix's start well past the old 50-min budget, so every push to a native-affected PR needed a manual re-run.

## Change

Give the gate enough slack to ride out queue spikes, within larger job budgets:

| | before | after |
|---|---|---|
| gate internal deadline | 50 min (`3000s`) | 80 min (`4800s`) |
| gate step ceiling (`timeout-minutes`) | 55 | 85 |
| `test.yml` job timeout | 90 | 130 |
| `codspeed.yml` job timeout | 65 | 105 |
| `preview-release.yaml` job timeout | 75 | 115 |

The gate still exits in ~minutes in the common case (artifacts already built), so the higher ceiling **only** costs wall-clock when the runner pool is genuinely saturated — exactly the case that was hard-failing before.

No logic change to the polling loop, the transient-401 retry, or the success/skip/neutral handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout windows in CI/CD workflows to provide more time for build and test processes to complete, reducing premature failures during native builds and preview releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->