### PR TITLE
test(vis,task-runner): native criterion benches + FxHashMap 

### DIFF
--- a/packages/tooling/task-runner/native/Cargo.lock
+++ b/packages/tooling/task-runner/native/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,12 +60,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -65,6 +178,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
@@ -183,6 +302,49 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -304,6 +466,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +531,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +579,49 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -399,6 +654,7 @@ dependencies = [
 name = "task-runner-native"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "fspy-seccomp",
  "libc",
  "napi",
@@ -406,10 +662,21 @@ dependencies = [
  "napi-derive",
  "nix",
  "rayon",
+ "rustc-hash",
  "tokio",
  "walkdir",
  "windows-sys",
  "xxhash-rust",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -495,3 +762,29 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/tooling/task-runner/native/Cargo.lock
+++ b/packages/tooling/task-runner/native/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +55,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -122,23 +141,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -146,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -206,6 +224,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fspy-seccomp"
@@ -315,27 +339,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -475,16 +482,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -624,6 +635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +751,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +774,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/packages/tooling/task-runner/native/Cargo.toml
+++ b/packages/tooling/task-runner/native/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+# `rlib` is added alongside `cdylib` so the in-crate criterion benches
+# (native/benches/) can link the pure graph/hash logic. The napi build
+# (`napi build`) still consumes the `cdylib` for the `.node` artifact; the
+# extra `rlib` has no effect on the shipped addon.
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 napi = { version = "3", features = ["async"] }
 napi-derive = "3"
+rustc-hash = "2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 walkdir = "2"
 rayon = "1"
@@ -52,6 +57,21 @@ windows-sys = { version = "0.61", features = [
 
 [build-dependencies]
 napi-build = "2"
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+# Native micro-benchmarks (criterion). Mirrors the cache-hash + workspace/topo
+# suite from nubjs/nub#17, but measures OUR Rust hot paths directly — the layer
+# the hyperfine/vitest harness in packages/tooling/vis/__bench__ cannot isolate
+# because the Node-boot floor swamps it. Run with `cargo bench`.
+[[bench]]
+name = "graph"
+harness = false
+
+[[bench]]
+name = "file_hasher"
+harness = false
 
 [profile.release]
 lto = true

--- a/packages/tooling/task-runner/native/Cargo.toml
+++ b/packages/tooling/task-runner/native/Cargo.toml
@@ -59,7 +59,7 @@ windows-sys = { version = "0.61", features = [
 napi-build = "2"
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 
 # Native micro-benchmarks (criterion). Mirrors the cache-hash + workspace/topo
 # suite from nubjs/nub#17, but measures OUR Rust hot paths directly — the layer

--- a/packages/tooling/task-runner/native/benches/file_hasher.rs
+++ b/packages/tooling/task-runner/native/benches/file_hasher.rs
@@ -16,7 +16,9 @@
 //!
 //!   Source: https://github.com/nubjs/nub/pull/17
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use task_runner_native::hash_bytes;
 
 fn bench_hash_bytes(c: &mut Criterion) {

--- a/packages/tooling/task-runner/native/benches/file_hasher.rs
+++ b/packages/tooling/task-runner/native/benches/file_hasher.rs
@@ -6,6 +6,15 @@
 //! to the hasher is a measured decision, not a guess.
 //!
 //! Run: `cargo bench -p task-runner-native --bench file_hasher`
+//!
+//! The bench structure (content-hash throughput sweep) is adapted from nub's
+//! `cache-hash` criterion bench, under the following license:
+//!
+//!   MIT License
+//!
+//!   Copyright (c) 2026 nub contributors
+//!
+//!   Source: https://github.com/nubjs/nub/pull/17
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use task_runner_native::hash_bytes;

--- a/packages/tooling/task-runner/native/benches/file_hasher.rs
+++ b/packages/tooling/task-runner/native/benches/file_hasher.rs
@@ -1,0 +1,29 @@
+//! Criterion micro-benchmark for the cache content hasher (`src/file_hasher.rs`).
+//!
+//! Counterpart to nubjs/nub#17's `cache-hash` criterion bench. nub switched
+//! SHA-256 → blake3; we already hash with xxh3-128 (non-cryptographic, faster
+//! than blake3 for cache content). This pins the throughput so a future change
+//! to the hasher is a measured decision, not a guess.
+//!
+//! Run: `cargo bench -p task-runner-native --bench file_hasher`
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use task_runner_native::hash_bytes;
+
+fn bench_hash_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("file_hasher/hash_bytes");
+    // Representative source-file sizes: a small module, a typical file, and a
+    // large generated/bundled artifact.
+    for size in [4 * 1024usize, 64 * 1024, 1024 * 1024] {
+        // Deterministic, non-uniform bytes so the hasher can't shortcut.
+        let data: Vec<u8> = (0..size).map(|i| (i.wrapping_mul(2654435761) >> 13) as u8).collect();
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, d| {
+            b.iter(|| black_box(hash_bytes(black_box(d))));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_hash_bytes);
+criterion_main!(benches);

--- a/packages/tooling/task-runner/native/benches/graph.rs
+++ b/packages/tooling/task-runner/native/benches/graph.rs
@@ -1,0 +1,85 @@
+//! Criterion micro-benchmarks for the native task-graph operations.
+//!
+//! Counterpart to nubjs/nub#17's `workspace/build_dep_graph` +
+//! `workspace/topological_chunks` criterion benches, pointed at OUR graph code
+//! (`src/graph.rs`). These run the pure Rust functions directly, so they measure
+//! the algorithm — not the Node-boot floor that the hyperfine/vitest harness in
+//! `packages/tooling/vis/__bench__` is bound by.
+//!
+//! Run: `cargo bench -p task-runner-native --bench graph`
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use task_runner_native::{find_all_cycles, get_transitive_deps, topological_sort, NativeTaskGraph};
+
+/// Builds a synthetic layered DAG: `layers` layers of `width` nodes each, every
+/// node depending on every node in the previous layer. Acyclic by construction,
+/// so `topological_sort` always succeeds. `200` total nodes is the size nub
+/// benches at; we sweep a couple of sizes to expose super-linear behaviour.
+fn layered_dag(layers: usize, width: usize) -> NativeTaskGraph {
+    let mut task_ids = Vec::with_capacity(layers * width);
+    for layer in 0..layers {
+        for node in 0..width {
+            task_ids.push(format!("t{layer}_{node}"));
+        }
+    }
+
+    let mut edges = Vec::new();
+    for layer in 1..layers {
+        for node in 0..width {
+            let to = format!("t{layer}_{node}");
+            for previous in 0..width {
+                let from = format!("t{}_{previous}", layer - 1);
+                edges.push(vec![from, to.clone()]);
+            }
+        }
+    }
+
+    NativeTaskGraph { task_ids, edges }
+}
+
+fn bench_topological_sort(c: &mut Criterion) {
+    let mut group = c.benchmark_group("graph/topological_sort");
+    // 10×20 = 200 nodes / 3 800 edges — the nub-comparable point — plus a
+    // larger one to catch a regression that 200 nodes would hide.
+    for (layers, width) in [(10, 20), (20, 30)] {
+        let graph = layered_dag(layers, width);
+        let nodes = layers * width;
+        group.bench_with_input(BenchmarkId::from_parameter(nodes), &graph, |b, g| {
+            // Clone per iteration: topological_sort takes the graph by value.
+            b.iter_batched(
+                || clone_graph(g),
+                |g| black_box(topological_sort(g).unwrap()),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_find_all_cycles(c: &mut Criterion) {
+    let graph = layered_dag(10, 20);
+    c.bench_function("graph/find_all_cycles/200", |b| {
+        b.iter_batched(|| clone_graph(&graph), |g| black_box(find_all_cycles(g)), criterion::BatchSize::SmallInput);
+    });
+}
+
+fn bench_transitive_deps(c: &mut Criterion) {
+    let graph = layered_dag(10, 20);
+    let root = graph.task_ids[0].clone();
+    c.bench_function("graph/get_transitive_deps/200", |b| {
+        b.iter_batched(
+            || (clone_graph(&graph), root.clone()),
+            |(g, id)| black_box(get_transitive_deps(g, id)),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+/// `NativeTaskGraph` is a plain `#[napi(object)]` struct (no `Clone` derive), so
+/// rebuild it by hand for each batched iteration.
+fn clone_graph(g: &NativeTaskGraph) -> NativeTaskGraph {
+    NativeTaskGraph { task_ids: g.task_ids.clone(), edges: g.edges.clone() }
+}
+
+criterion_group!(benches, bench_topological_sort, bench_find_all_cycles, bench_transitive_deps);
+criterion_main!(benches);

--- a/packages/tooling/task-runner/native/benches/graph.rs
+++ b/packages/tooling/task-runner/native/benches/graph.rs
@@ -7,6 +7,15 @@
 //! `packages/tooling/vis/__bench__` is bound by.
 //!
 //! Run: `cargo bench -p task-runner-native --bench graph`
+//!
+//! The bench structure (synthetic DAG + topological-sort/cycle sweep) is adapted
+//! from nub, under the following license:
+//!
+//!   MIT License
+//!
+//!   Copyright (c) 2026 nub contributors
+//!
+//!   Source: https://github.com/nubjs/nub/pull/17
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use task_runner_native::{find_all_cycles, get_transitive_deps, topological_sort, NativeTaskGraph};

--- a/packages/tooling/task-runner/native/benches/graph.rs
+++ b/packages/tooling/task-runner/native/benches/graph.rs
@@ -17,7 +17,9 @@
 //!
 //!   Source: https://github.com/nubjs/nub/pull/17
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use task_runner_native::{find_all_cycles, get_transitive_deps, topological_sort, NativeTaskGraph};
 
 /// Builds a synthetic layered DAG: `layers` layers of `width` nodes each, every

--- a/packages/tooling/task-runner/native/src/file_hasher.rs
+++ b/packages/tooling/task-runner/native/src/file_hasher.rs
@@ -149,7 +149,10 @@ fn make_relative(path: &str, workspace_root: &str) -> String {
 
 /// Core hashing function using xxh3-128.
 /// Produces a 32-character hex string (128-bit hash).
-fn hash_bytes(data: &[u8]) -> String {
+///
+/// `pub` so the criterion bench (`native/benches/file_hasher.rs`) can measure
+/// raw hashing throughput without going through the filesystem.
+pub fn hash_bytes(data: &[u8]) -> String {
     let h = xxh3_128(data);
     hex::encode(h.to_be_bytes())
 }

--- a/packages/tooling/task-runner/native/src/graph.rs
+++ b/packages/tooling/task-runner/native/src/graph.rs
@@ -5,10 +5,18 @@ use std::collections::VecDeque;
 // Graph IDs are short, trusted, in-process strings (task names), not
 // attacker-controlled network input — the DoS resistance of SipHash buys us
 // nothing here and costs throughput on the hot adjacency/in-degree maps. Swap
-// in rustc-hash's Fx hasher (the rustc/turbo/swc default) for these. Migrated
-// from nubjs/nub#17 (`workspace/filter.rs`, `pm/registry.rs`). Aliased to the
-// std names so the call sites below read unchanged; only `::new()` becomes
+// in rustc-hash's Fx hasher (the rustc/turbo/swc default) for these. Aliased to
+// the std names so the call sites below read unchanged; only `::new()` becomes
 // `::default()` (a custom-hasher map has no `::new`).
+//
+// The FxHashMap/FxHashSet swap is adapted from nub (`workspace/filter.rs` +
+// `pm/registry.rs`), under the following license:
+//
+//   MIT License
+//
+//   Copyright (c) 2026 nub contributors
+//
+//   Source: https://github.com/nubjs/nub/pull/17
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// Represents a task graph for native graph operations.

--- a/packages/tooling/task-runner/native/src/graph.rs
+++ b/packages/tooling/task-runner/native/src/graph.rs
@@ -1,6 +1,15 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
+
+// Graph IDs are short, trusted, in-process strings (task names), not
+// attacker-controlled network input — the DoS resistance of SipHash buys us
+// nothing here and costs throughput on the hot adjacency/in-degree maps. Swap
+// in rustc-hash's Fx hasher (the rustc/turbo/swc default) for these. Migrated
+// from nubjs/nub#17 (`workspace/filter.rs`, `pm/registry.rs`). Aliased to the
+// std names so the call sites below read unchanged; only `::new()` becomes
+// `::default()` (a custom-hasher map has no `::new`).
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// Represents a task graph for native graph operations.
 #[napi(object)]
@@ -24,9 +33,9 @@ pub struct CycleResult {
 #[napi(catch_unwind)]
 pub fn find_cycle(graph: NativeTaskGraph) -> CycleResult {
     let adjacency = build_adjacency(&graph);
-    let mut visited = HashSet::new();
-    let mut in_stack = HashSet::new();
-    let mut parent: HashMap<String, String> = HashMap::new();
+    let mut visited = HashSet::default();
+    let mut in_stack = HashSet::default();
+    let mut parent: HashMap<String, String> = HashMap::default();
 
     for task_id in &graph.task_ids {
         if visited.contains(task_id.as_str()) {
@@ -88,8 +97,8 @@ pub fn find_cycle(graph: NativeTaskGraph) -> CycleResult {
 pub fn find_all_cycles(graph: NativeTaskGraph) -> Vec<Vec<String>> {
     let adjacency = build_adjacency(&graph);
     let mut cycles: Vec<Vec<String>> = Vec::new();
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut in_stack: HashSet<String> = HashSet::new();
+    let mut visited: HashSet<String> = HashSet::default();
+    let mut in_stack: HashSet<String> = HashSet::default();
     let mut path: Vec<String> = Vec::new();
     let mut work: Vec<(String, usize)> = Vec::new();
 
@@ -142,7 +151,7 @@ pub fn find_all_cycles(graph: NativeTaskGraph) -> Vec<Vec<String>> {
 #[napi(catch_unwind)]
 pub fn topological_sort(graph: NativeTaskGraph) -> Result<Vec<String>> {
     let adjacency = build_adjacency(&graph);
-    let mut in_degree: HashMap<String, usize> = HashMap::new();
+    let mut in_degree: HashMap<String, usize> = HashMap::default();
 
     for task_id in &graph.task_ids {
         in_degree.entry(task_id.clone()).or_insert(0);
@@ -192,8 +201,8 @@ pub fn topological_sort(graph: NativeTaskGraph) -> Result<Vec<String>> {
 #[napi(catch_unwind)]
 pub fn find_back_edges(graph: NativeTaskGraph) -> Vec<Vec<String>> {
     let adjacency = build_adjacency(&graph);
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut in_stack: HashSet<String> = HashSet::new();
+    let mut visited: HashSet<String> = HashSet::default();
+    let mut in_stack: HashSet<String> = HashSet::default();
     let mut back_edges: Vec<Vec<String>> = Vec::new();
     let mut work: Vec<(String, usize)> = Vec::new();
 
@@ -239,7 +248,7 @@ pub fn find_back_edges(graph: NativeTaskGraph) -> Vec<Vec<String>> {
 pub fn get_transitive_deps(graph: NativeTaskGraph, task_id: String) -> Vec<String> {
     let adjacency = build_adjacency(&graph);
     let mut result: Vec<String> = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::default();
     let mut queue = VecDeque::new();
     queue.push_back(task_id.clone());
 
@@ -269,7 +278,7 @@ pub fn get_transitive_deps(graph: NativeTaskGraph, task_id: String) -> Vec<Strin
 #[napi(catch_unwind)]
 pub fn get_dependent_tasks(graph: NativeTaskGraph, task_id: String) -> Vec<String> {
     // Build reverse adjacency
-    let mut reverse_adj: HashMap<String, Vec<String>> = HashMap::new();
+    let mut reverse_adj: HashMap<String, Vec<String>> = HashMap::default();
     for id in &graph.task_ids {
         reverse_adj.entry(id.clone()).or_default();
     }
@@ -280,7 +289,7 @@ pub fn get_dependent_tasks(graph: NativeTaskGraph, task_id: String) -> Vec<Strin
     }
 
     let mut result: Vec<String> = Vec::new();
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::default();
     let mut queue = VecDeque::new();
     queue.push_back(task_id.clone());
 
@@ -308,7 +317,7 @@ pub fn get_dependent_tasks(graph: NativeTaskGraph, task_id: String) -> Vec<Strin
 
 /// Builds an adjacency list from the graph edges.
 fn build_adjacency(graph: &NativeTaskGraph) -> HashMap<String, Vec<String>> {
-    let mut adjacency: HashMap<String, Vec<String>> = HashMap::new();
+    let mut adjacency: HashMap<String, Vec<String>> = HashMap::default();
 
     for task_id in &graph.task_ids {
         adjacency.entry(task_id.clone()).or_default();

--- a/packages/tooling/task-runner/package.json
+++ b/packages/tooling/task-runner/package.json
@@ -62,6 +62,7 @@
         "LICENSE.md"
     ],
     "scripts": {
+        "bench:native": "cargo bench --manifest-path native/Cargo.toml",
         "build": "packem build --development",
         "build:native": "napi build --platform --release --esm --manifest-path native/Cargo.toml --output-dir . --js index.js",
         "build:native:debug": "napi build --platform --esm --manifest-path native/Cargo.toml --output-dir . --js index.js",

--- a/packages/tooling/vis/__bench__/cli/README.md
+++ b/packages/tooling/vis/__bench__/cli/README.md
@@ -65,6 +65,32 @@ These are the numbers to chase. vis will not match Rust dispatch today — recor
 
 **PM shim overhead:** nub adds **+4.9 ms** over `node pnpm.cjs -v`; corepack adds +14.0 ms. This is the bar for `vis install`'s wrapper overhead — vis delegates to the PM, so its overhead-over-raw-PM is the comparable metric.
 
+## Native micro-benchmarks (`cargo bench`)
+
+The hyperfine harness here measures **process wall-clock** and the vitest harness
+measures **in-process JS**; neither can isolate the Rust hot paths inside the
+native addons — the Node-boot floor swamps them (see `BASELINE.md` §findings).
+[`nubjs/nub#17`](https://github.com/nubjs/nub/pull/17) solved the same problem
+with a [criterion](https://github.com/bheisler/criterion.rs) harness (`cargo bench
+-p nub-core`); we mirror it:
+
+```sh
+pnpm --filter @visulima/task-runner run bench:native   # graph + file-hasher
+pnpm --filter @visulima/vis          run bench:native   # oxc transpile
+```
+
+- `task-runner/native/benches/graph.rs` — `topological_sort`, `find_all_cycles`,
+  `get_transitive_deps` on a synthetic layered DAG (200 / 600 nodes), the
+  counterpart to nub's `workspace/topological_chunks`.
+- `task-runner/native/benches/file_hasher.rs` — xxh3-128 throughput, the
+  counterpart to nub's `cache-hash` bench.
+- `vis/native/benches/transform.rs` — oxc TS→JS transpile, closing the
+  "transpile benchmark gap" nub documented.
+
+Also migrated from that PR: `graph.rs` now hashes its adjacency/in-degree maps
+with `rustc-hash`'s `FxHashMap` (nub's `workspace/filter.rs` change) — trusted
+in-process IDs don't need SipHash's DoS resistance.
+
 ## Fixtures
 
 Install fixtures mirror nub's: `simple` (~435 pkgs), `monorepo` (~407 pkgs / 4 workspaces), `t3` (Next/tRPC/Drizzle — Bun's create-t3-app bench), `large` (~1168 pkgs). Generate lockfiles with `bash __bench__/cli/gen-fixtures.sh` after editing a fixture's `package.json`. Each tool installs from its own lockfile family (`pnpm-lock.yaml`, `bun.lock`, `package-lock.json`); foreign lockfiles are pruned per-tool so no tool reads a stale lock.

--- a/packages/tooling/vis/native/Cargo.lock
+++ b/packages/tooling/vis/native/Cargo.lock
@@ -21,10 +21,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -111,6 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +161,58 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -204,10 +283,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -426,6 +545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +605,26 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -644,6 +800,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "outref"
@@ -884,7 +1046,7 @@ version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cc7ba86610d560bd6ef0b62286c0ea77d1f813e05fa56ee3b27adda1474035"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
@@ -1126,6 +1288,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "ropey"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1357,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "self_cell"
@@ -1343,6 +1543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1620,7 @@ name = "vis-native"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "criterion",
  "ec4rs",
  "napi",
  "napi-build",
@@ -1438,6 +1649,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,10 +1668,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zerocopy"

--- a/packages/tooling/vis/native/Cargo.lock
+++ b/packages/tooling/vis/native/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,23 +293,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -308,12 +316,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -583,12 +591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,21 +610,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1172,6 +1163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pep440_rs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1669,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1692,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/packages/tooling/vis/native/Cargo.toml
+++ b/packages/tooling/vis/native/Cargo.toml
@@ -9,7 +9,10 @@ license = "MIT"
 # consumes the `cdylib` for the `.node` artifact; the extra `rlib` does not
 # affect the shipped addon.
 [lib]
-crate-type = [ "cdylib", "rlib" ]
+crate-type = [
+  "cdylib",
+  "rlib"
+]
 
 [dependencies]
 blake3 = "1"

--- a/packages/tooling/vis/native/Cargo.toml
+++ b/packages/tooling/vis/native/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+# `rlib` is added alongside `cdylib` so the in-crate criterion benches
+# (native/benches/) can link the pure transpile/sort logic. `napi build` still
+# consumes the `cdylib` for the `.node` artifact; the extra `rlib` does not
+# affect the shipped addon.
 [lib]
-crate-type = [ "cdylib" ]
+crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 blake3 = "1"
@@ -33,6 +37,17 @@ zip = { version = "2", default-features = false, features = [ "deflate" ] }
 
 [build-dependencies]
 napi-build = "2"
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = [ "cargo_bench_support" ] }
+
+# Native micro-benchmarks (criterion). nubjs/nub#17 documented a "transpile
+# benchmark gap"; this closes ours by measuring the oxc TS→JS hot path
+# (`vis x` / config / generator loading) directly, free of the Node-boot floor
+# the hyperfine/vitest harness is bound by. Run with `cargo bench`.
+[[bench]]
+name = "transform"
+harness = false
 
 [profile.release]
 lto = true

--- a/packages/tooling/vis/native/Cargo.toml
+++ b/packages/tooling/vis/native/Cargo.toml
@@ -42,7 +42,7 @@ zip = { version = "2", default-features = false, features = [ "deflate" ] }
 napi-build = "2"
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false, features = [ "cargo_bench_support" ] }
+criterion = { version = "0.8", default-features = false, features = [ "cargo_bench_support" ] }
 
 # Native micro-benchmarks (criterion). nubjs/nub#17 documented a "transpile
 # benchmark gap"; this closes ours by measuring the oxc TS→JS hot path

--- a/packages/tooling/vis/native/benches/transform.rs
+++ b/packages/tooling/vis/native/benches/transform.rs
@@ -16,7 +16,9 @@
 //!
 //!   Source: https://github.com/nubjs/nub/pull/17
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use vis_native::transform_ts;
 
 /// A representative TS module: type annotations to strip, an enum + namespace to
@@ -56,7 +58,13 @@ fn bench_transform_ts(c: &mut Criterion) {
         let source = ts_source(repeat);
         group.throughput(Throughput::Bytes(source.len() as u64));
         group.bench_with_input(BenchmarkId::from_parameter(source.len()), &source, |b, s| {
-            b.iter(|| black_box(transform_ts(black_box("module.ts".to_string()), black_box(s.clone())).unwrap()));
+            // Clone the source + filename in untimed setup so the throughput
+            // metric reflects only transform_ts, not the per-iteration alloc.
+            b.iter_batched(
+                || ("module.ts".to_string(), s.clone()),
+                |(filename, source)| black_box(transform_ts(filename, source).unwrap()),
+                BatchSize::SmallInput,
+            );
         });
     }
     group.finish();

--- a/packages/tooling/vis/native/benches/transform.rs
+++ b/packages/tooling/vis/native/benches/transform.rs
@@ -6,6 +6,15 @@
 //! through the Node-boot floor. This measures the transpile itself.
 //!
 //! Run: `cargo bench -p vis-native --bench transform`
+//!
+//! Closing this transpile-benchmark gap is adapted from nub, under the following
+//! license:
+//!
+//!   MIT License
+//!
+//!   Copyright (c) 2026 nub contributors
+//!
+//!   Source: https://github.com/nubjs/nub/pull/17
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use vis_native::transform_ts;

--- a/packages/tooling/vis/native/benches/transform.rs
+++ b/packages/tooling/vis/native/benches/transform.rs
@@ -1,0 +1,57 @@
+//! Criterion micro-benchmark for the oxc TS→JS transpiler (`src/transform.rs`).
+//!
+//! Closes the "transpile benchmark gap" noted in nubjs/nub#17. `transform_ts`
+//! is the hot path behind `vis x`, config loading, and generator execution; the
+//! hyperfine/vitest harness in `packages/tooling/vis/__bench__` can only see it
+//! through the Node-boot floor. This measures the transpile itself.
+//!
+//! Run: `cargo bench -p vis-native --bench transform`
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use vis_native::transform_ts;
+
+/// A representative TS module: type annotations to strip, an enum + namespace to
+/// lower (non-erasable), generics, and a class with parameter properties.
+fn ts_source(repeat: usize) -> String {
+    let unit = r#"
+import type { Foo } from "./foo";
+
+export enum Color { Red, Green, Blue }
+
+export namespace Geometry {
+    export interface Point { x: number; y: number }
+    export const origin: Point = { x: 0, y: 0 };
+}
+
+export class Box<T> {
+    constructor(private readonly value: T, public label: string) {}
+    get(): T { return this.value; }
+}
+
+export function sum(values: readonly number[]): number {
+    return values.reduce((acc: number, n: number): number => acc + n, 0);
+}
+"#;
+
+    let mut out = String::with_capacity(unit.len() * repeat);
+    for _ in 0..repeat {
+        out.push_str(unit);
+    }
+    out
+}
+
+fn bench_transform_ts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transform/transform_ts");
+    // Small (single unit ≈ a config file) through large (a fat generator module).
+    for repeat in [1usize, 20, 100] {
+        let source = ts_source(repeat);
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(source.len()), &source, |b, s| {
+            b.iter(|| black_box(transform_ts(black_box("module.ts".to_string()), black_box(s.clone())).unwrap()));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_transform_ts);
+criterion_main!(benches);

--- a/packages/tooling/vis/package.json
+++ b/packages/tooling/vis/package.json
@@ -112,6 +112,7 @@
     ],
     "scripts": {
         "bench": "vitest bench __bench__",
+        "bench:native": "cargo bench --manifest-path native/Cargo.toml",
         "build": "pnpm --filter @visulima/vis-dashboard run build && packem build --development",
         "build:native": "napi build --platform --release --esm --manifest-path native/Cargo.toml --output-dir . --js index.js",
         "build:native:debug": "napi build --platform --esm --manifest-path native/Cargo.toml --output-dir . --js index.js",


### PR DESCRIPTION
## What

Ports the two highest-value ideas from [`nubjs/nub#17`](https://github.com/nubjs/nub/pull/17) ("perf: release-profile tuning, mimalloc, FxHashMap, and a bench harness") into our native addons. Every bench below was verified to **compile, link, and run** locally.

### 1. Criterion native-bench harness
The hyperfine/vitest harness in `packages/tooling/vis/__bench__` measures process wall-clock and in-process JS respectively — neither can isolate the Rust hot paths, because the Node-boot floor swamps them (see `BASELINE.md` §findings). nub solved the same problem with criterion (`cargo bench -p nub-core`); we mirror it:

| Bench | Mirrors nub's | Sample result |
| --- | --- | --- |
| `task-runner/native/benches/graph.rs` — `topological_sort`, `find_all_cycles`, `get_transitive_deps` on a synthetic 200/600-node layered DAG | `workspace/topological_chunks` | ~840 µs @ 200 nodes |
| `task-runner/native/benches/file_hasher.rs` — xxh3-128 content-hash throughput | `cache-hash` | — |
| `vis/native/benches/transform.rs` — oxc TS→JS transpile | the "transpile benchmark gap" nub documented | 25 µs–2.4 ms |

Run with `pnpm --filter <pkg> run bench:native`. `rlib` was added to each crate's `crate-type` so the in-crate benches link the pure logic; the napi `.node` build still consumes the `cdylib` (both artifacts confirmed to build).

### 2. FxHashMap in the native graph
`task-runner/native/src/graph.rs` now hashes its adjacency/in-degree maps with `rustc-hash`'s `FxHashMap`/`FxHashSet` — exactly nub's `workspace/filter.rs` + `pm/registry.rs` change. Graph IDs are short, trusted, in-process task names, so SipHash's DoS resistance costs throughput for nothing.

## Deliberately skipped (already ahead / N/A)
- **Release profile** — we already run *full* LTO + `codegen-units=1` + `strip` + `panic=unwind` (stronger than nub's thin-LTO).
- **Kahn's topo-sort & blake3/xxh3** — already done; our topo-sort is already O(V+E) and we're off SHA-256.
- **mimalloc** — nub put it in a standalone CLI binary; we ship cdylib-only addons loaded into Node, where overriding the global allocator is risky for marginal gain.

## Notes
- No production code-path behaviour change beyond the FxHashMap swap (identical observable output; only the hasher differs).
- The vis transpile bench required a `nightly` compiler *in the sandbox only* — `oxc_transformer` 0.136 uses `if_let_guard`, not stabilized on the sandbox's `stable` (1.94.1). This is a pre-existing dependency/toolchain quirk (a plain `cargo build` of the vis crate fails identically); it builds on the repo's pinned CI toolchain.

## Follow-ups (not in this PR)
- Wire `bench:native` into an Nx target / the CodSpeed workflow for CI tracking.
- Verify the oxc/rusqlite transpile cache folds the addon's own hash into cache keys (nub's binary-hash-folding idea — correctness, not just perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StP4xn9LskqyAScMvyMXmc

---
_Generated by [Claude Code](https://claude.ai/code/session_01StP4xn9LskqyAScMvyMXmc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Criterion-based native micro-benchmarks for task-graph operations and file hashing.
  * Added a native benchmark for the TypeScript→JavaScript transform hot path.
  * Introduced `bench:native` scripts to run Rust benchmarks for both task-runner and vis packages.
* **Performance**
  * Improved native hash benchmarking support by exposing the raw hashing helper for benching.
* **Documentation**
  * Documented how to run and interpret native micro-benchmarks, including what each suite measures.
* **Chores**
  * Updated native crate build settings to support in-crate Criterion benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->