### PR TITLE
feat(workflow): Durable Object store (Cloudflare)

### DIFF
--- a/packages/workflow/workflow/README.md
+++ b/packages/workflow/workflow/README.md
@@ -155,9 +155,10 @@ await runtime.signal(runId, "review-decision", { approved: true });
 
 ## Bring your own store
 
-Durability is a small contract. Four stores ship in the box — `MemoryStore` (default), `UnstorageStore`
-(Cloudflare KV/D1/Redis/fs), `SqlStore` (PostgreSQL/MySQL, atomic lease) and `RedisStore` (atomic Lua lease) — or
-implement `WorkflowStore` yourself to back runs with anything else.
+Durability is a small contract. Five stores ship in the box — `MemoryStore` (default), `UnstorageStore`
+(Cloudflare KV/D1/Redis/fs), `SqlStore` (PostgreSQL/MySQL, atomic lease), `RedisStore` (atomic Lua lease) and
+`DurableObjectStore` (Cloudflare DO — race-free lease + self-scheduling alarms, no cron) — or implement `WorkflowStore`
+yourself to back runs with anything else.
 
 ```typescript
 // SQL (atomic cross-process lease) — driver-agnostic via a structural client:

--- a/packages/workflow/workflow/__tests__/_helpers/fake-durable-object.ts
+++ b/packages/workflow/workflow/__tests__/_helpers/fake-durable-object.ts
@@ -1,0 +1,57 @@
+import type { DurableObjectStorageLike } from "../../src/store/durable-object-store";
+
+/**
+ * Faithful in-memory {@link DurableObjectStorageLike} for tests: serialises stored
+ * values (like real DO storage), returns `list` keys in UTF-8 order, and tracks a
+ * single alarm. Plain JS is single-threaded, so it models the DO's serial execution.
+ */
+class FakeDurableObjectStorage implements DurableObjectStorageLike {
+    readonly #data = new Map<string, unknown>();
+
+    #alarm: number | null = null;
+
+    public get<T = unknown>(key: string): Promise<T | undefined> {
+        const value = this.#data.get(key);
+
+        return Promise.resolve(value === undefined ? undefined : (structuredClone(value) as T));
+    }
+
+    public put(key: string, value: unknown): Promise<void> {
+        this.#data.set(key, structuredClone(value));
+
+        return Promise.resolve();
+    }
+
+    public delete(key: string): Promise<boolean> {
+        return Promise.resolve(this.#data.delete(key));
+    }
+
+    public list<T = unknown>(options?: { limit?: number; prefix?: string }): Promise<Map<string, T>> {
+        const prefix = options?.prefix ?? "";
+        // Durable Object storage orders keys by UTF-8 code units, not locale.
+        const keys = [...this.#data.keys()]
+            .filter((key) => key.startsWith(prefix))
+            .toSorted((a, b) => {
+                if (a < b) {
+                    return -1;
+                }
+
+                return a > b ? 1 : 0;
+            });
+        const limited = options?.limit === undefined ? keys : keys.slice(0, options.limit);
+
+        return Promise.resolve(new Map(limited.map((key) => [key, structuredClone(this.#data.get(key)) as T])));
+    }
+
+    public getAlarm(): Promise<number | null> {
+        return Promise.resolve(this.#alarm);
+    }
+
+    public setAlarm(scheduledTime: number): Promise<void> {
+        this.#alarm = scheduledTime;
+
+        return Promise.resolve();
+    }
+}
+
+export default FakeDurableObjectStorage;

--- a/packages/workflow/workflow/__tests__/_helpers/fake-durable-object.ts
+++ b/packages/workflow/workflow/__tests__/_helpers/fake-durable-object.ts
@@ -52,6 +52,12 @@ class FakeDurableObjectStorage implements DurableObjectStorageLike {
 
         return Promise.resolve();
     }
+
+    public deleteAlarm(): Promise<void> {
+        this.#alarm = null;
+
+        return Promise.resolve();
+    }
 }
 
 export default FakeDurableObjectStorage;

--- a/packages/workflow/workflow/__tests__/durable-object-store.test.ts
+++ b/packages/workflow/workflow/__tests__/durable-object-store.test.ts
@@ -35,6 +35,25 @@ describe("DurableObjectStore alarm scheduling", () => {
 
         await expect(storage.getAlarm()).resolves.toBeNull();
     });
+
+    it("re-arms the alarm to the next pending wake when the earliest run is deleted", async () => {
+        expect.assertions(2);
+
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectStore(storage);
+
+        await store.save({ definitionId: "w", runId: "early", snapshot: {}, status: "suspended", updatedAt: 0, wakeAt: 1000 });
+        await store.save({ definitionId: "w", runId: "late", snapshot: {}, status: "suspended", updatedAt: 0, wakeAt: 5000 });
+
+        await expect(storage.getAlarm()).resolves.toBe(1000);
+
+        // Deleting the earliest-waking run must move the alarm forward to the next
+        // pending wake; otherwise the stale 1000ms alarm fires, finds nothing due,
+        // and never re-arms — orphaning the 5000ms wake.
+        await store.delete("early");
+
+        await expect(storage.getAlarm()).resolves.toBe(5000);
+    });
 });
 
 describe("DurableObjectStore with a runtime (alarm-driven sweep)", () => {

--- a/packages/workflow/workflow/__tests__/durable-object-store.test.ts
+++ b/packages/workflow/workflow/__tests__/durable-object-store.test.ts
@@ -54,6 +54,22 @@ describe("DurableObjectStore alarm scheduling", () => {
 
         await expect(storage.getAlarm()).resolves.toBe(5000);
     });
+
+    it("clears the alarm once no pending wakes remain", async () => {
+        expect.assertions(2);
+
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectStore(storage);
+
+        await store.save({ definitionId: "w", runId: "only", snapshot: {}, status: "suspended", updatedAt: 0, wakeAt: 1000 });
+
+        await expect(storage.getAlarm()).resolves.toBe(1000);
+
+        // Removing the last wake should clear the alarm, not leave it firing spuriously.
+        await store.delete("only");
+
+        await expect(storage.getAlarm()).resolves.toBeNull();
+    });
 });
 
 describe("DurableObjectStore with a runtime (alarm-driven sweep)", () => {

--- a/packages/workflow/workflow/__tests__/durable-object-store.test.ts
+++ b/packages/workflow/workflow/__tests__/durable-object-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import defineWorkflow from "../src/define-workflow";
+import createRuntime from "../src/runtime";
+import DurableObjectStore from "../src/store/durable-object-store";
+import FakeDurableObjectStorage from "./_helpers/fake-durable-object";
+import { runStoreContract } from "./_helpers/store-contract";
+
+runStoreContract("DurableObjectStore", () => Promise.resolve({ store: new DurableObjectStore(new FakeDurableObjectStorage()) }));
+
+describe("DurableObjectStore alarm scheduling", () => {
+    it("arms the alarm at the earliest pending wake-at", async () => {
+        expect.assertions(2);
+
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectStore(storage);
+
+        await store.save({ definitionId: "w", runId: "late", snapshot: {}, status: "suspended", updatedAt: 0, wakeAt: 5000 });
+
+        await expect(storage.getAlarm()).resolves.toBe(5000);
+
+        // A run due earlier moves the alarm earlier.
+        await store.save({ definitionId: "w", runId: "early", snapshot: {}, status: "suspended", updatedAt: 0, wakeAt: 2000 });
+
+        await expect(storage.getAlarm()).resolves.toBe(2000);
+    });
+
+    it("does not arm an alarm for a completed run", async () => {
+        expect.assertions(1);
+
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectStore(storage);
+
+        await store.save({ definitionId: "w", runId: "done", snapshot: {}, status: "completed", updatedAt: 0 });
+
+        await expect(storage.getAlarm()).resolves.toBeNull();
+    });
+});
+
+describe("DurableObjectStore with a runtime (alarm-driven sweep)", () => {
+    it("persists a sleeping run, arms the alarm, and resumes via sweep", async () => {
+        expect.assertions(4);
+
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectStore(storage);
+        const sideEffect = vi.fn(() => "shipped");
+        const workflow = defineWorkflow({
+            id: "order",
+            run: async (context) => {
+                await context.sleep("settle", 1000);
+                await context.step("ship", sideEffect);
+            },
+        });
+
+        const runtime = createRuntime({ store, workflows: [workflow] });
+        const triggered = await runtime.trigger(workflow, {});
+
+        expect(triggered.status).toBe("suspended");
+
+        // The store armed an alarm at the sleep's wake-at — that's how a DO would wake itself.
+        const alarm = await storage.getAlarm();
+
+        expect(alarm).not.toBeNull();
+
+        // Simulate the DO's alarm() firing: sweep at (or after) the armed time.
+        const [resumed] = await runtime.sweep((alarm ?? Date.now()) + 1);
+
+        expect(resumed?.status).toBe("completed");
+        expect(sideEffect).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not drive a run whose lease is held by another holder", async () => {
+        expect.assertions(2);
+
+        const store = new DurableObjectStore(new FakeDurableObjectStorage());
+        const sideEffect = vi.fn(() => "x");
+        const workflow = defineWorkflow({
+            id: "leased-do",
+            run: async (context) => {
+                await context.sleep("nap", 1000);
+                await context.step("after", sideEffect);
+            },
+        });
+
+        const runtime = createRuntime({ store, workflows: [workflow] });
+        const triggered = await runtime.trigger(workflow, {});
+
+        // Another holder claims the lease (the Durable Object's input gate makes acquire atomic in production).
+        await store.acquire(triggered.runId, "other-holder", 60_000);
+
+        const [result] = await runtime.sweep(Date.now() + 2000);
+
+        expect(sideEffect).toHaveBeenCalledTimes(0);
+        expect(result?.status).toBe("suspended");
+    });
+});

--- a/packages/workflow/workflow/docs/stores.mdx
+++ b/packages/workflow/workflow/docs/stores.mdx
@@ -5,8 +5,8 @@ description: The WorkflowStore contract and the built-in adapters
 
 # Stores
 
-Durability is delegated to a small `WorkflowStore` contract; the engine stays storage-agnostic. Two stores ship in the
-box, and you can implement the contract over Redis, Postgres, a Durable Object, or anything else.
+Durability is delegated to a small `WorkflowStore` contract; the engine stays storage-agnostic. Five stores ship in the
+box (memory, unstorage, SQL, Redis, Durable Object), and you can implement the contract over anything else.
 
 ## Built-in stores
 
@@ -73,6 +73,38 @@ import Redis from "ioredis";
 const store = new RedisStore(new Redis(process.env.REDIS_URL));
 const runtime = createRuntime({ store });
 ```
+
+### DurableObjectStore (Cloudflare)
+
+Persistence in a [Cloudflare Durable Object](https://developers.cloudflare.com/durable-objects/)'s storage. Because a
+Durable Object processes requests **serially**, the lease is race-free by construction — the cleanest correct
+cross-process store. It also uses DO **alarms**: the store arms an alarm at the earliest wake-at, so the object wakes
+itself to `sweep` — **no external cron needed** (the push model the `due` contract was designed for). The adapter takes a
+structural storage object, so it needs no `@cloudflare/workers-types` dependency.
+
+```typescript
+import { createRuntime } from "@visulima/workflow";
+import { DurableObjectStore } from "@visulima/workflow/store/durable-object";
+
+export class WorkflowDurableObject {
+    #runtime;
+
+    constructor(state: DurableObjectState) {
+        this.#runtime = createRuntime({ store: new DurableObjectStore(state.storage), workflows });
+    }
+
+    async fetch(request: Request) {
+        // route trigger() / signal() calls into this.#runtime
+    }
+
+    async alarm() {
+        await this.#runtime.sweep(); // the store re-arms the next alarm after each save
+    }
+}
+```
+
+One Durable Object instance is one runtime, so there is no cross-instance contention to coordinate — the DO _is_ the
+single owner. Completed runs are retained in storage (for `getRun`); `delete(runId)` to evict them.
 
 ## The contract
 

--- a/packages/workflow/workflow/package.json
+++ b/packages/workflow/workflow/package.json
@@ -61,6 +61,10 @@
             "types": "./dist/store/sql-store.d.ts",
             "default": "./dist/store/sql-store.js"
         },
+        "./store/durable-object": {
+            "types": "./dist/store/durable-object-store.d.ts",
+            "default": "./dist/store/durable-object-store.js"
+        },
         "./store/redis": {
             "types": "./dist/store/redis-store.d.ts",
             "default": "./dist/store/redis-store.js"

--- a/packages/workflow/workflow/src/store/durable-object-store.ts
+++ b/packages/workflow/workflow/src/store/durable-object-store.ts
@@ -92,6 +92,8 @@ class DurableObjectStore implements WorkflowStore {
         if (run !== undefined && isWakeable(run)) {
             await this.#storage.delete(wakeKey(run.wakeAt as number, runId));
         }
+
+        await this.#reschedule();
     }
 
     public async due(now: number, limit: number): Promise<string[]> {
@@ -145,8 +147,12 @@ class DurableObjectStore implements WorkflowStore {
 
         const current = this.#storage.getAlarm === undefined ? undefined : await this.#storage.getAlarm();
 
-        // Only move the alarm earlier; firing early is harmless (sweep no-ops and re-arms).
-        if (typeof current !== "number" || next < current) {
+        // Keep the alarm aligned with the actual earliest pending wake. It must be
+        // able to move in BOTH directions: earlier when a sooner run is saved, and
+        // later when the earliest run is deleted — otherwise a stale alarm fires
+        // once, finds nothing due (so sweep never re-arms via save), and the
+        // remaining later wake-ups are orphaned.
+        if (current !== next) {
             await this.#storage.setAlarm(next);
         }
     }

--- a/packages/workflow/workflow/src/store/durable-object-store.ts
+++ b/packages/workflow/workflow/src/store/durable-object-store.ts
@@ -3,12 +3,14 @@ import type { StoredRun, WorkflowStore } from "./types";
 /**
  * The subset of [`DurableObjectStorage`](https://developers.cloudflare.com/durable-objects/api/storage-api/)
  * this store touches. Declared structurally so it needs no `@cloudflare/workers-types`
- * dependency and can be unit-tested with a plain object. `getAlarm`/`setAlarm` are
- * optional: when present, the store schedules a wake-up alarm so `sweep` is driven
- * by the runtime instead of an external cron (the push model).
+ * dependency and can be unit-tested with a plain object. `getAlarm`/`setAlarm`/
+ * `deleteAlarm` are optional: when present, the store schedules a wake-up alarm so
+ * `sweep` is driven by the runtime instead of an external cron (the push model),
+ * and clears it once no wakes remain.
  */
 interface DurableObjectStorageLike {
     delete: (key: string) => Promise<boolean>;
+    deleteAlarm?: () => Promise<void>;
     get: <T = unknown>(key: string) => Promise<T | undefined>;
     getAlarm?: () => Promise<number | null>;
     list: <T = unknown>(options?: { limit?: number; prefix?: string }) => Promise<Map<string, T>>;
@@ -25,7 +27,13 @@ const RUN_PREFIX = "run:";
 const LEASE_PREFIX = "lease:";
 const WAKE_PREFIX = "wake:";
 
-/** Fixed-width so `storage.list` (UTF-8 key order) yields wake keys ascending by time. */
+/**
+ * Fixed-width zero-padding so `storage.list` (UTF-8 key order) yields wake keys
+ * ascending by time. 16 digits holds every epoch-millisecond wake-at (13 digits
+ * today, room until ~year 318000) AND `Number.MAX_SAFE_INTEGER` (16 digits), which
+ * the store contract probes. Wake-at values with **more than 16 digits would break
+ * key ordering** — keep wake-at in epoch-ms (the runtime's `resolveWakeAt` does).
+ */
 const WAKE_WIDTH = 16;
 
 const wakeKey = (wakeAt: number, runId: string): string => `${WAKE_PREFIX}${String(wakeAt).padStart(WAKE_WIDTH, "0")}:${runId}`;
@@ -97,12 +105,14 @@ class DurableObjectStore implements WorkflowStore {
     }
 
     public async due(now: number, limit: number): Promise<string[]> {
-        const entries = await this.#storage.list<string>({ prefix: WAKE_PREFIX });
+        // `list` returns keys ascending by wake-at (earliest first), so capping at
+        // `limit` in the query yields the soonest-due runs without materialising the
+        // whole wake-index — matching the SQL/Redis stores' bounded reads.
+        const entries = await this.#storage.list<string>({ limit, prefix: WAKE_PREFIX });
         const due: string[] = [];
 
-        // `list` returns keys ascending by wake-at, so the earliest are first.
         for (const [key, runId] of entries) {
-            if (wakeAtOf(key) > now || due.length >= limit) {
+            if (wakeAtOf(key) > now) {
                 break;
             }
 
@@ -112,6 +122,11 @@ class DurableObjectStore implements WorkflowStore {
         return due;
     }
 
+    // Lease keys carry an `expiresAt` checked on acquire, so a stale lease is always
+    // reclaimable; unlike Redis' native TTL the DO has no auto-expiry, so a key for a
+    // run that crashes between acquire and release lingers until the run is re-driven
+    // or `delete`d. Harmless (the DO's serial execution already guarantees exclusion),
+    // just a slow accrual of dead keys in pathological crash loops.
     public async acquire(runId: string, token: string, ttlMs: number): Promise<boolean> {
         const now = Date.now();
         const existing = await this.#storage.get<Lease>(LEASE_PREFIX + runId);
@@ -140,12 +155,16 @@ class DurableObjectStore implements WorkflowStore {
         }
 
         const next = await this.#nextWakeAt();
+        const current = this.#storage.getAlarm === undefined ? undefined : await this.#storage.getAlarm();
 
         if (next === undefined) {
+            // No pending wakes: clear any leftover alarm so the DO doesn't wake spuriously.
+            if (typeof current === "number" && this.#storage.deleteAlarm !== undefined) {
+                await this.#storage.deleteAlarm();
+            }
+
             return;
         }
-
-        const current = this.#storage.getAlarm === undefined ? undefined : await this.#storage.getAlarm();
 
         // Keep the alarm aligned with the actual earliest pending wake. It must be
         // able to move in BOTH directions: earlier when a sooner run is saved, and

--- a/packages/workflow/workflow/src/store/durable-object-store.ts
+++ b/packages/workflow/workflow/src/store/durable-object-store.ts
@@ -1,0 +1,166 @@
+import type { StoredRun, WorkflowStore } from "./types";
+
+/**
+ * The subset of [`DurableObjectStorage`](https://developers.cloudflare.com/durable-objects/api/storage-api/)
+ * this store touches. Declared structurally so it needs no `@cloudflare/workers-types`
+ * dependency and can be unit-tested with a plain object. `getAlarm`/`setAlarm` are
+ * optional: when present, the store schedules a wake-up alarm so `sweep` is driven
+ * by the runtime instead of an external cron (the push model).
+ */
+interface DurableObjectStorageLike {
+    delete: (key: string) => Promise<boolean>;
+    get: <T = unknown>(key: string) => Promise<T | undefined>;
+    getAlarm?: () => Promise<number | null>;
+    list: <T = unknown>(options?: { limit?: number; prefix?: string }) => Promise<Map<string, T>>;
+    put: (key: string, value: unknown) => Promise<void>;
+    setAlarm?: (scheduledTime: number) => Promise<void>;
+}
+
+interface Lease {
+    expiresAt: number;
+    token: string;
+}
+
+const RUN_PREFIX = "run:";
+const LEASE_PREFIX = "lease:";
+const WAKE_PREFIX = "wake:";
+
+/** Fixed-width so `storage.list` (UTF-8 key order) yields wake keys ascending by time. */
+const WAKE_WIDTH = 16;
+
+const wakeKey = (wakeAt: number, runId: string): string => `${WAKE_PREFIX}${String(wakeAt).padStart(WAKE_WIDTH, "0")}:${runId}`;
+
+const wakeAtOf = (key: string): number => Number(key.slice(WAKE_PREFIX.length, WAKE_PREFIX.length + WAKE_WIDTH));
+
+const isWakeable = (run: StoredRun): boolean => (run.status === "suspended" || run.status === "waiting") && run.wakeAt !== undefined;
+
+/**
+ * {@link WorkflowStore} backed by a Cloudflare Durable Object's storage. Because a
+ * Durable Object processes requests **serially**, the lease (`acquire`/`release`)
+ * is race-free by construction — the cleanest correct cross-process store.
+ *
+ * It keeps a wake-index (sorted keys) so `due` and the next-alarm time are cheap,
+ * and, when the storage exposes `setAlarm`, schedules an alarm at the earliest
+ * wake-at. Pair it with a Durable Object whose `alarm()` calls `runtime.sweep()`:
+ *
+ * ```ts
+ * export class WorkflowDO {
+ *     #runtime;
+ *     constructor(state) {
+ *         this.#runtime = createRuntime({ store: new DurableObjectStore(state.storage), workflows });
+ *     }
+ *     // fetch() routes trigger / signal calls into this.#runtime
+ *     async alarm() {
+ *         await this.#runtime.sweep(); // the store re-arms the next alarm on save
+ *     }
+ * }
+ * ```
+ */
+class DurableObjectStore implements WorkflowStore {
+    readonly #storage: DurableObjectStorageLike;
+
+    public constructor(storage: DurableObjectStorageLike) {
+        this.#storage = storage;
+    }
+
+    public async save(run: StoredRun): Promise<void> {
+        const previous = await this.#storage.get<StoredRun>(RUN_PREFIX + run.runId);
+
+        if (previous !== undefined && isWakeable(previous)) {
+            await this.#storage.delete(wakeKey(previous.wakeAt as number, run.runId));
+        }
+
+        await this.#storage.put(RUN_PREFIX + run.runId, run);
+
+        if (isWakeable(run)) {
+            await this.#storage.put(wakeKey(run.wakeAt as number, run.runId), run.runId);
+        }
+
+        await this.#reschedule();
+    }
+
+    public async load(runId: string): Promise<StoredRun | undefined> {
+        return this.#storage.get<StoredRun>(RUN_PREFIX + runId);
+    }
+
+    public async delete(runId: string): Promise<void> {
+        const run = await this.#storage.get<StoredRun>(RUN_PREFIX + runId);
+
+        await this.#storage.delete(RUN_PREFIX + runId);
+        await this.#storage.delete(LEASE_PREFIX + runId);
+
+        if (run !== undefined && isWakeable(run)) {
+            await this.#storage.delete(wakeKey(run.wakeAt as number, runId));
+        }
+    }
+
+    public async due(now: number, limit: number): Promise<string[]> {
+        const entries = await this.#storage.list<string>({ prefix: WAKE_PREFIX });
+        const due: string[] = [];
+
+        // `list` returns keys ascending by wake-at, so the earliest are first.
+        for (const [key, runId] of entries) {
+            if (wakeAtOf(key) > now || due.length >= limit) {
+                break;
+            }
+
+            due.push(runId);
+        }
+
+        return due;
+    }
+
+    public async acquire(runId: string, token: string, ttlMs: number): Promise<boolean> {
+        const now = Date.now();
+        const existing = await this.#storage.get<Lease>(LEASE_PREFIX + runId);
+
+        if (existing !== undefined && existing.expiresAt > now && existing.token !== token) {
+            return false;
+        }
+
+        await this.#storage.put(LEASE_PREFIX + runId, { expiresAt: now + ttlMs, token } satisfies Lease);
+
+        return true;
+    }
+
+    public async release(runId: string, token: string): Promise<void> {
+        const existing = await this.#storage.get<Lease>(LEASE_PREFIX + runId);
+
+        if (existing?.token === token) {
+            await this.#storage.delete(LEASE_PREFIX + runId);
+        }
+    }
+
+    /** Arm the alarm at the earliest pending wake-at, so the DO wakes itself to sweep. */
+    async #reschedule(): Promise<void> {
+        if (this.#storage.setAlarm === undefined) {
+            return;
+        }
+
+        const next = await this.#nextWakeAt();
+
+        if (next === undefined) {
+            return;
+        }
+
+        const current = this.#storage.getAlarm === undefined ? undefined : await this.#storage.getAlarm();
+
+        // Only move the alarm earlier; firing early is harmless (sweep no-ops and re-arms).
+        if (typeof current !== "number" || next < current) {
+            await this.#storage.setAlarm(next);
+        }
+    }
+
+    async #nextWakeAt(): Promise<number | undefined> {
+        const entries = await this.#storage.list<string>({ limit: 1, prefix: WAKE_PREFIX });
+
+        for (const key of entries.keys()) {
+            return wakeAtOf(key);
+        }
+
+        return undefined;
+    }
+}
+
+export type { DurableObjectStorageLike };
+export default DurableObjectStore;

--- a/packages/workflow/workflow/src/store/index.ts
+++ b/packages/workflow/workflow/src/store/index.ts
@@ -1,3 +1,4 @@
+export { type DurableObjectStorageLike, default as DurableObjectStore } from "./durable-object-store";
 export { default as MemoryStore } from "./memory-store";
 export { type RedisLike, default as RedisStore, type RedisStoreOptions } from "./redis-store";
 export { type SqlClient, type SqlDialect, type SqlResult, default as SqlStore, type SqlStoreOptions } from "./sql-store";


### PR DESCRIPTION
## What

Adds **`@visulima/workflow/store/durable-object`** — a `WorkflowStore` backed by a Cloudflare Durable Object's storage. This closes the engine's one remaining durability gap (the *genuinely-atomic* cross-process store flagged when the lease landed) with the cleanest possible backend, and it's the **lunora unlock**.

## Why a DO is the ideal backend

- **Race-free lease** — a Durable Object processes requests **serially** (input gate), so `acquire`/`release` need no CAS; they're atomic by construction.
- **Self-scheduling (push, not poll)** — the store keeps a sorted wake-index and arms a **DO alarm** at the earliest `wakeAt`, so the object wakes *itself* to `sweep`. No external cron — exactly the push model the poll-based `due` contract was designed to allow.
- **Dependency-free adapter** — takes a *structural* `DurableObjectStorageLike` (`get/put/delete/list/getAlarm/setAlarm`), mirroring lunora's `session-do` pattern, so it needs **no `@cloudflare/workers-types`** dep and unit-tests with a plain object.

## Usage

```ts
import { createRuntime } from "@visulima/workflow";
import { DurableObjectStore } from "@visulima/workflow/store/durable-object";

export class WorkflowDurableObject {
    #runtime;
    constructor(state: DurableObjectState) {
        this.#runtime = createRuntime({ store: new DurableObjectStore(state.storage), workflows });
    }
    async alarm() { await this.#runtime.sweep(); } // store re-arms the next alarm on save
}
```

## Testing
- A faithful in-memory DO-storage fake (serialises values, UTF-8 key order, single alarm) runs through the **shared store contract** + DO-specific tests: alarm armed at earliest wake-at, alarm moved earlier, no alarm for completed runs, and an **alarm-driven sweep** round-trip (trigger → store arms alarm → simulate `alarm()` → completes).
- Note: one DO instance = one runtime (the DO *is* the single owner), so there's no concurrent-in-process lease test — the platform input gate provides atomicity; verified via the sequential "lease held elsewhere" test.
- A real-runtime (miniflare / `@cloudflare/vitest-pool-workers`) smoke test is a sensible **follow-up**; the structural fake models DO storage semantics faithfully in the meantime.

## Quality
- **100 tests**, eslint (`--max-warnings=0`) / tsc clean, packem build ✓, attw 🟢 for the new subpath, publint "All good!". Docs (`stores.mdx`) + README updated — **5 stores** now ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DurableObjectStore, a new storage backend for workflows powered by Cloudflare Durable Objects. Provides race-free concurrent access via automatic lease management and self-scheduling via Durable Object alarms, eliminating the need for external cron jobs.

* **Documentation**
  * Updated store documentation to describe the new DurableObjectStore implementation and its key features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->