### PR TITLE
fix(storage): path-traversal / URL-signing hardening + storage-client test-lint

### DIFF
--- a/packages/storage/storage-client/__tests__/core/chunked-rest-adapter-resume.test.ts
+++ b/packages/storage/storage-client/__tests__/core/chunked-rest-adapter-resume.test.ts
@@ -27,7 +27,7 @@ const captureFetchCall = (call: unknown[]): FetchArgs => {
             headers[key] = value;
         }
     } else {
-        Object.assign(headers, headersInit as Record<string, string>);
+        Object.assign(headers, headersInit);
     }
 
     return { headers, method: init?.method, url };
@@ -84,7 +84,7 @@ describe("chunked-rest-adapter resume", () => {
         // 5. GET — result
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "file-123", size: 100, status: "completed" }),
+            json: async () => { return { id: "file-123", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -134,7 +134,7 @@ describe("chunked-rest-adapter resume", () => {
         // 4. GET result
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "existing-id", size: 100, status: "completed" }),
+            json: async () => { return { id: "existing-id", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -163,7 +163,7 @@ describe("chunked-rest-adapter resume", () => {
             uploadUrl: "stale-id",
         });
 
-        const adapter = createChunkedRestAdapter({ chunkSize: 100, endpoint: ENDPOINT, urlStorage, retry: false });
+        const adapter = createChunkedRestAdapter({ chunkSize: 100, endpoint: ENDPOINT, retry: false, urlStorage });
 
         // 1. HEAD probe — 404 Gone
         mockFetch.mockResolvedValueOnce({
@@ -195,7 +195,7 @@ describe("chunked-rest-adapter resume", () => {
         // 6. GET result
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "fresh-id", size: 100, status: "completed" }),
+            json: async () => { return { id: "fresh-id", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -247,7 +247,7 @@ describe("chunked-rest-adapter resume", () => {
         // 5. GET result
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "snap-id", size: 100, status: "completed" }),
+            json: async () => { return { id: "snap-id", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -298,7 +298,7 @@ describe("chunked-rest-adapter resume", () => {
         // 4. GET result.
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "resumed-id", size: 100, status: "completed" }),
+            json: async () => { return { id: "resumed-id", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -309,7 +309,6 @@ describe("chunked-rest-adapter resume", () => {
         let observedAfterProbe = -1;
         const originalUpdate = control._updateOffset.bind(control);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional spy
         (control as any)._updateOffset = (offset: number): void => {
             if (observedAfterProbe === -1) {
                 observedAfterProbe = offset;
@@ -379,12 +378,12 @@ describe("chunked-rest-adapter resume", () => {
         // 3. PATCH hangs until the signal fires.
         mockFetch.mockImplementationOnce(
             async (_url: string, init?: RequestInit) =>
-                new Promise<Response>((_, reject) => {
+                new Promise<Response>((_resolve, reject) => {
                     init?.signal?.addEventListener("abort", () => {
-                        const err = new Error("Aborted");
+                        const error = new Error("Aborted");
 
-                        err.name = "AbortError";
-                        reject(err);
+                        error.name = "AbortError";
+                        reject(error);
                     });
                 }),
         );
@@ -430,7 +429,7 @@ describe("chunked-rest-adapter resume", () => {
         });
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "file-pause", size: 100, status: "completed" }),
+            json: async () => { return { id: "file-pause", size: 100, status: "completed" }; },
             ok: true,
         });
 
@@ -499,7 +498,7 @@ describe("chunked-rest-adapter resume", () => {
         // 6. GET result.
         mockFetch.mockResolvedValueOnce({
             headers: new Headers(),
-            json: async () => ({ id: "fresh-id", size: 100, status: "completed" }),
+            json: async () => { return { id: "fresh-id", size: 100, status: "completed" }; },
             ok: true,
         });
 

--- a/packages/storage/storage-client/__tests__/core/tus-adapter-resume.test.ts
+++ b/packages/storage/storage-client/__tests__/core/tus-adapter-resume.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createTusAdapter } from "../../src/core/tus-adapter";
 import { defaultFingerprint } from "../../src/core/fingerprint";
+import { createTusAdapter } from "../../src/core/tus-adapter";
 import { UploadControl } from "../../src/core/upload-control";
 import { MemoryUrlStorage } from "../../src/core/url-storage";
 
@@ -28,7 +28,7 @@ const captureFetchCall = (call: unknown[]): FetchArgs => {
             headers[key] = value;
         }
     } else {
-        Object.assign(headers, headersInit as Record<string, string>);
+        Object.assign(headers, headersInit);
     }
 
     return { body: init?.body, headers, method: init?.method, url };
@@ -338,12 +338,12 @@ describe("tus-adapter resume", () => {
         // PATCH delays so we can abort mid-flight via the control.
         mockFetch.mockImplementationOnce(
             async (_url: string, init?: RequestInit) =>
-                new Promise<Response>((_, reject) => {
+                new Promise<Response>((_resolve, reject) => {
                     init?.signal?.addEventListener("abort", () => {
-                        const err = new Error("Aborted");
+                        const error = new Error("Aborted");
 
-                        err.name = "AbortError";
-                        reject(err);
+                        error.name = "AbortError";
+                        reject(error);
                     });
                 }),
         );

--- a/packages/storage/storage-client/__tests__/core/upload-control.test.ts
+++ b/packages/storage/storage-client/__tests__/core/upload-control.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { UploadControl, type UploadControlSnapshot } from "../../src/core/upload-control";
+import type { UploadControlSnapshot } from "../../src/core/upload-control";
+import { UploadControl } from "../../src/core/upload-control";
 
-const makeMeta = () => ({
-    endpoint: "http://localhost/api/upload",
-    fingerprint: "tus::http://localhost/api/upload::test.bin::100::application/octet-stream::0",
-    protocol: "tus" as const,
-    uploadUrl: "http://localhost/api/upload/123",
-});
+const makeMeta = () => {
+    return {
+        endpoint: "http://localhost/api/upload",
+        fingerprint: "tus::http://localhost/api/upload::test.bin::100::application/octet-stream::0",
+        protocol: "tus" as const,
+        uploadUrl: "http://localhost/api/upload/123",
+    };
+};
 
 describe(UploadControl, () => {
     it("starts with all metadata undefined and offset 0", () => {

--- a/packages/storage/storage-client/__tests__/core/url-storage.test.ts
+++ b/packages/storage/storage-client/__tests__/core/url-storage.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { defaultUrlStorage, LocalStorageUrlStorage, MemoryUrlStorage, type UrlStorageEntry } from "../../src/core/url-storage";
+import type { UrlStorageEntry } from "../../src/core/url-storage";
+import { defaultUrlStorage, LocalStorageUrlStorage, MemoryUrlStorage } from "../../src/core/url-storage";
 
-const makeEntry = (overrides: Partial<UrlStorageEntry> = {}): UrlStorageEntry => ({
-    createdAt: 1_700_000_000_000,
-    endpoint: "http://localhost/api/upload",
-    fingerprint: "tus::http://localhost/api/upload::test.bin::100::application/octet-stream::0",
-    lastModified: 0,
-    protocol: "tus",
-    size: 100,
-    uploadUrl: "http://localhost/api/upload/123",
-    ...overrides,
-});
+const makeEntry = (overrides: Partial<UrlStorageEntry> = {}): UrlStorageEntry => {
+    return {
+        createdAt: 1_700_000_000_000,
+        endpoint: "http://localhost/api/upload",
+        fingerprint: "tus::http://localhost/api/upload::test.bin::100::application/octet-stream::0",
+        lastModified: 0,
+        protocol: "tus",
+        size: 100,
+        uploadUrl: "http://localhost/api/upload/123",
+        ...overrides,
+    };
+};
 
 interface MemoryStore {
     getItem: (key: string) => string | null;
@@ -92,7 +95,7 @@ describe(MemoryUrlStorage, () => {
         const entries = await storage.listEntries();
 
         expect(entries).toHaveLength(2);
-        expect(entries.map((entry) => entry.fingerprint).sort()).toStrictEqual(["a", "b"]);
+        expect(entries.map((entry) => entry.fingerprint).toSorted((first, second) => first.localeCompare(second))).toStrictEqual(["a", "b"]);
     });
 });
 

--- a/packages/storage/storage-client/__tests__/solid/abort-and-retry.test.ts
+++ b/packages/storage/storage-client/__tests__/solid/abort-and-retry.test.ts
@@ -12,26 +12,28 @@ type FakeAdapter = {
 
 const lastAdapter: { current: FakeAdapter | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const adapter: FakeAdapter = {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: {
-                retryBatch: vi.fn(),
-                retryItem: vi.fn(),
-            },
-        };
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const adapter: FakeAdapter = {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: {
+                    retryBatch: vi.fn(),
+                    retryItem: vi.fn(),
+                },
+            };
 
-        lastAdapter.current = adapter;
+            lastAdapter.current = adapter;
 
-        return adapter;
-    }),
-}));
+            return adapter;
+        }),
+    };
+});
 
 const { createAbortAll } = await import("../../src/solid/create-abort-all");
 const { createAbortBatch } = await import("../../src/solid/create-abort-batch");

--- a/packages/storage/storage-client/__tests__/solid/listeners.test.ts
+++ b/packages/storage/storage-client/__tests__/solid/listeners.test.ts
@@ -24,7 +24,7 @@ const createStubUploader = (): {
     });
 
     const emit = (event: UploaderEventType, payload: UploadItem | BatchState): void => {
-        handlers.get(event)?.forEach((handler) => handler(payload));
+        handlers.get(event)?.forEach((handler) => { handler(payload); });
     };
 
     return { emit, handlers, off, on };
@@ -33,23 +33,25 @@ const createStubUploader = (): {
 type StubUploader = ReturnType<typeof createStubUploader>;
 const stubRef: { current: StubUploader | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const stub = createStubUploader();
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const stub = createStubUploader();
 
-        stubRef.current = stub;
+            stubRef.current = stub;
 
-        return {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: stub,
-        };
-    }),
-}));
+            return {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: stub,
+            };
+        }),
+    };
+});
 
 const { createAllAbortListener } = await import("../../src/solid/create-all-abort-listener");
 const { createBatchCancelledListener } = await import("../../src/solid/create-batch-cancelled-listener");
@@ -60,27 +62,31 @@ const { createBatchProgressListener } = await import("../../src/solid/create-bat
 const { createBatchStartListener } = await import("../../src/solid/create-batch-start-listener");
 const { createRetryListener } = await import("../../src/solid/create-retry-listener");
 
-const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => ({
-    completed: 0,
-    file: new File(["x"], "x.txt"),
-    id: "item-1",
-    loaded: 0,
-    retryCount: 0,
-    size: 1,
-    status: "pending",
-    ...overrides,
-});
+const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => {
+    return {
+        completed: 0,
+        file: new File(["x"], "x.txt"),
+        id: "item-1",
+        loaded: 0,
+        retryCount: 0,
+        size: 1,
+        status: "pending",
+        ...overrides,
+    };
+};
 
-const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => ({
-    completedCount: 0,
-    errorCount: 0,
-    id: "batch-1",
-    itemIds: ["item-1"],
-    progress: 0,
-    status: "pending",
-    totalCount: 1,
-    ...overrides,
-});
+const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => {
+    return {
+        completedCount: 0,
+        errorCount: 0,
+        id: "batch-1",
+        itemIds: ["item-1"],
+        progress: 0,
+        status: "pending",
+        totalCount: 1,
+        ...overrides,
+    };
+};
 
 // Runs a Solid `onMount` factory inside a `createRoot` so onMount + onCleanup
 // fire. We need to actually mount via solid-js/web's render to trigger
@@ -116,7 +122,7 @@ describe("solid listener factories", () => {
             expect.assertions(4);
 
             const onAbort = vi.fn();
-            const { dispose } = await runInRoot(() => createAllAbortListener({ endpoint: "/upload", onAbort }));
+            const { dispose } = await runInRoot(() => { createAllAbortListener({ endpoint: "/upload", onAbort }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("ITEM_ABORT", expect.any(Function));
 
@@ -139,7 +145,7 @@ describe("solid listener factories", () => {
 
             const onBatchCancelled = vi.fn();
             const batch = makeBatch({ status: "cancelled" });
-            const { dispose } = await runInRoot(() => createBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }));
+            const { dispose } = await runInRoot(() => { createBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_CANCELLED", expect.any(Function));
             stubRef.current?.emit("BATCH_CANCELLED", batch);
@@ -156,7 +162,7 @@ describe("solid listener factories", () => {
 
             const onBatchError = vi.fn();
             const batch = makeBatch({ errorCount: 1, status: "error" });
-            const { dispose } = await runInRoot(() => createBatchErrorListener({ endpoint: "/upload", onBatchError }));
+            const { dispose } = await runInRoot(() => { createBatchErrorListener({ endpoint: "/upload", onBatchError }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_ERROR", expect.any(Function));
             stubRef.current?.emit("BATCH_ERROR", batch);
@@ -173,7 +179,7 @@ describe("solid listener factories", () => {
 
             const onBatchFinalize = vi.fn();
             const batch = makeBatch({ completedCount: 1, status: "completed" });
-            const { dispose } = await runInRoot(() => createBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }));
+            const { dispose } = await runInRoot(() => { createBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINALIZE", expect.any(Function));
             stubRef.current?.emit("BATCH_FINALIZE", batch);
@@ -190,7 +196,7 @@ describe("solid listener factories", () => {
 
             const onBatchFinish = vi.fn();
             const batch = makeBatch({ progress: 100, status: "completed" });
-            const { dispose } = await runInRoot(() => createBatchFinishListener({ endpoint: "/upload", onBatchFinish }));
+            const { dispose } = await runInRoot(() => { createBatchFinishListener({ endpoint: "/upload", onBatchFinish }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINISH", expect.any(Function));
             stubRef.current?.emit("BATCH_FINISH", batch);
@@ -208,7 +214,7 @@ describe("solid listener factories", () => {
             const onBatchProgress = vi.fn();
             const batch = makeBatch({ progress: 42, status: "uploading" });
 
-            await runInRoot(() => createBatchProgressListener({ endpoint: "/upload", onBatchProgress }));
+            await runInRoot(() => { createBatchProgressListener({ endpoint: "/upload", onBatchProgress }); });
 
             stubRef.current?.emit("BATCH_PROGRESS", batch);
             stubRef.current?.emit("BATCH_PROGRESS", makeItem());
@@ -226,7 +232,7 @@ describe("solid listener factories", () => {
             const onBatchStart = vi.fn();
             const batch = makeBatch({ status: "uploading" });
 
-            await runInRoot(() => createBatchStartListener({ endpoint: "/upload", onBatchStart }));
+            await runInRoot(() => { createBatchStartListener({ endpoint: "/upload", onBatchStart }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_START", expect.any(Function));
             stubRef.current?.emit("BATCH_START", batch);
@@ -242,7 +248,7 @@ describe("solid listener factories", () => {
             const first = makeItem({ retryCount: 0 });
             const retried = makeItem({ id: "item-2", retryCount: 4 });
 
-            await runInRoot(() => createRetryListener({ endpoint: "/upload", onRetry }));
+            await runInRoot(() => { createRetryListener({ endpoint: "/upload", onRetry }); });
 
             stubRef.current?.emit("ITEM_START", first);
             stubRef.current?.emit("ITEM_START", retried);

--- a/packages/storage/storage-client/__tests__/svelte/abort-and-retry.test.ts
+++ b/packages/storage/storage-client/__tests__/svelte/abort-and-retry.test.ts
@@ -14,26 +14,28 @@ type FakeAdapter = {
 
 const lastAdapter: { current: FakeAdapter | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const adapter: FakeAdapter = {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: {
-                retryBatch: vi.fn(),
-                retryItem: vi.fn(),
-            },
-        };
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const adapter: FakeAdapter = {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: {
+                    retryBatch: vi.fn(),
+                    retryItem: vi.fn(),
+                },
+            };
 
-        lastAdapter.current = adapter;
+            lastAdapter.current = adapter;
 
-        return adapter;
-    }),
-}));
+            return adapter;
+        }),
+    };
+});
 
 const { createAbortAll } = await import("../../src/svelte/create-abort-all");
 const { createAbortBatch } = await import("../../src/svelte/create-abort-batch");

--- a/packages/storage/storage-client/__tests__/svelte/listeners.test.ts
+++ b/packages/storage/storage-client/__tests__/svelte/listeners.test.ts
@@ -25,7 +25,7 @@ const createStubUploader = (): {
     });
 
     const emit = (event: UploaderEventType, payload: UploadItem | BatchState): void => {
-        handlers.get(event)?.forEach((handler) => handler(payload));
+        handlers.get(event)?.forEach((handler) => { handler(payload); });
     };
 
     return { emit, handlers, off, on };
@@ -34,23 +34,25 @@ const createStubUploader = (): {
 type StubUploader = ReturnType<typeof createStubUploader>;
 const stubRef: { current: StubUploader | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const stub = createStubUploader();
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const stub = createStubUploader();
 
-        stubRef.current = stub;
+            stubRef.current = stub;
 
-        return {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: stub,
-        };
-    }),
-}));
+            return {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: stub,
+            };
+        }),
+    };
+});
 
 const { createAllAbortListener } = await import("../../src/svelte/create-all-abort-listener");
 const { createBatchCancelledListener } = await import("../../src/svelte/create-batch-cancelled-listener");
@@ -61,31 +63,33 @@ const { createBatchProgressListener } = await import("../../src/svelte/create-ba
 const { createBatchStartListener } = await import("../../src/svelte/create-batch-start-listener");
 const { createRetryListener } = await import("../../src/svelte/create-retry-listener");
 
-const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => ({
-    completed: 0,
-    file: new File(["x"], "x.txt"),
-    id: "item-1",
-    loaded: 0,
-    retryCount: 0,
-    size: 1,
-    status: "pending",
-    ...overrides,
-});
-
-const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => ({
-    completedCount: 0,
-    errorCount: 0,
-    id: "batch-1",
-    itemIds: ["item-1"],
-    progress: 0,
-    status: "pending",
-    totalCount: 1,
-    ...overrides,
-});
-
-const mountListener = (listener: () => void): { unmount: () => void } => {
-    return render(ListenerHost, { props: { listener } });
+const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => {
+    return {
+        completed: 0,
+        file: new File(["x"], "x.txt"),
+        id: "item-1",
+        loaded: 0,
+        retryCount: 0,
+        size: 1,
+        status: "pending",
+        ...overrides,
+    };
 };
+
+const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => {
+    return {
+        completedCount: 0,
+        errorCount: 0,
+        id: "batch-1",
+        itemIds: ["item-1"],
+        progress: 0,
+        status: "pending",
+        totalCount: 1,
+        ...overrides,
+    };
+};
+
+const mountListener = (listener: () => void): { unmount: () => void } => render(ListenerHost, { props: { listener } });
 
 beforeEach(() => {
     stubRef.current = undefined;
@@ -110,7 +114,7 @@ describe("svelte listener factories", () => {
             const onAbort = vi.fn();
             const item = makeItem({ status: "aborted" });
 
-            mountListener(() => createAllAbortListener({ endpoint: "/upload", onAbort }));
+            mountListener(() => { createAllAbortListener({ endpoint: "/upload", onAbort }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("ITEM_ABORT", expect.any(Function));
 
@@ -130,7 +134,7 @@ describe("svelte listener factories", () => {
             const onBatchCancelled = vi.fn();
             const batch = makeBatch({ status: "cancelled" });
 
-            mountListener(() => createBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }));
+            mountListener(() => { createBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_CANCELLED", expect.any(Function));
             stubRef.current?.emit("BATCH_CANCELLED", batch);
@@ -148,7 +152,7 @@ describe("svelte listener factories", () => {
             const onBatchError = vi.fn();
             const batch = makeBatch({ errorCount: 1, status: "error" });
 
-            mountListener(() => createBatchErrorListener({ endpoint: "/upload", onBatchError }));
+            mountListener(() => { createBatchErrorListener({ endpoint: "/upload", onBatchError }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_ERROR", expect.any(Function));
             stubRef.current?.emit("BATCH_ERROR", batch);
@@ -163,7 +167,7 @@ describe("svelte listener factories", () => {
             const onBatchFinalize = vi.fn();
             const batch = makeBatch({ completedCount: 1, status: "completed" });
 
-            mountListener(() => createBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }));
+            mountListener(() => { createBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINALIZE", expect.any(Function));
             stubRef.current?.emit("BATCH_FINALIZE", batch);
@@ -178,7 +182,7 @@ describe("svelte listener factories", () => {
             const onBatchFinish = vi.fn();
             const batch = makeBatch({ progress: 100, status: "completed" });
 
-            mountListener(() => createBatchFinishListener({ endpoint: "/upload", onBatchFinish }));
+            mountListener(() => { createBatchFinishListener({ endpoint: "/upload", onBatchFinish }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINISH", expect.any(Function));
             stubRef.current?.emit("BATCH_FINISH", batch);
@@ -193,7 +197,7 @@ describe("svelte listener factories", () => {
             const onBatchProgress = vi.fn();
             const batch = makeBatch({ progress: 50, status: "uploading" });
 
-            mountListener(() => createBatchProgressListener({ endpoint: "/upload", onBatchProgress }));
+            mountListener(() => { createBatchProgressListener({ endpoint: "/upload", onBatchProgress }); });
 
             stubRef.current?.emit("BATCH_PROGRESS", batch);
             stubRef.current?.emit("BATCH_PROGRESS", makeItem());
@@ -211,7 +215,7 @@ describe("svelte listener factories", () => {
             const onBatchStart = vi.fn();
             const batch = makeBatch({ status: "uploading" });
 
-            mountListener(() => createBatchStartListener({ endpoint: "/upload", onBatchStart }));
+            mountListener(() => { createBatchStartListener({ endpoint: "/upload", onBatchStart }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_START", expect.any(Function));
             stubRef.current?.emit("BATCH_START", batch);
@@ -227,7 +231,7 @@ describe("svelte listener factories", () => {
             const first = makeItem({ retryCount: 0, status: "uploading" });
             const retried = makeItem({ id: "item-2", retryCount: 3, status: "uploading" });
 
-            mountListener(() => createRetryListener({ endpoint: "/upload", onRetry }));
+            mountListener(() => { createRetryListener({ endpoint: "/upload", onRetry }); });
 
             stubRef.current?.emit("ITEM_START", first);
             stubRef.current?.emit("ITEM_START", retried);

--- a/packages/storage/storage-client/__tests__/vue/abort-and-retry.test.ts
+++ b/packages/storage/storage-client/__tests__/vue/abort-and-retry.test.ts
@@ -16,26 +16,28 @@ type FakeAdapter = {
 
 const lastAdapter: { current: FakeAdapter | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const adapter: FakeAdapter = {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: {
-                retryBatch: vi.fn(),
-                retryItem: vi.fn(),
-            },
-        };
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const adapter: FakeAdapter = {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: {
+                    retryBatch: vi.fn(),
+                    retryItem: vi.fn(),
+                },
+            };
 
-        lastAdapter.current = adapter;
+            lastAdapter.current = adapter;
 
-        return adapter;
-    }),
-}));
+            return adapter;
+        }),
+    };
+});
 
 const { useAbortAll } = await import("../../src/vue/use-abort-all");
 const { useAbortBatch } = await import("../../src/vue/use-abort-batch");

--- a/packages/storage/storage-client/__tests__/vue/listeners.test.ts
+++ b/packages/storage/storage-client/__tests__/vue/listeners.test.ts
@@ -25,7 +25,7 @@ const createStubUploader = (): {
     });
 
     const emit = (event: UploaderEventType, payload: UploadItem | BatchState): void => {
-        handlers.get(event)?.forEach((handler) => handler(payload));
+        handlers.get(event)?.forEach((handler) => { handler(payload); });
     };
 
     return { emit, handlers, off, on };
@@ -34,23 +34,25 @@ const createStubUploader = (): {
 type StubUploader = ReturnType<typeof createStubUploader>;
 const stubRef: { current: StubUploader | undefined } = { current: undefined };
 
-vi.mock("../../src/core/multipart-adapter", () => ({
-    createMultipartAdapter: vi.fn(() => {
-        const stub = createStubUploader();
+vi.mock("../../src/core/multipart-adapter", () => {
+    return {
+        createMultipartAdapter: vi.fn(() => {
+            const stub = createStubUploader();
 
-        stubRef.current = stub;
+            stubRef.current = stub;
 
-        return {
-            abort: vi.fn(),
-            abortBatch: vi.fn(),
-            abortItem: vi.fn(),
-            clear: vi.fn(),
-            upload: vi.fn(),
-            uploadBatch: vi.fn(),
-            uploader: stub,
-        };
-    }),
-}));
+            return {
+                abort: vi.fn(),
+                abortBatch: vi.fn(),
+                abortItem: vi.fn(),
+                clear: vi.fn(),
+                upload: vi.fn(),
+                uploadBatch: vi.fn(),
+                uploader: stub,
+            };
+        }),
+    };
+});
 
 const { useAllAbortListener } = await import("../../src/vue/use-all-abort-listener");
 const { useBatchCancelledListener } = await import("../../src/vue/use-batch-cancelled-listener");
@@ -61,27 +63,31 @@ const { useBatchProgressListener } = await import("../../src/vue/use-batch-progr
 const { useBatchStartListener } = await import("../../src/vue/use-batch-start-listener");
 const { useRetryListener } = await import("../../src/vue/use-retry-listener");
 
-const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => ({
-    completed: 0,
-    file: new File(["x"], "x.txt"),
-    id: "item-1",
-    loaded: 0,
-    retryCount: 0,
-    size: 1,
-    status: "pending",
-    ...overrides,
-});
+const makeItem = (overrides: Partial<UploadItem> = {}): UploadItem => {
+    return {
+        completed: 0,
+        file: new File(["x"], "x.txt"),
+        id: "item-1",
+        loaded: 0,
+        retryCount: 0,
+        size: 1,
+        status: "pending",
+        ...overrides,
+    };
+};
 
-const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => ({
-    completedCount: 0,
-    errorCount: 0,
-    id: "batch-1",
-    itemIds: ["item-1"],
-    progress: 0,
-    status: "pending",
-    totalCount: 1,
-    ...overrides,
-});
+const makeBatch = (overrides: Partial<BatchState> = {}): BatchState => {
+    return {
+        completedCount: 0,
+        errorCount: 0,
+        id: "batch-1",
+        itemIds: ["item-1"],
+        progress: 0,
+        status: "pending",
+        totalCount: 1,
+        ...overrides,
+    };
+};
 
 const mountComposable = (composable: () => void): { unmount: () => void } => {
     const Cmp = defineComponent({
@@ -111,7 +117,7 @@ describe("vue listener composables", () => {
             expect.assertions(3);
 
             const onAbort = vi.fn();
-            const { unmount } = mountComposable(() => useAllAbortListener({ endpoint: "/upload", onAbort }));
+            const { unmount } = mountComposable(() => { useAllAbortListener({ endpoint: "/upload", onAbort }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("ITEM_ABORT", expect.any(Function));
 
@@ -127,7 +133,7 @@ describe("vue listener composables", () => {
             const onAbort = vi.fn();
             const item = makeItem({ status: "aborted" });
 
-            mountComposable(() => useAllAbortListener({ endpoint: "/upload", onAbort }));
+            mountComposable(() => { useAllAbortListener({ endpoint: "/upload", onAbort }); });
 
             stubRef.current?.emit("ITEM_ABORT", item);
             // Batch payload should be ignored
@@ -145,7 +151,7 @@ describe("vue listener composables", () => {
             const onBatchCancelled = vi.fn();
             const batch = makeBatch({ status: "cancelled" });
 
-            const { unmount } = mountComposable(() => useBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }));
+            const { unmount } = mountComposable(() => { useBatchCancelledListener({ endpoint: "/upload", onBatchCancelled }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_CANCELLED", expect.any(Function));
             stubRef.current?.emit("BATCH_CANCELLED", batch);
@@ -163,7 +169,7 @@ describe("vue listener composables", () => {
             const onBatchError = vi.fn();
             const batch = makeBatch({ errorCount: 1, status: "error" });
 
-            const { unmount } = mountComposable(() => useBatchErrorListener({ endpoint: "/upload", onBatchError }));
+            const { unmount } = mountComposable(() => { useBatchErrorListener({ endpoint: "/upload", onBatchError }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_ERROR", expect.any(Function));
             stubRef.current?.emit("BATCH_ERROR", batch);
@@ -181,7 +187,7 @@ describe("vue listener composables", () => {
             const onBatchFinalize = vi.fn();
             const batch = makeBatch({ completedCount: 1, status: "completed" });
 
-            const { unmount } = mountComposable(() => useBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }));
+            const { unmount } = mountComposable(() => { useBatchFinalizeListener({ endpoint: "/upload", onBatchFinalize }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINALIZE", expect.any(Function));
             stubRef.current?.emit("BATCH_FINALIZE", batch);
@@ -199,7 +205,7 @@ describe("vue listener composables", () => {
             const onBatchFinish = vi.fn();
             const batch = makeBatch({ progress: 100, status: "completed" });
 
-            const { unmount } = mountComposable(() => useBatchFinishListener({ endpoint: "/upload", onBatchFinish }));
+            const { unmount } = mountComposable(() => { useBatchFinishListener({ endpoint: "/upload", onBatchFinish }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_FINISH", expect.any(Function));
             stubRef.current?.emit("BATCH_FINISH", batch);
@@ -217,7 +223,7 @@ describe("vue listener composables", () => {
             const onBatchProgress = vi.fn();
             const batch = makeBatch({ progress: 50, status: "uploading" });
 
-            mountComposable(() => useBatchProgressListener({ endpoint: "/upload", onBatchProgress }));
+            mountComposable(() => { useBatchProgressListener({ endpoint: "/upload", onBatchProgress }); });
 
             stubRef.current?.emit("BATCH_PROGRESS", batch);
             stubRef.current?.emit("BATCH_PROGRESS", makeItem());
@@ -235,7 +241,7 @@ describe("vue listener composables", () => {
             const onBatchStart = vi.fn();
             const batch = makeBatch({ status: "uploading" });
 
-            const { unmount } = mountComposable(() => useBatchStartListener({ endpoint: "/upload", onBatchStart }));
+            const { unmount } = mountComposable(() => { useBatchStartListener({ endpoint: "/upload", onBatchStart }); });
 
             expect(stubRef.current?.on).toHaveBeenCalledWith("BATCH_START", expect.any(Function));
             stubRef.current?.emit("BATCH_START", batch);
@@ -254,7 +260,7 @@ describe("vue listener composables", () => {
             const firstAttempt = makeItem({ retryCount: 0, status: "uploading" });
             const retriedItem = makeItem({ id: "item-2", retryCount: 1, status: "uploading" });
 
-            mountComposable(() => useRetryListener({ endpoint: "/upload", onRetry }));
+            mountComposable(() => { useRetryListener({ endpoint: "/upload", onRetry }); });
 
             stubRef.current?.emit("ITEM_START", firstAttempt);
             stubRef.current?.emit("ITEM_START", retriedItem);


### PR DESCRIPTION
Storage-package changes split out of #655 (the lint/fmt PR) so they land on alpha independently — they're unrelated to the lint/fmt feature.

**`fix(storage)` — `packages/storage/storage`** (`8054bc4`): reject unenforceable URL-signing options and harden path traversal across the provider adapters + `files/index.ts` + `ai` executors/schemas, with tests (incl. the path-traversal-hardening suite and `download-cap`).

**`test(storage-client)`** (`dcd9dbc`): clear the error-level eslint findings in `storage-client/__tests__` (`--fix --quiet`, error-severity only, so unsafe vitest autofixes are untouched; manual `_resolve` param + `.toSorted(localeCompare)`). Suite: 370 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)