### PR TITLE
fix(tui): clear eslint errors in components

### DIFF
--- a/packages/terminal/tui/src/components/animate-presence.tsx
+++ b/packages/terminal/tui/src/components/animate-presence.tsx
@@ -111,7 +111,7 @@ export default function AnimatePresence({ children }: Props): ReactElement {
             incoming.set(key, isAnimatable(child) ? child : (child as ReactElement<AnimatableProps>));
         });
 
-        // eslint-disable-next-line react-x/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state -- AnimatePresence reconciles slots from children in an effect; "removed" slots persist with show=false until exit animation completes, so this is not pure derivation
+        // eslint-disable-next-line react-x/set-state-in-effect -- AnimatePresence reconciles slots from children in an effect; "removed" slots persist with show=false until exit animation completes, so this is not pure derivation
         setSlots((previous) => {
             const next: Slot[] = [];
             const seen = new Set<string>();

--- a/packages/terminal/tui/src/components/breadcrumb.tsx
+++ b/packages/terminal/tui/src/components/breadcrumb.tsx
@@ -42,7 +42,7 @@ export default function Breadcrumb({ currentColor = "blue", items, separator = "
                 const isLast = index === items.length - 1;
 
                 return (
-                    <Fragment key={item.key ?? `${index}:${item.label}`}>
+                    <Fragment key={item.key ?? item.label}>
                         {index > 0
                             ? (
 <Text dimColor>

--- a/packages/terminal/tui/src/components/command-palette.tsx
+++ b/packages/terminal/tui/src/components/command-palette.tsx
@@ -179,7 +179,6 @@ export default function CommandPalette({
 
         if (focusedIndexRef.current > maxIndex) {
             focusedIndexRef.current = maxIndex;
-            // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state -- focusedIndex is also driven by keystrokes via ref; cannot be derived during render
             setFocusedIndex(maxIndex);
         }
     }, [filtered]);

--- a/packages/terminal/tui/src/components/definition-list.tsx
+++ b/packages/terminal/tui/src/components/definition-list.tsx
@@ -50,6 +50,7 @@ export default function DefinitionList({ columnGap = 2, items, layout = "inline"
         return (
             <Box flexDirection="column" gap={1}>
                 {items.map((item, index) => (
+                    // eslint-disable-next-line react-x/no-array-index-key -- items expose an optional stable `key`; index is the documented fallback for keyless entries
                     <Box flexDirection="column" key={item.key ?? index}>
                         <Text bold color={termColor}>
                             {item.term}
@@ -64,6 +65,7 @@ export default function DefinitionList({ columnGap = 2, items, layout = "inline"
     return (
         <Box flexDirection="column">
             {items.map((item, index) => (
+                // eslint-disable-next-line react-x/no-array-index-key -- items expose an optional stable `key`; index is the documented fallback for keyless entries
                 <Box gap={columnGap} key={item.key ?? index}>
                     <Box flexShrink={0} width={termWidth}>
                         <Text color={termColor}>{item.term}</Text>

--- a/packages/terminal/tui/src/components/menu.tsx
+++ b/packages/terminal/tui/src/components/menu.tsx
@@ -159,7 +159,7 @@ export default function Menu({ accentColor = "blue", autoFocus = false, bordered
         if (!stillValid) {
             const next = firstEnabledIndex(rows);
 
-            // eslint-disable-next-line react-x/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state -- focusedIndex is also driven by keystrokes via ref; cannot be derived during render
+            // eslint-disable-next-line react-x/set-state-in-effect -- focusedIndex is also driven by keystrokes via ref; cannot be derived during render
             setFocusedIndex(next);
             focusedIndexRef.current = next;
         }

--- a/packages/terminal/tui/src/components/scroll/controlled-scroll-view.tsx
+++ b/packages/terminal/tui/src/components/scroll/controlled-scroll-view.tsx
@@ -395,6 +395,7 @@ export const ControlledScrollView = ({
                             return (
                                 <MeasurableItem
                                     index={index}
+                                    // eslint-disable-next-line react-x/no-array-index-key -- virtualized opaque children have no stable identity beyond position; index is the correct key
                                     key={isValidElement(child) ? child.key ?? index : index}
                                     measureKey={itemMeasureKeys[index]}
                                     onMeasure={handleItemMeasure}

--- a/packages/terminal/tui/src/components/scroll/scroll-list.tsx
+++ b/packages/terminal/tui/src/components/scroll/scroll-list.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-event-handler */
+/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
 import type React from "react";
 import type { Ref } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";

--- a/packages/terminal/tui/src/components/stepper.tsx
+++ b/packages/terminal/tui/src/components/stepper.tsx
@@ -85,6 +85,7 @@ export default function Stepper({ accentColor = "blue", activeIndex = 0, errorCo
                     const color = status === "error" ? errorColor : status === "pending" ? undefined : accentColor;
 
                     return (
+                        // eslint-disable-next-line react-x/no-array-index-key -- steps expose an optional stable `key`; index is the documented fallback for keyless entries
                         <Box flexDirection="column" key={step.key ?? index}>
                             <Box>
                                 <Text color={color} dimColor={status === "pending"}>
@@ -125,6 +126,7 @@ export default function Stepper({ accentColor = "blue", activeIndex = 0, errorCo
                 const isLast = index === steps.length - 1;
 
                 return (
+                    // eslint-disable-next-line react-x/no-array-index-key -- steps expose an optional stable `key`; index is the documented fallback for keyless entries
                     <Fragment key={step.key ?? index}>
                         <Box>
                             <Text color={color} dimColor={status === "pending"}>

--- a/packages/terminal/tui/src/components/textarea.tsx
+++ b/packages/terminal/tui/src/components/textarea.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-assignment, react-x/no-array-index-key, react-x/set-state-in-effect, react-you-might-not-need-an-effect/no-derived-state, react/function-component-definition, unicorn/prefer-single-call */
+/* eslint-disable no-useless-assignment, react-x/no-array-index-key, react-x/set-state-in-effect, react/function-component-definition, unicorn/prefer-single-call */
 
 /**
  * Multi-line text input component for Ink.

--- a/packages/terminal/tui/src/components/transition.tsx
+++ b/packages/terminal/tui/src/components/transition.tsx
@@ -163,7 +163,6 @@ function Transition({ children, distance = 4, duration = 240, onExit, preset = "
 
     // Restart animation whenever `show` flips. The `animationKey` state forces
     // the interval-owning effect to re-fire without depending on `progress`.
-    // eslint-disable-next-line react-x/no-unused-state -- animationKey is read inside the interval-owning effect via closure
     const [animationKey, setAnimationKey] = useState(0);
 
     useEffect(() => {


### PR DESCRIPTION
## What

Resolves the 13 ESLint **errors** reported by `nx run tui:lint:eslint` (the CI lint failure). No behavior changes.

### Unused `eslint-disable` directives removed (6)
`react-you-might-not-need-an-effect/no-derived-state` no longer fires at these sites, so the directives were flagged unused:

- `animate-presence.tsx` — kept `react-x/set-state-in-effect`, dropped the stale rule
- `command-palette.tsx`
- `menu.tsx` — kept `react-x/set-state-in-effect`
- `scroll/scroll-list.tsx` — kept `react-you-might-not-need-an-effect/no-event-handler`
- `textarea.tsx` — kept the rest of the file-wide disable list
- `transition.tsx` — dropped stale `react-x/no-unused-state`

### `react-x/no-array-index-key` (7)
- `breadcrumb.tsx` — `label` is a required `string`, so the index fallback becomes a content-based key
- `definition-list.tsx` (×2), `stepper.tsx` (×2), `scroll/controlled-scroll-view.tsx` (×2) — the keyable content is `ReactNode`/opaque virtualized children with no stable identity beyond position; these get justified inline disables (the components already expose an optional `key` prop, with index as the documented fallback — matching the existing `textarea.tsx` precedent)

## Verification

`nx run tui:lint:eslint` → **0 errors** (was 13). The 19 remaining items are pre-existing warnings; the lint target does not enforce `--max-warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)