### PR TITLE
feat(vis): add StepSecurity Threat Center supply-chain provider

### DIFF
--- a/packages/tooling/vis/README.md
+++ b/packages/tooling/vis/README.md
@@ -74,7 +74,7 @@
 
 - **`vis catalog check / update`** — pnpm + bun workspace catalog management
 - **`vis secrets`** — Rust-native secret scanning (gitleaks detection engine)
-- **`vis audit`** — OSV.dev vulnerability scanning with pluggable supply-chain providers ([Socket.dev](https://socket.dev) and [Google deps.dev](https://deps.dev), merged when both are enabled). `--explain` adds a plain-English AI explanation per finding (auto-detects an installed AI CLI, cached, no API key) in the terminal, JSON, and HTML report
+- **`vis audit`** — OSV.dev vulnerability scanning with pluggable supply-chain providers ([Socket.dev](https://socket.dev), [Google deps.dev](https://deps.dev), and [StepSecurity](https://docs.stepsecurity.io/oss-package-security/threat-center) Threat Center compromised-components, merged when more than one is enabled). `--explain` adds a plain-English AI explanation per finding (auto-detects an installed AI CLI, cached, no API key) in the terminal, JSON, and HTML report
 - **`vis docker scaffold`** — lockfile pruning for pnpm / npm / yarn classic + berry / bun, matching turbo's killer Docker-cache feature
 - **`vis hook install / migrate`** — git hooks (husky migration supported)
 - **`vis staged`** — built-in `lint-staged` replacement, no peer dependency

--- a/packages/tooling/vis/__tests__/security/marshall-registry.test.ts
+++ b/packages/tooling/vis/__tests__/security/marshall-registry.test.ts
@@ -23,6 +23,7 @@ describe(envVarFor, () => {
         ["downloads", "MARSHALL_DISABLE_DOWNLOADS"],
         ["metadata", "MARSHALL_DISABLE_METADATA"],
         ["archivedRepo", "MARSHALL_DISABLE_ARCHIVED_REPO"],
+        ["stepSecurity", "MARSHALL_DISABLE_STEP_SECURITY"],
     ])("maps %s → %s", (name, expected) => {
         expect.assertions(1);
 
@@ -149,7 +150,7 @@ describe("aLL_MARSHALLS contents", () => {
             "packageAge",
             "archivedRepo",
         ];
-        const integrations: MarshallName[] = ["minReleaseAge", "socket", "depsDev"];
+        const integrations: MarshallName[] = ["minReleaseAge", "socket", "depsDev", "stepSecurity"];
 
         expect(new Set([...policy, ...preInstall, ...integrations])).toStrictEqual(new Set(ALL_MARSHALLS));
     });

--- a/packages/tooling/vis/__tests__/security/stepsecurity-security.test.ts
+++ b/packages/tooling/vis/__tests__/security/stepsecurity-security.test.ts
@@ -1,0 +1,298 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock homedir before importing the module under test so the on-disk cache
+// lands in a throwaway directory.
+const TEST_HOME = join(tmpdir(), `vis-stepsecurity-test-${String(process.pid)}-${String(Date.now())}`);
+
+vi.mock(import("node:os"), async (importOriginal) => {
+    const original = await importOriginal<typeof import("node:os")>();
+
+    return { ...original, homedir: () => TEST_HOME };
+});
+
+const {
+    buildReport,
+    clearStepSecurityCache,
+    componentSeverity,
+    createStepSecurityProvider,
+    extractComponents,
+    extractIncidentIds,
+    fetchStepSecurityReports,
+    normaliseVersions,
+} = await import("../../src/security/stepsecurity-security");
+
+afterEach(() => {
+    clearStepSecurityCache();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.VIS_STEPSECURITY_TOKEN;
+    delete process.env.VIS_STEPSECURITY_OWNER;
+});
+
+// --- Pure helpers ---
+
+describe("normaliseVersions", () => {
+    it("returns undefined for wildcard / empty / missing", () => {
+        expect.assertions(4);
+        expect(normaliseVersions("*")).toBeUndefined();
+        expect(normaliseVersions("")).toBeUndefined();
+        expect(normaliseVersions(undefined)).toBeUndefined();
+        expect(normaliseVersions(["*"])).toBeUndefined();
+    });
+
+    it("splits comma-separated strings", () => {
+        expect.assertions(1);
+        expect(normaliseVersions("4.17.21, 4.17.20")).toStrictEqual(["4.17.21", "4.17.20"]);
+    });
+
+    it("flattens arrays", () => {
+        expect.assertions(1);
+        expect(normaliseVersions(["1.0.0", "2.0.0,2.0.1"])).toStrictEqual(["1.0.0", "2.0.0", "2.0.1"]);
+    });
+});
+
+describe("componentSeverity", () => {
+    it("defaults to critical when unscored", () => {
+        expect.assertions(1);
+        expect(componentSeverity({ ecosystem: "npm", incidentId: "i1", name: "x" })).toBe("critical");
+    });
+
+    it("respects a valid reported severity", () => {
+        expect.assertions(1);
+        expect(componentSeverity({ ecosystem: "npm", incidentId: "i1", name: "x", severity: "high" })).toBe("high");
+    });
+});
+
+describe("extractIncidentIds", () => {
+    it("reads a bare array of objects", () => {
+        expect.assertions(1);
+        expect(extractIncidentIds([{ id: "a" }, { incidentId: "b" }, { incident_id: "c" }])).toStrictEqual(["a", "b", "c"]);
+    });
+
+    it("reads the { incidents: [...] } envelope", () => {
+        expect.assertions(1);
+        expect(extractIncidentIds({ incidents: ["a", { id: "b" }] })).toStrictEqual(["a", "b"]);
+    });
+
+    it("returns [] for unrecognised shapes", () => {
+        expect.assertions(1);
+        expect(extractIncidentIds({ nope: true })).toStrictEqual([]);
+    });
+});
+
+describe("extractComponents", () => {
+    it("normalises a bare array with mixed field names", () => {
+        expect.assertions(1);
+
+        const components = extractComponents(
+            [
+                { name: "left-pad", version: "1.0.0", severity: "Critical", verified: true, description: "rat" },
+                { packageName: "@scope/pkg", ecosystem: "PyPI", affectedVersions: ["1.0", "2.0"] },
+            ],
+            "incident-1",
+        );
+
+        expect(components).toStrictEqual([
+            {
+                description: "rat",
+                ecosystem: "npm",
+                incidentId: "incident-1",
+                name: "left-pad",
+                severity: "critical",
+                verified: true,
+                versions: ["1.0.0"],
+            },
+            {
+                ecosystem: "pypi",
+                incidentId: "incident-1",
+                name: "@scope/pkg",
+                versions: ["1.0", "2.0"],
+            },
+        ]);
+    });
+
+    it("reads the { components: [...] } envelope and skips nameless rows", () => {
+        expect.assertions(1);
+
+        const components = extractComponents({ components: [{ version: "1.0.0" }, { name: "ok" }] }, "i1");
+
+        expect(components).toHaveLength(1);
+    });
+});
+
+describe("buildReport", () => {
+    it("crushes the score and emits a malware alert", () => {
+        expect.assertions(4);
+
+        const report = buildReport("left-pad", "1.0.0", [{ ecosystem: "npm", incidentId: "i1", name: "left-pad", severity: "critical" }]);
+
+        expect(report.score.overall).toBe(0);
+        expect(report.alerts).toHaveLength(1);
+        expect(report.alerts[0]).toMatchObject({ severity: "critical", type: "malware" });
+        expect(report.alerts[0]?.key).toBe("stepsecurity:i1:left-pad@1.0.0");
+    });
+
+    it("splits the namespace out of a scoped name", () => {
+        expect.assertions(2);
+
+        const report = buildReport("@scope/pkg", "2.0.0", [{ ecosystem: "npm", incidentId: "i1", name: "@scope/pkg" }]);
+
+        expect(report.name).toBe("pkg");
+        expect(report.namespace).toBe("@scope");
+    });
+});
+
+// --- Provider factory ---
+
+describe("createStepSecurityProvider", () => {
+    it("returns undefined when disabled", () => {
+        expect.assertions(1);
+        expect(createStepSecurityProvider({ apiToken: "t", enabled: false, owner: "o" })).toBeUndefined();
+    });
+
+    it("returns undefined when token or owner missing", () => {
+        expect.assertions(2);
+        expect(createStepSecurityProvider({ enabled: true, owner: "o" })).toBeUndefined();
+        expect(createStepSecurityProvider({ apiToken: "t", enabled: true })).toBeUndefined();
+    });
+
+    it("falls back to env credentials", () => {
+        expect.assertions(2);
+
+        process.env.VIS_STEPSECURITY_TOKEN = "env-token";
+        process.env.VIS_STEPSECURITY_OWNER = "env-owner";
+
+        const provider = createStepSecurityProvider({ enabled: true });
+
+        expect(provider).toBeDefined();
+        expect(provider?.id).toBe("step-security");
+    });
+});
+
+// --- Network flow ---
+
+describe("fetchStepSecurityReports", () => {
+    it("returns empty for no packages", async () => {
+        expect.assertions(1);
+
+        const result = await fetchStepSecurityReports([], {
+            apiBaseUrl: "https://api.stepsecurity.io",
+            apiToken: "t",
+            cacheTtlMs: 1000,
+            owner: "o",
+            timeoutMs: 1000,
+        });
+
+        expect(result.size).toBe(0);
+    });
+
+    it("matches a compromised npm package and flags it", async () => {
+        expect.assertions(3);
+
+        const fetchMock = vi.fn(async (url: string) => {
+            if (url.endsWith("/threat-intel/incidents")) {
+                return new Response(JSON.stringify([{ id: "inc-1" }]), { status: 200 });
+            }
+
+            return new Response(
+                JSON.stringify({
+                    components: [
+                        { ecosystem: "npm", name: "evil-pkg", severity: "critical", version: "1.2.3" },
+                        { ecosystem: "pypi", name: "evil-pkg", version: "9.9.9" },
+                    ],
+                }),
+                { status: 200 },
+            );
+        });
+
+        vi.stubGlobal("fetch", fetchMock);
+
+        const options = {
+            apiBaseUrl: "https://api.stepsecurity.io",
+            apiToken: "t",
+            cacheTtlMs: 60_000,
+            owner: "o",
+            timeoutMs: 1000,
+        };
+
+        const result = await fetchStepSecurityReports(
+            [
+                { name: "evil-pkg", version: "1.2.3" },
+                { name: "evil-pkg", version: "9.9.9" }, // only the pypi entry matches this version → npm provider ignores it
+                { name: "safe-pkg", version: "1.0.0" },
+            ],
+            options,
+        );
+
+        expect(result.has("evil-pkg@1.2.3")).toBe(true);
+        expect(result.has("safe-pkg@1.0.0")).toBe(false);
+        expect(result.get("evil-pkg@1.2.3")?.alerts[0]).toMatchObject({ severity: "critical", type: "malware" });
+    });
+
+    it("treats a versionless component as compromising every version", async () => {
+        expect.assertions(1);
+
+        const fetchMock = vi.fn(async (url: string) => {
+            if (url.endsWith("/threat-intel/incidents")) {
+                return new Response(JSON.stringify(["inc-1"]), { status: 200 });
+            }
+
+            return new Response(JSON.stringify([{ ecosystem: "npm", name: "wholly-bad", version: "*" }]), { status: 200 });
+        });
+
+        vi.stubGlobal("fetch", fetchMock);
+
+        const result = await fetchStepSecurityReports([{ name: "wholly-bad", version: "7.0.0" }], {
+            apiBaseUrl: "https://api.stepsecurity.io",
+            apiToken: "t",
+            cacheTtlMs: 60_000,
+            owner: "o",
+            timeoutMs: 1000,
+        });
+
+        expect(result.has("wholly-bad@7.0.0")).toBe(true);
+    });
+
+    it("degrades gracefully when the incident feed fails", async () => {
+        expect.assertions(1);
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => new Response("nope", { status: 500 })),
+        );
+
+        const result = await fetchStepSecurityReports([{ name: "x", version: "1.0.0" }], {
+            apiBaseUrl: "https://api.stepsecurity.io",
+            apiToken: "t",
+            cacheTtlMs: 60_000,
+            owner: "o",
+            timeoutMs: 1000,
+        });
+
+        expect(result.size).toBe(0);
+    });
+
+    it("honours pinned incidentIds and skips the feed call", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify([{ ecosystem: "npm", name: "pinned-bad", version: "1.0.0" }]), { status: 200 }));
+
+        vi.stubGlobal("fetch", fetchMock);
+
+        const result = await fetchStepSecurityReports([{ name: "pinned-bad", version: "1.0.0" }], {
+            apiBaseUrl: "https://api.stepsecurity.io",
+            apiToken: "t",
+            cacheTtlMs: 60_000,
+            incidentIds: ["pinned-incident"],
+            owner: "o",
+            timeoutMs: 1000,
+        });
+
+        expect(result.has("pinned-bad@1.0.0")).toBe(true);
+        // Only the compromised-components endpoint is hit — never the feed.
+        expect(fetchMock.mock.calls.every(([url]) => String(url).includes("/compromised-components"))).toBe(true);
+    });
+});

--- a/packages/tooling/vis/docs/commands/audit.mdx
+++ b/packages/tooling/vis/docs/commands/audit.mdx
@@ -5,7 +5,7 @@ description: "Audit installed packages for known vulnerabilities and supply-chai
 
 # vis audit
 
-`vis audit` scans every installed package (resolved from the lockfile) against the OSV vulnerability database and, when configured, one or more supply-chain intelligence providers — [Socket.dev](https://socket.dev) and [Google deps.dev](https://deps.dev) (the latter ships OpenSSF Scorecard signals + GHSA advisories and needs no API token).
+`vis audit` scans every installed package (resolved from the lockfile) against the OSV vulnerability database and, when configured, one or more supply-chain intelligence providers — [Socket.dev](https://socket.dev), [Google deps.dev](https://deps.dev) (ships OpenSSF Scorecard signals + GHSA advisories, no API token), and [StepSecurity](https://docs.stepsecurity.io/oss-package-security/threat-center) (Threat Center compromised-component intelligence; flags packages tied to known supply-chain incidents).
 
 It defaults to the local **offline OSV cache** populated by [`vis advisories sync`](./advisories.mdx) — no network access required at scan time. Falls back to the live OSV API when no cache is present.
 
@@ -227,8 +227,17 @@ export default defineConfig({
             // (24h project data, 7d versions + advisories).
             enabled: true,
         },
-        // When both providers are enabled, this controls which one's
-        // `score` wins on merge. Alerts from the secondary are still
+        stepSecurity: {
+            // StepSecurity Threat Center compromised components. Flags any
+            // name@version tied to a supply-chain incident (tj-actions, nx,
+            // the axios npm compromise, …) with a critical malware alert.
+            // Enterprise feature — needs a GitHub owner + API token
+            // (VIS_STEPSECURITY_OWNER / VIS_STEPSECURITY_TOKEN).
+            enabled: true,
+            owner: "my-org",
+        },
+        // When multiple providers are enabled, this controls which one's
+        // `score` wins on merge. Alerts from the secondaries are still
         // appended and deduped by `key`.
         primaryProvider: "socket",
         // Workspace-scoped acknowledged risks (shared across all policies).

--- a/packages/tooling/vis/docs/commands/cache.mdx
+++ b/packages/tooling/vis/docs/commands/cache.mdx
@@ -106,7 +106,7 @@ vis cache size --format=json    # { totalBytes, entryCount }
 
 Removes every entry. Prompts for confirmation when the cache directory is outside the workspace; pass `--force` to skip the prompt (useful in CI). `--dry-run` previews without deleting.
 
-`--type` scopes the wipe: `task` (the workspace task cache), `ai` (AI-response cache used by `vis ai`), `socket` (Socket.dev report cache used by `vis audit`), `deps-dev` (deps.dev report cache used by `vis audit`), or `all` (default).
+`--type` scopes the wipe: `task` (the workspace task cache), `ai` (AI-response cache used by `vis ai`), `socket` (Socket.dev report cache used by `vis audit`), `deps-dev` (deps.dev report cache used by `vis audit`), `snyk` (Snyk issue cache), `step-security` (StepSecurity Threat Center cache used by `vis audit`), or `all` (default).
 
 ## `vis cache verify <task>`
 

--- a/packages/tooling/vis/docs/configuration.mdx
+++ b/packages/tooling/vis/docs/configuration.mdx
@@ -399,7 +399,13 @@ export default defineConfig({
         // Optional second supply-chain provider (no auth, OpenSSF Scorecard + GHSA).
         // Off by default. Enable to cross-check Socket findings or replace them.
         depsDev: { enabled: true },
-        // When both providers are enabled, the "primary" wins score conflicts;
+        // Optional StepSecurity Threat Center provider — flags any package whose
+        // name@version appears in a supply-chain incident (tj-actions, nx, the
+        // axios npm compromise, …) with a critical malware alert. Enterprise
+        // feature: needs a GitHub owner + API token (VIS_STEPSECURITY_OWNER /
+        // VIS_STEPSECURITY_TOKEN). Off by default.
+        stepSecurity: { enabled: true, owner: "my-org" },
+        // When multiple providers are enabled, the "primary" wins score conflicts;
         // alerts always dedupe by id. Defaults to "socket".
         primaryProvider: "socket",
         allowBuilds: { esbuild: true, "@prisma/client": true },

--- a/packages/tooling/vis/docs/guides/security-audit.mdx
+++ b/packages/tooling/vis/docs/guides/security-audit.mdx
@@ -241,6 +241,7 @@ This writes the accepted risks into the appropriate PM config (`pnpm-workspace.y
 | -------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Socket.dev** (`socket`)        | Public token / `VIS_SOCKET_TOKEN` | Five-axis package score (quality, maintenance, supply chain, license, vulnerability), curated alerts (malware, install scripts, telemetry, typosquats), version-scoped data. |
 | **Google deps.dev** (`deps-dev`) | None                              | OpenSSF Scorecard signals (16 automated checks) + GHSA advisories, no API token, generous rate limits, completely free.                                                      |
+| **StepSecurity** (`step-security`) | Owner + token (`VIS_STEPSECURITY_OWNER` / `VIS_STEPSECURITY_TOKEN`) | [Threat Center](https://docs.stepsecurity.io/oss-package-security/threat-center) compromised-component intelligence — flags any `name@version` tied to a supply-chain incident (tj-actions, nx, the axios npm compromise, …) with a `critical` malware alert. No score signal for clean packages. Enterprise feature. |
 
 ```ts
 // vis.config.ts
@@ -250,6 +251,10 @@ export default defineConfig({
     security: {
         socket: { enabled: true }, // requires VIS_SOCKET_TOKEN
         depsDev: { enabled: true }, // no auth — safe to enable in CI
+
+        // Threat Center compromised components. Requires VIS_STEPSECURITY_TOKEN
+        // and the GitHub owner that owns the Threat Center.
+        stepSecurity: { enabled: true, owner: "my-org" },
 
         // Which provider's `score` wins on conflict. Alerts from the other
         // provider are still appended and deduped by `key`.
@@ -271,10 +276,11 @@ When both providers return data for the same package:
 
 | Env var                       | Effect                                                 |
 | ----------------------------- | ------------------------------------------------------ |
-| `MARSHALL_DISABLE_SOCKET=1`   | Skip the Socket.dev provider for the current process.  |
-| `MARSHALL_DISABLE_DEPS_DEV=1` | Skip the deps.dev provider for the current process.    |
-| `MARSHALL_DISABLE_ALL=1`      | Skip every marshall-gated check (including providers). |
-| `--offline` on `vis audit`    | Disables both providers for this command only.         |
+| `MARSHALL_DISABLE_SOCKET=1`        | Skip the Socket.dev provider for the current process.   |
+| `MARSHALL_DISABLE_DEPS_DEV=1`      | Skip the deps.dev provider for the current process.     |
+| `MARSHALL_DISABLE_STEP_SECURITY=1` | Skip the StepSecurity provider for the current process. |
+| `MARSHALL_DISABLE_ALL=1`           | Skip every marshall-gated check (including providers).  |
+| `--offline` on `vis audit`         | Disables every network provider for this command only.  |
 
 ### Cache locations
 
@@ -282,8 +288,9 @@ Each provider writes a JSON-on-disk cache under `~/.vis/cache/`:
 
 - `socket-security/` — Socket.dev reports (default TTL: 1 hour)
 - `deps-dev/` — deps.dev version + project + advisory entries (default TTL: 24h for project data, 7d for version and advisory data — those are immutable once published)
+- `stepsecurity/` — StepSecurity Threat Center aggregated compromised-component set, one file per owner (default TTL: 1 hour)
 
-Clear with `vis cache clean --type=socket` or `vis cache clean --type=deps-dev`. `vis cache clean` (no flag) clears every store.
+Clear with `vis cache clean --type=socket`, `vis cache clean --type=deps-dev`, or `vis cache clean --type=step-security`. `vis cache clean` (no flag) clears every store.
 
 ## Reference
 

--- a/packages/tooling/vis/schemas/vis-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-config.schema.json
@@ -1716,9 +1716,10 @@
                     "enum": [
                         "deps-dev",
                         "snyk",
-                        "socket"
+                        "socket",
+                        "step-security"
                     ],
-                    "description": "Which provider wins merge conflicts when multiple are enabled (e.g. both Socket.dev and deps.dev return data for the same package). The primary provider's `score` is kept; alerts from secondaries are appended and deduped by `key`. Defaults to whichever provider is enabled first in this order: socket → deps-dev → snyk."
+                    "description": "Which provider wins merge conflicts when multiple are enabled (e.g. both Socket.dev and deps.dev return data for the same package). The primary provider's `score` is kept; alerts from secondaries are appended and deduped by `key`. Defaults to whichever provider is enabled first in this order: socket → deps-dev → snyk → step-security."
                 },
                 "snyk": {
                     "type": "object",
@@ -1780,6 +1781,48 @@
                     },
                     "additionalProperties": false,
                     "description": "Socket.dev data-source configuration. Connection knobs only — score thresholds and accepted-risk overrides moved to `policies.score` and `security.acceptedRisks` respectively."
+                },
+                "stepSecurity": {
+                    "type": "object",
+                    "properties": {
+                        "apiBaseUrl": {
+                            "type": "string",
+                            "description": "Override the StepSecurity API base URL. Only change this if you proxy the API internally.",
+                            "default": "https://api.stepsecurity.io"
+                        },
+                        "apiToken": {
+                            "type": "string",
+                            "description": "StepSecurity API token. Set via VIS_STEPSECURITY_TOKEN environment variable or here."
+                        },
+                        "cacheTtlMs": {
+                            "type": "number",
+                            "description": "Cache TTL in milliseconds for the aggregated compromised-component set. 1 hour — the set changes as new incidents land.",
+                            "default": 3600000
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable StepSecurity Threat Center scanning on install/update/check/audit commands.",
+                            "default": false
+                        },
+                        "incidentIds": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "Pin the lookup to a specific set of Threat Center incident ids instead of fetching the full incident feed. Useful for confirming exposure to a single known incident."
+                        },
+                        "owner": {
+                            "type": "string",
+                            "description": "GitHub owner / organisation that owns the Threat Center. Set via VIS_STEPSECURITY_OWNER environment variable or here."
+                        },
+                        "timeoutMs": {
+                            "type": "number",
+                            "description": "Request timeout in milliseconds for the StepSecurity API. 15 seconds.",
+                            "default": 15000
+                        }
+                    },
+                    "additionalProperties": false,
+                    "description": "StepSecurity Threat Center data-source configuration. Contributes\n*compromised-component* intelligence — the same supply-chain incident data (tj-actions, nx, the axios npm compromise, …) that powers the StepSecurity dashboard. A package whose `name@version` appears in any Threat Center incident is flagged with a `critical` malware alert; StepSecurity carries no score signal for clean packages.\n\nRequires both a GitHub owner and an API token — if either is missing the provider is skipped. The Threat Center API is a StepSecurity Enterprise feature."
                 },
                 "typosquatAllowlist": {
                     "type": "array",

--- a/packages/tooling/vis/src/commands/add/handler.ts
+++ b/packages/tooling/vis/src/commands/add/handler.ts
@@ -499,6 +499,10 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
             disabledProviders.add("deps-dev");
         }
 
+        if (isMarshallDisabled("stepSecurity")) {
+            disabledProviders.add("step-security");
+        }
+
         const securityProviders = buildEnabledProviders(visConfig?.security, {
             disabled: disabledProviders,
             minimumScore: visConfig?.security?.policies?.score?.minimum,

--- a/packages/tooling/vis/src/commands/audit/handler.ts
+++ b/packages/tooling/vis/src/commands/audit/handler.ts
@@ -474,7 +474,7 @@ const executeAudit = async (
     const disabledProviders = new Set<string>();
 
     if (isOffline) {
-        disabledProviders.add("socket").add("deps-dev");
+        disabledProviders.add("socket").add("deps-dev").add("step-security");
     } else {
         if (isMarshallDisabled("socket")) {
             disabledProviders.add("socket");
@@ -482,6 +482,10 @@ const executeAudit = async (
 
         if (isMarshallDisabled("depsDev")) {
             disabledProviders.add("deps-dev");
+        }
+
+        if (isMarshallDisabled("stepSecurity")) {
+            disabledProviders.add("step-security");
         }
     }
 

--- a/packages/tooling/vis/src/commands/cache/handler.ts
+++ b/packages/tooling/vis/src/commands/cache/handler.ts
@@ -15,6 +15,7 @@ import { diffHashDetails, findTaskInSummary, readPreviousRunSummary, readRunSumm
 import { clearDepsDevCache, getDepsDevCacheStats } from "../../security/deps-dev-security";
 import { clearSnykCache, getSnykCacheStats } from "../../security/snyk-security";
 import { clearSocketCache, getSocketCacheStats } from "../../security/socket-security";
+import { clearStepSecurityCache, getStepSecurityCacheStats } from "../../security/stepsecurity-security";
 import { getVisRunsDir, getVisWorkspaceDataDir } from "../../util/vis-paths";
 import type { CacheCleanOptions, CacheHashOptions, CacheListOptions, CachePruneOptions, CacheSizeOptions, CacheVerifyOptions, CacheWhyOptions } from "./index";
 
@@ -256,6 +257,18 @@ export const clearSnykCacheSafe = (): void => {
         }
     } catch (error: unknown) {
         pail.warn(`Failed to clear Snyk cache: ${error instanceof Error ? error.message : String(error)}`);
+    }
+};
+
+export const clearStepSecurityCacheSafe = (): void => {
+    try {
+        const stepSecurityDeleted = clearStepSecurityCache();
+
+        if (stepSecurityDeleted > 0) {
+            pail.info(`Cleared ${String(stepSecurityDeleted)} cached StepSecurity record${stepSecurityDeleted === 1 ? "" : "s"}.`);
+        }
+    } catch (error: unknown) {
+        pail.warn(`Failed to clear StepSecurity cache: ${error instanceof Error ? error.message : String(error)}`);
     }
 };
 
@@ -993,11 +1006,12 @@ export const runVerify = async (taskId: string, options: RunVerifyOptions, logge
 // response cache under ~/.vis/cache/ai, "socket" is the Socket.dev report
 // cache under ~/.vis/cache/socket-security, "deps-dev" is the Google
 // deps.dev cache under ~/.vis/cache/deps-dev, "snyk" is the Snyk issue
-// cache under ~/.vis/cache/snyk. "all" means every store.
-type CacheTarget = "all" | "ai" | "deps-dev" | "snyk" | "socket" | "task";
+// cache under ~/.vis/cache/snyk, "step-security" is the StepSecurity Threat
+// Center cache under ~/.vis/cache/stepsecurity. "all" means every store.
+type CacheTarget = "all" | "ai" | "deps-dev" | "snyk" | "socket" | "step-security" | "task";
 
 const parseCacheTarget = (raw: string | undefined): CacheTarget => {
-    if (raw === "task" || raw === "ai" || raw === "socket" || raw === "deps-dev" || raw === "snyk" || raw === "all") {
+    if (raw === "task" || raw === "ai" || raw === "socket" || raw === "deps-dev" || raw === "snyk" || raw === "step-security" || raw === "all") {
         return raw;
     }
 
@@ -1170,6 +1184,16 @@ export const cacheCleanExecute = async ({ options, visConfig, workspaceRoot: wsR
             clearSnykCacheSafe();
         }
     }
+
+    if (includesTarget(target, "step-security")) {
+        if (dryRun) {
+            const stats = getStepSecurityCacheStats();
+
+            pail.info(`Would clear ${String(stats.entries)} cached StepSecurity record${stats.entries === 1 ? "" : "s"}.`);
+        } else {
+            clearStepSecurityCacheSafe();
+        }
+    }
 };
 
 export const cachePruneExecute = async ({ options, visConfig, workspaceRoot: wsRoot }: Toolbox<Console, CachePruneOptions>): Promise<void> => {
@@ -1304,6 +1328,17 @@ export const cacheSizeExecute = async ({ options, visConfig, workspaceRoot: wsRo
             };
         }
 
+        if (includesTarget(target, "step-security")) {
+            const stats = getStepSecurityCacheStats();
+
+            payload["step-security"] = {
+                entries: stats.entries,
+                newestEntry: isoOrNull(stats.newestEntry),
+                oldestEntry: isoOrNull(stats.oldestEntry),
+                totalBytes: stats.totalSizeBytes,
+            };
+        }
+
         process.stdout.write(`${JSON.stringify(payload, undefined, 2)}\n`);
 
         return;
@@ -1335,6 +1370,10 @@ export const cacheSizeExecute = async ({ options, visConfig, workspaceRoot: wsRo
 
     if (includesTarget(target, "snyk")) {
         printAuxStatsBlock("Snyk issue cache", getSnykCacheStats());
+    }
+
+    if (includesTarget(target, "step-security")) {
+        printAuxStatsBlock("StepSecurity Threat Center cache", getStepSecurityCacheStats());
     }
 };
 

--- a/packages/tooling/vis/src/commands/cache/index.ts
+++ b/packages/tooling/vis/src/commands/cache/index.ts
@@ -15,7 +15,7 @@ const scopeOption = {
 
 const typeOption = {
     description:
-        "Cache type: 'task' (workspace task cache), 'ai' (AI response cache), 'socket' (Socket.dev reports), 'deps-dev' (Google deps.dev reports), or 'all' (default)",
+        "Cache type: 'task' (workspace task cache), 'ai' (AI response cache), 'socket' (Socket.dev reports), 'deps-dev' (Google deps.dev reports), 'snyk' (Snyk issues), 'step-security' (StepSecurity Threat Center), or 'all' (default)",
     name: "type",
     type: String,
 } as const;

--- a/packages/tooling/vis/src/commands/check/handler.ts
+++ b/packages/tooling/vis/src/commands/check/handler.ts
@@ -125,6 +125,10 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
         disabledProviders.add("deps-dev");
     }
 
+    if (isMarshallDisabled("stepSecurity")) {
+        disabledProviders.add("step-security");
+    }
+
     const minimumScore = visConfig?.security?.policies?.score?.minimum;
     const securityProviders = buildEnabledProviders(visConfig?.security, {
         disabled: disabledProviders,

--- a/packages/tooling/vis/src/commands/update/handler.ts
+++ b/packages/tooling/vis/src/commands/update/handler.ts
@@ -523,6 +523,10 @@ const executeCatalogUpdate = async (
         disabledProviders.add("deps-dev");
     }
 
+    if (isMarshallDisabled("stepSecurity")) {
+        disabledProviders.add("step-security");
+    }
+
     const minimumScore = visConfig.security?.policies?.score?.minimum;
     const securityProviders = buildEnabledProviders(visConfig.security, {
         disabled: disabledProviders,

--- a/packages/tooling/vis/src/config/types.ts
+++ b/packages/tooling/vis/src/config/types.ts
@@ -1776,9 +1776,9 @@ export interface VisConfig {
          * both Socket.dev and deps.dev return data for the same package). The
          * primary provider's `score` is kept; alerts from secondaries are
          * appended and deduped by `key`. Defaults to whichever provider is
-         * enabled first in this order: socket → deps-dev → snyk.
+         * enabled first in this order: socket → deps-dev → snyk → step-security.
          */
-        primaryProvider?: "deps-dev" | "snyk" | "socket";
+        primaryProvider?: "deps-dev" | "snyk" | "socket" | "step-security";
 
         /**
          * Snyk data-source configuration. Snyk only contributes vulnerability
@@ -1853,6 +1853,67 @@ export interface VisConfig {
 
             /**
              * Request timeout in milliseconds for the Socket.dev API. 15 seconds.
+             * @default 15000
+             */
+            timeoutMs?: number;
+        };
+
+        /**
+         * StepSecurity Threat Center data-source configuration. Contributes
+         * *compromised-component* intelligence — the same supply-chain incident
+         * data (tj-actions, nx, the axios npm compromise, …) that powers the
+         * StepSecurity dashboard. A package whose `name@version` appears in any
+         * Threat Center incident is flagged with a `critical` malware alert;
+         * StepSecurity carries no score signal for clean packages.
+         *
+         * Requires both a GitHub owner and an API token — if either is missing
+         * the provider is skipped. The Threat Center API is a StepSecurity
+         * Enterprise feature.
+         * @see https://docs.stepsecurity.io/oss-package-security/threat-center
+         */
+        stepSecurity?: {
+            /**
+             * Override the StepSecurity API base URL. Only change this if you
+             * proxy the API internally.
+             * @default "https://api.stepsecurity.io"
+             */
+            apiBaseUrl?: string;
+
+            /**
+             * StepSecurity API token. Set via VIS_STEPSECURITY_TOKEN environment
+             * variable or here.
+             */
+            apiToken?: string;
+
+            /**
+             * Cache TTL in milliseconds for the aggregated compromised-component
+             * set. 1 hour — the set changes as new incidents land.
+             * @default 3600000
+             */
+            cacheTtlMs?: number;
+
+            /**
+             * Enable StepSecurity Threat Center scanning on
+             * install/update/check/audit commands.
+             * @default false
+             */
+            enabled?: boolean;
+
+            /**
+             * Pin the lookup to a specific set of Threat Center incident ids
+             * instead of fetching the full incident feed. Useful for confirming
+             * exposure to a single known incident.
+             */
+            incidentIds?: string[];
+
+            /**
+             * GitHub owner / organisation that owns the Threat Center. Set via
+             * VIS_STEPSECURITY_OWNER environment variable or here.
+             */
+            owner?: string;
+
+            /**
+             * Request timeout in milliseconds for the StepSecurity API. 15 seconds.
              * @default 15000
              */
             timeoutMs?: number;

--- a/packages/tooling/vis/src/security/marshalls/registry.ts
+++ b/packages/tooling/vis/src/security/marshalls/registry.ts
@@ -45,6 +45,7 @@ export type MarshallName
         | "score"
         | "signatures"
         | "socket"
+        | "stepSecurity"
         | "typosquats"
         | "unexpectedDeps"
         | "vulnerability";
@@ -78,6 +79,7 @@ export const ALL_MARSHALLS: ReadonlyArray<MarshallName> = [
     "archivedRepo",
     "socket",
     "depsDev",
+    "stepSecurity",
 ] as const;
 
 /**

--- a/packages/tooling/vis/src/security/registry.ts
+++ b/packages/tooling/vis/src/security/registry.ts
@@ -15,6 +15,7 @@ import type { PackageRef, PackageReportData, SecurityProvider } from "./provider
 import { mergeReports } from "./provider";
 import { createSnykProvider } from "./snyk-security";
 import { createSocketProvider } from "./socket-security";
+import { createStepSecurityProvider } from "./stepsecurity-security";
 
 /** Options for `buildEnabledProviders`. */
 export interface BuildEnabledProvidersOptions {
@@ -59,6 +60,14 @@ export const buildEnabledProviders = (security: VisConfig["security"] | undefine
 
         if (snyk) {
             providers.push(snyk);
+        }
+    }
+
+    if (!disabled?.has("step-security")) {
+        const stepSecurity = createStepSecurityProvider(security?.stepSecurity);
+
+        if (stepSecurity) {
+            providers.push(stepSecurity);
         }
     }
 

--- a/packages/tooling/vis/src/security/stepsecurity-security.ts
+++ b/packages/tooling/vis/src/security/stepsecurity-security.ts
@@ -1,0 +1,547 @@
+/**
+ * StepSecurity Threat Center security helpers.
+ *
+ * Fetches the set of *compromised OSS components* surfaced by StepSecurity's
+ * Threat Center — the same supply-chain incident intelligence that powers the
+ * dashboard (tj-actions, nx, the axios npm compromise, …) — and normalises it
+ * to the shared `PackageReportData` shape so the registry can merge results.
+ *
+ * StepSecurity's data is *incident-scoped*: the Compromised Components API
+ * returns every compromised component tied to a single incident. To answer the
+ * provider-level question "is this `name@version` a known-compromised package?"
+ * we aggregate the compromised components across every incident in the Threat
+ * Center (or a configured subset) into one lookup, cache it on disk, then match
+ * the resolved package set against it. A match emits a `critical` malware alert;
+ * clean packages produce no report (StepSecurity has no signal for them).
+ *
+ * Two endpoints are involved, both on `https://api.stepsecurity.io`:
+ *   1. `GET /github/{owner}/threat-intel/incidents`                                   – incident feed (ids)
+ *   2. `GET /github/{owner}/threat-intel/incidents/{incidentId}/compromised-components` – components per incident
+ *
+ * Requires a GitHub owner/org + an API token (config or VIS_STEPSECURITY_OWNER /
+ * VIS_STEPSECURITY_TOKEN). The Threat Center API is a StepSecurity Enterprise
+ * feature. Network failures degrade gracefully — an unreachable Threat Center
+ * simply contributes an empty map.
+ * @see https://www.stepsecurity.io/blog/new-in-the-threat-center-compromised-components-now-available-via-api
+ * @see https://docs.stepsecurity.io/oss-package-security/threat-center
+ */
+
+import { readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+
+import { ensureDirSync, isAccessibleSync, readJsonSync } from "@visulima/fs";
+import { join } from "@visulima/path";
+
+import { getVisCacheDir } from "../util/vis-paths";
+import type { PackageAlert, PackageReportData, SecurityProvider, SecurityProviderCacheStats } from "./provider";
+
+const DEFAULT_API_BASE_URL = "https://api.stepsecurity.io";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour — the compromised set changes as new incidents land
+const MAX_PARALLEL_REQUESTS = 6;
+const MAX_INCIDENTS = 500;
+
+const getCacheDirectory = (): string => join(getVisCacheDir(), "stepsecurity");
+
+interface StepSecurityConfig {
+    /** Override the StepSecurity API base URL. @default "https://api.stepsecurity.io" */
+    apiBaseUrl?: string;
+    /** StepSecurity API token. Set via VIS_STEPSECURITY_TOKEN or here. */
+    apiToken?: string;
+    /** Cache TTL in milliseconds for the aggregated compromised-component set. */
+    cacheTtlMs?: number;
+    /** Enable StepSecurity Threat Center scanning. @default false */
+    enabled?: boolean;
+    /**
+     * Pin the lookup to a specific set of incident ids instead of fetching the
+     * full incident feed. Useful for confirming exposure to a single known
+     * incident without listing the whole Threat Center.
+     */
+    incidentIds?: string[];
+    /** GitHub owner / organisation that owns the Threat Center. Set via VIS_STEPSECURITY_OWNER or here. */
+    owner?: string;
+    /** Request timeout in milliseconds. @default 15000 */
+    timeoutMs?: number;
+}
+
+/** One compromised component as surfaced by the Threat Center, normalised. */
+interface CompromisedComponent {
+    /** Threat description / summary, when provided. */
+    description?: string;
+    /** Package ecosystem (`npm`, `pypi`, …) lowercased. */
+    ecosystem: string;
+    /** Incident this component belongs to. */
+    incidentId: string;
+    /** Package name (scope included for npm). */
+    name: string;
+    /** Severity reported by StepSecurity, lowercased. */
+    severity?: string;
+    /** Whether StepSecurity has verified the compromise. */
+    verified?: boolean;
+    /**
+     * Affected versions. `undefined` / `["*"]` means "every version" — treat
+     * the whole package as compromised.
+     */
+    versions?: string[];
+}
+
+interface CacheEntry {
+    components: CompromisedComponent[];
+    createdAt: number;
+    ttlMs: number;
+}
+
+interface FetchStepSecurityReportsOptions {
+    apiBaseUrl: string;
+    apiToken: string;
+    cacheTtlMs: number;
+    incidentIds?: string[];
+    owner: string;
+    timeoutMs: number;
+}
+
+/** Cache key is per-owner — a token only ever sees its own org's Threat Center. */
+const buildCacheKey = (owner: string): string => encodeURIComponent(owner);
+
+const readCache = (owner: string): CompromisedComponent[] | undefined => {
+    const filePath = join(getCacheDirectory(), `${buildCacheKey(owner)}.json`);
+
+    try {
+        const entry = readJsonSync(filePath) as unknown as CacheEntry;
+
+        if (Date.now() - entry.createdAt > entry.ttlMs) {
+            rmSync(filePath, { force: true });
+
+            return undefined;
+        }
+
+        return entry.components;
+    } catch {
+        return undefined;
+    }
+};
+
+const writeCache = (owner: string, components: CompromisedComponent[], ttlMs: number): void => {
+    ensureDirSync(getCacheDirectory());
+
+    const entry: CacheEntry = { components, createdAt: Date.now(), ttlMs };
+
+    writeFileSync(join(getCacheDirectory(), `${buildCacheKey(owner)}.json`), JSON.stringify(entry), "utf8");
+};
+
+/** GETs a URL and parses JSON, returning `undefined` on any network / non-2xx failure. */
+const fetchJson = async (url: string, apiToken: string, timeoutMs: number): Promise<unknown> => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            headers: {
+                Accept: "application/json",
+                Authorization: `Bearer ${apiToken}`,
+                "User-Agent": "@visulima/vis",
+            },
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            return undefined;
+        }
+
+        return await response.json();
+    } catch {
+        return undefined;
+    } finally {
+        clearTimeout(timeout);
+    }
+};
+
+/** Pull a string field from an object trying several candidate keys. */
+const pickString = (object: Record<string, unknown>, keys: string[]): string | undefined => {
+    for (const key of keys) {
+        const value = object[key];
+
+        if (typeof value === "string" && value.trim() !== "") {
+            return value.trim();
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Normalises a raw version field into a list of exact versions. Accepts a bare
+ * string, a comma-separated string (`"4.17.21,4.17.20"`), or an array. Returns
+ * `undefined` when the field signals "all versions" (`*` / empty / missing).
+ */
+const normaliseVersions = (raw: unknown): string[] | undefined => {
+    const collected: string[] = [];
+
+    const push = (value: unknown): void => {
+        if (typeof value !== "string") {
+            return;
+        }
+
+        for (const part of value.split(",")) {
+            const trimmed = part.trim();
+
+            if (trimmed !== "") {
+                collected.push(trimmed);
+            }
+        }
+    };
+
+    if (Array.isArray(raw)) {
+        for (const value of raw) {
+            push(value);
+        }
+    } else {
+        push(raw);
+    }
+
+    if (collected.length === 0 || collected.includes("*")) {
+        return undefined;
+    }
+
+    return collected;
+};
+
+/**
+ * Defensively normalises the incident-list response. The endpoint may return a
+ * bare array, `{ incidents: [...] }`, or `{ data: [...] }`; ids may live under
+ * `id`, `incidentId`, or `incident_id`.
+ */
+const extractIncidentIds = (payload: unknown): string[] => {
+    const rows = Array.isArray(payload)
+        ? payload
+        : ((payload as { data?: unknown; incidents?: unknown } | undefined)?.incidents
+            ?? (payload as { data?: unknown } | undefined)?.data);
+
+    if (!Array.isArray(rows)) {
+        return [];
+    }
+
+    const ids: string[] = [];
+
+    for (const row of rows) {
+        if (typeof row === "string") {
+            ids.push(row);
+        } else if (row && typeof row === "object") {
+            const id = pickString(row as Record<string, unknown>, ["id", "incidentId", "incident_id"]);
+
+            if (id) {
+                ids.push(id);
+            }
+        }
+    }
+
+    return ids.slice(0, MAX_INCIDENTS);
+};
+
+/**
+ * Defensively normalises a compromised-components response into the internal
+ * shape. The endpoint may return a bare array or wrap it under
+ * `components` / `compromisedComponents` / `data`.
+ */
+const extractComponents = (payload: unknown, incidentId: string): CompromisedComponent[] => {
+    const rows = Array.isArray(payload)
+        ? payload
+        : ((payload as { compromisedComponents?: unknown; components?: unknown; data?: unknown } | undefined)?.components
+            ?? (payload as { compromisedComponents?: unknown } | undefined)?.compromisedComponents
+            ?? (payload as { data?: unknown } | undefined)?.data);
+
+    if (!Array.isArray(rows)) {
+        return [];
+    }
+
+    const components: CompromisedComponent[] = [];
+
+    for (const row of rows) {
+        if (!row || typeof row !== "object") {
+            continue;
+        }
+
+        const record = row as Record<string, unknown>;
+        const name = pickString(record, ["name", "packageName", "package", "component"]);
+
+        if (!name) {
+            continue;
+        }
+
+        const ecosystem = (pickString(record, ["ecosystem", "type", "packageEcosystem"]) ?? "npm").toLowerCase();
+        const component: CompromisedComponent = {
+            ecosystem,
+            incidentId,
+            name,
+            versions: normaliseVersions(record.versions ?? record.version ?? record.affectedVersions),
+        };
+
+        const description = pickString(record, ["description", "threat", "summary"]);
+
+        if (description) {
+            component.description = description;
+        }
+
+        const severity = pickString(record, ["severity", "severityLevel"]);
+
+        if (severity) {
+            component.severity = severity.toLowerCase();
+        }
+
+        const verified = record.verified ?? record.isVerified;
+
+        if (typeof verified === "boolean") {
+            component.verified = verified;
+        }
+
+        components.push(component);
+    }
+
+    return components;
+};
+
+/**
+ * Builds (or reads from cache) the aggregated set of compromised components for
+ * the configured owner. Returns an empty array on any hard failure.
+ */
+const buildCompromisedSet = async (options: FetchStepSecurityReportsOptions): Promise<CompromisedComponent[]> => {
+    const cached = readCache(options.owner);
+
+    if (cached) {
+        return cached;
+    }
+
+    const { apiBaseUrl, apiToken, cacheTtlMs, incidentIds, owner, timeoutMs } = options;
+    const base = apiBaseUrl.replace(/\/+$/, "");
+    const ownerSegment = encodeURIComponent(owner);
+
+    let resolvedIncidentIds = incidentIds;
+
+    if (!resolvedIncidentIds || resolvedIncidentIds.length === 0) {
+        const listed = await fetchJson(`${base}/github/${ownerSegment}/threat-intel/incidents`, apiToken, timeoutMs);
+
+        resolvedIncidentIds = extractIncidentIds(listed);
+    }
+
+    if (resolvedIncidentIds.length === 0) {
+        return [];
+    }
+
+    const components: CompromisedComponent[] = [];
+    const work = [...resolvedIncidentIds];
+
+    const worker = async (): Promise<void> => {
+        for (;;) {
+            const incidentId = work.shift();
+
+            if (incidentId === undefined) {
+                return;
+            }
+
+            const payload = await fetchJson(
+                `${base}/github/${ownerSegment}/threat-intel/incidents/${encodeURIComponent(incidentId)}/compromised-components`,
+                apiToken,
+                timeoutMs,
+            );
+
+            if (payload !== undefined) {
+                components.push(...extractComponents(payload, incidentId));
+            }
+        }
+    };
+
+    await Promise.all(Array.from({ length: Math.min(MAX_PARALLEL_REQUESTS, resolvedIncidentIds.length) }, worker));
+
+    writeCache(owner, components, cacheTtlMs);
+
+    return components;
+};
+
+const VALID_SEVERITIES = new Set<PackageAlert["severity"]>(["critical", "high", "low", "medium"]);
+
+/** A compromised component is malware — default to `critical` when unscored. */
+const componentSeverity = (component: CompromisedComponent): PackageAlert["severity"] => {
+    if (component.severity && VALID_SEVERITIES.has(component.severity as PackageAlert["severity"])) {
+        return component.severity as PackageAlert["severity"];
+    }
+
+    return "critical";
+};
+
+/** A known-compromised package: every axis crushed, malware alert attached. */
+const buildReport = (name: string, version: string, components: CompromisedComponent[]): PackageReportData => {
+    const alerts: PackageAlert[] = components.map((component) => {
+        return {
+            category: "supplyChainRisk",
+            key: `stepsecurity:${component.incidentId}:${name}@${version}`,
+            props: { lastPublish: "" },
+            severity: componentSeverity(component),
+            type: "malware",
+        } satisfies PackageAlert;
+    });
+
+    const namespace = name.startsWith("@") ? (name.slice(0, name.indexOf("/")) as `@${string}`) : undefined;
+    const shortName = namespace ? name.slice(namespace.length + 1) : name;
+
+    const report: PackageReportData = {
+        alerts,
+        author: [],
+        id: `pkg:npm/${name}@${version}`,
+        license: "",
+        name: shortName,
+        score: { license: 0.5, maintenance: 0.5, overall: 0, quality: 0.5, supplyChain: 0, vulnerability: 0 },
+        size: 0,
+        type: "npm",
+        version,
+    };
+
+    if (namespace) {
+        report.namespace = namespace;
+    }
+
+    return report;
+};
+
+/**
+ * Fetches StepSecurity Threat Center reports for the given packages. Returns a
+ * map keyed by `"name@version"`, matching the shape returned by the other
+ * providers. Only *compromised* packages appear in the result — StepSecurity
+ * carries no signal for clean packages.
+ */
+export const fetchStepSecurityReports = async (
+    packages: { name: string; version: string }[],
+    options: FetchStepSecurityReportsOptions,
+): Promise<Map<string, PackageReportData>> => {
+    const results = new Map<string, PackageReportData>();
+
+    if (packages.length === 0) {
+        return results;
+    }
+
+    const components = await buildCompromisedSet(options);
+
+    if (components.length === 0) {
+        return results;
+    }
+
+    // Index npm components by lowercased name for O(1) lookup per package.
+    const byName = new Map<string, CompromisedComponent[]>();
+
+    for (const component of components) {
+        if (component.ecosystem !== "npm") {
+            continue;
+        }
+
+        const key = component.name.toLowerCase();
+        const bucket = byName.get(key);
+
+        if (bucket) {
+            bucket.push(component);
+        } else {
+            byName.set(key, [component]);
+        }
+    }
+
+    for (const pkg of packages) {
+        const candidates = byName.get(pkg.name.toLowerCase());
+
+        if (!candidates) {
+            continue;
+        }
+
+        // A component matches when it has no version constraint (whole package
+        // compromised) or explicitly lists the resolved version.
+        const matched = candidates.filter((component) => component.versions === undefined || component.versions.includes(pkg.version));
+
+        if (matched.length > 0) {
+            results.set(`${pkg.name}@${pkg.version}`, buildReport(pkg.name, pkg.version, matched));
+        }
+    }
+
+    return results;
+};
+
+export const clearStepSecurityCache = (): number => {
+    const directory = getCacheDirectory();
+
+    if (!isAccessibleSync(directory)) {
+        return 0;
+    }
+
+    let removed = 0;
+
+    for (const file of readdirSync(directory).filter((f) => f.endsWith(".json"))) {
+        rmSync(join(directory, file), { force: true });
+        removed += 1;
+    }
+
+    return removed;
+};
+
+export const getStepSecurityCacheStats = (): SecurityProviderCacheStats => {
+    const directory = getCacheDirectory();
+
+    let entries = 0;
+    let totalSizeBytes = 0;
+    let oldest: number | undefined;
+    let newest: number | undefined;
+
+    if (isAccessibleSync(directory)) {
+        for (const file of readdirSync(directory).filter((f) => f.endsWith(".json"))) {
+            const stat = statSync(join(directory, file));
+
+            entries += 1;
+            totalSizeBytes += stat.size;
+
+            if (oldest === undefined || stat.mtimeMs < oldest) {
+                oldest = stat.mtimeMs;
+            }
+
+            if (newest === undefined || stat.mtimeMs > newest) {
+                newest = stat.mtimeMs;
+            }
+        }
+    }
+
+    return { entries, newestEntry: newest, oldestEntry: oldest, totalSizeBytes };
+};
+
+/**
+ * Constructs a StepSecurity `SecurityProvider` if the config is enabled and both
+ * an owner and an API token are resolvable (config or VIS_STEPSECURITY_OWNER /
+ * VIS_STEPSECURITY_TOKEN). Returns `undefined` otherwise so the registry skips it.
+ */
+export const createStepSecurityProvider = (config: StepSecurityConfig | undefined): SecurityProvider | undefined => {
+    if (!config?.enabled) {
+        return undefined;
+    }
+
+    const apiToken = config.apiToken ?? process.env.VIS_STEPSECURITY_TOKEN;
+    const owner = config.owner ?? process.env.VIS_STEPSECURITY_OWNER;
+
+    if (!apiToken || !owner) {
+        return undefined;
+    }
+
+    const resolved: FetchStepSecurityReportsOptions = {
+        apiBaseUrl: config.apiBaseUrl ?? DEFAULT_API_BASE_URL,
+        apiToken,
+        cacheTtlMs: config.cacheTtlMs ?? DEFAULT_TTL_MS,
+        incidentIds: config.incidentIds,
+        owner,
+        timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    };
+
+    return {
+        clearCache: clearStepSecurityCache,
+        displayName: "StepSecurity",
+        fetchReports: (packages) => fetchStepSecurityReports(packages, resolved),
+        getCacheStats: getStepSecurityCacheStats,
+        id: "step-security",
+    };
+};
+
+export type { CompromisedComponent, StepSecurityConfig };
+
+export { buildReport, componentSeverity, extractComponents, extractIncidentIds, normaliseVersions };


### PR DESCRIPTION
Adds a **StepSecurity Threat Center** supply-chain security provider to `@visulima/vis`, wired in alongside the existing Socket.dev, deps.dev, and Snyk providers.

It pulls StepSecurity's [Compromised Components API](https://www.stepsecurity.io/blog/new-in-the-threat-center-compromised-components-now-available-via-api) — the same incident intelligence behind the tj-actions, nx, and axios-npm compromises — and flags any installed `name@version` tied to a supply-chain incident with a **critical malware alert**.

## What's in here

**New provider** `src/security/stepsecurity-security.ts`:
- `GET https://api.stepsecurity.io/github/{owner}/threat-intel/incidents` → incident feed, then `.../incidents/{id}/compromised-components` per incident, authenticated with `Authorization: Bearer <token>`.
- Aggregates incidents into a per-owner on-disk cache (`~/.vis/cache/stepsecurity/`, 1h TTL), matches npm packages by name + version (comma-list / wildcard aware), and degrades gracefully on any network failure.
- Defensive response parsing (tolerates several envelope/field-name shapes) since the exact JSON schema is an Enterprise-gated endpoint.
- Requires an `owner` + token (`VIS_STEPSECURITY_OWNER` / `VIS_STEPSECURITY_TOKEN`); skipped otherwise.

**Wiring** (mirrors the other providers):
- Registered in the provider registry + added to the `primaryProvider` union.
- New `security.stepSecurity` config block + regenerated `vis-config.schema.json`.
- New `stepSecurity` marshall name + `MARSHALL_DISABLE_STEP_SECURITY` env gate, threaded through the `add` / `audit` / `check` / `update` handlers (and skipped under `--offline`).
- New `vis cache --type=step-security` target (clean / stats / json).

**Docs & tests:**
- `configuration.mdx`, `commands/audit.mdx`, `commands/cache.mdx`, the `security-audit.mdx` guide (provider table, merge semantics, escape hatches, cache locations), and the package README.
- Full unit-test suite for the provider (`__tests__/security/stepsecurity-security.test.ts`).

## Notes
- The schema change was spliced to be **byte-identical to the generator's output** for the new keys (verified locally), so the drift check should pass — a full regen wasn't committed because the sandbox can't build cross-package types.
- `vitest` / `lint:types` could not run in the dev container (the `npm.jsr.io` registry is blocked, so `pnpm install` can't complete and workspace deps have no build output). Every changed file was syntax-verified via `tsc transpileModule`. **Please confirm the test suite + type-check pass in CI.**
- The exact compromised-components JSON field names aren't publicly documented (Enterprise endpoint), so the parser is intentionally tolerant — easy to tighten given a sample response.

https://claude.ai/code/session_011dgm5tBXhTMm8H9WhmdAuE