### PR TITLE
fix(storage): reject unenforceable URL signing options and harden path traversal

### DIFF
--- a/packages/storage/storage/__tests__/ai/download-cap.test.ts
+++ b/packages/storage/storage/__tests__/ai/download-cap.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { executors } from "../../src/ai/internal/executors";
+import { downloadFileInputSchema, MAX_DOWNLOAD_BYTES } from "../../src/ai/internal/schemas";
+import { Files } from "../../src/files";
+import MemoryStorage from "../../src/storage/memory/memory-storage";
+
+describe("downloadFile maxBytes cap", () => {
+    it("schema accepts maxBytes up to MAX_DOWNLOAD_BYTES and rejects above it", () => {
+        expect.assertions(2);
+
+        expect(downloadFileInputSchema.safeParse({ key: "a.txt", maxBytes: MAX_DOWNLOAD_BYTES }).success).toBe(true);
+        expect(downloadFileInputSchema.safeParse({ key: "a.txt", maxBytes: MAX_DOWNLOAD_BYTES + 1 }).success).toBe(false);
+    });
+
+    it("executor refuses a maxBytes override above the absolute ceiling before any transfer", async () => {
+        expect.assertions(1);
+
+        const files = new Files({ adapter: new MemoryStorage({}) });
+
+        await expect(executors.downloadFile(files, { key: "a.txt", maxBytes: MAX_DOWNLOAD_BYTES + 1 })).rejects.toThrow(/exceeds the maximum/u);
+    });
+});

--- a/packages/storage/storage/__tests__/files/files.test.ts
+++ b/packages/storage/storage/__tests__/files/files.test.ts
@@ -340,6 +340,19 @@ describe("files facade", () => {
 
             expect(listed).toEqual(["a.txt", "b.txt"]);
         });
+
+        it("rejects a prefix containing . or .. path segments at construction", () => {
+            expect(() => makePrefixed(directory, "../escape")).toThrow(/path segments|InvalidFileName/);
+            expect(() => makePrefixed(directory, "users/../admin")).toThrow(/path segments|InvalidFileName/);
+        });
+
+        it("rejects a prefixed key that escapes the namespace via .. segments", async () => {
+            const { facade } = makePrefixed(directory, "users");
+
+            await expect(facade.head("../admin/secret")).rejects.toThrow(/path segments|InvalidFileName/);
+            await expect(facade.download("../../etc/passwd")).rejects.toThrow(/path segments|InvalidFileName/);
+            await expect(facade.upload("../escape.txt", "x")).rejects.toThrow(/path segments|InvalidFileName/);
+        });
     });
 
     describe("per-call OperationOptions", () => {

--- a/packages/storage/storage/__tests__/storage/azure/azure-storage.test.ts
+++ b/packages/storage/storage/__tests__/storage/azure/azure-storage.test.ts
@@ -177,9 +177,34 @@ describe("azureStorage authentication & signed URLs", () => {
         expect(readUrl).toBe("https://test-account.blob.core.windows.net/c/file.txt?sig=shared-key");
         expect(generateSasUrlMock).toHaveBeenCalledTimes(1);
 
-        await storage.getUploadUrl("file.txt", { contentType: "text/plain" });
+        await storage.getUploadUrl("file.txt", { expiresIn: 600 });
 
         expect(generateSasUrlMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects unenforceable contentType/contentLength on upload URLs", async () => {
+        expect.assertions(2);
+
+        const storage = new AzureStorage({
+            ...baseOptions,
+            accountKey: "test-account-key",
+            accountName: "test-account",
+        });
+
+        await expect(storage.getUploadUrl("file.txt", { contentType: "text/plain" })).rejects.toThrow(/contentType.*not supported/u);
+        await expect(storage.getUploadUrl("file.txt", { contentLength: 1024 })).rejects.toThrow(/not supported/u);
+    });
+
+    it("rejects responseContentDisposition on the pre-issued sasToken read path", async () => {
+        expect.assertions(1);
+
+        const storage = new AzureStorage({
+            ...baseOptions,
+            accountName: "test-account",
+            sasToken: "sv=2021-08-06&sig=preissued",
+        });
+
+        await expect(storage.getReadUrl("file.txt", { responseContentDisposition: "attachment" })).rejects.toThrow(/not supported|require a freshly minted SAS/u);
     });
 
     it("mints a User Delegation SAS when given a Microsoft Entra credential", async () => {

--- a/packages/storage/storage/__tests__/storage/bun-s3/bun-s3-storage.test.ts
+++ b/packages/storage/storage/__tests__/storage/bun-s3/bun-s3-storage.test.ts
@@ -306,10 +306,18 @@ describe(BunS3Storage, () => {
             const client = makeClient();
             const storage = makeStorage(client);
 
-            const url = await storage.getUploadUrl("file.mp4", { contentLength: 999, contentType: "video/mp4", expiresIn: 60 });
+            const url = await storage.getUploadUrl("file.mp4", { contentType: "video/mp4", expiresIn: 60 });
 
             expect(url).toBe("https://signed.example/put");
             expect(client.presign).toHaveBeenCalledWith("file.mp4", expect.objectContaining({ expiresIn: 60, method: "PUT", type: "video/mp4" }));
+        });
+
+        it("getUploadUrl rejects an unenforceable contentLength", async () => {
+            expect.assertions(1);
+
+            const storage = makeStorage(makeClient());
+
+            await expect(storage.getUploadUrl("file.mp4", { contentLength: 999 })).rejects.toThrow(/contentLength.*not supported/u);
         });
     });
 });

--- a/packages/storage/storage/__tests__/storage/google-drive/google-drive-storage.test.ts
+++ b/packages/storage/storage/__tests__/storage/google-drive/google-drive-storage.test.ts
@@ -152,7 +152,7 @@ describe(GoogleDriveStorage, () => {
                 fields: "files(id)",
                 includeItemsFromAllDrives: true,
                 pageSize: 2,
-                q: "appProperties has { key='fsdkKey' and value='video.mp4' } and trashed=false",
+                q: "appProperties has { key='fsdkKey' and value='video.mp4' } and 'root' in parents and trashed=false",
                 supportsAllDrives: true,
             });
             expect(mockDrive.files.delete).toHaveBeenCalledWith(expect.objectContaining({ fileId: "file-1" }));

--- a/packages/storage/storage/__tests__/storage/onedrive/onedrive-storage.test.ts
+++ b/packages/storage/storage/__tests__/storage/onedrive/onedrive-storage.test.ts
@@ -149,6 +149,32 @@ describe(OneDriveStorage, () => {
         });
     });
 
+    describe("path traversal guards", () => {
+        it("rejects a rootFolderPath containing .. segments at construction", () => {
+            expect.assertions(1);
+
+            expect(
+                () =>
+                    new OneDriveStorage({
+                        ...(storageOptions as OneDriveStorageOptions),
+                        accessToken: "tok",
+                        rootFolderPath: "../escape",
+                    }),
+            ).toThrow(/path segments/);
+        });
+
+        it("rejects a key containing .. segments before building the Graph item URL", async () => {
+            expect.assertions(1);
+
+            const storage = new OneDriveStorage({
+                ...(storageOptions as OneDriveStorageOptions),
+                accessToken: "tok",
+            });
+
+            await expect(storage.getUploadUrl("../../other/file.mp4")).rejects.toThrow(/path segments/);
+        });
+    });
+
     describe(".delete()", () => {
         it("uses bare path without trailing colon for non-root items", async () => {
             expect.assertions(2);

--- a/packages/storage/storage/src/ai/internal/executors.ts
+++ b/packages/storage/storage/src/ai/internal/executors.ts
@@ -9,7 +9,7 @@ import type {
     SignUploadUrlInput,
     UploadFileInput,
 } from "./schemas";
-import { DEFAULT_MAX_DOWNLOAD_BYTES } from "./schemas";
+import { DEFAULT_MAX_DOWNLOAD_BYTES, MAX_DOWNLOAD_BYTES } from "./schemas";
 
 const serializeLastModified = (value: Date | number | string | undefined): string | undefined => {
     if (value === undefined) {
@@ -115,6 +115,13 @@ export const executors: Executors = {
 
     downloadFile: async (files: Files, { binary, key, maxBytes }: DownloadFileInput): Promise<DownloadFileResult> => {
         const limit = maxBytes ?? DEFAULT_MAX_DOWNLOAD_BYTES;
+
+        if (limit > MAX_DOWNLOAD_BYTES) {
+            throw new RangeError(
+                `downloadFile refused: maxBytes (${limit}) exceeds the maximum of ${MAX_DOWNLOAD_BYTES}. Use getFileUrl to delegate larger downloads to the client.`,
+            );
+        }
+
         const head = await files.head(key);
 
         if (typeof head.size === "number" && head.size > limit) {

--- a/packages/storage/storage/src/ai/internal/schemas.ts
+++ b/packages/storage/storage/src/ai/internal/schemas.ts
@@ -4,9 +4,17 @@ import * as z from "zod";
  * Default upper bound on `downloadFile` payload size. The tool boundary is
  * JSON, so anything larger than ~1 MiB is almost certainly a mistake (it
  * blows up the model context and the response payload). Callers can raise
- * the cap per-invocation via `maxBytes`.
+ * the cap per-invocation via `maxBytes`, up to {@link MAX_DOWNLOAD_BYTES}.
  */
 export const DEFAULT_MAX_DOWNLOAD_BYTES: number = 1024 * 1024;
+
+/**
+ * Absolute ceiling on `downloadFile` payload size. A `maxBytes` override above
+ * this is rejected so an oversized download cannot be pulled inline into the
+ * model context / JSON tool response. Use `getFileUrl` to delegate larger
+ * downloads to the client.
+ */
+export const MAX_DOWNLOAD_BYTES: number = 10 * 1024 * 1024;
 
 export const listFilesInputSchema: z.ZodObject<{
     limit: z.ZodOptional<z.ZodNumber>;
@@ -32,9 +40,10 @@ export const downloadFileInputSchema: z.ZodObject<{
     maxBytes: z
         .int()
         .positive()
+        .max(MAX_DOWNLOAD_BYTES)
         .optional()
         .meta({
-            description: `Reject downloads larger than this byte count (default ${DEFAULT_MAX_DOWNLOAD_BYTES}). Verified via head() before transferring.`,
+            description: `Reject downloads larger than this byte count (default ${DEFAULT_MAX_DOWNLOAD_BYTES}, maximum ${MAX_DOWNLOAD_BYTES}). Verified via head() before transferring.`,
         }),
 });
 

--- a/packages/storage/storage/src/files/index.ts
+++ b/packages/storage/storage/src/files/index.ts
@@ -3,6 +3,7 @@ import { PassThrough, Readable } from "node:stream";
 import { BaseStorage } from "../storage/storage";
 import type { OperationOptions } from "../storage/types";
 import type { File as StorageFile, FilePart } from "../storage/utils/file";
+import { ERRORS, throwErrorCode } from "../utils/errors";
 import type { RetryConfig } from "../utils/retry";
 
 /**
@@ -346,6 +347,17 @@ const toFileObject = (file: StorageFile, fallbackKey?: string): FileObject => {
 };
 
 /**
+ * Reject `.` and `..` path segments. A prefix or key containing them would let a caller escape the
+ * configured namespace/root once it is joined into `${prefix}/${key}` (e.g. `prefix: "users"` +
+ * `key: "../admin/secret"`), so we fail closed before any adapter call.
+ */
+const assertNoRelativeSegments = (value: string, label: string): void => {
+    if (value.split("/").some((segment) => segment === "." || segment === "..")) {
+        throwErrorCode(ERRORS.INVALID_FILE_NAME, `${label} must not contain "." or ".." path segments: "${value}"`);
+    }
+};
+
+/**
  * Trim leading/trailing slashes; collapse internal repeats. Empty prefix → "".
  */
 const normalizePrefix = (raw: string): string => {
@@ -353,10 +365,14 @@ const normalizePrefix = (raw: string): string => {
         return "";
     }
 
-    return raw
+    const normalized = raw
         .split("/")
         .filter((segment) => segment.length > 0)
         .join("/");
+
+    assertNoRelativeSegments(normalized, "prefix");
+
+    return normalized;
 };
 
 /**
@@ -526,7 +542,15 @@ export class Files<TStorage extends BaseStorage = BaseStorage> {
 
     /** Resolve a caller-supplied key into the underlying storage key. */
     private resolveKey(key: string): string {
-        return this.prefix ? `${this.prefix}/${key}` : key;
+        if (!this.prefix) {
+            return key;
+        }
+
+        const normalized = key.replace(/^\/+/u, "");
+
+        assertNoRelativeSegments(normalized, "key");
+
+        return `${this.prefix}/${normalized}`;
     }
 
     /**

--- a/packages/storage/storage/src/storage/azure/azure-storage.ts
+++ b/packages/storage/storage/src/storage/azure/azure-storage.ts
@@ -549,8 +549,11 @@ class AzureStorage extends BaseStorage {
      * (public-container) adapters return the unsigned blob URL.
      * @param key Storage key.
      * @param options Optional expiry and response content overrides. Response
-     * content overrides only apply when the adapter mints a fresh SAS.
-     * @throws {UploadError} When the adapter has no way to authorise reads.
+     * content overrides only apply when the adapter mints a fresh SAS; they are
+     * rejected on the pre-issued `sasToken` and anonymous paths, which have no
+     * signature in which to bind them.
+     * @throws {UploadError} When the adapter has no way to authorise reads, or
+     * when a response content override is supplied on a non-signing path.
      */
     public override async getReadUrl(
         key: string,
@@ -565,6 +568,13 @@ class AzureStorage extends BaseStorage {
                 ...(options?.responseContentDisposition && { contentDisposition: options.responseContentDisposition }),
                 ...(options?.responseContentType && { contentType: options.responseContentType }),
             });
+        }
+
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "azure: `responseContentDisposition`/`responseContentType` require a freshly minted SAS (construct with a shared key or Microsoft Entra credential). A pre-issued `sasToken` or anonymous public-container URL has no signature in which to bind the override, so it cannot be enforced.",
+            );
         }
 
         if (this.sasToken) {
@@ -590,11 +600,20 @@ class AzureStorage extends BaseStorage {
      * header on the PUT — a SAS cannot pin the stored content type.
      * @param key Storage key.
      * @param options Optional expiry. `contentLength` and `contentType` are
-     * accepted for interface parity but a SAS cannot enforce a size limit or
-     * pin the content type.
-     * @throws {UploadError} When the adapter cannot authorise writes.
+     * rejected: an Azure SAS does not bind the request `Content-Type` into the
+     * signature and has no server-enforced size limit, so accepting them would
+     * hand the caller a guarantee that does not hold.
+     * @throws {UploadError} When the adapter cannot authorise writes, or when an
+     * unenforceable `contentType`/`contentLength` override is supplied.
      */
     public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+        if (options?.contentType !== undefined || options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "azure: `contentType`/`contentLength` are not supported for upload URLs. An Azure SAS does not bind the request Content-Type into the signature and cannot enforce a size limit; validate both at your application gateway/proxy before issuing the SAS, or omit them and accept the unbounded PUT.",
+            );
+        }
+
         const blobClient = this.containerClient.getBlobClient(this.getFullPath(key));
 
         if (this.signer) {

--- a/packages/storage/storage/src/storage/bun-s3/bun-s3-storage.ts
+++ b/packages/storage/storage/src/storage/bun-s3/bun-s3-storage.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 
 import type { UploadError } from "../../utils/errors";
-import { wrapStorageError } from "../../utils/errors";
+import { ERRORS, throwErrorCode, wrapStorageError } from "../../utils/errors";
 import type MetaStorage from "../meta-storage";
 import { BaseStorage } from "../storage";
 import type { OperationOptions } from "../types";
@@ -418,7 +418,13 @@ class BunS3Storage extends BaseStorage<BunS3File> {
     }
 
     public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
-        // `contentLength` cannot be enforced — Bun presign has no max-size policy. Ignored by design.
+        if (options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "bun-s3: `contentLength` is not supported for upload URLs. A Bun presigned PUT has no content-length-range policy, so the cap would not bind; enforce size limits at your application gateway/proxy, or use a presigned POST form.",
+            );
+        }
+
         return this.client.presign(toKey(key), {
             ...(options?.expiresIn !== undefined && { expiresIn: options.expiresIn }),
             method: "PUT",

--- a/packages/storage/storage/src/storage/bunny/bunny-storage.ts
+++ b/packages/storage/storage/src/storage/bunny/bunny-storage.ts
@@ -434,10 +434,10 @@ class BunnyStorage extends BaseStorage<BunnyFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
-        if (options?.responseContentDisposition) {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
             return throwErrorCode(
                 ERRORS.METHOD_NOT_ALLOWED,
-                "Bunny Storage: `responseContentDisposition` is not supported — no override exists on Bunny Storage / Pull Zone URLs.",
+                "Bunny Storage: `responseContentDisposition`/`responseContentType` are not supported — no override exists on Bunny Storage / Pull Zone URLs.",
             );
         }
 

--- a/packages/storage/storage/src/storage/cloudinary/cloudinary-storage.ts
+++ b/packages/storage/storage/src/storage/cloudinary/cloudinary-storage.ts
@@ -442,6 +442,13 @@ class CloudinaryStorage extends BaseStorage<CloudinaryFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "cloudinary: `responseContentDisposition`/`responseContentType` are not supported. A public delivery URL has no signature in which to bind the override, and Cloudinary's signed download URL cannot pin an arbitrary Content-Disposition/Content-Type; set the disposition via a Cloudinary delivery transformation instead.",
+            );
+        }
+
         if (this.deliveryType === "upload") {
             return this.client.url(key, {
                 resource_type: this.resourceType,

--- a/packages/storage/storage/src/storage/dropbox/dropbox-storage.ts
+++ b/packages/storage/storage/src/storage/dropbox/dropbox-storage.ts
@@ -554,10 +554,10 @@ class DropboxStorage extends BaseStorage<DropboxFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
-        if (options?.responseContentDisposition) {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
             return throwErrorCode(
                 ERRORS.METHOD_NOT_ALLOWED,
-                "Dropbox: `responseContentDisposition` is not supported — Dropbox temporary links have no Content-Disposition override.",
+                "Dropbox: `responseContentDisposition`/`responseContentType` are not supported — Dropbox temporary links have no Content-Disposition/Content-Type override.",
             );
         }
 

--- a/packages/storage/storage/src/storage/firebase/firebase-storage.ts
+++ b/packages/storage/storage/src/storage/firebase/firebase-storage.ts
@@ -372,6 +372,13 @@ class FirebaseStorage extends BaseStorage<FirebaseFile> {
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
         if (this.publicBaseUrl) {
+            if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
+                return throwErrorCode(
+                    ERRORS.BAD_REQUEST,
+                    "Firebase: `responseContentDisposition`/`responseContentType` are not supported when `publicBaseUrl` is configured — a static public URL has no signature in which to bind the override.",
+                );
+            }
+
             return `${this.publicBaseUrl}/${key}`;
         }
 
@@ -381,6 +388,8 @@ class FirebaseStorage extends BaseStorage<FirebaseFile> {
             const [url] = await this.bucket.file(key).getSignedUrl({
                 action: "read",
                 expires: Date.now() + expiresIn * 1000,
+                ...(options?.responseContentDisposition !== undefined && { responseDisposition: options.responseContentDisposition }),
+                ...(options?.responseContentType !== undefined && { responseType: options.responseContentType }),
             });
 
             return url;
@@ -390,6 +399,13 @@ class FirebaseStorage extends BaseStorage<FirebaseFile> {
     }
 
     public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+        if (options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "Firebase: `contentLength` is not supported for upload URLs. A GCS signed PUT has no content-length-range policy, so the cap would not bind; enforce size limits at your application gateway/proxy before issuing the URL.",
+            );
+        }
+
         const expiresIn = options?.expiresIn ?? this.defaultUrlExpiresIn;
 
         try {

--- a/packages/storage/storage/src/storage/google-drive/google-drive-storage.ts
+++ b/packages/storage/storage/src/storage/google-drive/google-drive-storage.ts
@@ -563,10 +563,10 @@ class GoogleDriveStorage extends BaseStorage<GoogleDriveFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
-        if (options?.responseContentDisposition) {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
             return throwErrorCode(
                 ERRORS.METHOD_NOT_ALLOWED,
-                "Google Drive: `responseContentDisposition` is not supported — Drive's webContentLink has no Content-Disposition override.",
+                "Google Drive: `responseContentDisposition`/`responseContentType` are not supported — Drive's webContentLink has no Content-Disposition/Content-Type override.",
             );
         }
 
@@ -584,6 +584,13 @@ class GoogleDriveStorage extends BaseStorage<GoogleDriveFile> {
     }
 
     public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+        if (options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "Google Drive: `contentLength` is not supported for upload URLs. A Drive resumable upload session does not enforce a server-side content-length policy, so the cap would not bind; enforce size limits at your application gateway/proxy before issuing the session URL.",
+            );
+        }
+
         if (!this.authForTokens) {
             return throwErrorCode(
                 ERRORS.METHOD_NOT_ALLOWED,
@@ -605,10 +612,6 @@ class GoogleDriveStorage extends BaseStorage<GoogleDriveFile> {
 
         if (options?.contentType) {
             headers["X-Upload-Content-Type"] = options.contentType;
-        }
-
-        if (options?.contentLength !== undefined) {
-            headers["X-Upload-Content-Length"] = String(options.contentLength);
         }
 
         const initBody = {
@@ -653,7 +656,12 @@ class GoogleDriveStorage extends BaseStorage<GoogleDriveFile> {
             return cached;
         }
 
-        const q = `appProperties has { key='${KEY_PROP}' and value='${escapeQueryValue(key)}' } and trashed=false`;
+        // Scope the lookup to the configured root folder. Without the `in parents` clause this
+        // query searches every file the credentials can see (My Drive + shared drives + anything
+        // shared with the service account), so a foreign file carrying a matching appProperties key
+        // would resolve and escape the adapter's root. All adapter-created files are written into
+        // `rootFolderId` (see write/copy/getUploadUrl), so the filter never excludes our own files.
+        const q = `appProperties has { key='${KEY_PROP}' and value='${escapeQueryValue(key)}' } and '${escapeQueryValue(this.rootFolderId)}' in parents and trashed=false`;
         const response = await this.runOperation(options, () =>
             this.driveClient.files.list({
                 ...this.sharedDriveParams,

--- a/packages/storage/storage/src/storage/onedrive/onedrive-storage.ts
+++ b/packages/storage/storage/src/storage/onedrive/onedrive-storage.ts
@@ -61,6 +61,22 @@ const trimSlashes = (s: string): string => {
     return start === 0 && end === s.length ? s : s.slice(start, end);
 };
 
+/**
+ * Reject `.` and `..` path segments. Microsoft Graph resolves `..` inside `/root:/` item paths, so
+ * a key or `rootFolderPath` containing relative segments would escape the configured root folder.
+ * `encodeURIComponent` leaves `.`/`..` untouched, so the guard must run before encoding.
+ */
+const assertNoRelativeSegments = (value: string, label: string): void => {
+    if (
+        trimSlashes(value)
+            .split("/")
+            .filter(Boolean)
+            .some((segment) => segment === "." || segment === "..")
+    ) {
+        throw new Error(`OneDrive storage: ${label} must not contain "." or ".." path segments.`);
+    }
+};
+
 const encodePathSegments = (path: string): string =>
     path
         .split("/")
@@ -294,6 +310,7 @@ class OneDriveStorage extends BaseStorage<OneDriveFile> {
             this.basePath = "/me/drive";
         }
 
+        assertNoRelativeSegments(config.rootFolderPath ?? "", "rootFolderPath");
         this.rootFolderPath = trimSlashes(config.rootFolderPath ?? "");
         this.publicByDefault = config.publicByDefault ?? false;
         this.copyTimeoutMs = config.copyTimeoutMs ?? 60_000;
@@ -645,6 +662,13 @@ class OneDriveStorage extends BaseStorage<OneDriveFile> {
     }
 
     public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+        if (options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "OneDrive: `contentLength` is not supported for upload URLs. A Graph upload session does not enforce a server-side content-length policy, so the cap would not bind; enforce size limits at your application gateway/proxy before issuing the session URL.",
+            );
+        }
+
         const session = (await this.client.api(this.itemActionPath(key, "createUploadSession")).post({
             item: {
                 "@microsoft.graph.conflictBehavior": "replace",
@@ -664,6 +688,8 @@ class OneDriveStorage extends BaseStorage<OneDriveFile> {
     }
 
     private keyParts(key: string): string[] {
+        assertNoRelativeSegments(key, "key");
+
         const inner = trimSlashes(key);
         const parts: string[] = [];
 
@@ -708,6 +734,8 @@ class OneDriveStorage extends BaseStorage<OneDriveFile> {
      * **not** with the configured base path (`/me/drive`, `/drives/{id}`, …).
      */
     private parentReferencePath(key: string): string {
+        assertNoRelativeSegments(key, "key");
+
         const inner = trimSlashes(key);
         const parts: string[] = [];
 

--- a/packages/storage/storage/src/storage/pocketbase/pocketbase-storage.ts
+++ b/packages/storage/storage/src/storage/pocketbase/pocketbase-storage.ts
@@ -443,6 +443,13 @@ class PocketBaseStorage extends BaseStorage<PocketBaseFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
+            return throwErrorCode(
+                ERRORS.METHOD_NOT_ALLOWED,
+                "PocketBase: `responseContentDisposition`/`responseContentType` are not supported — PocketBase file URLs have no Content-Disposition/Content-Type override.",
+            );
+        }
+
         if (this.publicBaseUrl) {
             return `${this.publicBaseUrl.replace(/\/+$/, "")}/${key}`;
         }

--- a/packages/storage/storage/src/storage/supabase/supabase-storage.ts
+++ b/packages/storage/storage/src/storage/supabase/supabase-storage.ts
@@ -429,7 +429,14 @@ class SupabaseStorage extends BaseStorage<SupabaseFile> {
         return data.signedUrl;
     }
 
-    public override async getUploadUrl(key: string, _options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+    public override async getUploadUrl(key: string, options?: { contentLength?: number; contentType?: string; expiresIn?: number }): Promise<string> {
+        if (options?.contentType !== undefined || options?.contentLength !== undefined) {
+            return throwErrorCode(
+                ERRORS.BAD_REQUEST,
+                "Supabase: `contentType`/`contentLength` are not supported for upload URLs. A Supabase signed upload URL does not bind the request Content-Type into the signature and cannot enforce a size limit; validate both at your application gateway/proxy before issuing the URL.",
+            );
+        }
+
         const { data, error } = await this.storageClient.from(this.bucket).createSignedUploadUrl(key);
 
         if (error || !data) {

--- a/packages/storage/storage/src/storage/uploadthing/uploadthing-storage.ts
+++ b/packages/storage/storage/src/storage/uploadthing/uploadthing-storage.ts
@@ -363,10 +363,10 @@ class UploadThingStorage extends BaseStorage<UploadThingFile> {
         key: string,
         options?: { expiresIn?: number; responseContentDisposition?: string; responseContentType?: string },
     ): Promise<string> {
-        if (options?.responseContentDisposition) {
+        if (options?.responseContentDisposition !== undefined || options?.responseContentType !== undefined) {
             return throwErrorCode(
                 ERRORS.METHOD_NOT_ALLOWED,
-                "UploadThing: `responseContentDisposition` is not supported — no override exists on UploadThing CDN/signed URLs.",
+                "UploadThing: `responseContentDisposition`/`responseContentType` are not supported — no override exists on UploadThing CDN/signed URLs.",
             );
         }
 


### PR DESCRIPTION
Storage-server hardening split out of #655 (the lint/fmt PR) so it lands on alpha on its own — unrelated to the lint/fmt feature. (#655 carried it; the storage-client test-lint portion already merged via #669, but this `fix(storage)` commit missed that merge window.)

- Reject unenforceable URL-signing options and harden key path-traversal across the provider adapters (`azure`, `bunny`, `bun-s3`, `cloudinary`, `dropbox`, `firebase`, `google-drive`, `onedrive`, `pocketbase`, `supabase`, `uploadthing`), `files/index.ts`, and the `ai` executors/schemas.
- Tests: path-traversal-hardening suite (`files.test.ts`), `download-cap`, plus per-adapter tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security by preventing path traversal attempts using `.` and `..` segments in file paths
  * Validates unsupported content-override and request options across storage backends to prevent misconfiguration
  * Rejects incompatible options for upload and download operations early with clear error messages

* **New Features**
  * Added download size limit validation with guidance to use alternative methods for large files

* **Documentation**
  * Updated documentation for download limits and storage backend constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->