### PR TITLE
feat(vis): task-runner feedback fixes + CI hook skip

### DIFF
--- a/packages/tooling/vis/__tests__/commands/hook/hook.test.ts
+++ b/packages/tooling/vis/__tests__/commands/hook/hook.test.ts
@@ -108,6 +108,30 @@ describe(hookScript, () => {
 
         expect(script).toContain("VIS_GIT_HOOKS");
     });
+
+    it("should not bake a CI skip guard by default", () => {
+        expect.assertions(2);
+
+        const script = hookScript(".vis/hooks");
+
+        expect(script).not.toContain("${CI-}");
+        // The blank line between the disable-guard and the `d=` assignment
+        // is preserved when no CI guard is injected.
+        expect(script).toContain("{ [ \"${VIS_GIT_HOOKS-}\" = \"0\" ]; } && exit 0\n\nd=");
+    });
+
+    it("should bake a CI skip guard when skipInCI is set", () => {
+        expect.assertions(3);
+
+        const script = hookScript(".vis/hooks", { skipInCI: true });
+
+        // Skips under any non-empty $CI, unless VIS_GIT_HOOKS=1 forces it on.
+        expect(script).toContain("{ [ -n \"${CI-}\" ] && [ \"${VIS_GIT_HOOKS-}\" != \"1\" ]; } && exit 0");
+        // Ordered AFTER the VIS_GIT_HOOKS=0 kill switch so 0 still wins.
+        expect(script.indexOf("= \"0\" ]; } && exit 0")).toBeLessThan(script.indexOf("[ -n \"${CI-}\" ]"));
+        // ...and before the hook body actually runs.
+        expect(script.indexOf("[ -n \"${CI-}\" ]")).toBeLessThan(script.indexOf("sh -e \"$s\""));
+    });
 });
 
 describe(installHooks, () => {
@@ -130,6 +154,30 @@ describe(installHooks, () => {
 
             // User hook scripts are NOT created
             expect(existsSync(join(root, ".vis/hooks", "pre-commit"))).toBe(false);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should bake the CI skip guard into the dispatcher when config.json sets skipInCI", () => {
+        expect.assertions(2);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+
+        try {
+            mkdirSync(join(root, ".vis/hooks"), { recursive: true });
+            writeFileSync(join(root, ".vis/hooks", "config.json"), JSON.stringify({ skipInCI: true, stages: {}, version: 1 }));
+
+            installHooks(".vis/hooks");
+            const dispatcher = readFileSync(join(root, ".vis/hooks", "_", "h"), "utf8");
+
+            expect(dispatcher).toContain("{ [ -n \"${CI-}\" ] && [ \"${VIS_GIT_HOOKS-}\" != \"1\" ]; } && exit 0");
+
+            // Without the opt-in the guard stays out (default config).
+            writeFileSync(join(root, ".vis/hooks", "config.json"), JSON.stringify({ stages: {}, version: 1 }));
+            installHooks(".vis/hooks");
+
+            expect(readFileSync(join(root, ".vis/hooks", "_", "h"), "utf8")).not.toContain("${CI-}");
         } finally {
             cleanup();
         }

--- a/packages/tooling/vis/__tests__/generate/passthrough.test.ts
+++ b/packages/tooling/vis/__tests__/generate/passthrough.test.ts
@@ -16,11 +16,16 @@ import { describe, expect, it } from "vitest";
 
 // The parsePassthroughOverrides helper isn't exported — exercise it
 // transitively by reproducing its shape inline.
-const parsePassthroughOverrides = (extraArguments: string[]): { overrides: Record<string, string>; remaining: string[] } => {
+const parsePassthroughOverrides = (
+    extraArguments: string[],
+    onWarning?: (message: string) => void,
+): { overrides: Record<string, string>; remaining: string[] } => {
     const overrides: Record<string, string> = {};
     const remaining: string[] = [];
 
-    for (const argument of extraArguments) {
+    for (let index = 0; index < extraArguments.length; index++) {
+        const argument = extraArguments[index]!;
+
         if (!argument.startsWith("--")) {
             remaining.push(argument);
             continue;
@@ -35,6 +40,14 @@ const parsePassthroughOverrides = (extraArguments: string[]): { overrides: Recor
                 overrides[key.slice(3)] = "false";
             } else {
                 overrides[key] = "true";
+
+                const next = extraArguments[index + 1];
+
+                if (next !== undefined && !next.startsWith("-")) {
+                    onWarning?.(
+                        `\`--${key} ${next}\` was read as boolean \`--${key}=true\` and \`${next}\` was ignored. For a string value use \`--${key}=${next}\`.`,
+                    );
+                }
             }
 
             continue;
@@ -75,6 +88,31 @@ describe("`--` passthrough parsing", () => {
             overrides: { flag: "true" },
             remaining: ["positional", "another"],
         });
+    });
+
+    it("warns on the `--name value` space form without changing the parse", () => {
+        expect.assertions(3);
+
+        const warnings: string[] = [];
+        const result = parsePassthroughOverrides(["--name", "listMessages"], (message) => warnings.push(message));
+
+        // Parse result is unchanged: bare flag stays `true`, the value
+        // token stays a (dropped) positional. The warning is what's new.
+        expect(result.overrides).toStrictEqual({ name: "true" });
+        expect(result.remaining).toStrictEqual(["listMessages"]);
+        expect(warnings).toStrictEqual([
+            "`--name listMessages` was read as boolean `--name=true` and `listMessages` was ignored. For a string value use `--name=listMessages`.",
+        ]);
+    });
+
+    it("does not warn for `--no-flag` or flags followed by another flag", () => {
+        expect.assertions(1);
+
+        const warnings: string[] = [];
+
+        parsePassthroughOverrides(["--no-install", "--verbose", "--force"], (message) => warnings.push(message));
+
+        expect(warnings).toStrictEqual([]);
     });
 
     it("handles values containing `=`", () => {

--- a/packages/tooling/vis/docs/commands/hook.mdx
+++ b/packages/tooling/vis/docs/commands/hook.mdx
@@ -127,6 +127,7 @@ All user-supplied values (regex patterns, filenames, hook args) travel via `proc
 | Variable               | Description                                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------------------- |
 | `VIS_GIT_HOOKS=0`      | Disable git hooks                                                                            |
+| `VIS_GIT_HOOKS=1`      | Force hooks to run even when `skipInCI` would skip them under CI (per-job override)          |
 | `VIS_GIT_HOOKS=2`      | Enable debug output for hooks                                                                |
 | `VIS_HOOK_ALL_FILES=1` | Tells the bundled runner to discover files via `git ls-files` instead of `git diff --cached` |
 | `VIS_HOOK_FROM_REF=…`  | Paired with `VIS_HOOK_TO_REF`, runs the hook against files changed between the two refs      |

--- a/packages/tooling/vis/docs/commands/run.mdx
+++ b/packages/tooling/vis/docs/commands/run.mdx
@@ -45,7 +45,7 @@ vis run dev --services=persistent --stop-services         # Boot service deps + 
 | Option               | Alias | Default        | Description                                                                                                                                                                                                                                                                                                         |
 | -------------------- | ----- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--projects`         | `-p`  | all            | Comma-separated list of projects to run                                                                                                                                                                                                                                                                             |
-| `--parallel`         |       | `3`            | Maximum number of parallel tasks (also reads `VIS_RUN_CONCURRENCY_LIMIT`)                                                                                                                                                                                                                                           |
+| `--parallel`         |       | `3`            | Maximum number of parallel tasks (also reads `VIS_RUN_CONCURRENCY_LIMIT`). The resolved value is exported to every task as `VIS_TASK_SLOTS` — see [Environment variables in child tasks](#environment-variables-in-child-tasks).                                                                                    |
 | `--preflight`        |       | enabled        | Detect lockfile / `node_modules` drift before running. Warns in TTY, fails in CI. `--no-preflight` opts out per run; workspace-wide via `preflight.lockfile: false` in `vis.config.ts`.                                                                                                                             |
 | `--skip-toolchain`   |       | `false`        | Skip the toolchain pre-flight (no auto-install for any pinned tool: node / pnpm / yarn / npm / bun / deno / go / python / ruby / rust)                                                                                                                                                                              |
 | `--cache`            |       | `true`         | Enable caching (`--no-cache` to disable)                                                                                                                                                                                                                                                                            |
@@ -272,6 +272,30 @@ So you can opt the whole repo into quiet, auto-closing runs with `quietOnSuccess
 ```
 
 Auto-cascade (`true`) loads in Next.js order: `.env` → `.env.{NODE_ENV}` → `.env.local` → `.env.{NODE_ENV}.local`. `.env.local` is skipped when `NODE_ENV=test` to avoid leaking CI secrets into tests.
+
+### Environment variables in child tasks
+
+Beyond your own `env` / `envFile`, vis injects a few variables into every spawned task:
+
+| Variable         | Value                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `INIT_CWD`       | The directory you invoked `vis` from (before workspace discovery changed cwd), matching the pnpm/npm/yarn convention. |
+| `VIS_TASK_SLOTS` | The effective parallelism for this run — the resolved `--parallel` value (default `3`).                               |
+
+`VIS_TASK_SLOTS` exists to avoid **nested oversubscription**. `vis run` already executes up to `VIS_TASK_SLOTS` projects at once; if each task then spawns its own worker pool sized to the full CPU count (Vitest's default `maxWorkers`, v8 coverage, jest, etc.), you get `slots × cores` processes fighting for the same cores — fast tasks blow past their timeouts and the whole run slows down. Size the inner pool against the slots vis grants you instead:
+
+```ts
+// vitest.config.ts
+import os from "node:os";
+import { defineConfig } from "vitest/config";
+
+const slots = Number(process.env.VIS_TASK_SLOTS) || 1;
+const maxWorkers = Math.max(1, Math.floor(os.availableParallelism() / slots));
+
+export default defineConfig({
+    test: { maxWorkers, minWorkers: 1 },
+});
+```
 
 ### Task conditions
 
@@ -503,6 +527,18 @@ export default defineConfig({
     },
 });
 ```
+
+### Execution model: vis runs the configured command
+
+`vis run <project>:<target>` executes the **command configured for that target** — the `command` in `vis.config.ts` / `vis.task.ts`, or the matching `package.json` script discovered for the project. There is no separate built-in ESLint/lint "inference" layer: `vis run :lint:eslint` runs whatever `lint:eslint` is wired to, so editing that script _does_ change what runs. Prerequisites (codegen, type generation, building a dependency) belong in `dependsOn`, not in vis-specific magic.
+
+A corollary: if a target's `dependsOn` names a target that has **no command** anywhere (e.g. `dependsOn: ["codegen"]` but the project has no `codegen` script), the dependency is a no-op — it can't run something that doesn't exist. vis now warns when this happens:
+
+```
+codegen required via dependsOn but no command is configured for @acme/app — skipping (no-op).
+```
+
+instead of silently succeeding, so a missing prerequisite surfaces locally rather than only in CI once a downstream task fails.
 
 ## Flakiness Report
 

--- a/packages/tooling/vis/docs/guides/git-hooks.mdx
+++ b/packages/tooling/vis/docs/guides/git-hooks.mdx
@@ -113,6 +113,34 @@ For debugging hook issues:
 VIS_GIT_HOOKS=2 git commit -m "debug hooks"
 ```
 
+## Skipping hooks in CI
+
+Automated commits in CI — release bots bumping versions, merge commits, changelog updates — shouldn't re-run your local hooks. The same checks (commitlint, secret scanning, lint-staged) usually run as dedicated CI jobs already, so firing them again on a generated commit just trips the pipeline (a release commit failing `commitlint` is the classic case).
+
+Set `skipInCI` in `.vis/hooks/config.json` to skip **all** hooks whenever a non-empty `CI` environment variable is present (every major CI provider sets it):
+
+```json
+{
+    "version": 1,
+    "skipInCI": true,
+    "stages": {}
+}
+```
+
+```bash
+vis hook install   # regenerate the dispatcher so the guard takes effect
+```
+
+`vis hook install` bakes the guard into the generated `_/` dispatcher, so it fires **before the hook body runs** — even for a hook that calls a tool directly (e.g. a raw `commitlint` `commit-msg`) instead of going through `vis hook run`. Because it lives in the dispatcher, **re-run `vis hook install` after changing `skipInCI`** to regenerate it.
+
+Need hooks to run in one specific CI job (say, a lint job that _wants_ commitlint)? Force them back on for that job only:
+
+```bash
+VIS_GIT_HOOKS=1 git commit -m "feat: …"   # overrides skipInCI
+```
+
+This is the portable, repo-tracked equivalent of setting `core.hooksPath=/dev/null` in a single job — `skipInCI` is the default for CI, `VIS_GIT_HOOKS=1` is the per-job exception, and both travel with the repo.
+
 ## Common Hook Recipes
 
 ### Lint Staged Files

--- a/packages/tooling/vis/src/commands/generate/handler.ts
+++ b/packages/tooling/vis/src/commands/generate/handler.ts
@@ -108,11 +108,16 @@ const printList = (templates: DiscoveredTemplate[]): void => {
     }
 };
 
-const parsePassthroughOverrides = (extraArguments: string[]): { overrides: Record<string, string>; remaining: string[] } => {
+const parsePassthroughOverrides = (
+    extraArguments: string[],
+    onWarning?: (message: string) => void,
+): { overrides: Record<string, string>; remaining: string[] } => {
     const overrides: Record<string, string> = {};
     const remaining: string[] = [];
 
-    for (const argument of extraArguments) {
+    for (let index = 0; index < extraArguments.length; index++) {
+        const argument = extraArguments[index]!;
+
         if (!argument.startsWith("--")) {
             remaining.push(argument);
             continue;
@@ -128,6 +133,21 @@ const parsePassthroughOverrides = (extraArguments: string[]): { overrides: Recor
                 overrides[key.slice(3)] = "false";
             } else {
                 overrides[key] = "true";
+
+                // Catch the recurring `--name value` (space-form) footgun.
+                // We can't tell a boolean flag from a string option here —
+                // template variable types aren't loaded yet — so a bare
+                // token right after `--name` is taken as a positional and
+                // silently dropped while `name` becomes `"true"`. That
+                // silent misparse is exactly the trap; warn and point at
+                // the unambiguous `--name=value` form instead.
+                const next = extraArguments[index + 1];
+
+                if (next !== undefined && !next.startsWith("-")) {
+                    onWarning?.(
+                        `\`--${key} ${next}\` was read as boolean \`--${key}=true\` and \`${next}\` was ignored. For a string value use \`--${key}=${next}\`.`,
+                    );
+                }
             }
 
             continue;
@@ -286,7 +306,9 @@ const execute = async ({ argument, options, rawUnknown, visConfig, workspaceRoot
     const legacyDashIndex = args.indexOf("--");
     const legacyExtras = legacyDashIndex === -1 ? [] : args.slice(legacyDashIndex + 1);
     const ownArgs = legacyDashIndex === -1 ? args : args.slice(0, legacyDashIndex);
-    const { overrides } = parsePassthroughOverrides([...legacyExtras, ...passthrough]);
+    const { overrides } = parsePassthroughOverrides([...legacyExtras, ...passthrough], (message: string) => {
+        pail.warn(message);
+    });
 
     let template: Template | undefined;
     let templateName: string | undefined;

--- a/packages/tooling/vis/src/commands/hook/config.ts
+++ b/packages/tooling/vis/src/commands/hook/config.ts
@@ -62,6 +62,21 @@ export interface HookEntry {
 export interface HookConfig {
     /** Stop on first hook failure. Mirrors prek `fail_fast`. */
     failFast?: boolean;
+
+    /**
+     * Skip **all** git hooks when running under CI (any non-empty `$CI`,
+     * which every major CI provider sets). `vis hook install` bakes this
+     * into the generated `_/` dispatcher, so it fires before the hook body
+     * — even for hooks that invoke a tool directly (e.g. a raw `commitlint`
+     * commit-msg) instead of going through `vis hook run`. The same checks
+     * normally run as dedicated CI jobs, so automated commits (release
+     * bots, merges) don't re-trigger them and trip on a generated commit
+     * message. Force hooks back on for a specific job with `VIS_GIT_HOOKS=1`.
+     *
+     * Changing this value requires re-running `vis hook install` to
+     * regenerate the dispatcher.
+     */
+    skipInCI?: boolean;
     /** stage name → ordered hook list. */
     stages: Record<string, HookEntry[]>;
     /** Schema version; bump for breaking changes. */
@@ -89,7 +104,7 @@ const ENTRY_KEYS = new Set<string>([
     "verbose",
 ]);
 
-const CONFIG_KEYS = new Set<string>(["failFast", "stages", "version"]);
+const CONFIG_KEYS = new Set<string>(["failFast", "skipInCI", "stages", "version"]);
 
 const FILTER_KEYS = ["args", "exclude", "excludeTypes", "files", "passFilenames", "types", "typesOr"] as const;
 
@@ -271,6 +286,12 @@ const parseConfig = (raw: unknown, warnings: ParseWarning[]): HookConfig => {
 
     if (failFast !== undefined) {
         config.failFast = failFast;
+    }
+
+    const skipInCI = asBoolean(raw["skipInCI"]);
+
+    if (skipInCI !== undefined) {
+        config.skipInCI = skipInCI;
     }
 
     for (const key of Object.keys(raw)) {

--- a/packages/tooling/vis/src/commands/hook/index.ts
+++ b/packages/tooling/vis/src/commands/hook/index.ts
@@ -15,7 +15,7 @@ const hooksDirectoryOption = {
 const sharedHookEnv = [
     {
         defaultValue: undefined,
-        description: "Set to 0 to disable git hooks, set to 2 for debug output",
+        description: "Set to 0 to disable git hooks, 1 to force-enable them under CI (override skipInCI), 2 for debug output",
         name: "VIS_GIT_HOOKS",
         type: String,
     },

--- a/packages/tooling/vis/src/commands/hook/install.ts
+++ b/packages/tooling/vis/src/commands/hook/install.ts
@@ -5,6 +5,7 @@ import { dirname } from "node:path";
 import { ensureDirSync } from "@visulima/fs";
 import { join } from "@visulima/path";
 
+import { loadHookConfig } from "./config";
 import type { InstallResult } from "./constants";
 import { DEFAULT_HOOKS_DIRECTORY, HOOKS, LEGACY_HOOKS_DIRECTORY } from "./constants";
 
@@ -51,11 +52,23 @@ const nestedDirname = (depth: number): string => {
 
 /**
  * Generates the shell script that dispatches to user-defined hooks.
+ *
+ * `options.skipInCI` (from `config.json`) bakes a CI kill-switch into the
+ * dispatcher: under any non-empty CI environment variable, every hook exits
+ * 0 before its body runs. It sits after the `VIS_GIT_HOOKS=0` guard (so 0
+ * still disables everything) and is bypassed when `VIS_GIT_HOOKS` equals 1
+ * (so a single CI job can force hooks back on). Mirrors where husky places
+ * its own dispatcher skip-guard, but is driven by config and regenerated on
+ * `vis hook install` rather than hand-written per repo.
  */
-const hookScript = (directory: string): string => {
+const hookScript = (directory: string, options: { skipInCI?: boolean } = {}): string => {
     const segments = directory.split("/").filter((s) => s !== "" && s !== ".").length;
     const depth = segments + 2;
     const rootExpression = nestedDirname(depth);
+
+    // Built as a plain string (not part of the template literal below) so the
+    // `${CI-}` / `${VIS_GIT_HOOKS-}` shell expansions reach the output verbatim.
+    const ciGuard = options.skipInCI ? "{ [ -n \"${CI-}\" ] && [ \"${VIS_GIT_HOOKS-}\" != \"1\" ]; } && exit 0\n" : "";
 
     return `#!/usr/bin/env sh
 { [ "$VIS_GIT_HOOKS" = "2" ]; } && set -x
@@ -65,7 +78,7 @@ s=$(dirname "$(dirname "$0")")/$n
 [ ! -f "$s" ] && exit 0
 
 { [ "\${VIS_GIT_HOOKS-}" = "0" ]; } && exit 0
-
+${ciGuard}
 d=${rootExpression}
 export PATH="$d/node_modules/.bin:$PATH"
 sh -e "$s" "$@"
@@ -124,9 +137,21 @@ const installHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallResul
         return { isError: true, message: String(stderr) };
     }
 
+    // Read `skipInCI` from config.json (created by migrate / hand-authored)
+    // so the dispatcher we write below carries the CI kill-switch. A
+    // malformed config shouldn't block install — `vis hook run` / `vis hook
+    // validate` surface that error loudly — so fall back to no guard.
+    const skipInCI = ((): boolean => {
+        try {
+            return loadHookConfig(process.cwd(), directory)?.skipInCI ?? false;
+        } catch {
+            return false;
+        }
+    })();
+
     ensureDirSync(internal());
     writeFileSync(internal(".gitignore"), "*");
-    writeFileSync(internal("h"), hookScript(directory), { mode: 0o755 });
+    writeFileSync(internal("h"), hookScript(directory, { skipInCI }), { mode: 0o755 });
 
     for (const hook of HOOKS) {
         writeFileSync(internal(hook), `#!/usr/bin/env sh\n. "$(dirname "$0")/h"`, { mode: 0o755 });

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -768,6 +768,15 @@ interface ExecutorDependencies {
      * `options.strictEnv`, then `vis.config.ts strictEnv`, then `false`.
      */
     strictEnv?: boolean;
+
+    /**
+     * Effective parallelism for this run (the resolved `--parallel` value).
+     * Surfaced to every child task as `VIS_TASK_SLOTS` so nested worker
+     * pools (e.g. Vitest's `maxWorkers`) can size themselves against the
+     * concurrency vis already grants them and avoid CPU oversubscription —
+     * `5 × cores` worker processes when 5 projects each spawn a full pool.
+     */
+    taskSlots: number;
     workspaceRoot: string;
 }
 
@@ -826,6 +835,7 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
             serviceEventBridge: bridge,
             stdinRegistry,
             strictEnv: workspaceStrictEnv,
+            taskSlots,
             workspaceRoot,
         } = deps;
 
@@ -870,6 +880,10 @@ const createConcurrentExecutor = (deps: ExecutorDependencies) => {
 
         const mergedEnv: Record<string, string> = {
             INIT_CWD: initCwd,
+            // Effective parallelism vis grants this run, so child tasks can
+            // size their own worker pools instead of assuming the whole
+            // machine (which oversubscribes when N projects run at once).
+            VIS_TASK_SLOTS: String(taskSlots),
             ...envFileVars,
             // Externally-registered service env merges below the
             // task's explicit env so users can override service-
@@ -1620,6 +1634,11 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
         }
     }
 
+    // User-requested task ids (post-partition), so the dependency-hydration
+    // pass below can tell a `dependsOn`-added task apart from one the user
+    // asked for directly and only warn about missing commands on the former.
+    const requestedTaskIds = new Set([...initialTasks, ...persistentTasks].map((task) => task.id));
+
     // Include persistent tasks in the graph so their `dependsOn` chain
     // (especially service deps like `web:serve → api:db`) is walked by
     // `applyServiceRegistry`. Without this, persistent tasks are split
@@ -1655,6 +1674,18 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
         const visTarget = projectOptions.get(projectName)?.[targetName];
 
         if (!visTarget) {
+            // A `dependsOn`-added dependency that resolves to a target with
+            // no configuration anywhere (e.g. `dependsOn: ["codegen"]` but
+            // the project has no `codegen` script/target). task-runner keeps
+            // it in the graph and the executor runs it as a silent 0-exit
+            // no-op, so the missing prerequisite vanishes instead of erroring
+            // — the trap that makes such gaps CI-only and hard to find. Warn
+            // so the misconfiguration is visible. Tasks the user invoked
+            // directly always carry config, so this only fires for deps.
+            if (!requestedTaskIds.has(taskId)) {
+                logger.warn(`${targetName} required via dependsOn but no command is configured for ${projectName} — skipping (no-op).`);
+            }
+
             continue;
         }
 
@@ -2515,6 +2546,7 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
                 serviceEventBridge: serviceEventBridge ?? undefined,
                 stdinRegistry,
                 strictEnv: resolvedStrictEnv,
+                taskSlots: resolvedParallel,
                 workspaceRoot,
             });
 
@@ -2714,6 +2746,7 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
                 serviceEnvByTaskId,
                 serviceEventBridge: serviceEventBridge ?? undefined,
                 strictEnv: resolvedStrictEnv,
+                taskSlots: resolvedParallel,
                 workspaceRoot,
             });
 

--- a/packages/tooling/vis/src/runtime/toolchain.ts
+++ b/packages/tooling/vis/src/runtime/toolchain.ts
@@ -1647,6 +1647,22 @@ export const ensureToolchain = async (
             const { expected } = tool;
 
             if (invocation.bin === "nvm" && invocation.args.length === 0) {
+                // nvm can't be activated for us from a child process — it's a
+                // shell function, not a binary. But the version already on
+                // PATH (the Node running vis, typically) often satisfies the
+                // pin anyway, which is the common case on CI where the right
+                // toolchain is pre-activated. Don't emit a warning that reads
+                // like an error and noises up every task; record success and
+                // move on. Only warn when the active runtime genuinely can't
+                // satisfy the requirement.
+                const active = queryToolVersion(expected.tool);
+
+                if (active !== undefined && satisfies(active, expected.version)) {
+                    logger.info(`toolchain: ${expected.tool} ${active} already satisfies ${expected.version}; skipping nvm shell activation`);
+                    attempted.push(expected);
+                    continue;
+                }
+
                 logger.warn(
                     `toolchain: nvm requires a shell-side activation for ${expected.tool} ${expected.version}. Run \`nvm install\` / \`nvm use\` manually.`,
                 );


### PR DESCRIPTION
Addresses a batch of `@visulima/vis` feedback collected while getting a downstream monorepo's CI green, plus a follow-up feature (skip git hooks in CI).

## Commits

### `feat(vis): task slots env + dependsOn warning`
- **`VIS_TASK_SLOTS`**: the resolved `--parallel` value is now exported to every child task, so nested worker pools (Vitest `maxWorkers`, v8 coverage) can size against the concurrency vis grants and avoid `slots × cores` CPU oversubscription (the cause of ~64 spurious 5s timeouts downstream).
- **`dependsOn` no-command warning**: a `dependsOn` that resolves to a target with no command anywhere (e.g. `dependsOn: ["codegen"]` with no `codegen` script) used to run as a silent 0-exit no-op. It now warns, so a missing prerequisite surfaces locally instead of only failing a downstream task in CI.
- Docs: new "Environment variables in child tasks" + "Execution model" sections in `docs/commands/run.mdx`.

### `fix(vis): clearer generate + toolchain warnings`
- **`generate`**: `--name value` (space form) parses as boolean `--name=true` with the value dropped. It can't be disambiguated from a boolean flag at parse time (template var types aren't loaded yet, and `--flag positional` is a pinned contract), so instead of silently taking `true` it now warns and points at the unambiguous `--name=value` form. Parse result unchanged.
- **`toolchain`**: stop emitting the scary "nvm requires shell-side activation" warning when the active runtime already satisfies the pin (the common CI case) — log it as info and record success. Only warn when the runtime genuinely can't satisfy the requirement.

### `feat(vis): skip git hooks in CI via skipInCI`
- New `skipInCI` option in `.vis/hooks/config.json`. When set, `vis hook install` bakes a CI kill-switch into the generated `_/` dispatcher so every hook exits 0 under a non-empty `CI` env — **before the hook body runs**, so it covers hooks that call a tool directly (e.g. a raw `commitlint` `commit-msg`) and not just those going through `vis hook run`.
- Ordered after the existing `VIS_GIT_HOOKS=0` guard and bypassed by `VIS_GIT_HOOKS=1`, giving a per-job force-on escape hatch that travels with the repo (vs `core.hooksPath=/dev/null` in a single CI job).
- Modeled on husky's `_/h` skip-guard placement; validated with `sh -n` and end-to-end behavior runs.

## Already-solved feedback items (no code, FYI)
- Cache key already folds dependency output hashes + lockfile.
- `vis sort-package-json --check` already exists (exits 1 if unsorted).
- `vis ci` already auto-detects merge-base/CI refs (bare `vis affected` still defaults to `HEAD~1` — docs route users to `vis ci`).

## Testing
- ESLint clean, `tsc --noEmit` clean.
- All affected suites green: passthrough, toolchain, the 12 run-command suites, and the hook unit tests (40/40).
- `hook-commands.test.ts` fails on a pre-existing native-addon-not-built import (`dispatch.ts`), unrelated to this branch — confirmed via stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `skipInCI` support for git hooks (overridable with `VIS_GIT_HOOKS=1`)
  * `vis run --parallel` now exports the resolved concurrency to child tasks via `VIS_TASK_SLOTS` to avoid nested oversubscription
* **Bug Fixes**
  * Improved `nvm` toolchain version handling to reduce unnecessary CI/shell activation warnings when the active version already matches the pin
* **Documentation**
  * Updated git hook and `vis run` documentation, including the CI skipping guide and clearer execution model details
* **Warnings**
  * Added warnings for ambiguous passthrough arguments and for missing `dependsOn` commands that become no-ops
<!-- end of auto-generated comment: release notes by coderabbit.ai -->