### PR TITLE
fix(task-runner): load native binding after bundling

### DIFF
--- a/packages/terminal/tui/src/core/load-native-root-binding.ts
+++ b/packages/terminal/tui/src/core/load-native-root-binding.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_WALK_UP_DEPTH = 12;
+
+/**
+ * Loads the napi-rs-generated, platform-detecting root `index.js` of this
+ * native package and returns its exports.
+ *
+ * The generated loader lives next to `package.json` at the package root (one
+ * level above `dist/`). It already does the hard part: selecting the right
+ * binary for the host platform and libc, trying the published
+ * `binding` optionalDependencies first and falling back to a locally-built
+ * `.node` addon at the root. The only thing the TypeScript side must do
+ * reliably is find and load that file.
+ *
+ * Why not a fixed relative path such as `../index.js`? Bundlers such as packem
+ * hoist shared modules into chunks at an unpredictable depth under `dist/`
+ * (for example `dist/packem_shared/`), so `../index.js` can resolve to the
+ * bundled public API, which re-exports the TS wrappers rather than the raw
+ * native functions, and the binding validation then fails. Walking up to the
+ * first directory that contains a `package.json` finds the true package root
+ * regardless of nesting: `dist/` has no `package.json`, so the walk never stops
+ * short.
+ *
+ * `require()` (not dynamic `import()`) keeps this synchronous. The generated
+ * `index.js` is ESM, but Node 22+ supports `require()` of ESM without
+ * top-level await, which the napi output never emits.
+ * @param importMetaUrl The caller's `import.meta.url`.
+ * @returns The native binding's exports.
+ */
+const loadNativeRootBinding = (importMetaUrl: string): unknown => {
+    const require = createRequire(importMetaUrl);
+    const start = dirname(fileURLToPath(importMetaUrl));
+
+    let directory = start;
+
+    for (let depth = 0; depth < MAX_WALK_UP_DEPTH; depth += 1) {
+        if (existsSync(join(directory, "package.json")) && existsSync(join(directory, "index.js"))) {
+            // eslint-disable-next-line import/no-dynamic-require -- the path is the package-root index.js, resolved by walking up at runtime
+            return require(join(directory, "index.js"));
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory) {
+            break;
+        }
+
+        directory = parent;
+    }
+
+    // Fall back to the historical relative path — correct when this module is
+    // emitted directly under dist/ without chunk hoisting.
+    // eslint-disable-next-line import/no-dynamic-require -- computed fallback path to the package-root index.js
+    return require(join(start, "..", "index.js"));
+};
+
+export default loadNativeRootBinding;

--- a/packages/terminal/tui/src/core/native-binding.ts
+++ b/packages/terminal/tui/src/core/native-binding.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-unsafe-assignment, import/no-commonjs */
-// ESM wrapper around the NAPI-RS CJS native binding
-import { createRequire } from "node:module";
+/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/no-duplicate-type-constituents */
+// ESM wrapper around the NAPI-RS native binding
+import loadNativeRootBinding from "./load-native-root-binding";
 
-const require = createRequire(import.meta.url);
-
-// Load the native binding through the NAPI-RS generated platform-detecting loader
-const native = require("../../index.js");
+// Load the native binding through the NAPI-RS generated platform-detecting
+// loader, resolved from the package root regardless of bundle nesting.
+const native = loadNativeRootBinding(import.meta.url);
 
 export interface TerminalSize {
     cols: number;

--- a/packages/terminal/tui/src/ink/log-update-native.ts
+++ b/packages/terminal/tui/src/ink/log-update-native.ts
@@ -8,6 +8,7 @@
  * line-based diffing. The Rust renderer produces minimal ANSI escape sequences
  * by comparing the current buffer against the previous frame cell-by-cell.
  */
+import loadNativeRootBinding from "../core/load-native-root-binding";
 import type { RendererConstructor, RendererInstance } from "../core/native-binding";
 import { bsu, esu } from "./write-synchronized";
 
@@ -32,9 +33,9 @@ const getRendererClass = (): RendererConstructor | undefined => {
     }
 
     try {
-        // Dynamic import to avoid hard dependency on native binding
-
-        const binding = require("../../index.js") as { Renderer: RendererConstructor };
+        // Load lazily so an unsupported platform degrades gracefully rather
+        // than hard-failing at import time.
+        const binding = loadNativeRootBinding(import.meta.url) as { Renderer: RendererConstructor };
 
         cachedRendererClass = binding.Renderer;
 

--- a/packages/tooling/secret-scanner/src/binding.ts
+++ b/packages/tooling/secret-scanner/src/binding.ts
@@ -1,17 +1,14 @@
 // Native NAPI binding loader.
 //
-// The napi-generated `index.js` at the package root is CJS and handles
-// platform-binding selection via the `@visulima/secret-scanner-binding-*`
-// optionalDependencies. We load it with `createRequire` so any bundler
-// (Vite, packem, Rollup) leaves the reference intact instead of trying to
-// statically resolve the platform-specific `.node` addon.
-
-import { createRequire } from "node:module";
+// The napi-generated `index.js` at the package root handles platform-binding
+// selection via the `@visulima/secret-scanner-binding-*` optionalDependencies.
+// `loadNativeRootBinding` requires it from the package root, walking up so the
+// reference survives however a bundler (Vite, packem, Rollup) nests this module
+// under dist/.
 
 import type * as Native from "../index.js";
+import loadNativeRootBinding from "./load-native-root-binding";
 
-const esmRequire = createRequire(import.meta.url);
-
-export const binding = esmRequire("../index.js") as typeof Native;
+export const binding = loadNativeRootBinding(import.meta.url) as typeof Native;
 
 export type * as Native from "../index.js";

--- a/packages/tooling/secret-scanner/src/load-native-root-binding.ts
+++ b/packages/tooling/secret-scanner/src/load-native-root-binding.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_WALK_UP_DEPTH = 12;
+
+/**
+ * Loads the napi-rs-generated, platform-detecting root `index.js` of this
+ * native package and returns its exports.
+ *
+ * The generated loader lives next to `package.json` at the package root (one
+ * level above `dist/`). It already does the hard part: selecting the right
+ * binary for the host platform and libc, trying the published
+ * `binding` optionalDependencies first and falling back to a locally-built
+ * `.node` addon at the root. The only thing the TypeScript side must do
+ * reliably is find and load that file.
+ *
+ * Why not a fixed relative path such as `../index.js`? Bundlers such as packem
+ * hoist shared modules into chunks at an unpredictable depth under `dist/`
+ * (for example `dist/packem_shared/`), so `../index.js` can resolve to the
+ * bundled public API, which re-exports the TS wrappers rather than the raw
+ * native functions, and the binding validation then fails. Walking up to the
+ * first directory that contains a `package.json` finds the true package root
+ * regardless of nesting: `dist/` has no `package.json`, so the walk never stops
+ * short.
+ *
+ * `require()` (not dynamic `import()`) keeps this synchronous. The generated
+ * `index.js` is ESM, but Node 22+ supports `require()` of ESM without
+ * top-level await, which the napi output never emits.
+ * @param importMetaUrl The caller's `import.meta.url`.
+ * @returns The native binding's exports.
+ */
+const loadNativeRootBinding = (importMetaUrl: string): unknown => {
+    const require = createRequire(importMetaUrl);
+    const start = dirname(fileURLToPath(importMetaUrl));
+
+    let directory = start;
+
+    for (let depth = 0; depth < MAX_WALK_UP_DEPTH; depth += 1) {
+        if (existsSync(join(directory, "package.json")) && existsSync(join(directory, "index.js"))) {
+            // eslint-disable-next-line import/no-dynamic-require -- the path is the package-root index.js, resolved by walking up at runtime
+            return require(join(directory, "index.js"));
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory) {
+            break;
+        }
+
+        directory = parent;
+    }
+
+    // Fall back to the historical relative path — correct when this module is
+    // emitted directly under dist/ without chunk hoisting.
+    // eslint-disable-next-line import/no-dynamic-require -- computed fallback path to the package-root index.js
+    return require(join(start, "..", "index.js"));
+};
+
+export default loadNativeRootBinding;

--- a/packages/tooling/task-runner/src/tracked-executor.ts
+++ b/packages/tooling/task-runner/src/tracked-executor.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { exec } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 
 import { join } from "@visulima/path";
 
@@ -187,7 +188,10 @@ export class TrackedTaskExecutor {
                     {
                         ...process.env,
                         ...env,
-                        NODE_OPTIONS: `${process.env["NODE_OPTIONS"] ?? ""} --import ${preloadFile}`.trim(),
+                        // `--import` needs a file URL, not a bare path: on Windows
+                        // a `C:\…` path is parsed as a `c:` URL scheme and rejected,
+                        // so the preload never loads and cooperative hints are lost.
+                        NODE_OPTIONS: `${process.env["NODE_OPTIONS"] ?? ""} --import ${pathToFileURL(preloadFile).href}`.trim(),
                     },
                     cwd,
                 ),

--- a/packages/tooling/task-runner/src/worktree.ts
+++ b/packages/tooling/task-runner/src/worktree.ts
@@ -45,6 +45,29 @@ const getNativeBindings = (): WorktreeBindings | undefined => {
 };
 
 /**
+ * Strips the Windows extended-length ("verbatim") prefix from a path.
+ *
+ * The Rust worktree resolver canonicalises paths, and Windows
+ * `fs::canonicalize` returns verbatim paths: `\\?\C:\…` for drives and
+ * `\\?\UNC\server\share` for network shares. Downstream `@visulima/path`
+ * joins normalise separators to `/` but keep the prefix, producing
+ * `/?/C:/…` which never matches a plain `C:/…` anchor. Stripping it at the
+ * boundary keeps the rest of the pipeline working with ordinary paths.
+ * No-op on POSIX, where the prefix never appears.
+ */
+const stripWindowsVerbatimPrefix = (path: string): string => {
+    if (path.startsWith("\\\\?\\UNC\\")) {
+        return `\\\\${path.slice(8)}`;
+    }
+
+    if (path.startsWith("\\\\?\\")) {
+        return path.slice(4);
+    }
+
+    return path;
+};
+
+/**
  * Returns the absolute path to the *main* git worktree root when
  * `workspaceRoot` is a linked worktree, or `undefined` for primary
  * checkouts and non-git directories.
@@ -57,7 +80,7 @@ const getNativeBindings = (): WorktreeBindings | undefined => {
 export const getMainWorktreeRoot = (workspaceRoot: string): string | undefined => {
     const result = getNativeBindings()?.getMainWorktreeRoot(workspaceRoot);
 
-    return typeof result === "string" && result.length > 0 ? result : undefined;
+    return typeof result === "string" && result.length > 0 ? stripWindowsVerbatimPrefix(result) : undefined;
 };
 
 /**

--- a/packages/tooling/vis/__tests__/staged/integration.test.ts
+++ b/packages/tooling/vis/__tests__/staged/integration.test.ts
@@ -140,8 +140,15 @@ describe("runStaged — integration", () => {
         });
 
         expect(result.success).toBe(true);
-        expect(readFileSync(join(root, "packages", "a", "ran-from.txt"), "utf8")).toBe(join(root, "packages", "a"));
-        expect(readFileSync(join(root, "packages", "b", "ran-from.txt"), "utf8")).toBe(join(root, "packages", "b"));
+
+        // The marker holds the child's native `process.cwd()` — backslashes on
+        // Windows — while `join` (@visulima/path) always emits forward slashes.
+        // Compare separator-normalised so the assertion checks the directory,
+        // not the platform's path style.
+        const normalize = (value: string): string => value.replaceAll("\\", "/");
+
+        expect(normalize(readFileSync(join(root, "packages", "a", "ran-from.txt"), "utf8"))).toBe(join(root, "packages", "a"));
+        expect(normalize(readFileSync(join(root, "packages", "b", "ran-from.txt"), "utf8"))).toBe(join(root, "packages", "b"));
     });
 
     it("fails the run when a task throws", async () => {

--- a/packages/tooling/vis/__tests__/util/git/subtree.test.ts
+++ b/packages/tooling/vis/__tests__/util/git/subtree.test.ts
@@ -211,7 +211,10 @@ describe("subtree split (real git)", () => {
 
         expect(tracked).toStrictEqual(["extra.js", "index.js"]);
         expect(countCommits("main", output)).toBe(2);
-    });
+        // `subtree split` shells out to git several times over real history;
+        // on Windows the process spawns are slow enough to blow the default
+        // 5s timeout, so give this real-git scenario more headroom.
+    }, 30_000);
 });
 
 describe(defaultGitRunner, () => {


### PR DESCRIPTION
## Problem

The `vis` **Tests** jobs have been red on `alpha` for a long time (every OS/runtime matrix job), independent of any feature PR — `nx run vis:test:coverage` failed with ~11 failures (`run-affected-tokens.test.ts` ×10 + 1 cache test). nx truncates the buffered vitest output on failed tasks, so the failing names never surfaced in CI logs.

## Root cause

The napi packages load their native addon through the napi-generated platform-detection loader at the **package root** (`index.js`, beside `package.json`, one level above `dist/`). `task-runner/src/native-binding.ts` required it via a fixed `../index.js`.

That path is correct in `src/`, but once **packem hoists the module into `dist/packem_shared/`**, `../index.js` resolves to `dist/index.js` — the *bundled public API*, which re-exports the TS wrappers (`getMainWorktreeRoot` exists) but **not** the raw native exports (`hashCommand`/`hashFile`/`runConcurrent` are `undefined`). Validation then failed, and since `a52dc4db7` made the addon **required** (hard-throw, no JS fallback), `loadNativeBindings` threw — breaking `getMainWorktreeRoot` → `resolveSharedCacheRoot` → every `vis run` cache resolution.

## Fix

Add `load-native-root-binding.ts` (byte-identical in all three native packages): it walks up from `import.meta.url` to the first directory containing a `package.json` and loads the `index.js` beside it, so the root loader is found regardless of how deeply packem nests the chunk (`dist/` has no `package.json`, so the walk never stops short). The generated root loader already handles platform/libc selection; the TS side just needs to *find* it bundler-agnostically.

Applied identically to `task-runner`, `secret-scanner`, and `tui` (both tui loaders) so all native packages resolve their root binding the same robust way.

## Verification (local, `CI=true`)

- `vis run-affected-tokens` (the 10 CI failures): **10/10 pass**
- full `vis` suite: **355 files, 4986 pass, 0 fail**
- `task-runner`: 750 pass · `secret-scanner`: 323 pass
- eslint clean on all 7 changed files; `secret-scanner`/`tui` typecheck clean

## Out of scope (pre-existing, not touched)

- `tui` has 47 failing rendering tests — identical on a pristine baseline, unrelated to this change.
- `task-runner/src/task-hasher.ts:865` `implicitDeps`/`implicit_deps` type error (fails `lint:types`, not vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched native addon loading to a unified ESM-aware loader across terminal and tooling packages while preserving public APIs and fallbacks.
  * Added synchronous root-binding loader used by multiple packages.
* **Bug Fix**
  * Preload/import handling now uses file URLs to improve cross-platform reliability.
* **Chores**
  * Renamed a task-runner type field to camelCase.
  * Clarified comments and lint guidance for regex cache handling.
* **Style**
  * Minor formatting and declaration-order tweaks with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->