### PR TITLE
fix(vis): unbreak full build — exclude variable-import modules from dynamic-import-vars

### DIFF
--- a/packages/tooling/vis-mcp/eslint.config.js
+++ b/packages/tooling/vis-mcp/eslint.config.js
@@ -62,6 +62,9 @@ export default createConfig(
             "sonarjs/no-alphabetical-sort": "off",
             "unicorn/no-array-sort": "off",
             "unicorn/prevent-abbreviations": "off",
+            // try/catch + `expect` on the caught error is the idiomatic assertion
+            // style here; a message arg to toThrow() would be redundant.
+            "vitest/require-to-throw-message": "off",
             "vitest/require-top-level-describe": "off",
         },
     },

--- a/packages/tooling/vis/__tests__/release/commands/release-add-from-bot.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-add-from-bot.test.ts
@@ -113,7 +113,7 @@ describe(parseBotPrTitle, () => {
     it("parses Dependabot 'build(deps): bump <pkg> from X to Y'", () => {
         const parsed = parseBotPrTitle("build(deps): bump lodash from 4.17.20 to 4.17.21");
 
-        expect(parsed).toEqual({
+        expect(parsed).toStrictEqual({
             dep: "lodash",
             fromVersion: "4.17.20",
             toVersion: "4.17.21",
@@ -130,7 +130,7 @@ describe(parseBotPrTitle, () => {
     it("parses Dependabot with 'in /path' suffix", () => {
         const parsed = parseBotPrTitle("chore(deps): bump @types/node from 20.10.0 to 20.11.0 in /examples");
 
-        expect(parsed).toEqual({
+        expect(parsed).toStrictEqual({
             dep: "@types/node",
             fromVersion: "20.10.0",
             toVersion: "20.11.0",

--- a/packages/tooling/vis/__tests__/release/commands/release-add-from-bot.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-add-from-bot.test.ts
@@ -111,6 +111,8 @@ const makeToolbox = (cwd: string, options: { "from-bot-pr"?: boolean; message?: 
 
 describe(parseBotPrTitle, () => {
     it("parses Dependabot 'build(deps): bump <pkg> from X to Y'", () => {
+        expect.hasAssertions();
+
         const parsed = parseBotPrTitle("build(deps): bump lodash from 4.17.20 to 4.17.21");
 
         expect(parsed).toStrictEqual({
@@ -121,6 +123,8 @@ describe(parseBotPrTitle, () => {
     });
 
     it("parses bare Dependabot 'Bump <pkg> from X to Y'", () => {
+        expect.hasAssertions();
+
         const parsed = parseBotPrTitle("Bump axios from 1.4.0 to 1.5.0");
 
         expect(parsed?.dep).toBe("axios");
@@ -128,6 +132,8 @@ describe(parseBotPrTitle, () => {
     });
 
     it("parses Dependabot with 'in /path' suffix", () => {
+        expect.hasAssertions();
+
         const parsed = parseBotPrTitle("chore(deps): bump @types/node from 20.10.0 to 20.11.0 in /examples");
 
         expect(parsed).toStrictEqual({
@@ -138,6 +144,8 @@ describe(parseBotPrTitle, () => {
     });
 
     it("parses Renovate 'Update dependency <pkg> to <version>'", () => {
+        expect.hasAssertions();
+
         const parsed = parseBotPrTitle("Update dependency lodash to v4.17.21");
 
         expect(parsed?.dep).toBe("lodash");
@@ -146,6 +154,8 @@ describe(parseBotPrTitle, () => {
     });
 
     it("parses Renovate with conventional-commit prefix", () => {
+        expect.hasAssertions();
+
         const parsed = parseBotPrTitle("chore(deps): update dependency typescript to 5.4.0");
 
         expect(parsed?.dep).toBe("typescript");
@@ -156,6 +166,8 @@ describe(parseBotPrTitle, () => {
         // Renovate occasionally appends "[skip-ci]" / "[security]" / scope
         // tags / emoji to the title; the dep + target version must still be
         // extracted cleanly. Regression test for F8.
+        expect.hasAssertions();
+
         const skipCi = parseBotPrTitle("Update module foo to 1.2.3 [skip-ci]");
 
         expect(skipCi?.dep).toBe("foo");
@@ -168,6 +180,7 @@ describe(parseBotPrTitle, () => {
     });
 
     it("returns undefined for an unrecognised title", () => {
+        expect.hasAssertions();
         expect(parseBotPrTitle("feat: add tab completion")).toBeUndefined();
         expect(parseBotPrTitle("Merge pull request #123 from foo/bar")).toBeUndefined();
         expect(parseBotPrTitle("")).toBeUndefined();
@@ -222,6 +235,8 @@ describe.skipIf(isWindows)("vis release add --from-bot-pr (handler integration)"
     });
 
     it("authors a patch-bump change file from a Dependabot PR title", async () => {
+        expect.hasAssertions();
+
         ghRun = ghPrView({ author: "dependabot[bot]", title: "build(deps): bump lodash from 4.17.20 to 4.17.21" });
 
         const { toolbox } = makeToolbox(cwd, { "from-bot-pr": true });
@@ -241,6 +256,8 @@ describe.skipIf(isWindows)("vis release add --from-bot-pr (handler integration)"
     });
 
     it("authors a patch-bump change file from a Renovate PR title", async () => {
+        expect.hasAssertions();
+
         ghRun = ghPrView({ author: "renovate[bot]", title: "Update dependency lodash to v4.18.0" });
 
         const { toolbox } = makeToolbox(cwd, { "from-bot-pr": true });
@@ -258,6 +275,8 @@ describe.skipIf(isWindows)("vis release add --from-bot-pr (handler integration)"
     });
 
     it("exits gracefully when the PR title is not a bot pattern (no change file written)", async () => {
+        expect.hasAssertions();
+
         ghRun = ghPrView({ author: "human-user", title: "feat: add a new awesome feature" });
 
         const { logs, toolbox } = makeToolbox(cwd, { "from-bot-pr": true });
@@ -278,6 +297,8 @@ describe.skipIf(isWindows)("vis release add --from-bot-pr (handler integration)"
         // Drop the PR_NUMBER env so the fallback path through `gh pr view`
         // is exercised. The injected runner returns exit code 1 to simulate
         // "gh not authenticated / no PR for this branch".
+        expect.hasAssertions();
+
         delete process.env.PR_NUMBER;
         delete process.env.GITHUB_REF;
 

--- a/packages/tooling/vis/__tests__/release/commands/release-check-additional-paths.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-check-additional-paths.test.ts
@@ -109,6 +109,8 @@ describe.skipIf(isWindows)("vis release check --strict — additionalPaths (rele
     });
 
     it("flags @scope/cli as uncovered when docs/cli/ changes match its additionalPaths glob", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             baseBranch: "main",
             packages: {
@@ -146,6 +148,8 @@ describe.skipIf(isWindows)("vis release check --strict — additionalPaths (rele
     });
 
     it("does NOT flag @scope/cli when docs/cli/ changes match no additionalPaths", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             baseBranch: "main",
             // No additionalPaths set — docs change is unattributed.
@@ -189,6 +193,8 @@ describe.skipIf(isWindows)("vis release check --strict — additionalPaths (rele
         // embedded copy. Over-attribution only ever yields a visible
         // "uncovered" warning the operator resolves (add a change file or
         // narrow the glob); under-attribution would be a silent stale release.
+        expect.hasAssertions();
+
         const cwd2 = mkdtempSync(join(tmpdir(), "vis-check-double-"));
 
         try {

--- a/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
@@ -119,6 +119,8 @@ describe("vis release ci release — C7 publish idempotency", () => {
     });
 
     it("version-pr mode with no pending files and no .state.json → publish without resume", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture("main");
 
         // Configure main as version-pr channel — no pending files → assume merge.
@@ -140,6 +142,8 @@ describe("vis release ci release — C7 publish idempotency", () => {
     });
 
     it("version-pr mode with no pending files and .state.json present → publish with resume", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture("main");
 
         writeVisConfigCjs(cwd, {
@@ -166,6 +170,8 @@ describe("vis release ci release — C7 publish idempotency", () => {
     });
 
     it("auto-publish mode → applyContext then publishContext with resume:true", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture("alpha");
 
         writeVisConfigCjs(cwd, {

--- a/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
@@ -133,7 +133,7 @@ describe("vis release ci release — C7 publish idempotency", () => {
             logger: { error: () => {}, info: () => {}, warn: () => {} },
             options: { channel: "main" },
             workspaceRoot: cwd,
-        } as never);
+        });
 
         expect(publishOptionsCaptured).toHaveLength(1);
         expect(publishOptionsCaptured[0]).toMatchObject({ resume: false });
@@ -159,7 +159,7 @@ describe("vis release ci release — C7 publish idempotency", () => {
             logger: { error: () => {}, info: () => {}, warn: () => {} },
             options: { channel: "main" },
             workspaceRoot: cwd,
-        } as never);
+        });
 
         expect(publishOptionsCaptured).toHaveLength(1);
         expect(publishOptionsCaptured[0]).toMatchObject({ resume: true });
@@ -185,7 +185,7 @@ describe("vis release ci release — C7 publish idempotency", () => {
             logger: { error: () => {}, info: () => {}, warn: () => {} },
             options: { channel: "alpha" },
             workspaceRoot: cwd,
-        } as never);
+        });
 
         expect(publishOptionsCaptured).toHaveLength(1);
         expect(publishOptionsCaptured[0]).toMatchObject({ resume: true, tag: "alpha" });

--- a/packages/tooling/vis/__tests__/release/commands/release-doctor-first-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-doctor-first-release.test.ts
@@ -145,6 +145,8 @@ describe("vis release doctor — first-release.repo-not-greenfield (M-1)", () =>
     });
 
     it("passes on a greenfield repo (no tags, no published versions) when --first-release is set", async () => {
+        expect.hasAssertions();
+
         const capture = captureStdout();
 
         try {
@@ -168,6 +170,8 @@ describe("vis release doctor — first-release.repo-not-greenfield (M-1)", () =>
     it("errors out when --first-release is set but a matching release tag exists", async () => {
         // Create a tag matching the default `{name}@{version}` pattern
         // — once present, the workspace is no longer greenfield.
+        expect.hasAssertions();
+
         execFileSync("git", ["tag", "@scope/a@0.0.1"], { cwd });
 
         const capture = captureStdout();
@@ -199,6 +203,8 @@ describe("vis release doctor — first-release.repo-not-greenfield (M-1)", () =>
         // Even with a tag present, the check is silent without the flag —
         // doctor is not a "is this greenfield?" probe, it's an opt-in
         // guardrail for the bootstrap workflow.
+        expect.hasAssertions();
+
         execFileSync("git", ["tag", "@scope/a@0.0.1"], { cwd });
 
         const capture = captureStdout();

--- a/packages/tooling/vis/__tests__/release/commands/release-doctor-signing.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-doctor-signing.test.ts
@@ -176,6 +176,8 @@ describe("vis release doctor — git.signing key redaction (F9)", () => {
     it("redacts filesystem-path signing keys (does not echo the full path)", async () => {
         // A path-style signing.key — common when operators point at an
         // exported private key file rather than a key id.
+        expect.hasAssertions();
+
         const keyPath = "/home/runner/.ssh/release-signing-key";
 
         cwd = setupRepo({ signing: { key: keyPath, mode: "gpg" } });
@@ -210,6 +212,8 @@ describe("vis release doctor — git.signing key redaction (F9)", () => {
     it("emits a redacted-tail hint for short key ids (no path chars)", async () => {
         // A short hex key id (no `/` or `\`) — keeping the last 4 chars
         // is useful for the operator to confirm WHICH key was picked.
+        expect.hasAssertions();
+
         const keyId = "ABCDEF1234567890";
 
         cwd = setupRepo({ signing: { key: keyId, mode: "gpg" } });
@@ -264,6 +268,8 @@ describe("vis release doctor — floating-major-tag.signing-risk (F24)", () => {
     });
 
     it("warns when floatingMajorTag AND signing.mode=sigstore are both set", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: true, signing: { mode: "sigstore" } });
 
         // Stub gitsign --version returning 0 so the sigstore check passes
@@ -315,6 +321,8 @@ describe("vis release doctor — floating-major-tag.signing-risk (F24)", () => {
     });
 
     it("does NOT emit the risk check when floatingMajorTag is off", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: false, signing: { mode: "sigstore" } });
 
         vi.doMock(import("../../../src/release/core/shell-runner"), () => {
@@ -355,6 +363,8 @@ describe("vis release doctor — floating-major-tag.signing-risk (F24)", () => {
     });
 
     it("does NOT emit the risk check when signing.mode is gpg (no Rekor entries)", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: true, signing: { mode: "gpg" } });
         stubShellRunnerForSigningPass("ABCD1234");
 
@@ -427,6 +437,8 @@ describe("vis release doctor — floating-major-tag.legacy-tags (wave-7)", () =>
     };
 
     it("is skipped (no check emitted) when floatingMajorTag is disabled", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: false });
         stubGitTagList(["v1", "v2"]); // legacy tags exist but should be ignored
 
@@ -449,6 +461,8 @@ describe("vis release doctor — floating-major-tag.legacy-tags (wave-7)", () =>
     });
 
     it("fires (warn / fail) when floatingMajorTag is on AND legacy v<major> tags exist", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: true });
         stubGitTagList(["v1", "v2", "v1.0.0", "acme-action-v1"]);
 
@@ -483,6 +497,8 @@ describe("vis release doctor — floating-major-tag.legacy-tags (wave-7)", () =>
     });
 
     it("passes when floatingMajorTag is on but only new-format tags exist", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: true });
         // No bare `v<N>` — only the new-format tags and a SemVer tag.
         stubGitTagList(["acme-action-v1", "acme-action-v2", "v1.0.0"]);
@@ -509,6 +525,8 @@ describe("vis release doctor — floating-major-tag.legacy-tags (wave-7)", () =>
     });
 
     it("caps the listed tags at 5 with a `+N more` suffix when there are more", async () => {
+        expect.hasAssertions();
+
         cwd = setupRepo({ floatingMajorTag: true });
         stubGitTagList(["v1", "v2", "v3", "v4", "v5", "v6", "v7"]);
 

--- a/packages/tooling/vis/__tests__/release/commands/release-doctor-token-scopes.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-doctor-token-scopes.test.ts
@@ -129,6 +129,8 @@ describe("vis release doctor — github.token-scopes (semantic-release #2469)", 
     });
 
     it("warns when the token carries the broad `repo` scope", async () => {
+        expect.hasAssertions();
+
         vi.doMock(import("../../../src/release/core/shell-runner"), () => {
             return {
                 createShellRunner: () => {
@@ -173,6 +175,8 @@ describe("vis release doctor — github.token-scopes (semantic-release #2469)", 
     });
 
     it("passes when the token scopes are appropriately narrow", async () => {
+        expect.hasAssertions();
+
         vi.doMock(import("../../../src/release/core/shell-runner"), () => {
             return {
                 createShellRunner: () => {
@@ -218,6 +222,8 @@ describe("vis release doctor — github.token-scopes (semantic-release #2469)", 
     });
 
     it("skips when `gh auth status` returns no parseable Token scopes line", async () => {
+        expect.hasAssertions();
+
         vi.doMock(import("../../../src/release/core/shell-runner"), () => {
             return {
                 createShellRunner: () => {

--- a/packages/tooling/vis/__tests__/release/commands/release-first-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-first-release.test.ts
@@ -102,6 +102,8 @@ describe("first-release flag — version", () => {
     });
 
     it("version --first-release succeeds on a fresh repo with no tags", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd, firstRelease: true });
 
         // The resolver should be forced to disk — no `git tag` fallback
@@ -129,6 +131,8 @@ describe("first-release flag — version", () => {
 
     it("publish --first-release succeeds (structural: no remote tag check leaks through)", async () => {
         // Apply first so there's something to publish.
+        expect.hasAssertions();
+
         const ctxV = await buildContext({ cwd, firstRelease: true });
 
         await applyContext(ctxV, { dryRun: false });
@@ -168,6 +172,8 @@ describe("first-release flag — fallback behaviour without the flag", () => {
     });
 
     it("wITHOUT --first-release on the same fresh fixture, the git-tag resolver falls back to manifest with a warning", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd, firstRelease: false });
 
         expect(ctx.firstRelease).toBe(false);
@@ -208,6 +214,8 @@ describe("first-release flag — idempotency", () => {
 
     it("running version --first-release twice on the same wave doesn't double-bump", async () => {
         // Run 1: change files present → 0.0.1 → 0.1.0.
+        expect.hasAssertions();
+
         const ctx1 = await buildContext({ cwd, firstRelease: true });
 
         expect(ctx1.plan.releases).toHaveLength(1);

--- a/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
@@ -92,7 +92,7 @@ const callHandler = async (cwd: string, options: Record<string, unknown>): Promi
     };
 
     return captureStdout(async () => {
-        await nextVersionHandler({ logger, options, workspaceRoot: cwd } as never);
+        await nextVersionHandler({ logger, options, workspaceRoot: cwd });
     });
 };
 
@@ -182,7 +182,7 @@ describe("vis release next-version", () => {
                     logger,
                     options: { package: "@scope/does-not-exist" },
                     workspaceRoot: cwd,
-                } as never);
+                });
             });
 
             expect(process.exitCode).toBe(1);
@@ -219,7 +219,7 @@ describe("vis release next-version", () => {
                     logger,
                     options: { package: "@scope/b" },
                     workspaceRoot: cwd,
-                } as never);
+                });
             });
 
             expect(process.exitCode).toBe(1);

--- a/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
@@ -112,6 +112,8 @@ describe("vis release next-version", () => {
     });
 
     it("prints `<name> <old> -> <new>` for every package in the plan", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture(SIMPLE_CHANGE);
 
         const stdout = await callHandler(cwd, {});
@@ -121,6 +123,8 @@ describe("vis release next-version", () => {
     });
 
     it("filters to a single package when --package is set", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture(SIMPLE_CHANGE);
 
         const stdout = await callHandler(cwd, { package: "@scope/a" });
@@ -130,6 +134,8 @@ describe("vis release next-version", () => {
     });
 
     it("emits a `{ name: { from, to } }` map with --json", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture(SIMPLE_CHANGE);
 
         const stdout = await callHandler(cwd, { json: true });
@@ -143,6 +149,8 @@ describe("vis release next-version", () => {
 
     it("exits 0 with no output when the plan is empty", async () => {
         // No change file in the fixture → plan is empty.
+        expect.hasAssertions();
+
         cwd = setupFixture();
 
         const stdout = await callHandler(cwd, {});
@@ -154,6 +162,8 @@ describe("vis release next-version", () => {
     });
 
     it("emits `{}` with --json on an empty plan", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture();
 
         const stdout = await callHandler(cwd, { json: true });
@@ -164,6 +174,8 @@ describe("vis release next-version", () => {
     // F11: --package filter-miss must exit non-zero so CI scripts can
     // distinguish "no bump needed" from "wrong / missing package name".
     it("exits non-zero with an explanatory error when --package matches nothing in the plan (unknown name)", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture(SIMPLE_CHANGE);
 
         const originalExitCode = process.exitCode;
@@ -199,6 +211,8 @@ describe("vis release next-version", () => {
     it("exits non-zero when --package names a workspace package with no pending change", async () => {
         // Change file only bumps @scope/a; @scope/b is in the workspace
         // but has no pending release.
+        expect.hasAssertions();
+
         const changeOnlyA = "---\n\"@scope/a\": minor\n---\n\nOnly a.\n";
 
         cwd = setupFixture(changeOnlyA);
@@ -235,6 +249,8 @@ describe("vis release next-version", () => {
     // F21: --first-release should flow through buildContext so a
     // greenfield-mode preview works on workspaces with no tags yet.
     it("accepts --first-release without crashing on a greenfield workspace", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture(SIMPLE_CHANGE);
 
         // The fixture has no release tags — exercising firstRelease=true

--- a/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-next-version.test.ts
@@ -135,7 +135,7 @@ describe("vis release next-version", () => {
         const stdout = await callHandler(cwd, { json: true });
         const parsed = JSON.parse(stdout);
 
-        expect(parsed).toEqual({
+        expect(parsed).toStrictEqual({
             "@scope/a": { from: "1.0.0", to: "1.1.0" },
             "@scope/b": { from: "2.5.0", to: "2.5.1" },
         });

--- a/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
@@ -85,7 +85,7 @@ const callHandler = async (cwd: string, options: Record<string, unknown>): Promi
     // satisfies that surface for the methods it uses.
     const fs = { access, mkdir, readdir, readFile, rm, stat, writeFile } as never;
 
-    await notificationsHandler({ fs, logger, options: { action: "test", ...options }, workspaceRoot: cwd } as never);
+    await notificationsHandler({ fs, logger, options: { action: "test", ...options }, workspaceRoot: cwd });
 
     const exitCode = typeof process.exitCode === "number" ? process.exitCode : 0;
 

--- a/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
@@ -120,6 +120,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("happy path — all channels succeed and exit code is 0", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 discord: { webhook: "https://discord.com/api/webhooks/123/abc" },
@@ -139,6 +141,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("one channel fails → exit code is non-zero", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 slack: { webhook: "https://hooks.slack.com/services/T/B/123" },
@@ -160,6 +164,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("--channel=slack filters to only the slack channel", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 discord: { webhook: "https://discord.com/api/webhooks/123/abc" },
@@ -180,6 +186,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("--channel=slack:eng filters to the id'd slack channel only", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 slack: [
@@ -198,6 +206,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("--custom-context reads JSON from disk and forwards it to channels", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 webhook: { url: "https://example.com/hook" },
@@ -234,6 +244,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("no notifications configured → graceful exit with hint, exit code 0", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({});
 
         const result = await callHandler(cwd, {});
@@ -244,6 +256,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("--channel filter matching nothing → exit non-zero with hint", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 slack: { webhook: "https://hooks.slack.com/services/T/B/123" },
@@ -258,6 +272,8 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
     });
 
     it("--json emits machine-readable output", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture({
             notifications: {
                 webhook: { url: "https://example.com/hook" },

--- a/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-notifications-test.test.ts
@@ -133,7 +133,7 @@ describe.skipIf(isWindows)("vis release notifications test", () => {
         // Three POSTs — one per channel kind.
         expect(fetchSpy).toHaveBeenCalledTimes(3);
         expect(result.exitCode).toBe(0);
-        expect(result.errors).toEqual([]);
+        expect(result.errors).toStrictEqual([]);
         // Per-channel "OK" lines.
         expect(result.infos.filter((m) => m.includes("OK"))).toHaveLength(3);
     });

--- a/packages/tooling/vis/__tests__/release/commands/release-pre.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-pre.test.ts
@@ -100,6 +100,8 @@ describe("vis release pre exit — C6 channel-conflict refusal", () => {
     it("refuses with CONFIG_INVALID when active channel pins its own prerelease", async () => {
         // git branch "alpha" → channel { alpha: { prerelease: "alpha" } }
         // → ctx.channel.prerelease === "alpha".
+        expect.hasAssertions();
+
         cwd = setupFixture("alpha");
 
         await writePreMode(cwd, ".vis/release", buildEnterFile("rc", [
@@ -128,6 +130,8 @@ describe("vis release pre exit — C6 channel-conflict refusal", () => {
     });
 
     it("error carries a hint pointing operator at the resolution", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture("beta");
 
         await writePreMode(cwd, ".vis/release", buildEnterFile("rc", []));
@@ -152,6 +156,8 @@ describe("vis release pre exit — C6 channel-conflict refusal", () => {
     });
 
     it("allows pre exit on a channel without its own prerelease", async () => {
+        expect.hasAssertions();
+
         cwd = setupFixture("main");
 
         await writePreMode(cwd, ".vis/release", buildEnterFile("rc", [
@@ -177,6 +183,8 @@ describe("vis release pre exit — C6 channel-conflict refusal", () => {
     it("allows pre exit when on a branch with no matching channel", async () => {
         // Branch "feature-random" matches no channel → ctx.channel is
         // undefined → no conflict possible → exit proceeds.
+        expect.hasAssertions();
+
         cwd = setupFixture("feature-random");
 
         await writePreMode(cwd, ".vis/release", buildEnterFile("rc", []));

--- a/packages/tooling/vis/__tests__/release/commands/release-pre.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-pre.test.ts
@@ -79,7 +79,7 @@ const callHandler = async (cwd: string, options: Record<string, unknown>): Promi
         warn: (message: string) => warns.push(message),
     };
 
-    await preHandler({ logger, options, workspaceRoot: cwd } as never);
+    await preHandler({ logger, options, workspaceRoot: cwd });
 
     return { errors, infos, warns };
 };

--- a/packages/tooling/vis/__tests__/release/config.test.ts
+++ b/packages/tooling/vis/__tests__/release/config.test.ts
@@ -24,12 +24,12 @@ describe("defaults — DEFAULT_CONFIG", () => {
         expect(DEFAULT_CONFIG.changesDir).toBe(".vis/release");
         expect(DEFAULT_CONFIG.access).toBe("public");
         expect(DEFAULT_CONFIG.changelog).toBe("default");
-        expect(DEFAULT_CONFIG.changedFilePatterns).toEqual(["**"]);
+        expect(DEFAULT_CONFIG.changedFilePatterns).toStrictEqual(["**"]);
         expect(DEFAULT_CONFIG.updateInternalDependencies).toBe("out-of-range");
-        expect(DEFAULT_CONFIG.fixed).toEqual([]);
-        expect(DEFAULT_CONFIG.linked).toEqual([]);
-        expect(DEFAULT_CONFIG.ignore).toEqual([]);
-        expect(DEFAULT_CONFIG.include).toEqual([]);
+        expect(DEFAULT_CONFIG.fixed).toStrictEqual([]);
+        expect(DEFAULT_CONFIG.linked).toStrictEqual([]);
+        expect(DEFAULT_CONFIG.ignore).toStrictEqual([]);
+        expect(DEFAULT_CONFIG.include).toStrictEqual([]);
         expect(DEFAULT_CONFIG.allowCustomCommands).toBe(false);
         expect(DEFAULT_CONFIG.defaultManaged).toBe(false);
     });
@@ -37,10 +37,10 @@ describe("defaults — DEFAULT_CONFIG", () => {
 
 describe("defaults — DEFAULT_DEPENDENCY_BUMP_RULES", () => {
     it("propagates patch on dependencies, match on peers, ignores devDeps", () => {
-        expect(DEFAULT_DEPENDENCY_BUMP_RULES.dependencies).toEqual({ bumpAs: "patch", trigger: "patch" });
-        expect(DEFAULT_DEPENDENCY_BUMP_RULES.peerDependencies).toEqual({ bumpAs: "match", trigger: "major" });
+        expect(DEFAULT_DEPENDENCY_BUMP_RULES.dependencies).toStrictEqual({ bumpAs: "patch", trigger: "patch" });
+        expect(DEFAULT_DEPENDENCY_BUMP_RULES.peerDependencies).toStrictEqual({ bumpAs: "match", trigger: "major" });
         expect(DEFAULT_DEPENDENCY_BUMP_RULES.devDependencies).toBe(false);
-        expect(DEFAULT_DEPENDENCY_BUMP_RULES.optionalDependencies).toEqual({ bumpAs: "patch", trigger: "minor" });
+        expect(DEFAULT_DEPENDENCY_BUMP_RULES.optionalDependencies).toStrictEqual({ bumpAs: "patch", trigger: "minor" });
     });
 });
 
@@ -61,15 +61,15 @@ describe("defaults — DEFAULT_CLEAN_STRIP / DEFAULT_CLEAN_KEEP", () => {
 
 describe(resolveCleanStripList, () => {
     it("returns [] for false (do not strip)", () => {
-        expect(resolveCleanStripList(false)).toEqual([]);
+        expect(resolveCleanStripList(false)).toStrictEqual([]);
     });
 
     it("returns defaults for true", () => {
-        expect(resolveCleanStripList(true)).toEqual([...DEFAULT_CLEAN_STRIP]);
+        expect(resolveCleanStripList(true)).toStrictEqual([...DEFAULT_CLEAN_STRIP]);
     });
 
     it("returns defaults for undefined", () => {
-        expect(resolveCleanStripList(undefined)).toEqual([...DEFAULT_CLEAN_STRIP]);
+        expect(resolveCleanStripList(undefined)).toStrictEqual([...DEFAULT_CLEAN_STRIP]);
     });
 
     it("merges user strip list with defaults", () => {
@@ -104,6 +104,6 @@ describe(resolveCleanStripList, () => {
     it("ignores keep entries that aren't in defaults — has no error", () => {
         const list = resolveCleanStripList({ keep: ["nonexistent-field"] });
 
-        expect(list).toEqual([...DEFAULT_CLEAN_STRIP]);
+        expect(list).toStrictEqual([...DEFAULT_CLEAN_STRIP]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/config.test.ts
+++ b/packages/tooling/vis/__tests__/release/config.test.ts
@@ -11,6 +11,8 @@ import {
 
 describe(defineReleaseConfig, () => {
     it("returns the input unchanged (identity for typing only)", () => {
+        expect.hasAssertions();
+
         const input = { access: "public" as const, baseBranch: "main" };
         const output = defineReleaseConfig(input);
 
@@ -20,6 +22,7 @@ describe(defineReleaseConfig, () => {
 
 describe("defaults — DEFAULT_CONFIG", () => {
     it("uses sane defaults", () => {
+        expect.hasAssertions();
         expect(DEFAULT_CONFIG.baseBranch).toBe("main");
         expect(DEFAULT_CONFIG.changesDir).toBe(".vis/release");
         expect(DEFAULT_CONFIG.access).toBe("public");
@@ -37,6 +40,7 @@ describe("defaults — DEFAULT_CONFIG", () => {
 
 describe("defaults — DEFAULT_DEPENDENCY_BUMP_RULES", () => {
     it("propagates patch on dependencies, match on peers, ignores devDeps", () => {
+        expect.hasAssertions();
         expect(DEFAULT_DEPENDENCY_BUMP_RULES.dependencies).toStrictEqual({ bumpAs: "patch", trigger: "patch" });
         expect(DEFAULT_DEPENDENCY_BUMP_RULES.peerDependencies).toStrictEqual({ bumpAs: "match", trigger: "major" });
         expect(DEFAULT_DEPENDENCY_BUMP_RULES.devDependencies).toBe(false);
@@ -46,12 +50,14 @@ describe("defaults — DEFAULT_DEPENDENCY_BUMP_RULES", () => {
 
 describe("defaults — DEFAULT_CLEAN_STRIP / DEFAULT_CLEAN_KEEP", () => {
     it("strips scripts and devDependencies by default", () => {
+        expect.hasAssertions();
         expect(DEFAULT_CLEAN_STRIP).toContain("scripts");
         expect(DEFAULT_CLEAN_STRIP).toContain("devDependencies");
         expect(DEFAULT_CLEAN_STRIP).toContain("vis-release");
     });
 
     it("keeps essential publish fields by default", () => {
+        expect.hasAssertions();
         expect(DEFAULT_CLEAN_KEEP).toContain("name");
         expect(DEFAULT_CLEAN_KEEP).toContain("version");
         expect(DEFAULT_CLEAN_KEEP).toContain("dependencies");
@@ -61,18 +67,23 @@ describe("defaults — DEFAULT_CLEAN_STRIP / DEFAULT_CLEAN_KEEP", () => {
 
 describe(resolveCleanStripList, () => {
     it("returns [] for false (do not strip)", () => {
+        expect.hasAssertions();
         expect(resolveCleanStripList(false)).toStrictEqual([]);
     });
 
     it("returns defaults for true", () => {
+        expect.hasAssertions();
         expect(resolveCleanStripList(true)).toStrictEqual([...DEFAULT_CLEAN_STRIP]);
     });
 
     it("returns defaults for undefined", () => {
+        expect.hasAssertions();
         expect(resolveCleanStripList(undefined)).toStrictEqual([...DEFAULT_CLEAN_STRIP]);
     });
 
     it("merges user strip list with defaults", () => {
+        expect.hasAssertions();
+
         const list = resolveCleanStripList({ strip: ["customField"] });
 
         expect(list).toContain("scripts");
@@ -80,6 +91,8 @@ describe(resolveCleanStripList, () => {
     });
 
     it("removes keys listed in keep[] from the strip list", () => {
+        expect.hasAssertions();
+
         const list = resolveCleanStripList({ keep: ["scripts"] });
 
         expect(list).not.toContain("scripts");
@@ -87,6 +100,8 @@ describe(resolveCleanStripList, () => {
     });
 
     it("strip + keep — strip wins for new fields, keep wins for defaults", () => {
+        expect.hasAssertions();
+
         const list = resolveCleanStripList({ keep: ["devDependencies"], strip: ["custom"] });
 
         expect(list).toContain("custom");
@@ -94,6 +109,8 @@ describe(resolveCleanStripList, () => {
     });
 
     it("deduplicates entries when user strip overlaps defaults", () => {
+        expect.hasAssertions();
+
         const list = resolveCleanStripList({ strip: ["scripts", "scripts"] });
 
         const scriptsCount = list.filter((s) => s === "scripts").length;
@@ -102,6 +119,8 @@ describe(resolveCleanStripList, () => {
     });
 
     it("ignores keep entries that aren't in defaults — has no error", () => {
+        expect.hasAssertions();
+
         const list = resolveCleanStripList({ keep: ["nonexistent-field"] });
 
         expect(list).toStrictEqual([...DEFAULT_CLEAN_STRIP]);

--- a/packages/tooling/vis/__tests__/release/core/apply-release-plan.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/apply-release-plan.test.ts
@@ -182,6 +182,6 @@ describe("applyReleasePlan — produces structured AppliedPlan", () => {
 
         const applied = await applyReleasePlan(plan, graph);
 
-        expect(applied.deletions).toEqual([".vis/release/abc.md"]);
+        expect(applied.deletions).toStrictEqual([".vis/release/abc.md"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/apply-release-plan.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/apply-release-plan.test.ts
@@ -32,57 +32,71 @@ const mkRelease = (name: string, oldV: string, newV: string, type: PlannedReleas
 
 describe("rewriteRangeForVersion — preserves protocol prefixes (RFC §11.1)", () => {
     it("preserves workspace:^ prefix", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("workspace:^1.0.0", "2.0.0")).toBe("workspace:^2.0.0");
     });
 
     it("preserves workspace:~ prefix", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("workspace:~1.0.0", "2.0.0")).toBe("workspace:~2.0.0");
     });
 
     it("preserves workspace:* shorthand", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("workspace:*", "2.0.0")).toBe("workspace:*");
     });
 
     it("preserves workspace:^ shorthand", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("workspace:^", "2.0.0")).toBe("workspace:^");
     });
 
     it("preserves workspace:~ shorthand", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("workspace:~", "2.0.0")).toBe("workspace:~");
     });
 
     it("preserves catalog: refs (catalog updates flow elsewhere)", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("catalog:dev", "2.0.0")).toBe("catalog:dev");
         expect(rewriteRangeForVersion("catalog:", "2.0.0")).toBe("catalog:");
     });
 
     it("rewrites plain ^ ranges", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("^1.0.0", "2.0.0")).toBe("^2.0.0");
     });
 
     it("rewrites plain ~ ranges", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("~1.0.0", "2.0.0")).toBe("~2.0.0");
     });
 
     it("preserves >= and other operators", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion(">=1.0.0", "2.0.0")).toBe(">=2.0.0");
     });
 
     it("defaults to ^ when no prefix is present", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("1.0.0", "2.0.0")).toBe("^2.0.0");
     });
 
     it("rewrites npm: alias inner spec", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("npm:other-pkg@^1.0.0", "2.0.0")).toBe("npm:other-pkg@^2.0.0");
     });
 
     it("preserves * as-is", () => {
+        expect.hasAssertions();
         expect(rewriteRangeForVersion("*", "2.0.0")).toBe("*");
     });
 });
 
 describe("prependChangelog — handles 3 RFC §17.4 cases", () => {
     it("inserts after `# Title` when present (bumpy/changesets convention)", () => {
+        expect.hasAssertions();
+
         const existing = `# Changelog\n\n## 1.0.0\n\nold entry\n`;
         const result = prependChangelog("## 1.1.0\n<sub>2026-05-02</sub>\n\n- new", existing);
 
@@ -91,6 +105,8 @@ describe("prependChangelog — handles 3 RFC §17.4 cases", () => {
     });
 
     it("inserts at top when file starts with `##` (semantic-release convention)", () => {
+        expect.hasAssertions();
+
         const existing = `## @scope/pkg [1.0.0](compare) (2026-04-01)\n\n### Bug Fixes\n\n* old\n`;
         const result = prependChangelog("## 1.1.0\n<sub>2026-05-02</sub>\n\n- new", existing);
 
@@ -99,6 +115,8 @@ describe("prependChangelog — handles 3 RFC §17.4 cases", () => {
     });
 
     it("creates `# Changelog` header when file is empty/missing", () => {
+        expect.hasAssertions();
+
         const result = prependChangelog("## 1.0.0\n<sub>2026-05-02</sub>\n\n- first", undefined);
 
         expect(result.startsWith("# Changelog\n")).toBe(true);
@@ -106,6 +124,8 @@ describe("prependChangelog — handles 3 RFC §17.4 cases", () => {
     });
 
     it("creates header for empty-string file", () => {
+        expect.hasAssertions();
+
         const result = prependChangelog("## 1.0.0\n<sub>2026-05-02</sub>", "");
 
         expect(result.startsWith("# Changelog")).toBe(true);
@@ -114,6 +134,8 @@ describe("prependChangelog — handles 3 RFC §17.4 cases", () => {
 
 describe("applyReleasePlan — produces structured AppliedPlan", () => {
     it("emits writes for each released package's manifest + changelog", async () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", "1.0.0");
         const graph = new DependencyGraph([a]);
 
@@ -133,6 +155,8 @@ describe("applyReleasePlan — produces structured AppliedPlan", () => {
     });
 
     it("rewrites internal-dep ranges in dependent's manifest", async () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", "1.0.0");
         const b = mkPkg("b", "2.0.0", { a: "^1.0.0" });
         const graph = new DependencyGraph([a, b]);
@@ -152,6 +176,8 @@ describe("applyReleasePlan — produces structured AppliedPlan", () => {
     });
 
     it("preserves workspace: prefix when rewriting", async () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", "1.0.0");
         const b = mkPkg("b", "2.0.0", { a: "workspace:^1.0.0" });
         const graph = new DependencyGraph([a, b]);
@@ -169,6 +195,8 @@ describe("applyReleasePlan — produces structured AppliedPlan", () => {
     });
 
     it("propagates change-file deletions into the deletions list", async () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", "1.0.0");
         const graph = new DependencyGraph([a]);
 

--- a/packages/tooling/vis/__tests__/release/core/catalog-detector.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/catalog-detector.test.ts
@@ -52,7 +52,7 @@ catalog:
 
         const result = parseCatalogs(yaml);
 
-        expect(result.get("")).toEqual({ react: "^18.2.0", typescript: "^5.5.0" });
+        expect(result.get("")).toStrictEqual({ react: "^18.2.0", typescript: "^5.5.0" });
     });
 
     it("parses named `catalogs.<name>` blocks into their own keys", () => {
@@ -66,8 +66,8 @@ catalogs:
 
         const result = parseCatalogs(yaml);
 
-        expect(result.get("dev")).toEqual({ vitest: "^2.0.0" });
-        expect(result.get("prod")).toEqual({ react: "^18.3.0" });
+        expect(result.get("dev")).toStrictEqual({ vitest: "^2.0.0" });
+        expect(result.get("prod")).toStrictEqual({ react: "^18.3.0" });
     });
 
     it("co-exists with non-catalog top-level keys without polluting the output", () => {
@@ -82,8 +82,8 @@ catalog:
 
         const result = parseCatalogs(yaml);
 
-        expect([...result.keys()]).toEqual([""]);
-        expect(result.get("")).toEqual({ react: "^18.2.0" });
+        expect([...result.keys()]).toStrictEqual([""]);
+        expect(result.get("")).toStrictEqual({ react: "^18.2.0" });
     });
 });
 
@@ -95,7 +95,7 @@ describe("catalog-detector: extractCatalogRefs", () => {
 
         const refs = extractCatalogRefs(pkg);
 
-        expect(refs).toEqual([
+        expect(refs).toStrictEqual([
             { catalog: "", dep: "react", kind: "dependencies", packageName: "@scope/a" },
         ]);
     });
@@ -105,7 +105,7 @@ describe("catalog-detector: extractCatalogRefs", () => {
             devDependencies: { vitest: "catalog:dev" },
         });
 
-        expect(extractCatalogRefs(pkg)).toEqual([
+        expect(extractCatalogRefs(pkg)).toStrictEqual([
             { catalog: "dev", dep: "vitest", kind: "devDependencies", packageName: "@scope/b" },
         ]);
     });
@@ -119,7 +119,7 @@ describe("catalog-detector: extractCatalogRefs", () => {
         const refs = extractCatalogRefs(pkg);
 
         expect(refs).toHaveLength(2);
-        expect(refs.map((r) => r.kind).sort()).toEqual(["dependencies", "peerDependencies"]);
+        expect(refs.map((r) => r.kind).sort()).toStrictEqual(["dependencies", "peerDependencies"]);
     });
 
     it("ignores ranges that don't start with `catalog:`", () => {
@@ -127,7 +127,7 @@ describe("catalog-detector: extractCatalogRefs", () => {
             dependencies: { bar: "workspace:*", baz: "github:user/repo", foo: "^1.0.0" },
         });
 
-        expect(extractCatalogRefs(pkg)).toEqual([]);
+        expect(extractCatalogRefs(pkg)).toStrictEqual([]);
     });
 });
 
@@ -151,11 +151,11 @@ catalogs:
 
         const defaultBlock = index.get("");
 
-        expect(defaultBlock?.get("react")?.map((c) => c.packageName).sort()).toEqual(["@scope/a", "@scope/b"]);
+        expect(defaultBlock?.get("react")?.map((c) => c.packageName).sort()).toStrictEqual(["@scope/a", "@scope/b"]);
 
         const devBlock = index.get("dev");
 
-        expect(devBlock?.get("vitest")?.map((c) => c.packageName)).toEqual(["@scope/c"]);
+        expect(devBlock?.get("vitest")?.map((c) => c.packageName)).toStrictEqual(["@scope/c"]);
     });
 
     it("seeds an empty inner map for every catalog block present even when no consumer references it", () => {
@@ -205,7 +205,7 @@ catalog:
   react: ^18.2.0
 `);
 
-        expect(detectCatalogChanges(prev, next)).toEqual([]);
+        expect(detectCatalogChanges(prev, next)).toStrictEqual([]);
     });
 
     it("detects a version bump (both sides present, version differs)", () => {
@@ -221,7 +221,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "", dep: "react", newVersion: "^18.3.0", oldVersion: "^18.2.0" },
         ]);
     });
@@ -240,7 +240,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "", dep: "zod", newVersion: "^3.23.0", oldVersion: undefined },
         ]);
     });
@@ -259,7 +259,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "", dep: "legacy", newVersion: undefined, oldVersion: "^1.0.0" },
         ]);
     });
@@ -279,7 +279,7 @@ catalogs:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "dev", dep: "vitest", newVersion: "^2.1.0", oldVersion: "^2.0.0" },
         ]);
     });
@@ -308,7 +308,7 @@ catalogs:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes.map((c) => `${c.catalog}/${c.dep}`)).toEqual(["/react", "/zod", "dev/vitest"]);
+        expect(changes.map((c) => `${c.catalog}/${c.dep}`)).toStrictEqual(["/react", "/zod", "dev/vitest"]);
     });
 
     // F25: when neither snapshot carries any catalog block (the most
@@ -325,7 +325,7 @@ catalogs:
 
         expect(prev.size).toBe(0);
         expect(next.size).toBe(0);
-        expect(detectCatalogChanges(prev, next)).toEqual([]);
+        expect(detectCatalogChanges(prev, next)).toStrictEqual([]);
     });
 
     it("does NOT bail when only `prev` is empty (additions still surface)", () => {
@@ -340,7 +340,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "", dep: "react", newVersion: "^18.2.0", oldVersion: undefined },
         ]);
     });
@@ -356,7 +356,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "", dep: "react", newVersion: undefined, oldVersion: "^18.2.0" },
         ]);
     });
@@ -378,7 +378,7 @@ catalog:
 
         const changes = detectCatalogChanges(prev, next);
 
-        expect(changes).toEqual([
+        expect(changes).toStrictEqual([
             { catalog: "legacy", dep: "bar", newVersion: undefined, oldVersion: "^2.0.0" },
             { catalog: "legacy", dep: "foo", newVersion: undefined, oldVersion: "^1.0.0" },
         ]);

--- a/packages/tooling/vis/__tests__/release/core/catalog-detector.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/catalog-detector.test.ts
@@ -39,11 +39,14 @@ const mkPkg = (name: string, deps: Partial<Record<"dependencies" | "devDependenc
 
 describe("catalog-detector: parseCatalogs", () => {
     it("parses an empty / undefined YAML into an empty Map", () => {
+        expect.hasAssertions();
         expect(parseCatalogs(undefined).size).toBe(0);
         expect(parseCatalogs("").size).toBe(0);
     });
 
     it("parses the default `catalog:` block into the empty-string key", () => {
+        expect.hasAssertions();
+
         const yaml = `
 catalog:
   react: ^18.2.0
@@ -56,6 +59,8 @@ catalog:
     });
 
     it("parses named `catalogs.<name>` blocks into their own keys", () => {
+        expect.hasAssertions();
+
         const yaml = `
 catalogs:
   dev:
@@ -73,6 +78,8 @@ catalogs:
     it("co-exists with non-catalog top-level keys without polluting the output", () => {
         // pnpm-workspace.yaml typically carries `packages:` and other
         // unrelated blocks. parseCatalogs must ignore them.
+        expect.hasAssertions();
+
         const yaml = `
 packages:
   - "packages/*"
@@ -89,6 +96,8 @@ catalog:
 
 describe("catalog-detector: extractCatalogRefs", () => {
     it("extracts a single `catalog:` ref from dependencies", () => {
+        expect.hasAssertions();
+
         const pkg = mkPkg("@scope/a", {
             dependencies: { "non-catalog": "^1.0.0", react: "catalog:" },
         });
@@ -101,6 +110,8 @@ describe("catalog-detector: extractCatalogRefs", () => {
     });
 
     it("extracts `catalog:<name>` refs and includes the catalog name", () => {
+        expect.hasAssertions();
+
         const pkg = mkPkg("@scope/b", {
             devDependencies: { vitest: "catalog:dev" },
         });
@@ -111,6 +122,8 @@ describe("catalog-detector: extractCatalogRefs", () => {
     });
 
     it("returns one entry per (dep, kind) pair when the same dep appears in multiple blocks", () => {
+        expect.hasAssertions();
+
         const pkg = mkPkg("@scope/c", {
             dependencies: { react: "catalog:" },
             peerDependencies: { react: "catalog:" },
@@ -123,6 +136,8 @@ describe("catalog-detector: extractCatalogRefs", () => {
     });
 
     it("ignores ranges that don't start with `catalog:`", () => {
+        expect.hasAssertions();
+
         const pkg = mkPkg("@scope/d", {
             dependencies: { bar: "workspace:*", baz: "github:user/repo", foo: "^1.0.0" },
         });
@@ -133,6 +148,8 @@ describe("catalog-detector: extractCatalogRefs", () => {
 
 describe("catalog-detector: findCatalogConsumers", () => {
     it("builds a reverse index of catalog → dep → consumers", () => {
+        expect.hasAssertions();
+
         const catalogs = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -162,6 +179,8 @@ catalogs:
         // Catalog block exists in YAML but no package depends on it.
         // The outer key should still be present so callers don't
         // special-case "first dep into a previously-untouched catalog".
+        expect.hasAssertions();
+
         const catalogs = parseCatalogs(`
 catalogs:
   experimental:
@@ -178,6 +197,8 @@ catalogs:
         // `catalog:typo` is a misconfiguration — the dependent package
         // is genuinely broken, but the detector shouldn't invent the
         // typo'd catalog name in the output.
+        expect.hasAssertions();
+
         const catalogs = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -195,6 +216,8 @@ catalog:
 
 describe("catalog-detector: detectCatalogChanges", () => {
     it("returns an empty array when both snapshots are identical", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -209,6 +232,8 @@ catalog:
     });
 
     it("detects a version bump (both sides present, version differs)", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -227,6 +252,8 @@ catalog:
     });
 
     it("detects additions (entry in next only, oldVersion undefined)", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -246,6 +273,8 @@ catalog:
     });
 
     it("detects removals (entry in prev only, newVersion undefined)", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -265,6 +294,8 @@ catalog:
     });
 
     it("detects changes inside named catalogs (catalog name preserved)", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalogs:
   dev:
@@ -289,6 +320,8 @@ catalogs:
         // catalog deps are sorted alphabetically. Verified explicitly
         // so a future change in YAML parser iteration doesn't silently
         // shift the public output ordering.
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -320,6 +353,8 @@ catalogs:
         // primarily a perf bail (the regular code path would also
         // produce []), so we assert the contract: empty input → empty
         // output, no exceptions, no false-positives.
+        expect.hasAssertions();
+
         const prev = parseCatalogs(undefined);
         const next = parseCatalogs("");
 
@@ -332,6 +367,8 @@ catalogs:
         // Adding a catalog block in `next` while `prev` was empty
         // (greenfield repo getting its first catalog) must still
         // produce the additions, not a silent no-op.
+        expect.hasAssertions();
+
         const prev = parseCatalogs(undefined);
         const next = parseCatalogs(`
 catalog:
@@ -348,6 +385,8 @@ catalog:
     it("does NOT bail when only `next` is empty (removals still surface)", () => {
         // Deleting the catalog block entirely — every dep must
         // surface as a removal.
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0
@@ -362,6 +401,8 @@ catalog:
     });
 
     it("treats an entirely-removed catalog as N removals", () => {
+        expect.hasAssertions();
+
         const prev = parseCatalogs(`
 catalog:
   react: ^18.2.0

--- a/packages/tooling/vis/__tests__/release/core/catalog.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/catalog.test.ts
@@ -7,27 +7,27 @@ describe(parseCatalogs, () => {
     it("returns empty for undefined input", () => {
         const result = parseCatalogs(undefined);
 
-        expect(result).toEqual({ default: {}, named: {} });
+        expect(result).toStrictEqual({ default: {}, named: {} });
     });
 
     it("returns empty for empty string", () => {
-        expect(parseCatalogs("")).toEqual({ default: {}, named: {} });
+        expect(parseCatalogs("")).toStrictEqual({ default: {}, named: {} });
     });
 
     it("parses default catalog", () => {
         const yaml = `catalog:\n  react: ^18.3.1\n  zod: ^3.22.0\n`;
         const result = parseCatalogs(yaml);
 
-        expect(result.default).toEqual({ react: "^18.3.1", zod: "^3.22.0" });
-        expect(result.named).toEqual({});
+        expect(result.default).toStrictEqual({ react: "^18.3.1", zod: "^3.22.0" });
+        expect(result.named).toStrictEqual({});
     });
 
     it("parses named catalogs", () => {
         const yaml = `catalogs:\n  dev:\n    eslint: ^9.0.0\n  test:\n    vitest: ^2.0.0\n`;
         const result = parseCatalogs(yaml);
 
-        expect(result.default).toEqual({});
-        expect(result.named).toEqual({
+        expect(result.default).toStrictEqual({});
+        expect(result.named).toStrictEqual({
             dev: { eslint: "^9.0.0" },
             test: { vitest: "^2.0.0" },
         });

--- a/packages/tooling/vis/__tests__/release/core/catalog.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/catalog.test.ts
@@ -5,16 +5,21 @@ import { VisReleaseError } from "../../../src/release/errors";
 
 describe(parseCatalogs, () => {
     it("returns empty for undefined input", () => {
+        expect.hasAssertions();
+
         const result = parseCatalogs(undefined);
 
         expect(result).toStrictEqual({ default: {}, named: {} });
     });
 
     it("returns empty for empty string", () => {
+        expect.hasAssertions();
         expect(parseCatalogs("")).toStrictEqual({ default: {}, named: {} });
     });
 
     it("parses default catalog", () => {
+        expect.hasAssertions();
+
         const yaml = `catalog:\n  react: ^18.3.1\n  zod: ^3.22.0\n`;
         const result = parseCatalogs(yaml);
 
@@ -23,6 +28,8 @@ describe(parseCatalogs, () => {
     });
 
     it("parses named catalogs", () => {
+        expect.hasAssertions();
+
         const yaml = `catalogs:\n  dev:\n    eslint: ^9.0.0\n  test:\n    vitest: ^2.0.0\n`;
         const result = parseCatalogs(yaml);
 
@@ -34,6 +41,8 @@ describe(parseCatalogs, () => {
     });
 
     it("parses both default + named together", () => {
+        expect.hasAssertions();
+
         const yaml = `catalog:\n  react: ^18.3.1\ncatalogs:\n  dev:\n    eslint: ^9.0.0\n`;
         const result = parseCatalogs(yaml);
 
@@ -42,6 +51,8 @@ describe(parseCatalogs, () => {
     });
 
     it("ignores non-string values in catalog blocks", () => {
+        expect.hasAssertions();
+
         const yaml = `catalog:\n  react: ^18.3.1\n  bad: 42\n`;
         const result = parseCatalogs(yaml);
 
@@ -50,6 +61,7 @@ describe(parseCatalogs, () => {
     });
 
     it("throws on malformed YAML", () => {
+        expect.hasAssertions();
         expect(() => parseCatalogs(": : :")).toThrow(/pnpm-workspace.yaml/);
     });
 });
@@ -61,22 +73,27 @@ describe(resolveCatalogRef, () => {
     };
 
     it("returns non-catalog refs unchanged", () => {
+        expect.hasAssertions();
         expect(resolveCatalogRef("^1.0.0", "any", catalogs)).toBe("^1.0.0");
     });
 
     it("resolves catalog: from default", () => {
+        expect.hasAssertions();
         expect(resolveCatalogRef("catalog:", "react", catalogs)).toBe("^18.3.1");
     });
 
     it("resolves catalog:<name> from named block", () => {
+        expect.hasAssertions();
         expect(resolveCatalogRef("catalog:dev", "eslint", catalogs)).toBe("^9.0.0");
     });
 
     it("returns undefined when package not in default catalog", () => {
+        expect.hasAssertions();
         expect(resolveCatalogRef("catalog:", "absent", catalogs)).toBeUndefined();
     });
 
     it("returns undefined when named catalog doesn't exist", () => {
+        expect.hasAssertions();
         expect(resolveCatalogRef("catalog:nonexistent", "anything", catalogs)).toBeUndefined();
     });
 });
@@ -88,6 +105,8 @@ describe(rewriteCatalogRefs, () => {
     };
 
     it("rewrites catalog: refs across all dep kinds", () => {
+        expect.hasAssertions();
+
         const manifest = {
             dependencies: { react: "catalog:" },
             devDependencies: { eslint: "catalog:dev" },
@@ -102,6 +121,8 @@ describe(rewriteCatalogRefs, () => {
     });
 
     it("returns a new object — does not mutate input", () => {
+        expect.hasAssertions();
+
         const manifest = {
             dependencies: { react: "catalog:" },
             name: "x",
@@ -114,6 +135,8 @@ describe(rewriteCatalogRefs, () => {
     });
 
     it("leaves non-catalog deps alone", () => {
+        expect.hasAssertions();
+
         const manifest = {
             dependencies: { lodash: "^4.0.0", react: "catalog:" },
             name: "x",
@@ -126,6 +149,8 @@ describe(rewriteCatalogRefs, () => {
     });
 
     it("throws CONFIG_INVALID on unresolvable catalog ref", () => {
+        expect.hasAssertions();
+
         const manifest = {
             dependencies: { absent: "catalog:" },
             name: "x",

--- a/packages/tooling/vis/__tests__/release/core/change-file-empty-release-as.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file-empty-release-as.test.ts
@@ -14,6 +14,8 @@ import { formatChangeFile, parseChangeFile } from "../../../src/release/core/cha
 
 describe("change-file: empty frontmatter", () => {
     it("parses a fully-empty frontmatter as an empty-bumps payload", () => {
+        expect.hasAssertions();
+
         const file = parseChangeFile("---\n{}\n---\nbody\n", "/repo/.vis/release/x.md");
 
         expect(file.payload).toStrictEqual({ bumps: {} });
@@ -23,12 +25,16 @@ describe("change-file: empty frontmatter", () => {
     it("parses a literal-null frontmatter as an empty-bumps payload", () => {
         // Authored as `---\n\n---` (only whitespace between delimiters).
         // YAML parses this as null; the reader must coerce to {}.
+        expect.hasAssertions();
+
         const file = parseChangeFile("---\n\n---\nbody\n", "/repo/.vis/release/x.md");
 
         expect(file.payload).toStrictEqual({ bumps: {} });
     });
 
     it("round-trips via formatChangeFile → parseChangeFile with no bumps", () => {
+        expect.hasAssertions();
+
         const serialised = formatChangeFile({ bumps: {} }, "body");
 
         // Must contain explicit `{}` so the YAML parser produces an
@@ -43,6 +49,8 @@ describe("change-file: empty frontmatter", () => {
 
 describe("change-file: releaseAs override (nested frontmatter)", () => {
     it("parses a valid semver string in releaseAs", () => {
+        expect.hasAssertions();
+
         const file = parseChangeFile(
             "---\n\"@scope/pkg\":\n  bump: minor\n  releaseAs: 2.0.0\n---\nbody\n",
             "/x.md",
@@ -57,6 +65,8 @@ describe("change-file: releaseAs override (nested frontmatter)", () => {
     });
 
     it("accepts semver with prerelease + build metadata", () => {
+        expect.hasAssertions();
+
         const file = parseChangeFile(
             "---\n\"@scope/pkg\":\n  bump: patch\n  releaseAs: 2.0.0-rc.1\n---\nbody\n",
             "/x.md",
@@ -70,6 +80,7 @@ describe("change-file: releaseAs override (nested frontmatter)", () => {
     });
 
     it("rejects non-semver strings with BUMP_FILE_INVALID", () => {
+        expect.hasAssertions();
         expect(() =>
             parseChangeFile(
                 "---\n\"@scope/pkg\":\n  bump: minor\n  releaseAs: not-a-version\n---\nbody\n",
@@ -79,6 +90,7 @@ describe("change-file: releaseAs override (nested frontmatter)", () => {
     });
 
     it("rejects non-string releaseAs values", () => {
+        expect.hasAssertions();
         expect(() =>
             parseChangeFile(
                 "---\n\"@scope/pkg\":\n  bump: minor\n  releaseAs: 200\n---\nbody\n",
@@ -88,6 +100,8 @@ describe("change-file: releaseAs override (nested frontmatter)", () => {
     });
 
     it("round-trips via formatChangeFile → parseChangeFile with releaseAs", () => {
+        expect.hasAssertions();
+
         const serialised = formatChangeFile(
             { bump: "minor", package: "@scope/pkg", releaseAs: "2.0.0" },
             "body",

--- a/packages/tooling/vis/__tests__/release/core/change-file-empty-release-as.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file-empty-release-as.test.ts
@@ -16,7 +16,7 @@ describe("change-file: empty frontmatter", () => {
     it("parses a fully-empty frontmatter as an empty-bumps payload", () => {
         const file = parseChangeFile("---\n{}\n---\nbody\n", "/repo/.vis/release/x.md");
 
-        expect(file.payload).toEqual({ bumps: {} });
+        expect(file.payload).toStrictEqual({ bumps: {} });
         expect(file.body).toBe("body");
     });
 
@@ -25,7 +25,7 @@ describe("change-file: empty frontmatter", () => {
         // YAML parses this as null; the reader must coerce to {}.
         const file = parseChangeFile("---\n\n---\nbody\n", "/repo/.vis/release/x.md");
 
-        expect(file.payload).toEqual({ bumps: {} });
+        expect(file.payload).toStrictEqual({ bumps: {} });
     });
 
     it("round-trips via formatChangeFile → parseChangeFile with no bumps", () => {
@@ -37,7 +37,7 @@ describe("change-file: empty frontmatter", () => {
 
         const parsed = parseChangeFile(serialised, "/x.md");
 
-        expect(parsed.payload).toEqual({ bumps: {} });
+        expect(parsed.payload).toStrictEqual({ bumps: {} });
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/change-file-reader.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file-reader.test.ts
@@ -23,8 +23,8 @@ describe(readChangeFiles, () => {
     it("returns empty (with no warning) when changes dir doesn't exist", async () => {
         const result = await readChangeFiles({ changesDir: ".vis/release", cwd });
 
-        expect(result.files).toEqual([]);
-        expect(result.warnings).toEqual([]);
+        expect(result.files).toStrictEqual([]);
+        expect(result.warnings).toStrictEqual([]);
     });
 
     it("reads + parses every .md file in the changes dir", async () => {
@@ -35,7 +35,7 @@ describe(readChangeFiles, () => {
         const result = await readChangeFiles({ changesDir: ".vis/release", cwd });
 
         expect(result.files).toHaveLength(2);
-        expect(result.files.map((f) => f.id).sort()).toEqual(["first", "second"]);
+        expect(result.files.map((f) => f.id).sort()).toStrictEqual(["first", "second"]);
     });
 
     it("skips README.md", async () => {

--- a/packages/tooling/vis/__tests__/release/core/change-file-reader.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file-reader.test.ts
@@ -21,6 +21,8 @@ describe(readChangeFiles, () => {
     });
 
     it("returns empty (with no warning) when changes dir doesn't exist", async () => {
+        expect.hasAssertions();
+
         const result = await readChangeFiles({ changesDir: ".vis/release", cwd });
 
         expect(result.files).toStrictEqual([]);
@@ -28,6 +30,8 @@ describe(readChangeFiles, () => {
     });
 
     it("reads + parses every .md file in the changes dir", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
         writeFileSync(join(cwd, ".vis", "release", "first.md"), `---\npkg-a: minor\n---\nA\n`);
         writeFileSync(join(cwd, ".vis", "release", "second.md"), `---\npkg-b: patch\n---\nB\n`);
@@ -39,6 +43,8 @@ describe(readChangeFiles, () => {
     });
 
     it("skips README.md", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
         writeFileSync(join(cwd, ".vis", "release", "README.md"), "# Change files");
         writeFileSync(join(cwd, ".vis", "release", "real.md"), `---\npkg-a: minor\n---\nA\n`);
@@ -50,6 +56,8 @@ describe(readChangeFiles, () => {
     });
 
     it("skips non-.md files", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
         writeFileSync(join(cwd, ".vis", "release", "config.json"), "{}");
         writeFileSync(join(cwd, ".vis", "release", "real.md"), `---\npkg-a: minor\n---\nA\n`);
@@ -60,6 +68,8 @@ describe(readChangeFiles, () => {
     });
 
     it("respects custom changesDir option", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, ".bumpy"), { recursive: true });
         writeFileSync(join(cwd, ".bumpy", "x.md"), `---\npkg-a: minor\n---\nA\n`);
 
@@ -69,6 +79,8 @@ describe(readChangeFiles, () => {
     });
 
     it("propagates parse errors as VisReleaseError", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
         writeFileSync(join(cwd, ".vis", "release", "bad.md"), "no frontmatter at all");
 
@@ -76,10 +88,12 @@ describe(readChangeFiles, () => {
     });
 
     it("rejects changesDir that escapes the workspace via ../ (RFC §19.4)", async () => {
+        expect.hasAssertions();
         await expect(readChangeFiles({ changesDir: "../../etc", cwd })).rejects.toThrow(VisReleaseError);
     });
 
     it("rejects absolute changesDir outside the workspace", async () => {
+        expect.hasAssertions();
         await expect(readChangeFiles({ changesDir: "/etc", cwd })).rejects.toThrow(VisReleaseError);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/change-file.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file.test.ts
@@ -22,7 +22,7 @@ describe("change-file: parseChangeFile (simple shape)", () => {
             throw new Error("expected simple shape");
         }
 
-        expect(result.payload.bumps).toEqual({ "@scope/pkg-a": "minor" });
+        expect(result.payload.bumps).toStrictEqual({ "@scope/pkg-a": "minor" });
         expect(result.body).toBe("Added a feature.");
         expect(result.meta).toBeUndefined();
     });
@@ -37,7 +37,7 @@ describe("change-file: parseChangeFile (simple shape)", () => {
             throw new Error("expected simple shape");
         }
 
-        expect(result.payload.bumps).toEqual({
+        expect(result.payload.bumps).toStrictEqual({
             "@scope/pkg-a": "minor",
             "@scope/pkg-b": "patch",
             "pkg-c": "major",
@@ -70,7 +70,7 @@ describe("change-file: parseChangeFile (nested shape)", () => {
 
         expect(result.payload.package).toBe("@scope/core");
         expect(result.payload.bump).toBe("minor");
-        expect(result.payload.cascade).toEqual({
+        expect(result.payload.cascade).toStrictEqual({
             "@scope/plugin-*": "patch",
             "@scope/react": "minor",
         });
@@ -156,7 +156,7 @@ describe("change-file: inline metadata extraction", () => {
             "f.md",
         );
 
-        expect(result.meta).toEqual({ author: "@prisis", commit: "abc1234", pr: 42 });
+        expect(result.meta).toStrictEqual({ author: "@prisis", commit: "abc1234", pr: 42 });
         expect(result.body).toBe("The actual changelog body.");
     });
 
@@ -190,7 +190,7 @@ describe("change-file: inline metadata extraction", () => {
             "f.md",
         );
 
-        expect(result.meta).toEqual({ pr: 1 });
+        expect(result.meta).toStrictEqual({ pr: 1 });
         expect(result.body).toBe("actual body line\nauthor: @foo\nmore body");
     });
 });
@@ -204,7 +204,7 @@ describe("change-file: formatChangeFile (round-trip)", () => {
             throw new Error("expected simple shape");
         }
 
-        expect(parsed.payload.bumps).toEqual({ "@scope/pkg-a": "minor", "pkg-b": "patch" });
+        expect(parsed.payload.bumps).toStrictEqual({ "@scope/pkg-a": "minor", "pkg-b": "patch" });
         expect(parsed.body).toBe("Body text.");
     });
 
@@ -221,7 +221,7 @@ describe("change-file: formatChangeFile (round-trip)", () => {
 
         expect(parsed.payload.package).toBe("@scope/core");
         expect(parsed.payload.bump).toBe("minor");
-        expect(parsed.payload.cascade).toEqual({ "@scope/plugin-*": "patch" });
+        expect(parsed.payload.cascade).toStrictEqual({ "@scope/plugin-*": "patch" });
     });
 
     it("emits empty body cleanly when body is empty", () => {
@@ -272,7 +272,7 @@ describe("change-file: findChangeFilesFor", () => {
 
         const result = findChangeFilesFor("pkg-a", files);
 
-        expect(result.map((f) => f.id)).toEqual(["1", "3"]);
+        expect(result.map((f) => f.id)).toStrictEqual(["1", "3"]);
     });
 
     it("finds files mentioning a given package (nested shape)", () => {
@@ -283,6 +283,6 @@ describe("change-file: findChangeFilesFor", () => {
 
         const result = findChangeFilesFor("pkg-a", files);
 
-        expect(result.map((f) => f.id)).toEqual(["1"]);
+        expect(result.map((f) => f.id)).toStrictEqual(["1"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/change-file.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/change-file.test.ts
@@ -10,6 +10,8 @@ import { VisReleaseError } from "../../../src/release/errors";
 
 describe("change-file: parseChangeFile (simple shape)", () => {
     it("parses a single-package simple change file", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\n"@scope/pkg-a": minor\n---\nAdded a feature.\n`,
             ".vis/release/abc123.md",
@@ -28,6 +30,8 @@ describe("change-file: parseChangeFile (simple shape)", () => {
     });
 
     it("parses a multi-package simple change file", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\n"@scope/pkg-a": minor\n"@scope/pkg-b": patch\npkg-c: major\n---\nMulti-package changelog body.\n`,
             "f.md",
@@ -45,12 +49,16 @@ describe("change-file: parseChangeFile (simple shape)", () => {
     });
 
     it("accepts an empty body", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(`---\npkg-a: patch\n---\n`, "f.md");
 
         expect(result.body).toBe("");
     });
 
     it("derives id from filename without extension", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(`---\npkg-a: patch\n---\n`, "/some/long/path/to/witty-frog.md");
 
         expect(result.id).toBe("witty-frog");
@@ -59,6 +67,8 @@ describe("change-file: parseChangeFile (simple shape)", () => {
 
 describe("change-file: parseChangeFile (nested shape)", () => {
     it("parses a nested change file with cascade", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\n"@scope/core":\n  bump: minor\n  cascade:\n    "@scope/plugin-*": patch\n    "@scope/react": minor\n---\nBody.\n`,
             "f.md",
@@ -77,6 +87,8 @@ describe("change-file: parseChangeFile (nested shape)", () => {
     });
 
     it("parses a nested change file without cascade", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\npkg-a:\n  bump: major\n---\nBody.\n`,
             "f.md",
@@ -92,6 +104,7 @@ describe("change-file: parseChangeFile (nested shape)", () => {
     });
 
     it("rejects mixed simple+nested entries (multiple top-level)", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(
             `---\npkg-a:\n  bump: minor\npkg-b: patch\n---\n`,
             "f.md",
@@ -101,10 +114,12 @@ describe("change-file: parseChangeFile (nested shape)", () => {
 
 describe("change-file: parseChangeFile (validation)", () => {
     it("rejects missing frontmatter", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile("Just a body, no frontmatter.", "f.md")).toThrow(/missing YAML frontmatter/);
     });
 
     it("rejects invalid bump level", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(`---\npkg-a: huge\n---\n`, "f.md")).toThrow(/Invalid bump level/);
     });
 
@@ -113,28 +128,36 @@ describe("change-file: parseChangeFile (validation)", () => {
         // the PR was considered for release but should not bump anything
         // (docs-only changes, CI gates requiring a change file). It parses to
         // empty bumps rather than throwing.
+        expect.hasAssertions();
+
         const parsed = parseChangeFile(`---\n\n---\n`, "f.md");
 
         expect(parsed.payload.bumps).toStrictEqual({});
     });
 
     it("rejects array frontmatter", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(`---\n- pkg-a: minor\n---\n`, "f.md")).toThrow(/must be a YAML object/);
     });
 
     it("rejects invalid package name (leading hyphen)", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(`---\n"-bad-pkg": minor\n---\n`, "f.md")).toThrow(/Invalid package name/);
     });
 
     it("rejects invalid package name (control char)", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(`---\n"bad pkg": minor\n---\n`, "f.md")).toThrow(/Invalid package name/);
     });
 
     it("rejects invalid YAML in frontmatter", () => {
+        expect.hasAssertions();
         expect(() => parseChangeFile(`---\n: : :\n---\n`, "f.md")).toThrow(/YAML parse failed|Invalid/);
     });
 
     it("attaches file path to thrown error", () => {
+        expect.hasAssertions();
+
         let caught: unknown;
 
         try {
@@ -151,6 +174,8 @@ describe("change-file: parseChangeFile (validation)", () => {
 
 describe("change-file: inline metadata extraction", () => {
     it("extracts pr / commit / author from body header", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\npkg-a: minor\n---\npr: 42\ncommit: abc1234\nauthor: @prisis\n\nThe actual changelog body.\n`,
             "f.md",
@@ -161,6 +186,8 @@ describe("change-file: inline metadata extraction", () => {
     });
 
     it("auto-prepends @ to author handles", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\npkg-a: minor\n---\nauthor: someone\nBody.\n`,
             "f.md",
@@ -170,12 +197,16 @@ describe("change-file: inline metadata extraction", () => {
     });
 
     it("returns no meta when none present", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(`---\npkg-a: minor\n---\nJust body.\n`, "f.md");
 
         expect(result.meta).toBeUndefined();
     });
 
     it("ignores invalid pr numbers", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\npkg-a: minor\n---\npr: not-a-number\nBody.\n`,
             "f.md",
@@ -185,6 +216,8 @@ describe("change-file: inline metadata extraction", () => {
     });
 
     it("stops scanning meta at the first non-meta non-blank line", () => {
+        expect.hasAssertions();
+
         const result = parseChangeFile(
             `---\npkg-a: minor\n---\npr: 1\nactual body line\nauthor: @foo\nmore body\n`,
             "f.md",
@@ -197,6 +230,8 @@ describe("change-file: inline metadata extraction", () => {
 
 describe("change-file: formatChangeFile (round-trip)", () => {
     it("formats then re-parses a simple file", () => {
+        expect.hasAssertions();
+
         const formatted = formatChangeFile({ bumps: { "@scope/pkg-a": "minor", "pkg-b": "patch" } }, "Body text.");
         const parsed = parseChangeFile(formatted, "x.md");
 
@@ -209,6 +244,8 @@ describe("change-file: formatChangeFile (round-trip)", () => {
     });
 
     it("formats then re-parses a nested file with cascade", () => {
+        expect.hasAssertions();
+
         const formatted = formatChangeFile(
             { bump: "minor", cascade: { "@scope/plugin-*": "patch" }, package: "@scope/core" },
             "Body.",
@@ -225,6 +262,8 @@ describe("change-file: formatChangeFile (round-trip)", () => {
     });
 
     it("emits empty body cleanly when body is empty", () => {
+        expect.hasAssertions();
+
         const formatted = formatChangeFile({ bumps: { "pkg-a": "patch" } }, "");
 
         expect(formatted).toBe(`---\npkg-a: patch\n---\n`);
@@ -233,6 +272,8 @@ describe("change-file: formatChangeFile (round-trip)", () => {
 
 describe("change-file: collectExplicitBumps", () => {
     it("max-merges multiple files mentioning the same package", () => {
+        expect.hasAssertions();
+
         const files = [
             parseChangeFile(`---\npkg-a: patch\n---\nA.\n`, "1.md"),
             parseChangeFile(`---\npkg-a: minor\n---\nB.\n`, "2.md"),
@@ -245,6 +286,8 @@ describe("change-file: collectExplicitBumps", () => {
     });
 
     it("collects bumps from nested-shape files", () => {
+        expect.hasAssertions();
+
         const files = [parseChangeFile(`---\npkg-a:\n  bump: major\n---\n`, "1.md")];
 
         const result = collectExplicitBumps(files);
@@ -253,6 +296,8 @@ describe("change-file: collectExplicitBumps", () => {
     });
 
     it("preserves none entries (recorded but no direct bump)", () => {
+        expect.hasAssertions();
+
         const files = [parseChangeFile(`---\npkg-a: none\npkg-b: patch\n---\n`, "1.md")];
 
         const result = collectExplicitBumps(files);
@@ -264,6 +309,8 @@ describe("change-file: collectExplicitBumps", () => {
 
 describe("change-file: findChangeFilesFor", () => {
     it("finds files mentioning a given package (simple shape)", () => {
+        expect.hasAssertions();
+
         const files = [
             parseChangeFile(`---\npkg-a: minor\npkg-b: patch\n---\nA.\n`, "1.md"),
             parseChangeFile(`---\npkg-c: patch\n---\nB.\n`, "2.md"),
@@ -276,6 +323,8 @@ describe("change-file: findChangeFilesFor", () => {
     });
 
     it("finds files mentioning a given package (nested shape)", () => {
+        expect.hasAssertions();
+
         const files = [
             parseChangeFile(`---\npkg-a:\n  bump: minor\n---\nA.\n`, "1.md"),
             parseChangeFile(`---\npkg-b:\n  bump: patch\n---\nB.\n`, "2.md"),

--- a/packages/tooling/vis/__tests__/release/core/changelog-default.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-default.test.ts
@@ -32,6 +32,8 @@ const mkCtx = (overrides: Partial<ChangelogContext> = {}): ChangelogContext => {
 
 describe(defaultFormatter, () => {
     it("renders header + sub date for changelog target", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(mkCtx());
 
         expect(result).toContain("## 1.1.0");
@@ -39,6 +41,8 @@ describe(defaultFormatter, () => {
     });
 
     it("strips version heading for github-release target", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(mkCtx({ target: "github-release" }));
 
         expect(result).not.toContain("## 1.1.0");
@@ -46,6 +50,8 @@ describe(defaultFormatter, () => {
     });
 
     it("renders change-file body lines as bullets", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(
             mkCtx({
                 changeFiles: [
@@ -64,6 +70,8 @@ describe(defaultFormatter, () => {
     });
 
     it("preserves existing bullet markers", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(
             mkCtx({
                 changeFiles: [
@@ -78,6 +86,8 @@ describe(defaultFormatter, () => {
     });
 
     it("emits 'Cascade from' line for cascade bumps", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(
             mkCtx({
                 release: mkRelease({
@@ -91,6 +101,8 @@ describe(defaultFormatter, () => {
     });
 
     it("emits 'Group bump with' line for group bumps", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(
             mkCtx({
                 release: mkRelease({
@@ -104,6 +116,8 @@ describe(defaultFormatter, () => {
     });
 
     it("emits 'Updated dependency' line for pure dep bumps with no change file", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(
             mkCtx({
                 release: mkRelease({
@@ -119,6 +133,8 @@ describe(defaultFormatter, () => {
 
 describe("default formatter: authorCredit option", () => {
     it("appends `(@user)` when the option is enabled and the change file has author meta", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ authorCredit: true });
         const result = await formatter(mkCtx({
             changeFiles: [
@@ -136,6 +152,8 @@ describe("default formatter: authorCredit option", () => {
     });
 
     it("does NOT append author when the option is off (default behaviour)", async () => {
+        expect.hasAssertions();
+
         const result = await defaultFormatter(mkCtx({
             changeFiles: [
                 {
@@ -153,6 +171,8 @@ describe("default formatter: authorCredit option", () => {
     });
 
     it("normalises authors without leading @", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ authorCredit: true });
         const result = await formatter(mkCtx({
             changeFiles: [
@@ -170,6 +190,8 @@ describe("default formatter: authorCredit option", () => {
     });
 
     it("skips credit when no author meta is present (silent)", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ authorCredit: true });
         const result = await formatter(mkCtx({
             changeFiles: [
@@ -198,6 +220,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     };
 
     it("emits a flat list when `sections` is omitted (legacy default)", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter();
         const result = await formatter(mkCtx({
             changeFiles: [mkFile("feat: add tab completion\nfix: handle empty input")],
@@ -209,6 +233,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     });
 
     it("groups entries under inferred conventional-commit sections when `sections: []`", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ sections: [] });
         const result = await formatter(mkCtx({
             changeFiles: [mkFile("feat: add tab completion\nfix: handle empty input")],
@@ -220,6 +246,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     });
 
     it("treats `feat!:` as a breaking change", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ sections: [] });
         const result = await formatter(mkCtx({
             changeFiles: [mkFile("feat!: drop legacy API")],
@@ -230,6 +258,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     });
 
     it("hidden types are dropped entirely from the output", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ sections: [] });
         const result = await formatter(mkCtx({
             changeFiles: [mkFile("chore: bump linter\nfeat: real feature")],
@@ -241,6 +271,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     });
 
     it("custom sections override the default mapping", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({
             sections: [
                 { section: "Headlines", type: "feat" },
@@ -257,6 +289,8 @@ describe("default formatter: sections option (release-please parity)", () => {
     });
 
     it("lines without a conventional prefix go to a `Miscellaneous` section", async () => {
+        expect.hasAssertions();
+
         const formatter = createDefaultFormatter({ sections: [] });
         const result = await formatter(mkCtx({
             changeFiles: [mkFile("feat: typed thing\nUntagged note here.")],

--- a/packages/tooling/vis/__tests__/release/core/changelog-github.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-github.test.ts
@@ -54,6 +54,8 @@ const repoMockRunner = (repo = "owner/repo"): MockRunner => {
 
 describe("github formatter", () => {
     it("renders header + sub date for changelog target", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({ repo: "owner/repo", runner });
         const result = await fmt(mkCtx());
@@ -63,6 +65,8 @@ describe("github formatter", () => {
     });
 
     it("strips heading for github-release target", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({ repo: "owner/repo", runner });
         const result = await fmt(mkCtx({ target: "github-release" }));
@@ -71,6 +75,8 @@ describe("github formatter", () => {
     });
 
     it("links #N references using the configured repo slug", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({ repo: "owner/repo", runner });
 
@@ -87,6 +93,8 @@ describe("github formatter", () => {
     });
 
     it("appends pr / commit refs from inline meta", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({ repo: "owner/repo", runner });
 
@@ -109,6 +117,8 @@ describe("github formatter", () => {
     });
 
     it("emits 'Thanks @user!' when an author is present", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({ repo: "owner/repo", runner });
 
@@ -130,6 +140,8 @@ describe("github formatter", () => {
     });
 
     it("suppresses thanks for internalAuthors", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({
             internalAuthors: ["maintainer"],
@@ -155,6 +167,8 @@ describe("github formatter", () => {
     });
 
     it("disables thanks when thankContributors is false", async () => {
+        expect.hasAssertions();
+
         const runner = repoMockRunner();
         const fmt = createGithubFormatter({
             repo: "owner/repo",
@@ -181,6 +195,8 @@ describe("github formatter", () => {
 
     it("falls back to plain text when no repo can be resolved", async () => {
         // Runner has no git remote handler — detection returns undefined.
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const fmt = createGithubFormatter({ runner });
 

--- a/packages/tooling/vis/__tests__/release/core/changelog-keep-a-changelog.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-keep-a-changelog.test.ts
@@ -32,6 +32,8 @@ const mkCtx = (overrides: Partial<ChangelogContext> = {}): ChangelogContext => {
 
 describe("keep-a-changelog formatter", () => {
     it("renders the version+date header per Keep-a-Changelog spec", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
 
         const result = await fmt(mkCtx());
@@ -40,6 +42,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("strips version heading for github-release target", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
 
         const result = await fmt(mkCtx({ target: "github-release" }));
@@ -48,6 +52,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("buckets `feat:` lines into Added", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "feat: shiny new thing", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } }],
@@ -57,6 +63,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("buckets `fix:` lines into Fixed", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "fix: a flaky bug", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "patch" } } }],
@@ -67,6 +75,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("respects explicit `[Section]` prefix overrides", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "[Security] Patched a CVE\n[Deprecated] old API", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } }],
@@ -79,6 +89,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("falls back to bump-type heuristic when no prefix found", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "did stuff", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } }],
@@ -90,6 +102,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("emits BREAKING CHANGES section for major bumps", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "feat!: removed old api", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "major" } } }],
@@ -101,6 +115,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("emits BREAKING CHANGES when body contains BREAKING CHANGE", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "feat: added thing\n\nBREAKING CHANGE: caller must update config", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "major" } } }],
@@ -111,6 +127,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("appends a comparison-link footer when repo is provided", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter({ repo: "owner/repo" });
         const result = await fmt(mkCtx());
 
@@ -118,6 +136,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("supports compareUrlPrefix override (e.g. self-hosted GitLab)", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter({ compareUrlPrefix: "https://gitlab.example/group/proj" });
         const result = await fmt(mkCtx());
 
@@ -125,6 +145,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("omits link footer when neither repo nor compareUrlPrefix provided", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx());
 
@@ -132,6 +154,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("emits cascade lines under Changed", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             release: mkRelease({
@@ -145,6 +169,8 @@ describe("keep-a-changelog formatter", () => {
     });
 
     it("ignores empty sections", async () => {
+        expect.hasAssertions();
+
         const fmt = createKeepAChangelogFormatter();
         const result = await fmt(mkCtx({
             changeFiles: [{ body: "feat: only an addition", id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } }],

--- a/packages/tooling/vis/__tests__/release/core/changelog-resolve.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-resolve.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { resolveFormatter } from "../../../src/release/core/changelog/resolve";
 import type { ChangeFile, PlannedRelease } from "../../../src/release/types";
@@ -32,6 +32,8 @@ const mkChangeFile = (body: string): ChangeFile => {
 
 describe("resolveFormatter — built-ins", () => {
     it("returns a no-op formatter for setting=false", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter(false, "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
@@ -39,6 +41,8 @@ describe("resolveFormatter — built-ins", () => {
     });
 
     it("returns the default formatter for setting=undefined", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter(undefined, "/tmp");
         const out = await formatter({
             changeFiles: [mkChangeFile("- something happened")],
@@ -53,6 +57,8 @@ describe("resolveFormatter — built-ins", () => {
     });
 
     it("returns the default formatter for setting=\"default\"", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter("default", "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
@@ -63,6 +69,8 @@ describe("resolveFormatter — built-ins", () => {
     // per-change-file `git log`) plus a dynamic `import("../remote/detect")`. Fine
     // in isolation, but the cold spawn is slow under full-suite parallel load.
     it("returns the github formatter for setting=\"github\"", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter("github", "/tmp");
         const out = await formatter({
             changeFiles: [mkChangeFile("did a thing\n\npr: 42")],
@@ -71,46 +79,56 @@ describe("resolveFormatter — built-ins", () => {
             target: "changelog",
         });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
 
         expect(out).toContain("1.1.0");
     }, 15_000);
 
     it("returns the keep-a-changelog formatter for setting=\"keep-a-changelog\"", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter("keep-a-changelog", "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
     });
 
     it("aliases \"keepachangelog\" to the same formatter", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter("keepachangelog", "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
     });
 });
 
 describe("resolveFormatter — tuple form for built-ins", () => {
     it("forwards options to the github factory", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter(["github", { repo: "owner/name" }], "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
     });
 
     it("forwards options to the keep-a-changelog factory", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter(["keep-a-changelog", {}], "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
     });
 
     it("aliases \"keepachangelog\" tuple form", async () => {
+        expect.hasAssertions();
+
         const formatter = await resolveFormatter(["keepachangelog", {}], "/tmp");
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
-        expectTypeOf(out).toBeString();
+        expect(out).toBeTypeOf("string");
     });
 });
 
@@ -128,6 +146,8 @@ describe("resolveFormatter — custom user module", () => {
     });
 
     it("loads a relative module that default-exports a formatter", async () => {
+        expect.hasAssertions();
+
         const file = join(cwd, "my-formatter.mjs");
 
         writeFileSync(file, "export default (ctx) => `CUSTOM ${ctx.release.newVersion}`;\n");
@@ -139,6 +159,8 @@ describe("resolveFormatter — custom user module", () => {
     });
 
     it("loads a relative module whose default export is already callable (factory shape)", async () => {
+        expect.hasAssertions();
+
         const file = join(cwd, "factory.mjs");
 
         writeFileSync(file, "export default (opts) => (ctx) => `FACTORY ${opts.prefix} ${ctx.release.newVersion}`;\n");
@@ -153,6 +175,8 @@ describe("resolveFormatter — custom user module", () => {
         // If the default export *is* the formatter (not a factory) but the user
         // passed tuple form by mistake — calling it with options yields a string,
         // not a function, so resolve.ts returns the original export.
+        expect.hasAssertions();
+
         const file = join(cwd, "noopt.mjs");
 
         writeFileSync(file, "export default (ctx) => `PLAIN ${ctx.release.newVersion}`;\n");
@@ -164,6 +188,8 @@ describe("resolveFormatter — custom user module", () => {
     });
 
     it("throws when the module's default is not a function", async () => {
+        expect.hasAssertions();
+
         const file = join(cwd, "bad.mjs");
 
         writeFileSync(file, "export default { not: 'a function' };\n");

--- a/packages/tooling/vis/__tests__/release/core/changelog-workspace.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-workspace.test.ts
@@ -27,20 +27,25 @@ const stubFormatter: ChangelogFormatter = (ctx: ChangelogContext): string => `Bo
 
 describe(workspaceChangelogPath, () => {
     it("defaults to CHANGELOG.md at workspace root", () => {
+        expect.hasAssertions();
         expect(workspaceChangelogPath("/r")).toBe("/r/CHANGELOG.md");
     });
 
     it("respects custom file option", () => {
+        expect.hasAssertions();
         expect(workspaceChangelogPath("/r", { file: "RELEASES.md" })).toBe("/r/RELEASES.md");
     });
 
     it("preserves absolute paths", () => {
+        expect.hasAssertions();
         expect(workspaceChangelogPath("/r", { file: "/elsewhere/log.md" })).toBe("/elsewhere/log.md");
     });
 });
 
 describe(renderWorkspaceChangelog, () => {
     it("emits a heading + per-release sections", async () => {
+        expect.hasAssertions();
+
         const releases = [mkRelease("@scope/a", "1.1.0"), mkRelease("@scope/b", "2.1.0")];
         const out = await renderWorkspaceChangelog(releases, "2026-05-02", stubFormatter);
 
@@ -52,6 +57,8 @@ describe(renderWorkspaceChangelog, () => {
     });
 
     it("supports {date} and {count} tokens in custom waveHeading", async () => {
+        expect.hasAssertions();
+
         const releases = [mkRelease("a", "1.1.0")];
         const out = await renderWorkspaceChangelog(releases, "2026-05-02", stubFormatter, {
             waveHeading: "## My release on {date} — {count} bumps",
@@ -61,6 +68,8 @@ describe(renderWorkspaceChangelog, () => {
     });
 
     it("emits placeholder when a per-release formatter returns empty", async () => {
+        expect.hasAssertions();
+
         const emptyFormatter: ChangelogFormatter = () => "";
         const releases = [mkRelease("a", "1.1.0")];
         const out = await renderWorkspaceChangelog(releases, "2026-05-02", emptyFormatter);
@@ -69,6 +78,8 @@ describe(renderWorkspaceChangelog, () => {
     });
 
     it("forwards the github-release target so per-release formatter strips its version heading", async () => {
+        expect.hasAssertions();
+
         let captured: ChangelogContext | undefined;
         const captureFormatter: ChangelogFormatter = (ctx) => {
             captured = ctx;
@@ -103,6 +114,8 @@ describe(resolveGroupChangelogRouting, () => {
     ];
 
     it("returns an empty map when no group opts into shared mode", () => {
+        expect.hasAssertions();
+
         const config: VisReleaseConfig = {
             fixed: [["@scope/a", "@scope/b"]],
         };
@@ -113,6 +126,8 @@ describe(resolveGroupChangelogRouting, () => {
     });
 
     it("routes shared fixed-group members to a single default path", () => {
+        expect.hasAssertions();
+
         const config: VisReleaseConfig = {
             fixed: [
                 {
@@ -130,6 +145,8 @@ describe(resolveGroupChangelogRouting, () => {
     });
 
     it("honours an explicit `path` override (relative)", () => {
+        expect.hasAssertions();
+
         const config: VisReleaseConfig = {
             fixed: [
                 {
@@ -146,6 +163,8 @@ describe(resolveGroupChangelogRouting, () => {
     });
 
     it("honours an explicit `path` override (absolute)", () => {
+        expect.hasAssertions();
+
         const config: VisReleaseConfig = {
             linked: [
                 {
@@ -162,6 +181,8 @@ describe(resolveGroupChangelogRouting, () => {
     });
 
     it("keeps backward compat: a bare string[] group is per-package (no routing)", () => {
+        expect.hasAssertions();
+
         const config: VisReleaseConfig = {
             fixed: [["@scope/a", "@scope/b"]],
             linked: [["@scope/c"]],

--- a/packages/tooling/vis/__tests__/release/core/channels.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/channels.test.ts
@@ -6,7 +6,7 @@ describe("channels: resolveChannel (literal match)", () => {
     it("matches a literal branch name", () => {
         const result = resolveChannel("main", { main: { tag: "latest" } });
 
-        expect(result).toEqual({ branch: "main", mode: "auto-publish", prerelease: undefined, range: undefined, tag: "latest" });
+        expect(result).toStrictEqual({ branch: "main", mode: "auto-publish", prerelease: undefined, range: undefined, tag: "latest" });
     });
 
     it("includes prerelease + mode when configured", () => {

--- a/packages/tooling/vis/__tests__/release/core/channels.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/channels.test.ts
@@ -4,12 +4,16 @@ import { resolveChannel } from "../../../src/release/core/channels";
 
 describe("channels: resolveChannel (literal match)", () => {
     it("matches a literal branch name", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("main", { main: { tag: "latest" } });
 
         expect(result).toStrictEqual({ branch: "main", mode: "auto-publish", prerelease: undefined, range: undefined, tag: "latest" });
     });
 
     it("includes prerelease + mode when configured", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("alpha", {
             alpha: { mode: "auto-publish", prerelease: "alpha", tag: "alpha" },
         });
@@ -19,12 +23,15 @@ describe("channels: resolveChannel (literal match)", () => {
     });
 
     it("returns undefined for unknown branch", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("feature/foo", { main: { tag: "latest" } });
 
         expect(result).toBeUndefined();
     });
 
     it("returns undefined when no channels configured", () => {
+        expect.hasAssertions();
         expect(resolveChannel("main", undefined)).toBeUndefined();
         expect(resolveChannel("main", {})).toBeUndefined();
     });
@@ -32,6 +39,8 @@ describe("channels: resolveChannel (literal match)", () => {
 
 describe("channels: resolveChannel (glob match)", () => {
     it("matches a glob pattern (maintenance branches)", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("1.x", {
             "[0-9]*.x": { range: "match", tag: "branch-name" },
         });
@@ -42,6 +51,8 @@ describe("channels: resolveChannel (glob match)", () => {
     });
 
     it("matches dotted maintenance pattern (1.2.x)", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("1.2.x", {
             "[0-9]*.x": { tag: "branch-name" },
         });
@@ -51,6 +62,8 @@ describe("channels: resolveChannel (glob match)", () => {
 
     it("does not match non-glob patterns as globs", () => {
         // 'release' is plain text, no glob meta; must not be glob-matched.
+        expect.hasAssertions();
+
         const result = resolveChannel("release", { other: { tag: "latest" } });
 
         expect(result).toBeUndefined();
@@ -59,6 +72,8 @@ describe("channels: resolveChannel (glob match)", () => {
 
 describe("channels: resolveChannel (precedence)", () => {
     it("literal wins over glob when both could match", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("alpha", {
             alpha: { tag: "alpha-literal" },
             "alpha*": { tag: "alpha-glob" },
@@ -70,6 +85,8 @@ describe("channels: resolveChannel (precedence)", () => {
     it("first-listed glob wins among glob matches", () => {
         // Order is the system under test — keep insertion order, not alphabetical.
         /* eslint-disable perfectionist/sort-objects */
+        expect.hasAssertions();
+
         const result = resolveChannel("alpha-1", {
             "alpha*": { tag: "first" },
             "*-1": { tag: "second" },
@@ -82,6 +99,8 @@ describe("channels: resolveChannel (precedence)", () => {
 
 describe("channels: tag = 'branch-name' sanitisation", () => {
     it("uses the branch name as the dist-tag", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("1.x", {
             "[0-9]*.x": { tag: "branch-name" },
         });
@@ -90,6 +109,8 @@ describe("channels: tag = 'branch-name' sanitisation", () => {
     });
 
     it("sanitises slashes / spaces from branch names", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("feature/Foo Bar", {
             "feature/*": { tag: "branch-name" },
         });
@@ -98,6 +119,8 @@ describe("channels: tag = 'branch-name' sanitisation", () => {
     });
 
     it("falls back to 'branch' when sanitised name is empty", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("---", {
             "*": { tag: "branch-name" },
         });
@@ -108,12 +131,16 @@ describe("channels: tag = 'branch-name' sanitisation", () => {
 
 describe("channels: mode default", () => {
     it("defaults to auto-publish when mode is not set", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("main", { main: { tag: "latest" } });
 
         expect(result?.mode).toBe("auto-publish");
     });
 
     it("respects explicit version-pr mode", () => {
+        expect.hasAssertions();
+
         const result = resolveChannel("main", { main: { mode: "version-pr", tag: "latest" } });
 
         expect(result?.mode).toBe("version-pr");

--- a/packages/tooling/vis/__tests__/release/core/clean-package-json.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/clean-package-json.test.ts
@@ -40,17 +40,17 @@ describe(cleanPackageJsonForPublish, () => {
         expect(result.name).toBe("@scope/pkg");
         expect(result.version).toBe("1.0.0");
         expect(result.description).toBe("A package");
-        expect(result.dependencies).toEqual({ lodash: "^4.0.0" });
-        expect(result.engines).toEqual({ node: ">=22" });
-        expect(result.publishConfig).toEqual({ access: "public" });
+        expect(result.dependencies).toStrictEqual({ lodash: "^4.0.0" });
+        expect(result.engines).toStrictEqual({ node: ">=22" });
+        expect(result.publishConfig).toStrictEqual({ access: "public" });
     });
 
     it("ships unmodified when cfg is false", () => {
         const result = cleanPackageJsonForPublish(fullManifest, false);
 
-        expect(result.scripts).toEqual({ build: "tsc" });
-        expect(result.devDependencies).toEqual({ vitest: "^2.0.0" });
-        expect(result.nx).toEqual({ tags: ["lib"] });
+        expect(result.scripts).toStrictEqual({ build: "tsc" });
+        expect(result.devDependencies).toStrictEqual({ vitest: "^2.0.0" });
+        expect(result.nx).toStrictEqual({ tags: ["lib"] });
     });
 
     it("extends defaults via cfg.strip", () => {
@@ -63,7 +63,7 @@ describe(cleanPackageJsonForPublish, () => {
     it("preserves a default-stripped field when added to cfg.keep", () => {
         const result = cleanPackageJsonForPublish(fullManifest, { keep: ["scripts"] });
 
-        expect(result.scripts).toEqual({ build: "tsc" });
+        expect(result.scripts).toStrictEqual({ build: "tsc" });
         expect(result.devDependencies).toBeUndefined();
     });
 

--- a/packages/tooling/vis/__tests__/release/core/clean-package-json.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/clean-package-json.test.ts
@@ -18,6 +18,8 @@ describe(cleanPackageJsonForPublish, () => {
     };
 
     it("strips default fields when cfg is true", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest, true);
 
         expect(result.scripts).toBeUndefined();
@@ -28,6 +30,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("strips defaults when cfg is undefined", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest);
 
         expect(result.scripts).toBeUndefined();
@@ -35,6 +39,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("preserves runtime-relevant fields", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest);
 
         expect(result.name).toBe("@scope/pkg");
@@ -46,6 +52,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("ships unmodified when cfg is false", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest, false);
 
         expect(result.scripts).toStrictEqual({ build: "tsc" });
@@ -54,6 +62,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("extends defaults via cfg.strip", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest, { strip: ["description"] });
 
         expect(result.description).toBeUndefined();
@@ -61,6 +71,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("preserves a default-stripped field when added to cfg.keep", () => {
+        expect.hasAssertions();
+
         const result = cleanPackageJsonForPublish(fullManifest, { keep: ["scripts"] });
 
         expect(result.scripts).toStrictEqual({ build: "tsc" });
@@ -68,6 +80,8 @@ describe(cleanPackageJsonForPublish, () => {
     });
 
     it("does not mutate input", () => {
+        expect.hasAssertions();
+
         const original = JSON.stringify(fullManifest);
 
         cleanPackageJsonForPublish(fullManifest, true);

--- a/packages/tooling/vis/__tests__/release/core/dep-graph-deeper.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/dep-graph-deeper.test.ts
@@ -31,7 +31,7 @@ describe("dependencyGraph — multi-kind indexing", () => {
         const dependents = graph.getDependents("a");
 
         expect(dependents).toHaveLength(2);
-        expect(dependents.map((d) => d.kind).sort()).toEqual(["dependencies", "devDependencies"]);
+        expect(dependents.map((d) => d.kind).sort()).toStrictEqual(["dependencies", "devDependencies"]);
     });
 
     it("topo-sort with diamond dep graph", () => {

--- a/packages/tooling/vis/__tests__/release/core/dep-graph-deeper.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/dep-graph-deeper.test.ts
@@ -16,6 +16,8 @@ const pkg = (name: string, deps: Record<string, string> = {}): WorkspacePackage 
 
 describe("dependencyGraph — multi-kind indexing", () => {
     it("returns disjoint dependent lists across dep kinds", () => {
+        expect.hasAssertions();
+
         const a = pkg("a");
         const b: WorkspacePackage = {
             ...pkg("b"),
@@ -37,6 +39,8 @@ describe("dependencyGraph — multi-kind indexing", () => {
     it("topo-sort with diamond dep graph", () => {
         // d → b → a
         // d → c → a
+        expect.hasAssertions();
+
         const a = pkg("a");
         const b = pkg("b", { a: "^1.0.0" });
         const c = pkg("c", { a: "^1.0.0" });
@@ -52,6 +56,8 @@ describe("dependencyGraph — multi-kind indexing", () => {
     });
 
     it("size + isInternal + getPackage are consistent", () => {
+        expect.hasAssertions();
+
         const graph = new DependencyGraph([pkg("a"), pkg("b")]);
 
         expect(graph.size).toBe(2);

--- a/packages/tooling/vis/__tests__/release/core/dep-graph.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/dep-graph.test.ts
@@ -24,9 +24,9 @@ describe("dep-graph: build inverted index", () => {
         const b = makePkg("b");
         const graph = new DependencyGraph([a, b]);
 
-        expect(graph.getDependents("b")).toEqual([{ kind: "dependencies", name: "a", range: "^1.0.0" }]);
-        expect(graph.getDependents("a")).toEqual([]);
-        expect(graph.getDependencies("a")).toEqual([{ kind: "dependencies", name: "b", range: "^1.0.0" }]);
+        expect(graph.getDependents("b")).toStrictEqual([{ kind: "dependencies", name: "a", range: "^1.0.0" }]);
+        expect(graph.getDependents("a")).toStrictEqual([]);
+        expect(graph.getDependencies("a")).toStrictEqual([{ kind: "dependencies", name: "b", range: "^1.0.0" }]);
     });
 
     it("indexes peerDependencies, devDependencies, and optionalDependencies separately", () => {

--- a/packages/tooling/vis/__tests__/release/core/dep-graph.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/dep-graph.test.ts
@@ -20,6 +20,8 @@ const makePkg = (
 
 describe("dep-graph: build inverted index", () => {
     it("indexes a simple workspace dep", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", { dependencies: { b: "^1.0.0" } });
         const b = makePkg("b");
         const graph = new DependencyGraph([a, b]);
@@ -30,6 +32,8 @@ describe("dep-graph: build inverted index", () => {
     });
 
     it("indexes peerDependencies, devDependencies, and optionalDependencies separately", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", {
             devDependencies: { b: "*" },
             optionalDependencies: { d: "~1.0.0" },
@@ -43,6 +47,8 @@ describe("dep-graph: build inverted index", () => {
     });
 
     it("ignores external (non-workspace) deps", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", { dependencies: { b: "^1.0.0", lodash: "^4.0.0" } });
         const graph = new DependencyGraph([a, makePkg("b")]);
 
@@ -52,6 +58,8 @@ describe("dep-graph: build inverted index", () => {
     });
 
     it("preserves the original range string (incl. workspace: / catalog: prefixes)", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", { dependencies: { b: "workspace:^1.0.0", c: "catalog:dev" } });
         const graph = new DependencyGraph([a, makePkg("b"), makePkg("c")]);
 
@@ -60,6 +68,8 @@ describe("dep-graph: build inverted index", () => {
     });
 
     it("rejects duplicate package names", () => {
+        expect.hasAssertions();
+
         const a1 = makePkg("a");
         const a2 = { ...makePkg("a"), dir: "/repo/packages/elsewhere" };
 
@@ -80,6 +90,8 @@ describe("dep-graph: build inverted index", () => {
 
 describe("dep-graph: topologicalSort", () => {
     it("sorts a linear chain a → b → c (deps before dependents)", () => {
+        expect.hasAssertions();
+
         const c = makePkg("c");
         const b = makePkg("b", { dependencies: { c: "^1.0.0" } });
         const a = makePkg("a", { dependencies: { b: "^1.0.0" } });
@@ -93,6 +105,8 @@ describe("dep-graph: topologicalSort", () => {
 
     it("sorts a fan-out graph correctly", () => {
         // shared depended on by a, b, c
+        expect.hasAssertions();
+
         const shared = makePkg("shared");
         const a = makePkg("a", { dependencies: { shared: "^1.0.0" } });
         const b = makePkg("b", { dependencies: { shared: "^1.0.0" } });
@@ -107,6 +121,8 @@ describe("dep-graph: topologicalSort", () => {
     });
 
     it("detects cyclic dependencies (non-dev)", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", { dependencies: { b: "^1.0.0" } });
         const b = makePkg("b", { dependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -126,6 +142,8 @@ describe("dep-graph: topologicalSort", () => {
     });
 
     it("tolerates devDependency cycles", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a", { devDependencies: { b: "^1.0.0" } });
         const b = makePkg("b", { devDependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -138,6 +156,8 @@ describe("dep-graph: topologicalSort", () => {
     });
 
     it("respects subset filter — only sorts requested packages", () => {
+        expect.hasAssertions();
+
         const c = makePkg("c");
         const b = makePkg("b", { dependencies: { c: "^1.0.0" } });
         const a = makePkg("a", { dependencies: { b: "^1.0.0" } });
@@ -154,12 +174,16 @@ describe("dep-graph: topologicalSort", () => {
 
 describe("dep-graph: helpers", () => {
     it("size returns total package count", () => {
+        expect.hasAssertions();
+
         const graph = new DependencyGraph([makePkg("a"), makePkg("b"), makePkg("c")]);
 
         expect(graph.size).toBe(3);
     });
 
     it("getPackage returns the workspace entry", () => {
+        expect.hasAssertions();
+
         const a = makePkg("a");
         const graph = new DependencyGraph([a]);
 
@@ -168,6 +192,8 @@ describe("dep-graph: helpers", () => {
     });
 
     it("isInternal reports membership", () => {
+        expect.hasAssertions();
+
         const graph = new DependencyGraph([makePkg("a"), makePkg("b")]);
 
         expect(graph.isInternal("a")).toBe(true);

--- a/packages/tooling/vis/__tests__/release/core/extra-files.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/extra-files.test.ts
@@ -16,6 +16,8 @@ import { VisReleaseError } from "../../../src/release/errors";
 
 describe("extra-files: compileRule", () => {
     it("compiles a valid pattern with default `g` flag", () => {
+        expect.hasAssertions();
+
         const re = compileRule({ path: "x", search: String.raw`v\d+\.\d+\.\d+` }, "test");
 
         expect(re.flags).toBe("g");
@@ -23,6 +25,8 @@ describe("extra-files: compileRule", () => {
     });
 
     it("honours explicit flags", () => {
+        expect.hasAssertions();
+
         const re = compileRule({ flags: "gmi", path: "x", search: "version" }, "test");
 
         // RegExp.prototype.flags always reports flags in canonical order
@@ -31,6 +35,7 @@ describe("extra-files: compileRule", () => {
     });
 
     it("throws CONFIG_INVALID on syntactically invalid regex", () => {
+        expect.hasAssertions();
         expect(() => compileRule({ path: "x", search: "(unbalanced" }, "test")).toThrow(VisReleaseError);
     });
 });
@@ -48,6 +53,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("substitutes the bare match when no `replace` template is given", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "README.md"), "Stable release: v1.0.0 (was v0.9.0).\n");
 
         const result = await applyExtraFilesForRelease(
@@ -64,6 +71,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("expands `{version}` token in the replace template", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "src.ts"), "export const VERSION = \"0.9.0\";\n");
 
         const result = await applyExtraFilesForRelease(
@@ -79,6 +88,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("supports regex backreferences in the replace template", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "config.toml"), "name = \"pkg\"\nversion = \"0.9.0\"\n");
 
         const result = await applyExtraFilesForRelease(
@@ -99,6 +110,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("resolves per-package rules relative to the package directory", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "packages", "a", "VERSION.txt"), "0.9.0\n");
 
         const result = await applyExtraFilesForRelease(
@@ -115,6 +128,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("warns (does not throw) on missing files", async () => {
+        expect.hasAssertions();
+
         const result = await applyExtraFilesForRelease(
             cwd,
             join(cwd, "packages", "a"),
@@ -129,6 +144,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("warns on stale rules (regex matched nothing)", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "stable.md"), "no version here\n");
 
         const result = await applyExtraFilesForRelease(
@@ -149,6 +166,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
         // substitutes the matched version with the version literal, so when
         // the file is already at that literal the content is identical and no
         // write is emitted.
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "README.md"), "1.0.0\n");
 
         const result = await applyExtraFilesForRelease(
@@ -164,6 +183,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("composes multiple rules against the same file in one read", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "README.md"), "[![v0.9.0](badge.svg)](url)\nversion: 0.9.0\n");
 
         const result = await applyExtraFilesForRelease(
@@ -187,6 +208,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("expands `{packageName}` as an alias for `{name}` (release-please parity)", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "id.txt"), "old-name\n");
 
         const result = await applyExtraFilesForRelease(
@@ -202,6 +225,8 @@ describe("extra-files: applyExtraFilesForRelease", () => {
     });
 
     it("handles absolute paths as-is", async () => {
+        expect.hasAssertions();
+
         const absolute = join(cwd, "ABS.md");
 
         await writeFile(absolute, "v0.0.1\n");
@@ -238,6 +263,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("replaces the semver on the same line when the marker is inline", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "src.ts"),
             "export const VERSION = \"0.1.0\"; // x-release-please-version\nexport const OTHER = \"1.0.0\";\n",
@@ -259,6 +286,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("replaces the semver on the next line when the marker sits on its own line (Dockerfile style)", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "Dockerfile"),
             "FROM node:18-alpine\n# x-release-please-version\nENV APP_VERSION=\"0.1.0\"\n",
@@ -281,6 +310,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("honours a custom marker via `marker:` option", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "CUSTOM.txt"),
             "foo = \"0.1.0\" // x-release-vis-version\n",
@@ -299,6 +330,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("treats legacy rules without `type` as regex (backwards compat)", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "README.md"), "v0.9.0\n");
 
         const result = await applyExtraFilesForRelease(
@@ -317,6 +350,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("warns (does not throw) when the marker is not found in the file", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "plain.txt"), "no markers here\nversion 1.2.3\n");
 
         const result = await applyExtraFilesForRelease(
@@ -336,6 +371,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("warns when the marker is present but no semver is on the marked line", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "weird.ts"),
             "const NOT_A_VERSION = \"hello\"; // x-release-please-version\n",
@@ -356,6 +393,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("rewrites multiple occurrences of the marker in one pass", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "multi.ts"),
             "export const A = \"0.1.0\"; // x-release-please-version\n"
@@ -376,6 +415,8 @@ describe("extra-files: annotation-comment mode", () => {
     });
 
     it("supports an explicit `type: \"regex\"` discriminator (mirror of the legacy default)", async () => {
+        expect.hasAssertions();
+
         await writeFile(join(cwd, "explicit.md"), "v0.0.1\n");
 
         const result = await applyExtraFilesForRelease(
@@ -415,6 +456,8 @@ describe("extra-files: annotation-comment mode — anchor (M-6)", () => {
         // A Dockerfile with TWO semver-shaped substrings on the marked
         // line: the base image tag (1.21.0) and APP_VERSION (0.1.0).
         // Without an anchor, the first one would be incorrectly replaced.
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "Dockerfile"),
 
@@ -447,6 +490,8 @@ describe("extra-files: annotation-comment mode — anchor (M-6)", () => {
         // mitigate. This test pins that legacy behaviour so a future
         // accidental change to the default semver-search bound is
         // caught.
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "Dockerfile"),
 
@@ -470,6 +515,8 @@ describe("extra-files: annotation-comment mode — anchor (M-6)", () => {
     it("with `anchor` set on a preceding-line marker, the anchor applies to the FOLLOWING line", async () => {
         // Dockerfile-style: own-line marker followed by a line with two
         // semvers. The anchor scopes the replacement on the next line.
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "Dockerfile"),
 
@@ -500,6 +547,8 @@ describe("extra-files: annotation-comment mode — anchor (M-6)", () => {
         // sits in a comment and the anchor scopes the rewrite to a
         // specific `"version":` substring — the kind of file where
         // anchorless annotation rules are the documented footgun.
+        expect.hasAssertions();
+
         await writeFile(
             join(cwd, "manifest.json"),
 

--- a/packages/tooling/vis/__tests__/release/core/fetch.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/fetch.test.ts
@@ -17,6 +17,8 @@ describe("safeFetchVersionMetadata — httpProxy → undici ProxyAgent", () => {
     });
 
     it("attaches a `dispatcher` to the fetch init when httpProxy is set", async () => {
+        expect.hasAssertions();
+
         const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
 
         await safeFetchVersionMetadata("https://registry.example/foo", {
@@ -34,6 +36,8 @@ describe("safeFetchVersionMetadata — httpProxy → undici ProxyAgent", () => {
     });
 
     it("omits `dispatcher` when httpProxy is not set", async () => {
+        expect.hasAssertions();
+
         const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
 
         await safeFetchVersionMetadata("https://registry.example/foo", {
@@ -46,6 +50,8 @@ describe("safeFetchVersionMetadata — httpProxy → undici ProxyAgent", () => {
     });
 
     it("reuses a single ProxyAgent across consecutive requests to the same proxy", async () => {
+        expect.hasAssertions();
+
         const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
 
         await safeFetchVersionMetadata("https://a.example", {

--- a/packages/tooling/vis/__tests__/release/core/generate-reverts.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/generate-reverts.test.ts
@@ -23,6 +23,8 @@ const mk = (hash: string, subject: string, body = "", files: string[] = []): Com
 
 describe(detectRevert, () => {
     it("flags conventional `revert: <subject>` headers", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("revert: feat(api): add retry", "");
         const result = detectRevert("revert: feat(api): add retry", "", parsed);
 
@@ -31,6 +33,8 @@ describe(detectRevert, () => {
     });
 
     it("flags default git `Revert \"<subject>\"` headers", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("Revert \"feat(api): add retry\"", "");
         const result = detectRevert("Revert \"feat(api): add retry\"", "", parsed);
 
@@ -39,6 +43,8 @@ describe(detectRevert, () => {
     });
 
     it("extracts the SHA trailer from the body when present", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("Revert \"feat: foo\"", "This reverts commit abc1234.");
         const result = detectRevert("Revert \"feat: foo\"", "This reverts commit abc1234.", parsed);
 
@@ -46,6 +52,8 @@ describe(detectRevert, () => {
     });
 
     it("returns isRevert=false for a normal feat commit", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("feat: ship retry", "");
         const result = detectRevert("feat: ship retry", "", parsed);
 
@@ -59,6 +67,8 @@ describe(annotateAndResolveReverts, () => {
     // caller can surface cross-cutting observability findings. Re-
     // assert the shape to lock the contract down.
     it("returns { commits, warnings } and the commits array carries the annotated records", () => {
+        expect.hasAssertions();
+
         const result = annotateAndResolveReverts([mk("a1", "feat: x")]);
 
         expect(Array.isArray(result.commits)).toBe(true);
@@ -70,6 +80,8 @@ describe(annotateAndResolveReverts, () => {
         // git log lists newest first. Order:
         //   c2 (Revert "feat: retry")   ← newest
         //   c1 (feat: retry)            ← older
+        expect.hasAssertions();
+
         const commits = [
             mk("c2", "Revert \"feat: retry\""),
             mk("c1", "feat: retry"),
@@ -85,6 +97,8 @@ describe(annotateAndResolveReverts, () => {
     });
 
     it("cancels via the `This reverts commit <sha>` body trailer", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("def4567", "revert: something different", "Bla bla\n\nThis reverts commit abc1234."),
             mk("abc1234", "feat(foo): land thing"),
@@ -102,6 +116,8 @@ describe(annotateAndResolveReverts, () => {
         //   c3 Revert "Revert "feat: retry""   ← newest (re-applies)
         //   c2 Revert "feat: retry"            ← cancels
         //   c1 feat: retry
+        expect.hasAssertions();
+
         const commits = [
             // git wraps the reverted subject in quotes WITHOUT escaping inner
             // quotes, so a revert-of-revert reads: Revert "Revert "feat: retry""
@@ -139,6 +155,8 @@ describe(annotateAndResolveReverts, () => {
     // (avoids the subject-string escaping pitfalls that bite when
     // double-revert subjects encode each other).
     it("toggles the original across a 4-deep revert chain (revert of revert of revert)", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("c4", "Revert \"feat: retry\"", "Layer 4\n\nThis reverts commit c3."),
             mk("c3", "Revert \"feat: retry\"", "Layer 3\n\nThis reverts commit c2."),
@@ -170,6 +188,8 @@ describe(annotateAndResolveReverts, () => {
         // 40-char hashes are what git emits in `git log %H`. The body
         // trailer carries an 11-char abbrev (mimicking a repo with
         // core.abbrev=11).
+        expect.hasAssertions();
+
         const fullSha = "abc1234567890123456789012345678901234567";
         const eleven = fullSha.slice(0, 11);
         const commits = [
@@ -190,6 +210,8 @@ describe(annotateAndResolveReverts, () => {
     // otherwise the case-sensitive `startsWith` linear fallback would
     // silently miss the target.
     it("matches when the `This reverts commit` trailer SHA is uppercase", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("def4567", "Revert \"feat: y\"", "This reverts commit ABC1234."),
             mk("abc1234567890123456789012345678901234567", "feat: y"),
@@ -211,6 +233,8 @@ describe(annotateAndResolveReverts, () => {
     // full SHA → should resolve to the later commit, not the earlier
     // one that claimed the short slot first.
     it("does not mis-resolve when two commits share a 7-char SHA prefix", () => {
+        expect.hasAssertions();
+
         const earlySha = "abc1234aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         const lateSha = "abc1234bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         // Newest first (git log order):
@@ -235,6 +259,8 @@ describe(annotateAndResolveReverts, () => {
     });
 
     it("treats a revert of an already-released commit as a no-op", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("c2", "Revert \"feat: shipped already\""),
         ];
@@ -253,6 +279,8 @@ describe(annotateAndResolveReverts, () => {
     });
 
     it("respects releasedShas: when revert target IS in the window but already shipped, keep the revert active", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("c2", "Revert \"feat: shipped already\"", "This reverts commit shipped1."),
             mk("shipped1", "feat: shipped already"),
@@ -274,6 +302,8 @@ describe(annotateAndResolveReverts, () => {
 
 describe("annotateAndResolveReverts: F19 no-type-ratio warning", () => {
     it("emits a warning when > 50% of active commits have no conventional-commits prefix", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("h1", "Just a thing"),
             mk("h2", "another untyped commit"),
@@ -290,6 +320,8 @@ describe("annotateAndResolveReverts: F19 no-type-ratio warning", () => {
     });
 
     it("does NOT emit the warning when the no-type ratio is at or below 50%", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("h1", "feat: typed one"),
             mk("h2", "fix: typed two"),
@@ -307,6 +339,8 @@ describe("annotateAndResolveReverts: F19 no-type-ratio warning", () => {
         // Pure revert pair: revert resolves cleanly so c1 becomes
         // cancelled. The remaining "active" set is empty → ratio is
         // 0/0 → no warning.
+        expect.hasAssertions();
+
         const commits = [
             mk("c2", "Revert \"feat: x\"", "This reverts commit c1."),
             mk("c1", "feat: x"),
@@ -318,6 +352,8 @@ describe("annotateAndResolveReverts: F19 no-type-ratio warning", () => {
     });
 
     it("uses a sensible default range label when none is passed", () => {
+        expect.hasAssertions();
+
         const commits = [mk("h1", "no type here either")];
         const { warnings } = annotateAndResolveReverts(commits);
 
@@ -331,6 +367,8 @@ describe("annotateAndResolveReverts: F19 no-type-ratio warning", () => {
     // emits by default: `Merge pull request`, `Merge branch`,
     // `Merge remote-tracking branch`, `Merge tag`.
     it("excludes merge commits from the no-type ratio", () => {
+        expect.hasAssertions();
+
         const commits = [
             mk("m1", "Merge pull request #123 from foo/bar"),
             mk("m2", "Merge branch 'main' into feature"),
@@ -365,6 +403,8 @@ describe("annotateAndResolveReverts: F17 revert-chain depth cap", () => {
         // older layer, and the OLDEST layer's trailer references
         // ITSELF — that closes the loop the resolver would otherwise
         // walk forever.
+        expect.hasAssertions();
+
         const layers = 70;
         const commits: CommitRecord[] = [];
 
@@ -393,12 +433,16 @@ describe("annotateAndResolveReverts: F17 revert-chain depth cap", () => {
 
 describe("parseCommit: gitmoji / shortcode prefix strip", () => {
     it("strips a leading Unicode emoji before parsing", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("🚀 feat: add tab completion", "");
 
         expect(parsed.type).toBe("feat");
     });
 
     it("strips a leading :shortcode: prefix before parsing", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit(":rocket: feat(cli): add tab completion", "");
 
         expect(parsed.type).toBe("feat");
@@ -406,6 +450,8 @@ describe("parseCommit: gitmoji / shortcode prefix strip", () => {
     });
 
     it("parses a bare conventional commit unchanged when no emoji prefix is present", () => {
+        expect.hasAssertions();
+
         const parsed = parseCommit("feat(api): add retry logic", "");
 
         expect(parsed.type).toBe("feat");

--- a/packages/tooling/vis/__tests__/release/core/git-signing.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git-signing.test.ts
@@ -39,6 +39,8 @@ describe(createTag, () => {
     });
 
     it("passes -s when signing.mode is `gpg` without an explicit key", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 
@@ -63,6 +65,8 @@ describe(createTag, () => {
     });
 
     it("passes -u <key> when signing.mode is `gpg` with an explicit key", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 
@@ -86,6 +90,8 @@ describe(createTag, () => {
     });
 
     it("passes -s when signing.mode is `ssh` (relies on git config gpg.format=ssh)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 
@@ -113,6 +119,8 @@ describe(createTag, () => {
     });
 
     it("falls back to GPG with a warning when signing.mode is `sigstore` and gitsign is missing", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 

--- a/packages/tooling/vis/__tests__/release/core/git-signing.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git-signing.test.ts
@@ -59,7 +59,7 @@ describe(createTag, () => {
         const tagCall = calls.find((c) => c.command === "git" && c.args[0] === "tag");
 
         expect(tagCall).toBeDefined();
-        expect(tagCall!.args).toEqual(["tag", "-s", "-a", "pkg@1.0.0", "-m", "Release pkg@1.0.0"]);
+        expect(tagCall!.args).toStrictEqual(["tag", "-s", "-a", "pkg@1.0.0", "-m", "Release pkg@1.0.0"]);
     });
 
     it("passes -u <key> when signing.mode is `gpg` with an explicit key", async () => {
@@ -82,7 +82,7 @@ describe(createTag, () => {
         const tagCall = calls.find((c) => c.command === "git" && c.args[0] === "tag");
 
         expect(tagCall).toBeDefined();
-        expect(tagCall!.args).toEqual(["tag", "-u", "ABCD1234", "-a", "pkg@1.0.0", "-m", "msg"]);
+        expect(tagCall!.args).toStrictEqual(["tag", "-u", "ABCD1234", "-a", "pkg@1.0.0", "-m", "msg"]);
     });
 
     it("passes -s when signing.mode is `ssh` (relies on git config gpg.format=ssh)", async () => {
@@ -109,7 +109,7 @@ describe(createTag, () => {
         // `user.signingkey`. The doctor surfaces missing config at
         // preflight; the create path stays simple.
         expect(tagCall).toBeDefined();
-        expect(tagCall!.args).toEqual(["tag", "-s", "-a", "pkg@1.0.0", "-m", "msg"]);
+        expect(tagCall!.args).toStrictEqual(["tag", "-s", "-a", "pkg@1.0.0", "-m", "msg"]);
     });
 
     it("falls back to GPG with a warning when signing.mode is `sigstore` and gitsign is missing", async () => {

--- a/packages/tooling/vis/__tests__/release/core/git-stage-and-commit-file.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git-stage-and-commit-file.test.ts
@@ -12,6 +12,8 @@ import { MockRunner } from "../../../src/release/core/shell-runner";
  */
 describe("git: stageAndCommitFile", () => {
     it("no-op when `git diff --cached` reports no change after staging", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: string[] = [];
 
@@ -46,6 +48,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("commits when the file has staged changes", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let committed = false;
 
@@ -70,6 +74,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("pushes when `push: true` and a branch is resolvable", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let pushed = false;
 
@@ -95,6 +101,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("commits but does NOT push when push is false", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let pushed = false;
 
@@ -120,6 +128,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("returns pushed=false when push attempt fails (soft-fail)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["add"], () => { return { exitCode: 0, stderr: "", stdout: "" }; });
@@ -146,6 +156,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("skips the push step when no branch is resolvable (detached HEAD)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let pushed = false;
 
@@ -172,6 +184,8 @@ describe("git: stageAndCommitFile", () => {
     });
 
     it("commits with author when provided (smoke test — env propagation is exercised by stageAndCommit's test)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let committed = false;
 

--- a/packages/tooling/vis/__tests__/release/core/git-tag-pattern.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git-tag-pattern.test.ts
@@ -5,20 +5,26 @@ import { MockRunner } from "../../../src/release/core/shell-runner";
 
 describe(renderTagPattern, () => {
     it("substitutes {name} and {version}", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{name}@{version}", { name: "@scope/pkg", version: "1.2.3" })).toBe("@scope/pkg@1.2.3");
     });
 
     it("supports v-prefix style", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("v{version}", { version: "1.2.3" })).toBe("v1.2.3");
     });
 
     it("supports release-{date} aggregate pattern", () => {
+        expect.hasAssertions();
+
         const out = renderTagPattern("release-{date}", { date: "2026-05-02" });
 
         expect(out).toBe("release-2026-05-02");
     });
 
     it("defaults date to today's ISO date when not supplied", () => {
+        expect.hasAssertions();
+
         const out = renderTagPattern("v-{date}", {});
         const today = new Date().toISOString().slice(0, 10);
 
@@ -26,34 +32,42 @@ describe(renderTagPattern, () => {
     });
 
     it("supports name-prefix workflows", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{name}-v{version}", { name: "cerebro", version: "3.0.0" })).toBe("cerebro-v3.0.0");
     });
 
     it("leaves unsubstituted tokens with empty strings (forgiving)", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{name}@{version}", { version: "1.0.0" })).toBe("@1.0.0");
     });
 
     it("substitutes {unscopedName} stripping the scope", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{unscopedName}@{version}", { name: "@visulima/cerebro", version: "3.0.0" })).toBe("cerebro@3.0.0");
     });
 
     it("returns name unchanged for {unscopedName} on non-scoped names", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{unscopedName}@{version}", { name: "react", version: "19.0.0" })).toBe("react@19.0.0");
     });
 
     it("substitutes {major} / {minor} / {patch}", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("{major}.{minor}.{patch}", { version: "4.5.6" })).toBe("4.5.6");
     });
 
     it("substitutes {major} from a prerelease version", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("v{major}", { version: "2.0.0-alpha.4" })).toBe("v2");
     });
 
     it("substitutes {channel}", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("release-{channel}-{date}", { channel: "alpha", date: "2026-05-02" })).toBe("release-alpha-2026-05-02");
     });
 
     it("blanks out {channel} when not provided", () => {
+        expect.hasAssertions();
         expect(renderTagPattern("v{version}-{channel}", { version: "1.0.0" })).toBe("v1.0.0-");
     });
 });
@@ -72,6 +86,8 @@ describe(createOrUpdateFloatingTag, () => {
     };
 
     it("creates the floating tag with `tag -f` and force-pushes the single ref", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 
@@ -95,6 +111,8 @@ describe(createOrUpdateFloatingTag, () => {
     });
 
     it("skips the push step when push=false", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 
@@ -110,6 +128,8 @@ describe(createOrUpdateFloatingTag, () => {
     });
 
     it("propagates signing.mode through to the floating tag", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const calls: InvocationLog[] = [];
 

--- a/packages/tooling/vis/__tests__/release/core/git-tag-pattern.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git-tag-pattern.test.ts
@@ -87,7 +87,7 @@ describe(createOrUpdateFloatingTag, () => {
         expect(tagCall).toBeDefined();
         // `-f` forces retarget when the tag already exists (the whole
         // point of a floating major-version tag).
-        expect(tagCall!.args).toEqual(["tag", "-f", "v1"]);
+        expect(tagCall!.args).toStrictEqual(["tag", "-f", "v1"]);
 
         expect(pushCall).toBeDefined();
         expect(pushCall!.args).toContain("--force");
@@ -121,6 +121,6 @@ describe(createOrUpdateFloatingTag, () => {
 
         const tagCall = calls.find((c) => c.command === "git" && c.args[0] === "tag");
 
-        expect(tagCall!.args).toEqual(["tag", "-f", "-s", "v1"]);
+        expect(tagCall!.args).toStrictEqual(["tag", "-f", "-s", "v1"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/git.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git.test.ts
@@ -13,11 +13,13 @@ import { MockRunner } from "../../../src/release/core/shell-runner";
 
 describe("git: defaultTagFor", () => {
     it("matches the semantic-release / changesets / bumpy convention", () => {
+        expect.hasAssertions();
         expect(defaultTagFor("@scope/pkg", "1.2.3")).toBe("@scope/pkg@1.2.3");
         expect(defaultTagFor("plain", "0.0.1")).toBe("plain@0.0.1");
     });
 
     it("includes prerelease + build-metadata in tags", () => {
+        expect.hasAssertions();
         expect(defaultTagFor("pkg", "1.0.0-alpha.0")).toBe("pkg@1.0.0-alpha.0");
         expect(defaultTagFor("pkg", "1.0.0+build.7")).toBe("pkg@1.0.0+build.7");
     });
@@ -25,6 +27,8 @@ describe("git: defaultTagFor", () => {
 
 describe("git: getCurrentBranch", () => {
     it("returns the trimmed branch name on success", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--abbrev-ref", "HEAD"], () => {
@@ -35,6 +39,8 @@ describe("git: getCurrentBranch", () => {
     });
 
     it("returns undefined for detached HEAD", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--abbrev-ref", "HEAD"], () => {
@@ -45,6 +51,8 @@ describe("git: getCurrentBranch", () => {
     });
 
     it("returns undefined for empty output", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--abbrev-ref", "HEAD"], () => {
@@ -55,6 +63,8 @@ describe("git: getCurrentBranch", () => {
     });
 
     it("returns undefined on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--abbrev-ref", "HEAD"], () => {
@@ -67,6 +77,8 @@ describe("git: getCurrentBranch", () => {
 
 describe("git: getCurrentSha + getShortSha", () => {
     it("returns the trimmed sha on success", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {
@@ -81,6 +93,8 @@ describe("git: getCurrentSha + getShortSha", () => {
     });
 
     it("returns undefined on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {
@@ -93,6 +107,8 @@ describe("git: getCurrentSha + getShortSha", () => {
 
 describe("git: hasUncommittedChanges", () => {
     it("returns true when porcelain output is non-empty", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["status", "--porcelain"], () => {
@@ -103,6 +119,8 @@ describe("git: hasUncommittedChanges", () => {
     });
 
     it("returns false when working tree is clean", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["status", "--porcelain"], () => {
@@ -115,6 +133,8 @@ describe("git: hasUncommittedChanges", () => {
 
 describe("git: tagExists", () => {
     it("returns true when local tag exists", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--verify", "--quiet", "refs/tags/pkg@1.0.0"], () => {
@@ -125,6 +145,8 @@ describe("git: tagExists", () => {
     });
 
     it("returns false when local tag is missing", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "--verify", "--quiet", "refs/tags/pkg@9.9.9"], () => {
@@ -137,6 +159,8 @@ describe("git: tagExists", () => {
 
 describe("git: tagExistsRemote", () => {
     it("returns true when remote tag exists", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["ls-remote", "--tags", "origin", "pkg@1.0.0"], () => {
@@ -151,6 +175,8 @@ describe("git: tagExistsRemote", () => {
     });
 
     it("returns false when remote returns no output", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["ls-remote", "--tags", "origin", "missing"], () => {

--- a/packages/tooling/vis/__tests__/release/core/group-glob-regression.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/group-glob-regression.test.ts
@@ -31,6 +31,8 @@ const mkPkg = (name: string): WorkspacePackage => {
 
 describe("orchestrator groupPreVersionCommands — glob expansion regression", () => {
     it("a fixed group with glob members is correctly detected as touched when any member is in the plan", () => {
+        expect.hasAssertions();
+
         const packages = [mkPkg("@scope/a"), mkPkg("@scope/b"), mkPkg("@scope/c"), mkPkg("@other/x")];
         const graph = new DependencyGraph(packages);
 
@@ -54,6 +56,8 @@ describe("orchestrator groupPreVersionCommands — glob expansion regression", (
     });
 
     it("mixed literal + glob group members all expand correctly", () => {
+        expect.hasAssertions();
+
         const packages = [mkPkg("core"), mkPkg("plugin-foo"), mkPkg("plugin-bar"), mkPkg("unrelated")];
         const graph = new DependencyGraph(packages);
 

--- a/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
@@ -131,6 +131,6 @@ describe("native-addon: temp-dir cleanup on failure (RFC §19.4)", () => {
 
         const leaked = listTempVisDirs().filter((d) => !baseline.has(d));
 
-        expect(leaked).toEqual([]);
+        expect(leaked).toStrictEqual([]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
@@ -92,6 +92,8 @@ describe("native-addon: temp-dir cleanup on failure (RFC §19.4)", () => {
     });
 
     it("removes every mkdtemp dir even when publish throws", async () => {
+        expect.hasAssertions();
+
         const pkg: WorkspacePackage = {
             dir: workspace,
             manifest: {

--- a/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/native-addon-cleanup.test.ts
@@ -129,7 +129,7 @@ describe("native-addon: temp-dir cleanup on failure (RFC §19.4)", () => {
 
         const actions = new NativeAddonVersionActions();
 
-        await expect(actions.publish(ctx)).rejects.toThrow();
+        await expect(actions.publish(ctx)).rejects.toThrow(/Failed to publish platform package/);
 
         const leaked = listTempVisDirs().filter((d) => !baseline.has(d));
 

--- a/packages/tooling/vis/__tests__/release/core/notifications.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/notifications.test.ts
@@ -31,6 +31,8 @@ const buildContext = (overrides: Partial<NotificationContext> = {}): Notificatio
 
 describe(expandNotificationTemplate, () => {
     it("substitutes every documented token", () => {
+        expect.hasAssertions();
+
         const out = expandNotificationTemplate(
             "Released {count} ({packages}) on {channel} via {repo} on {date} — first {firstName}@{firstVersion}",
             buildContext(),
@@ -45,6 +47,8 @@ describe(expandNotificationTemplate, () => {
     });
 
     it("substitutes empty for unset optional fields", () => {
+        expect.hasAssertions();
+
         const out = expandNotificationTemplate("[{repo}][{channel}]", buildContext({ channel: undefined, repo: undefined }));
 
         expect(out).toBe("[][]");
@@ -54,6 +58,7 @@ describe(expandNotificationTemplate, () => {
         // A misconfigured user passing a number / boolean / object as
         // `title` previously threw TypeError on .replaceAll. The guard
         // collapses it to a String() coercion so the channel still works.
+        expect.hasAssertions();
         expect(expandNotificationTemplate(42 as unknown as string, buildContext())).toBe("42");
         expect(expandNotificationTemplate(true as unknown as string, buildContext())).toBe("true");
         expect(expandNotificationTemplate(null as unknown as string, buildContext())).toBe("");
@@ -75,6 +80,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("skips entirely when no channels are configured", async () => {
+        expect.hasAssertions();
+
         const result = await dispatchNotifications({}, buildContext());
 
         expect(fetchSpy).not.toHaveBeenCalled();
@@ -82,6 +89,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("skips when published[] is empty (no-op wave)", async () => {
+        expect.hasAssertions();
+
         const result = await dispatchNotifications(
             { slack: { webhook: "https://hooks.slack.com/services/T/B/X" } },
             buildContext({ published: [] }),
@@ -92,6 +101,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("skips prerelease waves by default", async () => {
+        expect.hasAssertions();
+
         const result = await dispatchNotifications(
             { slack: { webhook: "https://hooks.slack.com/services/T/B/X" } },
             buildContext({
@@ -107,6 +118,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("honours skipPrerelease: false", async () => {
+        expect.hasAssertions();
+
         const result = await dispatchNotifications(
             { skipPrerelease: false, slack: { webhook: "https://hooks.slack.com/services/T/B/X" } },
             buildContext({
@@ -119,6 +132,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("dispatches to multiple channels in parallel", async () => {
+        expect.hasAssertions();
+
         const result = await dispatchNotifications(
             {
                 discord: { webhook: "https://discord.com/api/webhooks/123/abc" },
@@ -133,6 +148,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("supports array form for multiple instances of the same channel", async () => {
+        expect.hasAssertions();
+
         await dispatchNotifications(
             {
                 slack: [
@@ -147,6 +164,8 @@ describe(dispatchNotifications, () => {
     });
 
     it("isolates per-channel failures — one bad webhook doesn't take down the others", async () => {
+        expect.hasAssertions();
+
         fetchSpy.mockReset();
         // First call (slack) fails; second (discord) succeeds.
         let invocation = 0;
@@ -181,6 +200,8 @@ describe(dispatchNotifications, () => {
     it("tolerates null channel configs without throwing (N-1)", async () => {
         // A templating tool that resolves an env var to null shouldn't
         // crash the constructor. arrayify(null) returns [].
+        expect.hasAssertions();
+
         const result = await dispatchNotifications(
 
             { discord: null as any, slack: null as any, webhook: null as any },
@@ -195,6 +216,8 @@ describe(dispatchNotifications, () => {
     it("does NOT leak the webhook URL into failed[].error on fetch rejection (C-2)", async () => {
         // Simulate what Node does when a webhook host is unreachable:
         // the URL ends up embedded in the rejection message.
+        expect.hasAssertions();
+
         const secretUrl = "https://hooks.slack.com/services/T0/B0/SECRETTOKEN";
 
         fetchSpy.mockReset();
@@ -223,6 +246,8 @@ describe(dispatchNotifications, () => {
         // Same as above but covers the response.ok === false branch in
         // webhook.ts where we previously embedded `${this.config.url}`
         // directly into the thrown message.
+        expect.hasAssertions();
+
         const secretUrl = "https://hooks.slack.com/services/T0/B0/SECRETTOKEN";
 
         fetchSpy.mockReset();
@@ -260,6 +285,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("renders the default title when none is configured", async () => {
+        expect.hasAssertions();
+
         await new SlackNotificationChannel({ webhook: "https://hooks.slack.com/x" }).send(buildContext());
 
         const body = JSON.parse(capturedBody!);
@@ -269,6 +296,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("interpolates the configured title template", async () => {
+        expect.hasAssertions();
+
         await new SlackNotificationChannel({
             title: "{count} new on {channel}",
             webhook: "https://hooks.slack.com/x",
@@ -280,6 +309,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("includes a Skipped block when there are skipped entries (default)", async () => {
+        expect.hasAssertions();
+
         await new SlackNotificationChannel({ webhook: "https://hooks.slack.com/x" }).send(
             buildContext({ skipped: [{ name: "@scope/c", reason: "stage-rejected" }] }),
         );
@@ -290,6 +321,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("omits the Skipped block when includeSkipped: false", async () => {
+        expect.hasAssertions();
+
         await new SlackNotificationChannel({
             includeSkipped: false,
             webhook: "https://hooks.slack.com/x",
@@ -301,6 +334,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("throws on non-2xx responses", async () => {
+        expect.hasAssertions();
+
         fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
 
         await expect(
@@ -309,6 +344,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("appends an id suffix when configured (for multi-channel disambiguation)", () => {
+        expect.hasAssertions();
+
         const channel = new SlackNotificationChannel({
             id: "releases",
             webhook: "https://hooks.slack.com/x",
@@ -318,6 +355,8 @@ describe(SlackNotificationChannel, () => {
     });
 
     it("falls back to plain timestamp when completedAt is not parseable (M-5)", async () => {
+        expect.hasAssertions();
+
         await new SlackNotificationChannel({ webhook: "https://hooks.slack.com/x" }).send(
             buildContext({ completedAt: "definitely-not-a-date" }),
         );
@@ -350,6 +389,8 @@ describe(DiscordNotificationChannel, () => {
     });
 
     it("emits a single embed with package list as the description", async () => {
+        expect.hasAssertions();
+
         await new DiscordNotificationChannel({ webhook: "https://discord.com/x" }).send(buildContext());
 
         const body = JSON.parse(capturedBody!);
@@ -360,6 +401,8 @@ describe(DiscordNotificationChannel, () => {
     });
 
     it("truncates the description on very large waves", async () => {
+        expect.hasAssertions();
+
         const big = Array.from({ length: 200 }, (_, i) => {
             return {
                 name: `@scope/pkg-${i}`,
@@ -381,6 +424,8 @@ describe(DiscordNotificationChannel, () => {
     });
 
     it("includes channel + repo fields", async () => {
+        expect.hasAssertions();
+
         await new DiscordNotificationChannel({ webhook: "https://discord.com/x" }).send(buildContext());
 
         const body = JSON.parse(capturedBody!);
@@ -410,6 +455,8 @@ describe(WebhookNotificationChannel, () => {
     });
 
     it("sends the safe-by-default subset of NotificationContext when no body template is set", async () => {
+        expect.hasAssertions();
+
         await new WebhookNotificationChannel({ url: "https://example.com/hook" }).send(buildContext());
 
         const body = JSON.parse(capturedInit!.body as string);
@@ -426,6 +473,8 @@ describe(WebhookNotificationChannel, () => {
         // fragments that may carry secrets escaping the upstream redactor.
         // The default body must NOT include these — operators wanting
         // them must opt in with an explicit `body` template.
+        expect.hasAssertions();
+
         const secretReason = "publish failed: token=ghp_LEAKEDSECRET123 invalid";
 
         await new WebhookNotificationChannel({ url: "https://example.com/hook" }).send(
@@ -450,6 +499,8 @@ describe(WebhookNotificationChannel, () => {
         // Counterpoint to M-10: operators who explicitly opt in by
         // authoring a body template are consciously choosing to forward
         // free text. The dispatcher respects that.
+        expect.hasAssertions();
+
         await new WebhookNotificationChannel({
             body: { reasonCount: "{count}", text: "see logs" },
             url: "https://example.com/hook",
@@ -461,6 +512,8 @@ describe(WebhookNotificationChannel, () => {
     });
 
     it("interpolates string leaves in a body template; preserves structure", async () => {
+        expect.hasAssertions();
+
         await new WebhookNotificationChannel({
             body: {
                 meta: { count: "{count}" }, // string `"{count}"` becomes `"2"` (not a number)
@@ -478,6 +531,8 @@ describe(WebhookNotificationChannel, () => {
     });
 
     it("uses configured method + headers", async () => {
+        expect.hasAssertions();
+
         await new WebhookNotificationChannel({
             headers: { "X-Auth": "Bearer abc" },
             method: "PUT",
@@ -489,6 +544,8 @@ describe(WebhookNotificationChannel, () => {
     });
 
     it("interpolates header values", async () => {
+        expect.hasAssertions();
+
         await new WebhookNotificationChannel({
             headers: { "X-Release": "{firstName}@{firstVersion}" },
             url: "https://example.com/hook",

--- a/packages/tooling/vis/__tests__/release/core/notifications.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/notifications.test.ts
@@ -78,7 +78,7 @@ describe(dispatchNotifications, () => {
         const result = await dispatchNotifications({}, buildContext());
 
         expect(fetchSpy).not.toHaveBeenCalled();
-        expect(result.succeeded).toEqual([]);
+        expect(result.succeeded).toStrictEqual([]);
     });
 
     it("skips when published[] is empty (no-op wave)", async () => {
@@ -88,7 +88,7 @@ describe(dispatchNotifications, () => {
         );
 
         expect(fetchSpy).not.toHaveBeenCalled();
-        expect(result.succeeded).toEqual([]);
+        expect(result.succeeded).toStrictEqual([]);
     });
 
     it("skips prerelease waves by default", async () => {
@@ -103,7 +103,7 @@ describe(dispatchNotifications, () => {
         );
 
         expect(fetchSpy).not.toHaveBeenCalled();
-        expect(result.succeeded).toEqual([]);
+        expect(result.succeeded).toStrictEqual([]);
     });
 
     it("honours skipPrerelease: false", async () => {
@@ -115,7 +115,7 @@ describe(dispatchNotifications, () => {
         );
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(result.succeeded).toEqual(["slack"]);
+        expect(result.succeeded).toStrictEqual(["slack"]);
     });
 
     it("dispatches to multiple channels in parallel", async () => {
@@ -129,7 +129,7 @@ describe(dispatchNotifications, () => {
         );
 
         expect(fetchSpy).toHaveBeenCalledTimes(3);
-        expect(result.succeeded.toSorted()).toEqual(["discord", "slack", "webhook"]);
+        expect(result.succeeded.toSorted()).toStrictEqual(["discord", "slack", "webhook"]);
     });
 
     it("supports array form for multiple instances of the same channel", async () => {
@@ -171,7 +171,7 @@ describe(dispatchNotifications, () => {
             { warn: (m) => warnings.push(m) },
         );
 
-        expect(result.succeeded).toEqual(["discord"]);
+        expect(result.succeeded).toStrictEqual(["discord"]);
         expect(result.failed).toHaveLength(1);
         expect(result.failed[0]!.id).toBe("slack");
         expect(result.failed[0]!.error).toContain("429");
@@ -188,8 +188,8 @@ describe(dispatchNotifications, () => {
         );
 
         expect(fetchSpy).not.toHaveBeenCalled();
-        expect(result.succeeded).toEqual([]);
-        expect(result.failed).toEqual([]);
+        expect(result.succeeded).toStrictEqual([]);
+        expect(result.failed).toStrictEqual([]);
     });
 
     it("does NOT leak the webhook URL into failed[].error on fetch rejection (C-2)", async () => {

--- a/packages/tooling/vis/__tests__/release/core/npm-version-actions-resume.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/npm-version-actions-resume.test.ts
@@ -106,6 +106,8 @@ const baseContext = (overrides: { resumeStageId?: string; stageEnabled?: boolean
 
 describe("npmVersionActions.publish: resume path", () => {
     it("does NOT pack or publish — only waits on the existing stage decision", async () => {
+        expect.hasAssertions();
+
         const actions = new NpmVersionActions();
         const ctx = baseContext({ resumeStageId: "stage-xyz", stageEnabled: true });
 
@@ -128,6 +130,8 @@ describe("npmVersionActions.publish: resume path", () => {
     });
 
     it("throws CONFIG_INVALID when publish.stage is disabled but resume is requested", async () => {
+        expect.hasAssertions();
+
         const actions = new NpmVersionActions();
         const ctx = baseContext({ resumeStageId: "stage-xyz", stageEnabled: false });
 
@@ -137,6 +141,8 @@ describe("npmVersionActions.publish: resume path", () => {
     });
 
     it("returns `stage-rejected` on the resume path when the wait decides rejected", async () => {
+        expect.hasAssertions();
+
         const actions = new NpmVersionActions();
         // Set up runner: stage view gone, npm view returns nothing → rejected
         const { calls, runner } = buildRunner([
@@ -164,6 +170,8 @@ describe("npmVersionActions.publish: resume path", () => {
     });
 
     it("returns `stage-timeout` on the resume path when the wait deadline elapses", async () => {
+        expect.hasAssertions();
+
         const actions = new NpmVersionActions();
         // Set up runner: stage view always pending → timeout
         const { calls, runner } = buildRunner(

--- a/packages/tooling/vis/__tests__/release/core/orchestrator-stage-integration.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/orchestrator-stage-integration.test.ts
@@ -106,6 +106,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
     });
 
     it("records a stage-timeout outcome in staged.json with reason=timeout", async () => {
+        expect.hasAssertions();
+
         const actions = new StubVersionActions({
             alreadyPublished: false,
             output: "stage-timeout: stage-xyz",
@@ -141,6 +143,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
     });
 
     it("records a stage-rejected outcome with reason=rejected", async () => {
+        expect.hasAssertions();
+
         const actions = new StubVersionActions({
             alreadyPublished: false,
             output: "stage-rejected: stage-abc",
@@ -167,6 +171,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
 
     it("drains a prior pending entry when the same (name, version) goes through the published path", async () => {
         // Seed: a leftover stage from a prior wave.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-prior",
@@ -203,6 +209,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
     });
 
     it("passes resumeStageId to the action when staged.json already holds an entry for the planned (name, version)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-resume",
@@ -240,6 +248,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
     });
 
     it("drains the registry entry on a successful resume (out.published from resume path)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-resume",
@@ -367,6 +377,8 @@ describe.skipIf(isWindows)("orchestrator: cross-runner notify/walk dedupe via st
         // Seed the tracked registry as if a prior CI run (on a different
         // machine) had already dispatched the notification for the
         // package + version we're about to publish.
+        expect.hasAssertions();
+
         const seeded = recordRecentlyNotified(
             { pending: [], updatedAt: new Date().toISOString(), version: 1 },
             ["@scope/a@1.0.1"],
@@ -396,6 +408,8 @@ describe.skipIf(isWindows)("orchestrator: cross-runner notify/walk dedupe via st
         // Happy path: nothing in staged.json yet, publishContext dispatches
         // the webhook, then commits the (name, version) into the registry
         // so the next runner sees it.
+        expect.hasAssertions();
+
         const actions = new StubVersionActions({ output: "ok", published: true });
         const ctx = await buildContext({ cwd });
 
@@ -418,6 +432,8 @@ describe.skipIf(isWindows)("orchestrator: cross-runner notify/walk dedupe via st
         // dedupe check — if recentlyWalked already covers the published
         // entry, the gate filter empties `walkable.published` and the
         // walk function isn't entered at all (zero-cost dedupe).
+        expect.hasAssertions();
+
         const seeded = recordRecentlyWalked(
             { pending: [], updatedAt: new Date().toISOString(), version: 1 },
             ["@scope/a@1.0.1"],
@@ -499,6 +515,8 @@ describe.skipIf(isWindows)("orchestrator: publish loop does not orphan dependent
 
     it("skips a dependent when its internal dependency fails to publish", async () => {
         // @scope/a throws; @scope/b (which depends on it) must be skipped, not published.
+        expect.hasAssertions();
+
         const actions = new StubVersionActions((context: PublishContext): PublishResult => {
             if (context.pkg.name === "@scope/a") {
                 throw new Error("npm publish failed (E500 internal registry error)");

--- a/packages/tooling/vis/__tests__/release/core/orchestrator-stage-integration.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/orchestrator-stage-integration.test.ts
@@ -199,7 +199,7 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
         // Registry was drained — file is deleted when pending is empty.
         const registry = await readStagedRegistry(cwd, ".vis/release");
 
-        expect(registry.pending).toEqual([]);
+        expect(registry.pending).toStrictEqual([]);
     });
 
     it("passes resumeStageId to the action when staged.json already holds an entry for the planned (name, version)", async () => {
@@ -271,7 +271,7 @@ describe.skipIf(isWindows)("orchestrator: publishContext → staged.json wiring"
 
         const registry = await readStagedRegistry(cwd, ".vis/release");
 
-        expect(registry.pending).toEqual([]);
+        expect(registry.pending).toStrictEqual([]);
     });
 });
 
@@ -430,7 +430,7 @@ describe.skipIf(isWindows)("orchestrator: cross-runner notify/walk dedupe via st
         const result = await publishContext(ctx, { publishActionsOverride: actions });
 
         // Publish itself succeeded.
-        expect(result.published.map((p) => p.name)).toEqual(["@scope/a"]);
+        expect(result.published.map((p) => p.name)).toStrictEqual(["@scope/a"]);
 
         // No `successWalk:` warning surfaced (the gate skipped the walk
         // before any remote-client call could fail). Compare with the
@@ -438,7 +438,7 @@ describe.skipIf(isWindows)("orchestrator: cross-runner notify/walk dedupe via st
         // either "successWalk" or "post-release walk".
         const walkWarnings = ctx.plan.warnings.filter((w) => w.toLowerCase().includes("walk"));
 
-        expect(walkWarnings).toEqual([]);
+        expect(walkWarnings).toStrictEqual([]);
     });
 });
 
@@ -529,6 +529,6 @@ describe.skipIf(isWindows)("orchestrator: publish loop does not orphan dependent
 
         // The dependent's publish was never even attempted (short-circuited
         // before the action call), so the stub only saw @scope/a.
-        expect(actions.calls.map((c) => c.pkg)).toEqual(["@scope/a"]);
+        expect(actions.calls.map((c) => c.pkg)).toStrictEqual(["@scope/a"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
@@ -202,7 +202,7 @@ describe.skipIf(isWindows)("orchestrator: project filter (the bug from audit #1)
 
         // The audit-bug previously made this filter accept everything.
         // Confirm only the requested packages remain.
-        expect(ctx.plan.releases.map((r) => r.name).sort()).toEqual(["@scope/a", "@scope/b"]);
+        expect(ctx.plan.releases.map((r) => r.name).sort()).toStrictEqual(["@scope/a", "@scope/b"]);
     });
 
     it("--filter glob with wildcard works", async () => {
@@ -499,7 +499,7 @@ describe.skipIf(isWindows)(extractInternalAuthors, () => {
             { internalAuthors: ["renovate[bot]", "dependabot"] },
         ]);
 
-        expect(result).toEqual(["renovate[bot]", "dependabot"]);
+        expect(result).toStrictEqual(["renovate[bot]", "dependabot"]);
     });
 
     it("filters out non-string entries defensively (e.g. operator passed a number)", () => {
@@ -508,6 +508,6 @@ describe.skipIf(isWindows)(extractInternalAuthors, () => {
             { internalAuthors: ["renovate", 42, null, "dependabot"] as unknown as string[] },
         ]);
 
-        expect(result).toEqual(["renovate", "dependabot"]);
+        expect(result).toStrictEqual(["renovate", "dependabot"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
@@ -86,6 +86,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
     });
 
     it("merges file-level config with defaults", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, { baseBranch: "develop", changesDir: ".vis/release" });
 
         const ctx = await buildContext({ cwd });
@@ -97,6 +99,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
     });
 
     it("inline options.config wins over file config", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, { baseBranch: "develop" });
 
         const ctx = await buildContext({
@@ -108,6 +112,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
     });
 
     it("falls back to defaults when no config file is present", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd });
 
         expect(ctx.config.baseBranch).toBe("main");
@@ -117,6 +123,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
 
     it("emits unstable warning when not acknowledged", async () => {
         // No vis.config.json → defaults → no acknowledgeUnstable
+        expect.hasAssertions();
+
         const stderrChunks: string[] = [];
         const orig = process.stderr.write.bind(process.stderr);
 
@@ -136,6 +144,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
     });
 
     it("suppresses unstable warning when acknowledged in config", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, {});
 
         const stderrChunks: string[] = [];
@@ -157,6 +167,8 @@ describe.skipIf(isWindows)("orchestrator: buildContext loads vis.config.ts relea
     });
 
     it("suppresses unstable warning when env var is set", async () => {
+        expect.hasAssertions();
+
         process.env["VIS_RELEASE_SUPPRESS_UNSTABLE"] = "1";
         const stderrChunks: string[] = [];
         const orig = process.stderr.write.bind(process.stderr);
@@ -198,6 +210,8 @@ describe.skipIf(isWindows)("orchestrator: project filter (the bug from audit #1)
     });
 
     it("--filter glob narrows the plan", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd, projects: ["@scope/a", "@scope/b"] });
 
         // The audit-bug previously made this filter accept everything.
@@ -206,12 +220,16 @@ describe.skipIf(isWindows)("orchestrator: project filter (the bug from audit #1)
     });
 
     it("--filter glob with wildcard works", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd, projects: ["@scope/*"] });
 
         expect(ctx.plan.releases).toHaveLength(3);
     });
 
     it("returns empty plan when filter matches nothing", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd, projects: ["@other/*"] });
 
         expect(ctx.plan.releases).toHaveLength(0);
@@ -234,6 +252,8 @@ describe.skipIf(isWindows)("orchestrator: applyContext lifecycle hooks", () => {
     });
 
     it("runs preVersionCommand before applying", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, {
             defaultManaged: true,
             preVersionCommand: `mkdir -p ${sentinel("PRE_RAN")}`,
@@ -249,6 +269,8 @@ describe.skipIf(isWindows)("orchestrator: applyContext lifecycle hooks", () => {
     });
 
     it("runs postVersionCommand after applying", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, {
             defaultManaged: true,
             postVersionCommand: `mkdir -p ${sentinel("POST_RAN")}`,
@@ -264,6 +286,8 @@ describe.skipIf(isWindows)("orchestrator: applyContext lifecycle hooks", () => {
     });
 
     it("skips hooks in dry-run mode", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, {
             defaultManaged: true,
             preVersionCommand: `mkdir -p ${sentinel("SHOULD_NOT_RUN")}`,
@@ -279,6 +303,8 @@ describe.skipIf(isWindows)("orchestrator: applyContext lifecycle hooks", () => {
     });
 
     it("aborts when preVersionCommand fails", async () => {
+        expect.hasAssertions();
+
         writeVisConfig(cwd, {
             defaultManaged: true,
             preVersionCommand: "exit 1",
@@ -311,6 +337,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext in-flight version-PR ch
     it("refuses to publish when a version-PR is open and channel mode is version-pr", async () => {
         // Force the active channel to be `main` (version-pr mode) by setting
         // the branch via the override.
+        expect.hasAssertions();
+
         const ctx = await buildContext({ channel: "main", cwd });
 
         // We can't easily mock the global runner used inside publishContext
@@ -323,6 +351,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext in-flight version-PR ch
     });
 
     it("does NOT block publish in auto-publish mode even with open PRs", async () => {
+        expect.hasAssertions();
+
         const cwd2 = setupFixture([{ name: "@scope/a", version: "1.0.0" }]);
 
         writeVisConfig(cwd2, {
@@ -343,6 +373,8 @@ describe.skipIf(isWindows)("orchestrator: publishContext in-flight version-PR ch
 
 describe.skipIf(isWindows)("orchestrator: composeRelatedReleasesBlock (addReleases)", () => {
     it("renders bullet list with name + url for each release", () => {
+        expect.hasAssertions();
+
         const block = composeRelatedReleasesBlock([
             { name: "@scope/pkg v1.4.2", tag: "@scope/pkg@1.4.2", url: "https://github.com/o/r/releases/tag/x" },
             { name: "@scope/pkg v1.4.1", tag: "@scope/pkg@1.4.1", url: "https://github.com/o/r/releases/tag/y" },
@@ -354,10 +386,13 @@ describe.skipIf(isWindows)("orchestrator: composeRelatedReleasesBlock (addReleas
     });
 
     it("returns empty string when there are no previous releases", () => {
+        expect.hasAssertions();
         expect(composeRelatedReleasesBlock([])).toBe("");
     });
 
     it("addReleases: 'top' vs 'bottom' positioning (composition test)", () => {
+        expect.hasAssertions();
+
         const recent = [{ name: "v1.0.0", tag: "v1.0.0", url: "https://x/y/releases/tag/v1.0.0" }];
         const block = composeRelatedReleasesBlock(recent);
         const body = "Release of @scope/pkg@1.1.0.";
@@ -382,23 +417,30 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
     };
 
     it("returns body unchanged when no template is supplied", () => {
+        expect.hasAssertions();
         expect(applyReleaseNoteTemplate("body", undefined, tokens)).toBe("body");
         expect(applyReleaseNoteTemplate("body", {}, tokens)).toBe("body");
     });
 
     it("prepends the header above the body, separated by a blank line", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate("BODY", { header: "See [migration guide](#)." }, tokens);
 
         expect(rendered).toBe("See [migration guide](#).\n\nBODY");
     });
 
     it("appends the footer below the body, separated by a blank line", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate("BODY", { footer: "Sponsored by acme." }, tokens);
 
         expect(rendered).toBe("BODY\n\nSponsored by acme.");
     });
 
     it("interpolates {name}, {version}, {previousVersion}, {date}, {repo} tokens", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             {
@@ -413,6 +455,8 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
     });
 
     it("places header above body and footer below body (full composition)", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             { footer: "FOOTER", header: "HEADER" },
@@ -424,6 +468,8 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
 
     // release-please #292 parity — `{contributors}` token.
     it("interpolates {contributors} inside header and footer", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             {
@@ -437,6 +483,8 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
     });
 
     it("renders {contributors} as empty when no authors were collected", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             { header: "Thanks: {contributors}done" },
@@ -450,6 +498,8 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
     // to "" used to leave a stray leading "\n\n" because the
     // empty-template guard was evaluated pre-interpolation.
     it("drops the header entirely when it interpolates to empty (audit V1)", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             { footer: "{contributors}", header: "{contributors}" },
@@ -463,6 +513,8 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
     // used to leave `## Contributors\n\n\n\nBODY`; trailing whitespace
     // should be stripped after interpolation.
     it("strips trailing whitespace from header after interpolation (audit S-2)", () => {
+        expect.hasAssertions();
+
         const rendered = applyReleaseNoteTemplate(
             "BODY",
             { header: "## Contributors\n\n{contributors}" },
@@ -478,22 +530,27 @@ describe.skipIf(isWindows)("orchestrator: applyReleaseNoteTemplate (releaseNoteT
 // too (not just the `CHANGELOG.md` body).
 describe.skipIf(isWindows)(extractInternalAuthors, () => {
     it("returns undefined when changelog is not configured or not a tuple", () => {
+        expect.hasAssertions();
         expect(extractInternalAuthors(undefined)).toBeUndefined();
         expect(extractInternalAuthors(false)).toBeUndefined();
         expect(extractInternalAuthors("github")).toBeUndefined();
     });
 
     it("returns undefined for non-github formatters", () => {
+        expect.hasAssertions();
         expect(extractInternalAuthors(["default", { internalAuthors: ["bot"] }])).toBeUndefined();
         expect(extractInternalAuthors(["keep-a-changelog", { internalAuthors: ["bot"] }])).toBeUndefined();
     });
 
     it("returns undefined when github formatter has no internalAuthors option", () => {
+        expect.hasAssertions();
         expect(extractInternalAuthors(["github", {}])).toBeUndefined();
         expect(extractInternalAuthors(["github", { somethingElse: true }])).toBeUndefined();
     });
 
     it("extracts the internalAuthors array from a github-formatter tuple", () => {
+        expect.hasAssertions();
+
         const result = extractInternalAuthors([
             "github",
             { internalAuthors: ["renovate[bot]", "dependabot"] },
@@ -503,6 +560,8 @@ describe.skipIf(isWindows)(extractInternalAuthors, () => {
     });
 
     it("filters out non-string entries defensively (e.g. operator passed a number)", () => {
+        expect.hasAssertions();
+
         const result = extractInternalAuthors([
             "github",
             { internalAuthors: ["renovate", 42, null, "dependabot"] as unknown as string[] },

--- a/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/orchestrator.test.ts
@@ -299,7 +299,7 @@ describe.skipIf(isWindows)("orchestrator: applyContext lifecycle hooks", () => {
 
         const fs = await import("node:fs/promises");
 
-        await expect(fs.access(sentinel("SHOULD_NOT_RUN"))).rejects.toThrow();
+        await expect(fs.access(sentinel("SHOULD_NOT_RUN"))).rejects.toThrow(/ENOENT/);
     });
 
     it("aborts when preVersionCommand fails", async () => {

--- a/packages/tooling/vis/__tests__/release/core/package-managers-bun.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-bun.test.ts
@@ -86,7 +86,7 @@ describe("bunAdapter — pack", () => {
         // bun pm pack supports --destination from the pinned minVersion (1.1.36)
         // but NOT --filename (added later). The adapter renames post-pack
         // when a filename override is requested.
-        expect(seenArgs).toEqual(["pm", "pack", "--destination", "/dst"]);
+        expect(seenArgs).toStrictEqual(["pm", "pack", "--destination", "/dst"]);
     });
 
     it("renames the tarball post-pack when filename is requested", async () => {
@@ -177,7 +177,7 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
 
         const list = await new BunAdapter(new MockRunner()).listWorkspacePackages(cwd);
 
-        expect(list.map((p) => p.name).sort()).toEqual(["a", "b"]);
+        expect(list.map((p) => p.name).sort()).toStrictEqual(["a", "b"]);
 
         const bEntry = list.find((p) => p.name === "b");
 
@@ -222,11 +222,11 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
     it("returns empty array when workspaces field is missing", async () => {
         writeFileSync(join(cwd, "package.json"), JSON.stringify({ name: "root" }));
 
-        await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toEqual([]);
+        await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toStrictEqual([]);
     });
 
     it("returns empty array when package.json is missing", async () => {
-        await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toEqual([]);
+        await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toStrictEqual([]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/package-managers-bun.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-bun.test.ts
@@ -22,6 +22,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("parses the tarball filename from bun pm pack stdout", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["pm", "pack"], () => {
@@ -38,6 +40,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("treats absolute filenames in stdout as-is", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["pm", "pack"], () => {
@@ -54,6 +58,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("falls back to deriving the tarball name from package.json when stdout has no filename", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["pm", "pack"], () => {
@@ -71,6 +77,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("forwards --destination to bun pm pack", async () => {
+        expect.hasAssertions();
+
         let seenArgs: ReadonlyArray<string> | undefined;
 
         const adapter = new BunAdapter({
@@ -90,6 +98,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("renames the tarball post-pack when filename is requested", async () => {
+        expect.hasAssertions();
+
         const dest = mkdtempSync(join(tmpdir(), "vis-bun-pack-dest-"));
         const tarballPath = join(dest, "s-pkg-1.2.3.tgz");
 
@@ -114,6 +124,8 @@ describe("bunAdapter — pack", () => {
     });
 
     it("throws PUBLISH_FAILED on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["pm", "pack"], () => {
@@ -126,6 +138,8 @@ describe("bunAdapter — pack", () => {
 
 describe("bunAdapter — installLockfileOnly", () => {
     it("invokes bun install --lockfile-only", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let called = false;
 
@@ -141,6 +155,8 @@ describe("bunAdapter — installLockfileOnly", () => {
     });
 
     it("throws on failure", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["install"], () => {
@@ -167,6 +183,8 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
     });
 
     it("discovers packages under workspaces[] globs", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(cwd, "package.json"), JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
 
         mkdirSync(join(cwd, "packages", "a"), { recursive: true });
@@ -185,6 +203,8 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
     });
 
     it("supports the workspaces.packages object form", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(cwd, "package.json"), JSON.stringify({
             name: "root",
             workspaces: { packages: ["pkg-*"] },
@@ -200,6 +220,8 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
     });
 
     it("skips node_modules + dotfiles during traversal", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(cwd, "package.json"), JSON.stringify({ name: "root", workspaces: ["**/package"] }));
 
         mkdirSync(join(cwd, "node_modules", "thing", "package"), { recursive: true });
@@ -212,26 +234,32 @@ describe("bunAdapter — listWorkspacePackages (no first-class CLI)", () => {
         writeFileSync(join(cwd, ".cache", "package", "package.json"), JSON.stringify({ name: "hidden", version: "0.0.0" }));
 
         const list = await new BunAdapter(new MockRunner()).listWorkspacePackages(cwd);
+        const names = list.map((entry) => entry.name);
 
-        for (const entry of list) {
-            expect(entry.name).not.toBe("should-not-see");
-            expect(entry.name).not.toBe("hidden");
-        }
+        // Both candidate packages live under node_modules / a dotdir, so neither
+        // should be discovered (asserted unconditionally — the list may be empty).
+        expect(names).not.toContain("should-not-see");
+        expect(names).not.toContain("hidden");
     });
 
     it("returns empty array when workspaces field is missing", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(cwd, "package.json"), JSON.stringify({ name: "root" }));
 
         await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toStrictEqual([]);
     });
 
     it("returns empty array when package.json is missing", async () => {
+        expect.hasAssertions();
         await expect(new BunAdapter(new MockRunner()).listWorkspacePackages(cwd)).resolves.toStrictEqual([]);
     });
 });
 
 describe("bunAdapter — publish delegates to npm", () => {
     it("invokes npm publish (bun lacks OIDC + provenance)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let npmInvoked = false;
 
@@ -250,6 +278,8 @@ describe("bunAdapter — publish delegates to npm", () => {
 
 describe("bunAdapter — detectVersion", () => {
     it("returns trimmed version", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["--version"], () => {
@@ -260,6 +290,8 @@ describe("bunAdapter — detectVersion", () => {
     });
 
     it("returns undefined when CLI is absent", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("bun", ["--version"], () => {

--- a/packages/tooling/vis/__tests__/release/core/package-managers-detect.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-detect.test.ts
@@ -29,6 +29,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("detects pnpm from packageManager field", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "pnpm@10.0.0" });
         const result = await detectPackageManager(cwd, new MockRunner());
 
@@ -36,6 +38,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("detects yarn from packageManager field", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "yarn@4.5.0" });
         const result = await detectPackageManager(cwd, new MockRunner());
 
@@ -43,6 +47,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("detects bun from packageManager field", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "bun@1.1.36" });
         const result = await detectPackageManager(cwd, new MockRunner());
 
@@ -50,6 +56,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("detects npm from packageManager field", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "npm@11.0.0" });
         const result = await detectPackageManager(cwd, new MockRunner());
 
@@ -57,6 +65,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("handles packageManager value without `@` suffix", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "pnpm" });
         const result = await detectPackageManager(cwd, new MockRunner());
 
@@ -64,6 +74,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("corepack hint wins over lockfile presence", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "yarn@4.5.0" });
         writeLockfile(cwd, "pnpm-lock.yaml");
 
@@ -73,6 +85,8 @@ describe("detectPackageManager — Corepack packageManager field", () => {
     });
 
     it("falls through to lockfile when packageManager value is unrecognised", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x", packageManager: "deno@1.0.0" });
         writeLockfile(cwd, "pnpm-lock.yaml");
 
@@ -96,6 +110,8 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("detects bun via bun.lock", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "bun.lock");
 
@@ -103,6 +119,8 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("detects bun via bun.lockb", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "bun.lockb");
 
@@ -110,6 +128,8 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("detects pnpm via pnpm-lock.yaml", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "pnpm-lock.yaml");
 
@@ -117,6 +137,8 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("detects yarn via yarn.lock", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "yarn.lock");
 
@@ -124,16 +146,21 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("falls back to npm when no lockfile is present", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
 
         await expect(detectPackageManager(cwd, new MockRunner())).resolves.toBe("npm");
     });
 
     it("falls back to npm when package.json is missing", async () => {
+        expect.hasAssertions();
         await expect(detectPackageManager(cwd, new MockRunner())).resolves.toBe("npm");
     });
 
     it("bun lockfile wins over pnpm + yarn lockfiles", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "bun.lock");
         writeLockfile(cwd, "pnpm-lock.yaml");
@@ -143,6 +170,8 @@ describe("detectPackageManager — lockfile resolution", () => {
     });
 
     it("pnpm lockfile wins over yarn lockfile", async () => {
+        expect.hasAssertions();
+
         writePkg(cwd, { name: "x" });
         writeLockfile(cwd, "pnpm-lock.yaml");
         writeLockfile(cwd, "yarn.lock");
@@ -153,24 +182,32 @@ describe("detectPackageManager — lockfile resolution", () => {
 
 describe(createAdapter, () => {
     it("returns NpmAdapter for npm", () => {
+        expect.hasAssertions();
+
         const adapter = createAdapter("npm", new MockRunner());
 
         expect(adapter.id).toBe("npm");
     });
 
     it("returns PnpmAdapter for pnpm", () => {
+        expect.hasAssertions();
+
         const adapter = createAdapter("pnpm", new MockRunner());
 
         expect(adapter.id).toBe("pnpm");
     });
 
     it("returns YarnAdapter for yarn", () => {
+        expect.hasAssertions();
+
         const adapter = createAdapter("yarn", new MockRunner());
 
         expect(adapter.id).toBe("yarn");
     });
 
     it("returns BunAdapter for bun", () => {
+        expect.hasAssertions();
+
         const adapter = createAdapter("bun", new MockRunner());
 
         expect(adapter.id).toBe("bun");

--- a/packages/tooling/vis/__tests__/release/core/package-managers-npm.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-npm.test.ts
@@ -26,6 +26,8 @@ describe("npmAdapter — pack", () => {
     });
 
     it("returns the tarball path on success", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["pack", "--json"], () => {
@@ -42,6 +44,8 @@ describe("npmAdapter — pack", () => {
     });
 
     it("passes --pack-destination when destination is set", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let seenArgs: ReadonlyArray<string> | undefined;
 
@@ -62,6 +66,8 @@ describe("npmAdapter — pack", () => {
     });
 
     it("throws PUBLISH_FAILED when npm pack exits non-zero", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["pack"], () => {
@@ -72,6 +78,8 @@ describe("npmAdapter — pack", () => {
     });
 
     it("throws PUBLISH_FAILED when output is missing filename", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["pack"], () => {
@@ -84,6 +92,8 @@ describe("npmAdapter — pack", () => {
 
 describe("npmAdapter — installLockfileOnly", () => {
     it("uses --package-lock-only flag", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let called = false;
 
@@ -99,6 +109,8 @@ describe("npmAdapter — installLockfileOnly", () => {
     });
 
     it("throws CONFIG_INVALID when install fails", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["install", "--package-lock-only"], () => {
@@ -117,6 +129,8 @@ describe("npmAdapter — installLockfileOnly", () => {
 
 describe("npmAdapter — listWorkspacePackages", () => {
     it("returns empty array on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["query", ".workspace", "--json"], () => {
@@ -127,6 +141,8 @@ describe("npmAdapter — listWorkspacePackages", () => {
     });
 
     it("returns empty array when JSON is malformed", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["query", ".workspace", "--json"], () => {
@@ -137,6 +153,8 @@ describe("npmAdapter — listWorkspacePackages", () => {
     });
 
     it("parses package entries with all fields", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["query", ".workspace", "--json"], () => {
@@ -158,6 +176,8 @@ describe("npmAdapter — listWorkspacePackages", () => {
     });
 
     it("filters out entries without a name", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["query", ".workspace", "--json"], () => {
@@ -177,6 +197,8 @@ describe("npmAdapter — listWorkspacePackages", () => {
 
 describe("npmAdapter — publish", () => {
     it("returns published: true on success", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["publish", "/tmp/pkg.tgz"], () => {
@@ -190,6 +212,8 @@ describe("npmAdapter — publish", () => {
     });
 
     it("appends optional tag/access/registry/otp/provenance flags", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let seenArgs: ReadonlyArray<string> | undefined;
 
@@ -232,6 +256,8 @@ describe("npmAdapter — publish", () => {
     });
 
     it("detects alreadyPublished via EPUBLISHCONFLICT in stderr", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["publish"], () => {
@@ -249,6 +275,8 @@ describe("npmAdapter — publish", () => {
     });
 
     it("detects alreadyPublished via 409 forbidden", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["publish"], () => {
@@ -265,6 +293,8 @@ describe("npmAdapter — publish", () => {
     });
 
     it("throws PUBLISH_FAILED on non-conflict errors", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["publish"], () => {
@@ -283,6 +313,8 @@ describe("npmAdapter — publish", () => {
 
 describe("npmAdapter — detectVersion", () => {
     it("returns trimmed stdout on success", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["--version"], () => {
@@ -293,6 +325,8 @@ describe("npmAdapter — detectVersion", () => {
     });
 
     it("returns undefined on failure", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("npm", ["--version"], () => {
@@ -320,6 +354,8 @@ describe("publishNative — per-pm command construction (publishStrategy: native
     };
 
     it("npm: runs `npm publish` in the package dir with flags", async () => {
+        expect.hasAssertions();
+
         const { adapterRunner, seen } = capture();
 
         const result = await new NpmAdapter(adapterRunner).publishNative({
@@ -336,6 +372,8 @@ describe("publishNative — per-pm command construction (publishStrategy: native
     });
 
     it("pnpm: runs `pnpm publish --no-git-checks` in the package dir", async () => {
+        expect.hasAssertions();
+
         const { adapterRunner, seen } = capture();
 
         await new PnpmAdapter(adapterRunner).publishNative({ cwd: "/repo/pkg", tag: "latest" });
@@ -345,6 +383,8 @@ describe("publishNative — per-pm command construction (publishStrategy: native
     });
 
     it("yarn: runs `yarn npm publish` (no --otp/--registry flags)", async () => {
+        expect.hasAssertions();
+
         const { adapterRunner, seen } = capture();
 
         await new YarnAdapter(adapterRunner).publishNative({ access: "restricted", cwd: "/repo/pkg", otp: "123456", registry: "https://r.example.com" });
@@ -354,6 +394,8 @@ describe("publishNative — per-pm command construction (publishStrategy: native
     });
 
     it("bun: runs `bun publish` (no --provenance/--otp)", async () => {
+        expect.hasAssertions();
+
         const { adapterRunner, seen } = capture();
 
         await new BunAdapter(adapterRunner).publishNative({ cwd: "/repo/pkg", otp: "123456", provenance: true, tag: "beta" });
@@ -363,6 +405,8 @@ describe("publishNative — per-pm command construction (publishStrategy: native
     });
 
     it("maps EPUBLISHCONFLICT to alreadyPublished", async () => {
+        expect.hasAssertions();
+
         const conflictRunner: CommandRunner = {
             run: async () => {
                 return { exitCode: 1, stderr: "npm error code EPUBLISHCONFLICT", stdout: "" };

--- a/packages/tooling/vis/__tests__/release/core/package-managers-npm.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-npm.test.ts
@@ -123,7 +123,7 @@ describe("npmAdapter — listWorkspacePackages", () => {
             return { exitCode: 1, stderr: "", stdout: "" };
         });
 
-        await expect(new NpmAdapter(runner).listWorkspacePackages("/r")).resolves.toEqual([]);
+        await expect(new NpmAdapter(runner).listWorkspacePackages("/r")).resolves.toStrictEqual([]);
     });
 
     it("returns empty array when JSON is malformed", async () => {
@@ -133,7 +133,7 @@ describe("npmAdapter — listWorkspacePackages", () => {
             return { exitCode: 0, stderr: "", stdout: "not json" };
         });
 
-        await expect(new NpmAdapter(runner).listWorkspacePackages("/r")).resolves.toEqual([]);
+        await expect(new NpmAdapter(runner).listWorkspacePackages("/r")).resolves.toStrictEqual([]);
     });
 
     it("parses package entries with all fields", async () => {
@@ -153,8 +153,8 @@ describe("npmAdapter — listWorkspacePackages", () => {
         const list = await new NpmAdapter(runner).listWorkspacePackages("/r");
 
         expect(list).toHaveLength(2);
-        expect(list[0]).toEqual({ name: "@s/a", path: "/r/packages/a", private: false, version: "1.0.0" });
-        expect(list[1]).toEqual({ name: "b", path: "/r/packages/b", private: true, version: "2.0.0" });
+        expect(list[0]).toStrictEqual({ name: "@s/a", path: "/r/packages/a", private: false, version: "1.0.0" });
+        expect(list[1]).toStrictEqual({ name: "b", path: "/r/packages/b", private: true, version: "2.0.0" });
     });
 
     it("filters out entries without a name", async () => {
@@ -215,7 +215,7 @@ describe("npmAdapter — publish", () => {
             tarball: "/tmp/pkg.tgz",
         });
 
-        expect(seenArgs).toEqual([
+        expect(seenArgs).toStrictEqual([
             "publish",
             "/tmp/pkg.tgz",
             "--tag",
@@ -331,7 +331,7 @@ describe("publishNative — per-pm command construction (publishStrategy: native
 
         expect(result.published).toBe(true);
         expect(seen.command).toBe("npm");
-        expect(seen.args).toEqual(["publish", "--tag", "next", "--access", "public", "--provenance"]);
+        expect(seen.args).toStrictEqual(["publish", "--tag", "next", "--access", "public", "--provenance"]);
         expect(seen.cwd).toBe("/repo/pkg");
     });
 
@@ -341,7 +341,7 @@ describe("publishNative — per-pm command construction (publishStrategy: native
         await new PnpmAdapter(adapterRunner).publishNative({ cwd: "/repo/pkg", tag: "latest" });
 
         expect(seen.command).toBe("pnpm");
-        expect(seen.args).toEqual(["publish", "--no-git-checks", "--tag", "latest"]);
+        expect(seen.args).toStrictEqual(["publish", "--no-git-checks", "--tag", "latest"]);
     });
 
     it("yarn: runs `yarn npm publish` (no --otp/--registry flags)", async () => {
@@ -350,7 +350,7 @@ describe("publishNative — per-pm command construction (publishStrategy: native
         await new YarnAdapter(adapterRunner).publishNative({ access: "restricted", cwd: "/repo/pkg", otp: "123456", registry: "https://r.example.com" });
 
         expect(seen.command).toBe("yarn");
-        expect(seen.args).toEqual(["npm", "publish", "--access", "restricted"]);
+        expect(seen.args).toStrictEqual(["npm", "publish", "--access", "restricted"]);
     });
 
     it("bun: runs `bun publish` (no --provenance/--otp)", async () => {
@@ -359,7 +359,7 @@ describe("publishNative — per-pm command construction (publishStrategy: native
         await new BunAdapter(adapterRunner).publishNative({ cwd: "/repo/pkg", otp: "123456", provenance: true, tag: "beta" });
 
         expect(seen.command).toBe("bun");
-        expect(seen.args).toEqual(["publish", "--tag", "beta"]);
+        expect(seen.args).toStrictEqual(["publish", "--tag", "beta"]);
     });
 
     it("maps EPUBLISHCONFLICT to alreadyPublished", async () => {

--- a/packages/tooling/vis/__tests__/release/core/package-managers-pnpm.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-pnpm.test.ts
@@ -119,7 +119,7 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
             return { exitCode: 1, stderr: "", stdout: "" };
         });
 
-        await expect(new PnpmAdapter(runner).listWorkspacePackages("/r")).resolves.toEqual([]);
+        await expect(new PnpmAdapter(runner).listWorkspacePackages("/r")).resolves.toStrictEqual([]);
     });
 
     it("returns empty array when JSON is malformed", async () => {
@@ -129,7 +129,7 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
             return { exitCode: 0, stderr: "", stdout: "not json" };
         });
 
-        await expect(new PnpmAdapter(runner).listWorkspacePackages("/r")).resolves.toEqual([]);
+        await expect(new PnpmAdapter(runner).listWorkspacePackages("/r")).resolves.toStrictEqual([]);
     });
 
     it("filters out entries without a name", async () => {

--- a/packages/tooling/vis/__tests__/release/core/package-managers-pnpm.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-pnpm.test.ts
@@ -22,6 +22,8 @@ describe("pnpmAdapter — pack", () => {
     });
 
     it("returns the tarball path on success (pnpm emits a single object, not array)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["pack", "--json"], () => {
@@ -38,6 +40,8 @@ describe("pnpmAdapter — pack", () => {
     });
 
     it("treats absolute filenames as-is", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["pack", "--json"], () => {
@@ -54,6 +58,8 @@ describe("pnpmAdapter — pack", () => {
     });
 
     it("respects --pack-destination", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["pack", "--json", "--pack-destination", "/dst"], () => {
@@ -70,6 +76,8 @@ describe("pnpmAdapter — pack", () => {
     });
 
     it("throws PUBLISH_FAILED on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["pack"], () => {
@@ -80,6 +88,8 @@ describe("pnpmAdapter — pack", () => {
     });
 
     it("throws when output has no filename field", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["pack"], () => {
@@ -92,6 +102,8 @@ describe("pnpmAdapter — pack", () => {
 
 describe("pnpmAdapter — listWorkspacePackages", () => {
     it("parses pnpm's recursive ls JSON output", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["-r", "ls", "--depth", "-1", "--json"], () => {
@@ -113,6 +125,8 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
     });
 
     it("returns empty array on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["-r", "ls"], () => {
@@ -123,6 +137,8 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
     });
 
     it("returns empty array when JSON is malformed", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["-r", "ls"], () => {
@@ -133,6 +149,8 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
     });
 
     it("filters out entries without a name", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["-r", "ls"], () => {
@@ -152,6 +170,8 @@ describe("pnpmAdapter — listWorkspacePackages", () => {
 
 describe("pnpmAdapter — installLockfileOnly", () => {
     it("calls pnpm install --lockfile-only", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let called = false;
 
@@ -167,6 +187,8 @@ describe("pnpmAdapter — installLockfileOnly", () => {
     });
 
     it("throws on failure", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["install"], () => {
@@ -181,6 +203,8 @@ describe("pnpmAdapter — installLockfileOnly", () => {
 
 describe("pnpmAdapter — publish delegates to npm", () => {
     it("invokes `npm publish <tarball>` instead of pnpm publish", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let npmPublishCalled = false;
 
@@ -211,6 +235,8 @@ describe("pnpmAdapter — readCatalogYaml", () => {
     });
 
     it("returns the file content when present", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(cwd, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
 
         const yaml = await new PnpmAdapter(new MockRunner()).readCatalogYaml(cwd);
@@ -219,6 +245,8 @@ describe("pnpmAdapter — readCatalogYaml", () => {
     });
 
     it("returns undefined when the file is missing", async () => {
+        expect.hasAssertions();
+
         const yaml = await new PnpmAdapter(new MockRunner()).readCatalogYaml(cwd);
 
         expect(yaml).toBeUndefined();
@@ -227,6 +255,8 @@ describe("pnpmAdapter — readCatalogYaml", () => {
 
 describe("pnpmAdapter — detectVersion", () => {
     it("returns trimmed pnpm version", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["--version"], () => {
@@ -237,6 +267,8 @@ describe("pnpmAdapter — detectVersion", () => {
     });
 
     it("returns undefined when the CLI is unavailable", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("pnpm", ["--version"], () => {

--- a/packages/tooling/vis/__tests__/release/core/package-managers-yarn.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-yarn.test.ts
@@ -83,7 +83,7 @@ describe("yarnAdapter — installLockfileOnly", () => {
 
         await adapter.installLockfileOnly({ cwd: "/r" });
 
-        expect(seenArgs).toEqual(["install", "--mode", "update-lockfile"]);
+        expect(seenArgs).toStrictEqual(["install", "--mode", "update-lockfile"]);
     });
 
     it("throws on failure", async () => {
@@ -159,7 +159,7 @@ describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
             return { exitCode: 1, stderr: "", stdout: "" };
         });
 
-        await expect(new YarnAdapter(runner).listWorkspacePackages("/r")).resolves.toEqual([]);
+        await expect(new YarnAdapter(runner).listWorkspacePackages("/r")).resolves.toStrictEqual([]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/package-managers-yarn.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/package-managers-yarn.test.ts
@@ -22,6 +22,8 @@ describe("yarnAdapter — pack", () => {
     });
 
     it("expands %s/%v placeholders using package.json name and version", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["pack", "--out"], () => {
@@ -35,6 +37,8 @@ describe("yarnAdapter — pack", () => {
     });
 
     it("honours a custom filename template", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["pack", "--out"], () => {
@@ -47,6 +51,8 @@ describe("yarnAdapter — pack", () => {
     });
 
     it("writes to the destination directory when provided", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["pack", "--out"], () => {
@@ -59,6 +65,8 @@ describe("yarnAdapter — pack", () => {
     });
 
     it("throws PUBLISH_FAILED on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["pack"], () => {
@@ -71,6 +79,8 @@ describe("yarnAdapter — pack", () => {
 
 describe("yarnAdapter — installLockfileOnly", () => {
     it("uses `yarn install --mode update-lockfile`", async () => {
+        expect.hasAssertions();
+
         let seenArgs: ReadonlyArray<string> | undefined;
 
         const adapter = new YarnAdapter({
@@ -87,6 +97,8 @@ describe("yarnAdapter — installLockfileOnly", () => {
     });
 
     it("throws on failure", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["install"], () => {
@@ -101,6 +113,8 @@ describe("yarnAdapter — installLockfileOnly", () => {
 
 describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
     it("parses newline-delimited JSON entries", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["workspaces", "list", "--json"], () => {
@@ -119,6 +133,8 @@ describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
     });
 
     it("skips malformed NDJSON lines", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["workspaces", "list", "--json"], () => {
@@ -136,6 +152,8 @@ describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
     });
 
     it("skips entries with empty name", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["workspaces", "list", "--json"], () => {
@@ -153,6 +171,8 @@ describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
     });
 
     it("returns empty list on non-zero exit", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["workspaces", "list", "--json"], () => {
@@ -165,6 +185,8 @@ describe("yarnAdapter — listWorkspacePackages (NDJSON)", () => {
 
 describe("yarnAdapter — publish delegates to npm", () => {
     it("invokes npm publish even though we're on yarn", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let invokedNpm = false;
 
@@ -183,6 +205,8 @@ describe("yarnAdapter — publish delegates to npm", () => {
 
 describe("yarnAdapter — detectVersion", () => {
     it("returns trimmed version", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["--version"], () => {
@@ -193,6 +217,8 @@ describe("yarnAdapter — detectVersion", () => {
     });
 
     it("returns undefined when CLI is absent", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("yarn", ["--version"], () => {

--- a/packages/tooling/vis/__tests__/release/core/pre-mode.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/pre-mode.test.ts
@@ -123,7 +123,7 @@ describe("pre-mode: buildEnterFile", () => {
 
         expect(file.tag).toBe("rc");
         expect(file.mode).toBe("pre");
-        expect(file.initialVersions).toEqual({ "@a/one": "0.5.0", "@a/two": "1.0.0" });
+        expect(file.initialVersions).toStrictEqual({ "@a/one": "0.5.0", "@a/two": "1.0.0" });
         expect(file.version).toBe(1);
         expect(Date.parse(file.enteredAt)).not.toBeNaN();
     });

--- a/packages/tooling/vis/__tests__/release/core/pre-mode.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/pre-mode.test.ts
@@ -27,10 +27,13 @@ describe("pre-mode: file I/O round-trip", () => {
     });
 
     it("returns undefined when pre.json is absent", async () => {
+        expect.hasAssertions();
         await expect(readPreMode(cwd, CHANGES_DIR)).resolves.toBeUndefined();
     });
 
     it("writes a file readable by readPreMode", async () => {
+        expect.hasAssertions();
+
         const file = buildEnterFile("alpha", [
             { name: "@scope/a", version: "1.2.0" },
             { name: "@scope/b", version: "0.5.0" },
@@ -49,6 +52,8 @@ describe("pre-mode: file I/O round-trip", () => {
     });
 
     it("deletePreMode returns true when a file was removed", async () => {
+        expect.hasAssertions();
+
         const file = buildEnterFile("alpha", []);
 
         await writePreMode(cwd, CHANGES_DIR, file);
@@ -58,6 +63,7 @@ describe("pre-mode: file I/O round-trip", () => {
     });
 
     it("deletePreMode returns false when there's nothing to delete", async () => {
+        expect.hasAssertions();
         await expect(deletePreMode(cwd, CHANGES_DIR)).resolves.toBe(false);
     });
 });
@@ -75,6 +81,8 @@ describe("pre-mode: corrupt file errors", () => {
     });
 
     it("throws STATE_FILE_CORRUPT on malformed JSON", async () => {
+        expect.hasAssertions();
+
         await writeFile(preModeFilePath(cwd, CHANGES_DIR), "{ malformed");
 
         await expect(readPreMode(cwd, CHANGES_DIR)).rejects.toMatchObject({
@@ -83,6 +91,8 @@ describe("pre-mode: corrupt file errors", () => {
     });
 
     it("throws on unknown schema version", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             preModeFilePath(cwd, CHANGES_DIR),
             JSON.stringify({ initialVersions: {}, mode: "pre", tag: "alpha", version: 99 }),
@@ -92,6 +102,8 @@ describe("pre-mode: corrupt file errors", () => {
     });
 
     it("throws on invalid mode value", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             preModeFilePath(cwd, CHANGES_DIR),
             JSON.stringify({ initialVersions: {}, mode: "bogus", tag: "alpha", version: 1 }),
@@ -103,6 +115,8 @@ describe("pre-mode: corrupt file errors", () => {
     });
 
     it("throws on missing tag", async () => {
+        expect.hasAssertions();
+
         await writeFile(
             preModeFilePath(cwd, CHANGES_DIR),
             JSON.stringify({ initialVersions: {}, mode: "pre", version: 1 }),
@@ -116,6 +130,8 @@ describe("pre-mode: corrupt file errors", () => {
 
 describe("pre-mode: buildEnterFile", () => {
     it("snapshots every package's current version", () => {
+        expect.hasAssertions();
+
         const file = buildEnterFile("rc", [
             { name: "@a/one", version: "0.5.0" },
             { name: "@a/two", version: "1.0.0" },

--- a/packages/tooling/vis/__tests__/release/core/print-config.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/print-config.test.ts
@@ -40,15 +40,19 @@ const noopLogger = { error: () => {}, info: () => {}, warn: () => {} } as unknow
 
 describe(printConfigIfRequested, () => {
     it("returns false when --print-config is not set", () => {
+        expect.hasAssertions();
         expect(printConfigIfRequested({}, mkCtx(), noopLogger)).toBe(false);
         expect(stdoutChunks.join("")).toBe("");
     });
 
     it("returns false on empty string", () => {
+        expect.hasAssertions();
         expect(printConfigIfRequested({ printConfig: "" }, mkCtx(), noopLogger)).toBe(false);
     });
 
     it("prints user-facing config + returns true on truthy value", () => {
+        expect.hasAssertions();
+
         const result = printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
 
         expect(result).toBe(true);
@@ -61,6 +65,8 @@ describe(printConfigIfRequested, () => {
     });
 
     it("prints runtime-resolved fields with =debug", () => {
+        expect.hasAssertions();
+
         const result = printConfigIfRequested({ printConfig: "debug" }, mkCtx(), noopLogger);
 
         expect(result).toBe(true);
@@ -74,6 +80,8 @@ describe(printConfigIfRequested, () => {
     });
 
     it("redacts gitUser.email but preserves name (RFC §19.4)", () => {
+        expect.hasAssertions();
+
         const ctx = mkCtx();
 
         ctx.config.gitUser = { email: "bot@example.com", name: "release-bot" };
@@ -87,6 +95,8 @@ describe(printConfigIfRequested, () => {
     });
 
     it("leaves gitUser undefined when not configured", () => {
+        expect.hasAssertions();
+
         printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
 
         const out = JSON.parse(stdoutChunks.join(""));

--- a/packages/tooling/vis/__tests__/release/core/print-config.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/print-config.test.ts
@@ -22,85 +22,87 @@ const mkCtx = (): OrchestratorContext => {
 let stdoutChunks: string[] = [];
 let originalWrite: typeof process.stdout.write;
 
-beforeEach(() => {
-    stdoutChunks = [];
-    originalWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: string | Uint8Array) => {
-        stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+describe("release print-config", () => {
+    beforeEach(() => {
+        stdoutChunks = [];
+        originalWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
 
-        return true;
-    });
-});
-
-afterEach(() => {
-    process.stdout.write = originalWrite;
-});
-
-const noopLogger = { error: () => {}, info: () => {}, warn: () => {} } as unknown as Parameters<typeof printConfigIfRequested>[2];
-
-describe(printConfigIfRequested, () => {
-    it("returns false when --print-config is not set", () => {
-        expect.hasAssertions();
-        expect(printConfigIfRequested({}, mkCtx(), noopLogger)).toBe(false);
-        expect(stdoutChunks.join("")).toBe("");
+            return true;
+        });
     });
 
-    it("returns false on empty string", () => {
-        expect.hasAssertions();
-        expect(printConfigIfRequested({ printConfig: "" }, mkCtx(), noopLogger)).toBe(false);
+    afterEach(() => {
+        process.stdout.write = originalWrite;
     });
 
-    it("prints user-facing config + returns true on truthy value", () => {
-        expect.hasAssertions();
+    const noopLogger = { error: () => {}, info: () => {}, warn: () => {} } as unknown as Parameters<typeof printConfigIfRequested>[2];
 
-        const result = printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
+    describe(printConfigIfRequested, () => {
+        it("returns false when --print-config is not set", () => {
+            expect.hasAssertions();
+            expect(printConfigIfRequested({}, mkCtx(), noopLogger)).toBe(false);
+            expect(stdoutChunks.join("")).toBe("");
+        });
 
-        expect(result).toBe(true);
+        it("returns false on empty string", () => {
+            expect.hasAssertions();
+            expect(printConfigIfRequested({ printConfig: "" }, mkCtx(), noopLogger)).toBe(false);
+        });
 
-        const out = JSON.parse(stdoutChunks.join(""));
+        it("prints user-facing config + returns true on truthy value", () => {
+            expect.hasAssertions();
 
-        expect(out.baseBranch).toBe("main");
-        expect(out.channels.main.tag).toBe("latest");
-        expect(out["__resolved__"]).toBeUndefined();
-    });
+            const result = printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
 
-    it("prints runtime-resolved fields with =debug", () => {
-        expect.hasAssertions();
+            expect(result).toBe(true);
 
-        const result = printConfigIfRequested({ printConfig: "debug" }, mkCtx(), noopLogger);
+            const out = JSON.parse(stdoutChunks.join(""));
 
-        expect(result).toBe(true);
+            expect(out.baseBranch).toBe("main");
+            expect(out.channels.main.tag).toBe("latest");
+            expect(out["__resolved__"]).toBeUndefined();
+        });
 
-        const out = JSON.parse(stdoutChunks.join(""));
+        it("prints runtime-resolved fields with =debug", () => {
+            expect.hasAssertions();
 
-        expect(out["__resolved__"]).toBeDefined();
-        expect(out["__resolved__"].cwd).toBe("/r");
-        expect(out["__resolved__"].packageManager).toBe("pnpm");
-        expect(out["__resolved__"].channel.tag).toBe("latest");
-    });
+            const result = printConfigIfRequested({ printConfig: "debug" }, mkCtx(), noopLogger);
 
-    it("redacts gitUser.email but preserves name (RFC §19.4)", () => {
-        expect.hasAssertions();
+            expect(result).toBe(true);
 
-        const ctx = mkCtx();
+            const out = JSON.parse(stdoutChunks.join(""));
 
-        ctx.config.gitUser = { email: "bot@example.com", name: "release-bot" };
+            expect(out["__resolved__"]).toBeDefined();
+            expect(out["__resolved__"].cwd).toBe("/r");
+            expect(out["__resolved__"].packageManager).toBe("pnpm");
+            expect(out["__resolved__"].channel.tag).toBe("latest");
+        });
 
-        printConfigIfRequested({ printConfig: "true" }, ctx, noopLogger);
+        it("redacts gitUser.email but preserves name (RFC §19.4)", () => {
+            expect.hasAssertions();
 
-        const out = JSON.parse(stdoutChunks.join(""));
+            const ctx = mkCtx();
 
-        expect(out.gitUser.name).toBe("release-bot");
-        expect(out.gitUser.email).toBe("[REDACTED]");
-    });
+            ctx.config.gitUser = { email: "bot@example.com", name: "release-bot" };
 
-    it("leaves gitUser undefined when not configured", () => {
-        expect.hasAssertions();
+            printConfigIfRequested({ printConfig: "true" }, ctx, noopLogger);
 
-        printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
+            const out = JSON.parse(stdoutChunks.join(""));
 
-        const out = JSON.parse(stdoutChunks.join(""));
+            expect(out.gitUser.name).toBe("release-bot");
+            expect(out.gitUser.email).toBe("[REDACTED]");
+        });
 
-        expect(out.gitUser).toBeUndefined();
+        it("leaves gitUser undefined when not configured", () => {
+            expect.hasAssertions();
+
+            printConfigIfRequested({ printConfig: "true" }, mkCtx(), noopLogger);
+
+            const out = JSON.parse(stdoutChunks.join(""));
+
+            expect(out.gitUser).toBeUndefined();
+        });
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/publish-guards.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/publish-guards.test.ts
@@ -82,7 +82,7 @@ describe(runExportsExist, () => {
         const result = await runExportsExist(pkgDir, manifest);
 
         expect(result.passed).toBe(false);
-        expect(result.findings.map((f) => f.id).sort()).toEqual([
+        expect(result.findings.map((f) => f.id).sort()).toStrictEqual([
             "exportsExist:bin:./dist/cli.js",
             "exportsExist:main:./dist/index.js",
             "exportsExist:types:./dist/index.d.ts",
@@ -272,7 +272,7 @@ describe(extractPackFilesFromRaw, () => {
             },
         ];
 
-        expect(extractPackFilesFromRaw(raw)).toEqual(["package.json", "dist/index.js"]);
+        expect(extractPackFilesFromRaw(raw)).toStrictEqual(["package.json", "dist/index.js"]);
     });
 
     it("reads pnpm pack --json shape (object)", () => {
@@ -281,7 +281,7 @@ describe(extractPackFilesFromRaw, () => {
             files: [{ path: "package.json" }, { path: "dist/index.js" }],
         };
 
-        expect(extractPackFilesFromRaw(raw)).toEqual(["package.json", "dist/index.js"]);
+        expect(extractPackFilesFromRaw(raw)).toStrictEqual(["package.json", "dist/index.js"]);
     });
 
     it("returns undefined for plain stdout strings (yarn, bun)", () => {
@@ -301,7 +301,7 @@ describe(extractPackFilesFromRaw, () => {
     it("skips file entries without a string path", () => {
         const raw = { files: [{ path: "ok.js" }, { size: 10 }, { path: 42 }] };
 
-        expect(extractPackFilesFromRaw(raw)).toEqual(["ok.js"]);
+        expect(extractPackFilesFromRaw(raw)).toStrictEqual(["ok.js"]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/publish-guards.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/publish-guards.test.ts
@@ -49,6 +49,8 @@ describe(runExportsExist, () => {
     });
 
     it("passes when every leaf exists", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(pkgDir, "dist"), { recursive: true });
         writeFileSync(join(pkgDir, "dist", "index.js"), "");
         writeFileSync(join(pkgDir, "dist", "index.d.ts"), "");
@@ -71,6 +73,8 @@ describe(runExportsExist, () => {
     });
 
     it("flags missing main / types / bin", async () => {
+        expect.hasAssertions();
+
         const manifest: PackageManifest = {
             bin: "./dist/cli.js",
             main: "./dist/index.js",
@@ -90,6 +94,8 @@ describe(runExportsExist, () => {
     });
 
     it("checks wildcard prefix dirs", async () => {
+        expect.hasAssertions();
+
         const manifest: PackageManifest = {
             exports: { "./feat/*": "./dist/feat/*.js" },
             name: "x",
@@ -108,6 +114,8 @@ describe(runExportsExist, () => {
     });
 
     it("ignores bare specifiers", async () => {
+        expect.hasAssertions();
+
         const manifest: PackageManifest = {
             exports: { ".": "react" },
             name: "x",
@@ -120,6 +128,8 @@ describe(runExportsExist, () => {
     });
 
     it("rejects manifest exports that traverse outside the package dir (RFC §19.4)", async () => {
+        expect.hasAssertions();
+
         const manifest: PackageManifest = {
             bin: { evil: "./../../usr/bin/env" },
             main: "./../../etc/passwd",
@@ -150,12 +160,16 @@ describe(runLifecycleScripts, () => {
     };
 
     it("returns passed when no lifecycle scripts present", () => {
+        expect.hasAssertions();
+
         const result = runLifecycleScripts(manifest({ build: "tsc" }), "strict");
 
         expect(result.passed).toBe(true);
     });
 
     it("strict mode flags any unauthorized lifecycle script", () => {
+        expect.hasAssertions();
+
         const result = runLifecycleScripts(manifest({ postinstall: "node bad.js" }), "strict");
 
         expect(result.passed).toBe(false);
@@ -164,6 +178,8 @@ describe(runLifecycleScripts, () => {
     });
 
     it("allow-list bypasses on exact-match", () => {
+        expect.hasAssertions();
+
         const result = runLifecycleScripts(
             manifest({ postinstall: "node-gyp rebuild" }),
             { allow: { postinstall: "node-gyp rebuild" }, mode: "strict" },
@@ -173,6 +189,8 @@ describe(runLifecycleScripts, () => {
     });
 
     it("allow-list rejects on partial match", () => {
+        expect.hasAssertions();
+
         const result = runLifecycleScripts(
             manifest({ postinstall: "node-gyp rebuild --debug" }),
             { allow: { postinstall: "node-gyp rebuild" }, mode: "strict" },
@@ -182,6 +200,8 @@ describe(runLifecycleScripts, () => {
     });
 
     it("off mode short-circuits to passed", () => {
+        expect.hasAssertions();
+
         const result = runLifecycleScripts(manifest({ postinstall: "rm -rf /" }), "off");
 
         expect(result.passed).toBe(true);
@@ -201,6 +221,8 @@ describe(runRuntimeAudit, () => {
     });
 
     it("passes when no runtime advisories", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([
             {
                 args: ["audit", "--omit=dev", "--json"],
@@ -214,6 +236,8 @@ describe(runRuntimeAudit, () => {
     });
 
     it("fails when count >= configured severity", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([
             {
                 args: ["audit", "--omit=dev", "--json"],
@@ -228,6 +252,8 @@ describe(runRuntimeAudit, () => {
     });
 
     it("ignores severities below the threshold", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([
             {
                 args: ["audit", "--omit=dev", "--json"],
@@ -241,6 +267,8 @@ describe(runRuntimeAudit, () => {
     });
 
     it("short-circuits when setting is off", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([]);
 
         const result = await runRuntimeAudit(pkgDir, runner, "off");
@@ -249,6 +277,8 @@ describe(runRuntimeAudit, () => {
     });
 
     it("returns parse-failure finding when output isn't JSON", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([
             { args: ["audit", "--omit=dev", "--json"], exitCode: 0, stdout: "not json" },
         ]);
@@ -262,6 +292,8 @@ describe(runRuntimeAudit, () => {
 
 describe(extractPackFilesFromRaw, () => {
     it("reads npm pack --json shape (array)", () => {
+        expect.hasAssertions();
+
         const raw = [
             {
                 filename: "pkg-1.0.0.tgz",
@@ -276,6 +308,8 @@ describe(extractPackFilesFromRaw, () => {
     });
 
     it("reads pnpm pack --json shape (object)", () => {
+        expect.hasAssertions();
+
         const raw = {
             filename: "pkg-1.0.0.tgz",
             files: [{ path: "package.json" }, { path: "dist/index.js" }],
@@ -285,20 +319,25 @@ describe(extractPackFilesFromRaw, () => {
     });
 
     it("returns undefined for plain stdout strings (yarn, bun)", () => {
+        expect.hasAssertions();
         expect(extractPackFilesFromRaw("➤ YN0036: │ Calling the \"prepack\" lifecycle script")).toBeUndefined();
     });
 
     it("returns undefined for null / non-objects", () => {
+        expect.hasAssertions();
         expect(extractPackFilesFromRaw(null)).toBeUndefined();
         expect(extractPackFilesFromRaw(42)).toBeUndefined();
     });
 
     it("returns undefined when the files key is missing or wrong type", () => {
+        expect.hasAssertions();
         expect(extractPackFilesFromRaw({ filename: "x.tgz" })).toBeUndefined();
         expect(extractPackFilesFromRaw({ files: "not an array" })).toBeUndefined();
     });
 
     it("skips file entries without a string path", () => {
+        expect.hasAssertions();
+
         const raw = { files: [{ path: "ok.js" }, { size: 10 }, { path: 42 }] };
 
         expect(extractPackFilesFromRaw(raw)).toStrictEqual(["ok.js"]);
@@ -317,6 +356,8 @@ describe(hashTarball, () => {
     });
 
     it("computes deterministic SHA256 + SHA512 hashes", async () => {
+        expect.hasAssertions();
+
         const tarball = join(dir, "pkg-1.0.0.tgz");
 
         writeFileSync(tarball, "stable test content");
@@ -346,6 +387,8 @@ describe("runPublishGuards orchestration", () => {
     });
 
     it("runs only the gates that are enabled", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([]);
         const manifest: PackageManifest = { main: "./dist/index.js", name: "x", version: "1.0.0" };
 
@@ -362,6 +405,8 @@ describe("runPublishGuards orchestration", () => {
     });
 
     it("classifies lifecycle warnings vs strict blockers", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([]);
         const manifest: PackageManifest = {
             name: "x",
@@ -393,6 +438,8 @@ describe("runPublishGuards orchestration", () => {
     });
 
     it("returns empty report when config is undefined", async () => {
+        expect.hasAssertions();
+
         const runner = stubRunner([]);
         const manifest: PackageManifest = { name: "x", version: "1.0.0" };
 

--- a/packages/tooling/vis/__tests__/release/core/release-note-template.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/release-note-template.test.ts
@@ -11,6 +11,8 @@ import { collectContributors, expandReleaseNoteTemplate } from "../../../src/rel
 
 describe(expandReleaseNoteTemplate, () => {
     it("interpolates every supported token in a single pass", () => {
+        expect.hasAssertions();
+
         const template = "Release {name} v{version} on {date} ({repo}) — was {previousVersion}";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -28,6 +30,8 @@ describe(expandReleaseNoteTemplate, () => {
         // Only `name` and `version` supplied — `previousVersion`, `date`,
         // and `repo` should render empty (NOT leave their `{token}` text
         // visible in the output).
+        expect.hasAssertions();
+
         const template = "Release {name} v{version} prev={previousVersion} date={date} repo={repo}";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -39,6 +43,8 @@ describe(expandReleaseNoteTemplate, () => {
     });
 
     it("returns a template with no tokens unchanged", () => {
+        expect.hasAssertions();
+
         const template = "Just a plain header — no interpolation tokens here.";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -53,6 +59,7 @@ describe(expandReleaseNoteTemplate, () => {
     });
 
     it("returns the empty string for an empty template", () => {
+        expect.hasAssertions();
         expect(
             expandReleaseNoteTemplate("", {
                 date: "2026-01-01",
@@ -69,6 +76,8 @@ describe(expandReleaseNoteTemplate, () => {
     // be interpolated by the partial match `{version}`. Single-pass
     // regex with full-name alternation guarantees that.
     it("f20: leaves malformed `{previousVer` (no closing brace) untouched", () => {
+        expect.hasAssertions();
+
         const template = "Header {previousVer with {version} inline";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -82,6 +91,8 @@ describe(expandReleaseNoteTemplate, () => {
     });
 
     it("f20: leaves unknown tokens (e.g. `{author}`) untouched", () => {
+        expect.hasAssertions();
+
         const template = "Released by {author} as {name} v{version}";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -97,6 +108,8 @@ describe(expandReleaseNoteTemplate, () => {
         // mis-handle if ordering changed: a name value containing
         // literal `{version}` text. Single-pass replace ignores the
         // already-substituted value.
+        expect.hasAssertions();
+
         const template = "{name} v{version}";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -108,6 +121,8 @@ describe(expandReleaseNoteTemplate, () => {
     });
 
     it("substitutes the same token multiple times within one template", () => {
+        expect.hasAssertions();
+
         const template = "{name}: {name}@{version} — see https://npm.im/{name}";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -120,6 +135,8 @@ describe(expandReleaseNoteTemplate, () => {
 
     // release-please #292 parity — the new `{contributors}` token.
     it("substitutes the {contributors} token verbatim", () => {
+        expect.hasAssertions();
+
         const template = "## Thanks\n\n{contributors}\n";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -130,6 +147,8 @@ describe(expandReleaseNoteTemplate, () => {
     });
 
     it("renders {contributors} as empty when not supplied", () => {
+        expect.hasAssertions();
+
         const template = "Header\n{contributors}Footer";
 
         const result = expandReleaseNoteTemplate(template, {
@@ -145,11 +164,14 @@ describe(expandReleaseNoteTemplate, () => {
 
 describe(collectContributors, () => {
     it("returns the empty string when no change files declare an author", () => {
+        expect.hasAssertions();
         expect(collectContributors([])).toBe("");
         expect(collectContributors([{}, { meta: {} }, { meta: { author: "" } }])).toBe("");
     });
 
     it("renders a bullet list with one author per line, in input order", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice" } },
             { meta: { author: "@bob" } },
@@ -159,6 +181,8 @@ describe(collectContributors, () => {
     });
 
     it("de-duplicates authors case-insensitively across multiple change files", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice" } },
             { meta: { author: "@Alice" } }, // duplicate (case-insensitive)
@@ -170,6 +194,8 @@ describe(collectContributors, () => {
     });
 
     it("trims surrounding whitespace and ignores blank author fields", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "  @alice  " } },
             { meta: { author: "   " } }, // blank → skip
@@ -180,6 +206,8 @@ describe(collectContributors, () => {
     });
 
     it("tolerates missing `meta` and missing `author` keys", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice" } },
             {},
@@ -192,6 +220,8 @@ describe(collectContributors, () => {
 
     // Audit V9: comma-separated handles on a single `author:` line.
     it("splits a comma-separated `author:` line into one bullet per handle", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice, @bob,@carol" } },
         ]);
@@ -202,6 +232,8 @@ describe(collectContributors, () => {
     // Audit V2: a bare `@` (handle missing) must not render as a stray
     // `- @` bullet.
     it("rejects a bare `@` with no handle attached", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@" } },
             { meta: { author: "@   " } },
@@ -215,6 +247,8 @@ describe(collectContributors, () => {
     // escape so a malicious or accidental frontmatter value can't
     // inject HTML / break out of the bullet syntax.
     it("escapes markdown / HTML in author handles (audit V5)", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice<img src=x>" } },
             { meta: { author: "@bob & friends" } },
@@ -226,6 +260,8 @@ describe(collectContributors, () => {
 
     // Audit V2 + dedup across `@`-prefixed and bare forms.
     it("treats `@alice` and `alice` as the same handle for dedup", () => {
+        expect.hasAssertions();
+
         const result = collectContributors([
             { meta: { author: "@alice" } },
             { meta: { author: "alice" } }, // duplicate (bare form)
@@ -239,6 +275,8 @@ describe(collectContributors, () => {
     // option so {contributors} and CHANGELOG.md agree on which bots
     // to hide.
     it("suppresses handles listed in `internalAuthors` (case-insensitive, with or without `@`)", () => {
+        expect.hasAssertions();
+
         const result = collectContributors(
             [
                 { meta: { author: "@alice" } },

--- a/packages/tooling/vis/__tests__/release/core/release-plan-perf.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/release-plan-perf.test.ts
@@ -22,6 +22,8 @@ describe("release-plan: glob-expansion cache", () => {
         // Phase B (fixed group) + Phase C1 (cascade) both expand globs every
         // iteration of the fixed-point loop. The WeakMap cache should make
         // this O(patterns) per loop instead of O(patterns × packages).
+        expect.hasAssertions();
+
         const packages: WorkspacePackage[] = [mkPkg("@scope/source")];
 
         for (let i = 0; i < 100; i += 1) {
@@ -53,6 +55,8 @@ describe("release-plan: glob-expansion cache", () => {
         // Build a workspace where the fixed group gets bumped by ONE explicit
         // change file but the fixed-point loop runs many iterations because of
         // chained dep propagation.
+        expect.hasAssertions();
+
         const packages: WorkspacePackage[] = [];
 
         for (let i = 0; i < 50; i += 1) {

--- a/packages/tooling/vis/__tests__/release/core/release-plan.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/release-plan.test.ts
@@ -29,6 +29,8 @@ const findRelease = (plan: ReturnType<typeof assembleReleasePlan>, name: string)
 
 describe("release-plan: phase A — out-of-range fix", () => {
     it("propagates patch to dependent when explicit minor bump breaks range", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", { version: "1.0.0" });
         const b = mkPkg("b", { dependencies: { a: "~1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -45,6 +47,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("does NOT propagate when range still satisfies new version", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { dependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -56,6 +60,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("peer deps inherit source bump level (no major escalation)", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { peerDependencies: { a: "~1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -69,6 +75,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("ignores devDependencies", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { devDependencies: { a: "~1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -79,6 +87,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("treats workspace:* and catalog: as always satisfied (no out-of-range trigger)", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { dependencies: { a: "workspace:*" } });
         const c = mkPkg("c", { dependencies: { a: "catalog:" } });
@@ -92,6 +102,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("warns on ^0.x peer dep producing non-patch propagation", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", { version: "0.5.0" });
         const b = mkPkg("b", { peerDependencies: { a: "^0.5.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -104,6 +116,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     // Devdep-cascade opt-in (changesets #944): default off, true cascades
     // every source, an allow-list narrows to specific source packages.
     it("cascades devDependency consumers as patch when bumpDevDependencies is true", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { devDependencies: { a: "~1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -122,6 +136,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("narrows devDependency cascade to the bumpDevDependencies allow-list", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const c = mkPkg("c");
         const b = mkPkg("b", { devDependencies: { a: "~1.0.0", c: "~1.0.0" } });
@@ -143,6 +159,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
     });
 
     it("still ignores devDependencies when bumpDevDependencies is omitted", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { devDependencies: { a: "~1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -157,6 +175,8 @@ describe("release-plan: phase A — out-of-range fix", () => {
 
 describe("release-plan: phase B — fixed groups", () => {
     it("max-bumps every member of a fixed group", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const c = mkPkg("c");
@@ -172,6 +192,8 @@ describe("release-plan: phase B — fixed groups", () => {
     });
 
     it("expands glob patterns within fixed groups", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("@scope/core");
         const b = mkPkg("@scope/plugin-foo");
         const c = mkPkg("@scope/plugin-bar");
@@ -187,6 +209,8 @@ describe("release-plan: phase B — fixed groups", () => {
 
 describe("release-plan: phase B — linked groups", () => {
     it("max-bumps only already-planned members (no pull-in of new packages)", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const c = mkPkg("c");
@@ -206,6 +230,8 @@ describe("release-plan: phase B — linked groups", () => {
 
 describe("release-plan: phase C1 — bump-file cascade", () => {
     it("cascades to globbed packages from nested change file", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("@scope/core");
         const b = mkPkg("@scope/plugin-foo");
         const c = mkPkg("@scope/plugin-bar");
@@ -222,6 +248,8 @@ describe("release-plan: phase C1 — bump-file cascade", () => {
     });
 
     it("runs cascade even in out-of-range mode", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b"); // not depending on a — pure cascade
         const graph = new DependencyGraph([a, b]);
@@ -235,6 +263,8 @@ describe("release-plan: phase C1 — bump-file cascade", () => {
 
 describe("release-plan: phase C2 — cascadeTo from per-pkg config", () => {
     it("triggers cascadeTo when source bump meets trigger", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const graph = new DependencyGraph([a, b]);
@@ -255,6 +285,8 @@ describe("release-plan: phase C2 — cascadeTo from per-pkg config", () => {
     });
 
     it("does not trigger cascadeTo when source bump is below trigger", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const graph = new DependencyGraph([a, b]);
@@ -274,6 +306,8 @@ describe("release-plan: phase C2 — cascadeTo from per-pkg config", () => {
     });
 
     it("supports bumpAs: 'match' to inherit source level", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const graph = new DependencyGraph([a, b]);
@@ -295,6 +329,8 @@ describe("release-plan: phase C2 — cascadeTo from per-pkg config", () => {
 
 describe("release-plan: phase C3 — dep-graph rules (gated by mode)", () => {
     it("does NOT run dep-graph rules in out-of-range mode", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { dependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -310,6 +346,8 @@ describe("release-plan: phase C3 — dep-graph rules (gated by mode)", () => {
     });
 
     it("runs dep-graph rules in patch mode (default rule: deps:patch:patch)", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { dependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -325,6 +363,8 @@ describe("release-plan: phase C3 — dep-graph rules (gated by mode)", () => {
     });
 
     it("respects minor-mode threshold — patch source does not trigger", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b", { dependencies: { a: "^1.0.0" } });
         const graph = new DependencyGraph([a, b]);
@@ -344,6 +384,8 @@ describe("release-plan: phase C3 — dep-graph rules (gated by mode)", () => {
 
 describe("release-plan: combined scenarios", () => {
     it("max-merges multiple change files for the same package", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const graph = new DependencyGraph([a]);
 
@@ -360,6 +402,8 @@ describe("release-plan: combined scenarios", () => {
     });
 
     it("`none` entries are recorded but produce no release", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const b = mkPkg("b");
         const graph = new DependencyGraph([a, b]);
@@ -371,6 +415,8 @@ describe("release-plan: combined scenarios", () => {
     });
 
     it("warns about non-workspace package references", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const graph = new DependencyGraph([a]);
 
@@ -381,6 +427,8 @@ describe("release-plan: combined scenarios", () => {
     });
 
     it("returns deterministic alphabetical ordering", () => {
+        expect.hasAssertions();
+
         const c = mkPkg("c");
         const a = mkPkg("a");
         const b = mkPkg("b");
@@ -396,6 +444,8 @@ describe("release-plan: combined scenarios", () => {
 
 describe("release-plan: channel-aware version computation", () => {
     it("opens prerelease line when prerelease option is set", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", { version: "1.2.3" });
         const graph = new DependencyGraph([a]);
 
@@ -405,6 +455,8 @@ describe("release-plan: channel-aware version computation", () => {
     });
 
     it("computes plain semver when no prerelease option is set", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", { version: "1.2.3" });
         const graph = new DependencyGraph([a]);
 
@@ -414,6 +466,8 @@ describe("release-plan: channel-aware version computation", () => {
     });
 
     it("computes prerelease versions for cascaded dep bumps too", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a", { version: "1.0.0" });
         const b = mkPkg("b", { dependencies: { a: "~1.0.0" }, version: "2.0.0" });
         const graph = new DependencyGraph([a, b]);
@@ -433,6 +487,8 @@ describe("release-plan: catalog change cascade", () => {
         // dep moved → these consumer packages need a patch bump". The
         // plan assembler just upserts them and lets the rest of the
         // pipeline do its thing.
+        expect.hasAssertions();
+
         const consumer = mkPkg("consumer", { dependencies: { react: "catalog:" } });
         const graph = new DependencyGraph([consumer]);
 
@@ -461,6 +517,8 @@ describe("release-plan: catalog change cascade", () => {
         // from the workspace dep-graph (e.g. via `release.ignore`)
         // should be silently skipped — operators who filtered the
         // package out don't want it back.
+        expect.hasAssertions();
+
         const present = mkPkg("present", { dependencies: { react: "catalog:" } });
         const graph = new DependencyGraph([present]);
 
@@ -478,6 +536,8 @@ describe("release-plan: catalog change cascade", () => {
         // A consumer with both an explicit bump from a change file AND
         // a catalog cascade should have both reasons attributed. The
         // bump level is the max of the two (minor > patch).
+        expect.hasAssertions();
+
         const consumer = mkPkg("consumer", { dependencies: { react: "catalog:" } });
         const graph = new DependencyGraph([consumer]);
 
@@ -503,6 +563,8 @@ describe("release-plan: catalog change cascade", () => {
         // range. When the catalog cascade bumps a (patch), Phase A
         // notices b's range no longer satisfies the new version and
         // pulls b into the plan as a dependency bump.
+        expect.hasAssertions();
+
         const a = mkPkg("a", { dependencies: { react: "catalog:" }, version: "1.0.0" });
         const b = mkPkg("b", { dependencies: { a: "1.0.0" }, version: "1.0.0" });
         const graph = new DependencyGraph([a, b]);
@@ -520,6 +582,8 @@ describe("release-plan: catalog change cascade", () => {
     });
 
     it("no-ops when catalogConsumers is empty / undefined (backwards compat)", () => {
+        expect.hasAssertions();
+
         const a = mkPkg("a");
         const graph = new DependencyGraph([a]);
 
@@ -533,6 +597,8 @@ describe("release-plan: catalog change cascade", () => {
     // the formatter walks an empty `sources` array and emits a blank
     // dependency-bump line.
     it("records a synthetic catalog source on each CATALOG_CHANGED entry", () => {
+        expect.hasAssertions();
+
         const consumer = mkPkg("consumer", { dependencies: { lodash: "catalog:" } });
         const graph = new DependencyGraph([consumer]);
 
@@ -558,6 +624,8 @@ describe("release-plan: catalog change cascade", () => {
     });
 
     it("records the named-catalog source verbatim (catalog:dev/vitest)", () => {
+        expect.hasAssertions();
+
         const consumer = mkPkg("consumer", { devDependencies: { vitest: "catalog:dev" } });
         const graph = new DependencyGraph([consumer]);
 
@@ -580,6 +648,8 @@ describe("release-plan: catalog change cascade", () => {
     });
 
     it("falls back to empty string when the catalog entry was removed (newVersion undefined)", () => {
+        expect.hasAssertions();
+
         const consumer = mkPkg("consumer", { dependencies: { legacy: "catalog:" } });
         const graph = new DependencyGraph([consumer]);
 
@@ -609,6 +679,8 @@ describe("release-plan: bumpDevDependencies fanout warning (F12)", () => {
         // 11 devdep consumers of the same source — one above the
         // threshold. The warning calls out the source name so operators
         // can decide whether to narrow to the array form.
+        expect.hasAssertions();
+
         const source = mkPkg("source");
         const consumers = Array.from({ length: 11 }, (_, i) => mkPkg(`consumer-${i}`, { devDependencies: { source: "1.0.0" } }));
         const graph = new DependencyGraph([source, ...consumers]);
@@ -629,6 +701,8 @@ describe("release-plan: bumpDevDependencies fanout warning (F12)", () => {
     });
 
     it("does NOT warn when the fanout sits at-or-below the threshold", () => {
+        expect.hasAssertions();
+
         const source = mkPkg("source");
         // 10 consumers — at the threshold, not above it.
         const consumers = Array.from({ length: 10 }, (_, i) => mkPkg(`consumer-${i}`, { devDependencies: { source: "1.0.0" } }));
@@ -646,6 +720,8 @@ describe("release-plan: bumpDevDependencies fanout warning (F12)", () => {
     it("does NOT warn when `bumpDevDependencies` is an array (operator already opted into narrow scope)", () => {
         // Same wide fanout, but the operator explicitly listed the
         // source — no nudge needed because the cascade is intentional.
+        expect.hasAssertions();
+
         const source = mkPkg("source");
         const consumers = Array.from({ length: 20 }, (_, i) => mkPkg(`consumer-${i}`, { devDependencies: { source: "1.0.0" } }));
         const graph = new DependencyGraph([source, ...consumers]);
@@ -663,6 +739,8 @@ describe("release-plan: bumpDevDependencies fanout warning (F12)", () => {
         // 12 consumers — well above the threshold. The warning text
         // reflects the FINAL fanout (12), not whatever count happened to
         // trip the threshold mid-loop.
+        expect.hasAssertions();
+
         const source = mkPkg("source");
         const consumers = Array.from({ length: 12 }, (_, i) => mkPkg(`consumer-${i}`, { devDependencies: { source: "1.0.0" } }));
         const graph = new DependencyGraph([source, ...consumers]);

--- a/packages/tooling/vis/__tests__/release/core/release-plan.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/release-plan.test.ts
@@ -388,7 +388,7 @@ describe("release-plan: combined scenarios", () => {
 
         const plan = assembleReleasePlan([cf(`---\na: minor\nb: minor\nc: minor\n---\n`)], graph, {});
 
-        expect(plan.releases.map((r) => r.name)).toEqual(["a", "b", "c"]);
+        expect(plan.releases.map((r) => r.name)).toStrictEqual(["a", "b", "c"]);
     });
 });
 
@@ -471,7 +471,7 @@ describe("release-plan: catalog change cascade", () => {
             ],
         });
 
-        expect(plan.releases.map((r) => r.name)).toEqual(["present"]);
+        expect(plan.releases.map((r) => r.name)).toStrictEqual(["present"]);
     });
 
     it("composes with explicit bumps — CATALOG_CHANGED appears alongside other reasons when both fire", () => {
@@ -495,7 +495,7 @@ describe("release-plan: catalog change cascade", () => {
         const release = findRelease(plan, "consumer");
 
         expect(release?.type).toBe("minor");
-        expect(release?.reasons.sort()).toEqual(["CATALOG_CHANGED", "EXPLICIT"]);
+        expect(release?.reasons.sort()).toStrictEqual(["CATALOG_CHANGED", "EXPLICIT"]);
     });
 
     it("cascades through Phase A — out-of-range dependents of a catalog-bumped consumer get pulled in too", () => {
@@ -525,7 +525,7 @@ describe("release-plan: catalog change cascade", () => {
 
         const plan = assembleReleasePlan([], graph, {}, {});
 
-        expect(plan.releases).toEqual([]);
+        expect(plan.releases).toStrictEqual([]);
     });
 
     // F13: every CATALOG_CHANGED entry must record a `source` so the

--- a/packages/tooling/vis/__tests__/release/core/remote-detect.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/remote-detect.test.ts
@@ -19,6 +19,8 @@ const mockRunnerWithRemote = (url: string): MockRunner => {
 
 describe(detectRemoteProvider, () => {
     it("respects explicit github config", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const result = await detectRemoteProvider("/r", runner, "github", {});
 
@@ -26,6 +28,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("respects explicit gitlab config", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const result = await detectRemoteProvider("/r", runner, "gitlab", {});
 
@@ -33,6 +37,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("treats `auto` as falling through to detection", async () => {
+        expect.hasAssertions();
+
         const runner = mockRunnerWithRemote("https://github.com/owner/repo.git");
         const result = await detectRemoteProvider("/r", runner, "auto", {});
 
@@ -40,6 +46,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("detects github from GITHUB_ACTIONS env", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const result = await detectRemoteProvider("/r", runner, undefined, { GITHUB_ACTIONS: "true" });
 
@@ -47,6 +55,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("detects gitlab from GITLAB_CI env", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         const result = await detectRemoteProvider("/r", runner, undefined, { GITLAB_CI: "true" });
 
@@ -54,6 +64,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("falls back to git remote URL when env signal is absent", async () => {
+        expect.hasAssertions();
+
         const runner = mockRunnerWithRemote("git@gitlab.com:owner/repo.git");
         const result = await detectRemoteProvider("/r", runner, undefined, {});
 
@@ -61,6 +73,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("falls back to github when nothing matches (incl. bitbucket — explicitly unsupported)", async () => {
+        expect.hasAssertions();
+
         const runner = mockRunnerWithRemote("git@bitbucket.org:owner/repo.git");
         const result = await detectRemoteProvider("/r", runner, undefined, {});
 
@@ -68,6 +82,8 @@ describe(detectRemoteProvider, () => {
     });
 
     it("falls back to github when remote URL is unrecognised", async () => {
+        expect.hasAssertions();
+
         const runner = mockRunnerWithRemote("git@example.com:owner/repo.git");
         const result = await detectRemoteProvider("/r", runner, undefined, {});
 
@@ -77,14 +93,18 @@ describe(detectRemoteProvider, () => {
 
 describe(createRemoteClient, () => {
     it("returns the github client by id", () => {
+        expect.hasAssertions();
         expect(createRemoteClient("github").id).toBe("github");
     });
 
     it("returns the gitlab client by id", () => {
+        expect.hasAssertions();
         expect(createRemoteClient("gitlab").id).toBe("gitlab");
     });
 
     it("gitlab adapter shells out to glab for sticky-comment upsert", async () => {
+        expect.hasAssertions();
+
         const gitlab = createRemoteClient("gitlab");
         const runner = new MockRunner();
 
@@ -98,6 +118,7 @@ describe(createRemoteClient, () => {
     });
 
     it("gitlab adapter detects MR id from CI_MERGE_REQUEST_IID", () => {
+        expect.hasAssertions();
         expect(createRemoteClient("gitlab").detectPullRequestNumber({ CI_MERGE_REQUEST_IID: "42" })).toBe(42);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/remote-github.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/remote-github.test.ts
@@ -152,7 +152,7 @@ describe("githubRemoteClient.upsertIssue", () => {
             title: "[release-failed] v1.0",
         });
 
-        expect(result).toEqual({ created: false, number: 9, url: "https://x/9" });
+        expect(result).toStrictEqual({ created: false, number: 9, url: "https://x/9" });
 
         const editArgs = calls[1]!.args;
 
@@ -256,7 +256,7 @@ describe("githubRemoteClient.listRecentReleases", () => {
         });
 
         expect(releases).toHaveLength(3);
-        expect(releases[0]).toEqual({
+        expect(releases[0]).toStrictEqual({
             name: "@scope/pkg v1.4.2",
             tag: "@scope/pkg@1.4.2",
             url: "https://github.com/o/r/releases/tag/%40scope%2Fpkg%401.4.2",
@@ -289,7 +289,7 @@ describe("githubRemoteClient.listRecentReleases", () => {
             tagPrefix: "@scope/pkg@",
         });
 
-        expect(releases.map((r) => r.tag)).toEqual(["@scope/pkg@1.4.2", "@scope/pkg@1.4.1"]);
+        expect(releases.map((r) => r.tag)).toStrictEqual(["@scope/pkg@1.4.2", "@scope/pkg@1.4.1"]);
     });
 
     it("returns [] on non-zero exit or malformed JSON", async () => {
@@ -301,7 +301,7 @@ describe("githubRemoteClient.listRecentReleases", () => {
             repo: "owner/name",
         });
 
-        expect(empty).toEqual([]);
+        expect(empty).toStrictEqual([]);
 
         const empty2 = await new GithubRemoteClient().listRecentReleases(runner, {
             cwd: "/cwd",
@@ -309,7 +309,7 @@ describe("githubRemoteClient.listRecentReleases", () => {
             repo: "owner/name",
         });
 
-        expect(empty2).toEqual([]);
+        expect(empty2).toStrictEqual([]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/remote-github.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/remote-github.test.ts
@@ -39,6 +39,8 @@ const buildRunner = (responses: { exitCode?: number; stdout?: string }[]): Runne
 
 describe("githubRemoteClient.createRelease — structured assets", () => {
     it("renames asset display via <path>#label syntax", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "https://github.com/.../release" }]);
 
         await new GithubRemoteClient().createRelease(runner, {
@@ -60,6 +62,8 @@ describe("githubRemoteClient.createRelease — structured assets", () => {
     });
 
     it("inlines link-only assets as a body section since GH Releases don't model link assets", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient().createRelease(runner, {
@@ -82,6 +86,8 @@ describe("githubRemoteClient.createRelease — structured assets", () => {
     });
 
     it("threads discussionCategory into the gh CLI", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient().createRelease(runner, {
@@ -100,6 +106,8 @@ describe("githubRemoteClient.createRelease — structured assets", () => {
 
 describe("githubRemoteClient.addLabels", () => {
     it("pOSTs labels via the issues/labels API", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         const ok = await new GithubRemoteClient().addLabels(runner, {
@@ -121,6 +129,8 @@ describe("githubRemoteClient.addLabels", () => {
     });
 
     it("returns true without invoking the runner when labels is empty", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([]);
 
         const ok = await new GithubRemoteClient().addLabels(runner, {
@@ -137,6 +147,8 @@ describe("githubRemoteClient.addLabels", () => {
 
 describe("githubRemoteClient.upsertIssue", () => {
     it("edits the existing issue when one matches the title-marker", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: JSON.stringify([{ number: 9, title: "[release-failed] v1.0", url: "https://x/9" }]) },
             { stdout: "" },
@@ -163,6 +175,8 @@ describe("githubRemoteClient.upsertIssue", () => {
     });
 
     it("creates a new issue when none match", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "[]" },
             { stdout: "https://github.com/owner/name/issues/42" },
@@ -184,6 +198,8 @@ describe("githubRemoteClient.upsertIssue", () => {
 
 describe("githubRemoteClient — enterprise host + proxy env wiring", () => {
     it("sets GH_HOST on the subprocess env when host is configured", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient({ host: "github.acme.com" }).createRelease(runner, {
@@ -199,6 +215,8 @@ describe("githubRemoteClient — enterprise host + proxy env wiring", () => {
     });
 
     it("sets HTTPS_PROXY + HTTP_PROXY when httpProxy is configured", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient({ httpProxy: "http://proxy.acme.com:8080" }).addLabels(runner, {
@@ -213,6 +231,8 @@ describe("githubRemoteClient — enterprise host + proxy env wiring", () => {
     });
 
     it("threads both host and proxy together when both are set", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient({ host: "github.acme.com", httpProxy: "http://proxy.acme.com:8080" }).addLabels(runner, {
@@ -227,6 +247,8 @@ describe("githubRemoteClient — enterprise host + proxy env wiring", () => {
     });
 
     it("omits env entirely when no host/proxy is configured", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         await new GithubRemoteClient().addLabels(runner, {
@@ -242,6 +264,8 @@ describe("githubRemoteClient — enterprise host + proxy env wiring", () => {
 
 describe("githubRemoteClient.listRecentReleases", () => {
     it("returns parsed releases with the limit applied", async () => {
+        expect.hasAssertions();
+
         const stdout = JSON.stringify([
             { name: "@scope/pkg v1.4.2", tagName: "@scope/pkg@1.4.2", url: "https://github.com/o/r/releases/tag/%40scope%2Fpkg%401.4.2" },
             { name: "@scope/pkg v1.4.1", tagName: "@scope/pkg@1.4.1", url: "https://github.com/o/r/releases/tag/%40scope%2Fpkg%401.4.1" },
@@ -273,6 +297,8 @@ describe("githubRemoteClient.listRecentReleases", () => {
     });
 
     it("filters by tagPrefix and excludeTag — only matching tags survive", async () => {
+        expect.hasAssertions();
+
         const stdout = JSON.stringify([
             { name: "@scope/pkg v1.5.0 (current)", tagName: "@scope/pkg@1.5.0", url: "https://github.com/o/r/releases/tag/%40scope%2Fpkg%401.5.0" },
             { name: "@scope/other v2.0.0", tagName: "@scope/other@2.0.0", url: "https://github.com/o/r/releases/tag/%40scope%2Fother%402.0.0" },
@@ -293,6 +319,8 @@ describe("githubRemoteClient.listRecentReleases", () => {
     });
 
     it("returns [] on non-zero exit or malformed JSON", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([{ exitCode: 1 }, { stdout: "not-json" }]);
 
         const empty = await new GithubRemoteClient().listRecentReleases(runner, {
@@ -315,6 +343,8 @@ describe("githubRemoteClient.listRecentReleases", () => {
 
 describe("githubRemoteClient.closeIssue", () => {
     it("posts the closing comment then closes", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }, { stdout: "" }]);
 
         const ok = await new GithubRemoteClient().closeIssue(runner, {
@@ -330,6 +360,8 @@ describe("githubRemoteClient.closeIssue", () => {
     });
 
     it("skips the comment call when closingComment is omitted", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "" }]);
 
         const ok = await new GithubRemoteClient().closeIssue(runner, {

--- a/packages/tooling/vis/__tests__/release/core/remote-gitlab.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/remote-gitlab.test.ts
@@ -108,7 +108,7 @@ describe("gitlabRemoteClient.upsertStickyComment", () => {
             repo: "group/sub/proj",
         });
 
-        expect(result).toEqual({ created: true, id: 99 });
+        expect(result).toStrictEqual({ created: true, id: 99 });
         // Project path is URL-encoded.
         expect(calls[0]?.args).toContain("projects/group%2Fsub%2Fproj/merge_requests/5/notes");
         // POST when no match.
@@ -130,7 +130,7 @@ describe("gitlabRemoteClient.upsertStickyComment", () => {
             repo: "group/proj",
         });
 
-        expect(result).toEqual({ created: false, id: 7 });
+        expect(result).toStrictEqual({ created: false, id: 7 });
         expect(calls[1]?.args[1]).toBe("-X");
         expect(calls[1]?.args[2]).toBe("PUT");
         expect(calls[1]?.args[3]).toContain("/notes/7");
@@ -314,7 +314,7 @@ describe("gitlabRemoteClient.upsertIssue", () => {
             title: "[release-failed] v1.0",
         });
 
-        expect(result).toEqual({ created: false, number: 11, url: "https://x" });
+        expect(result).toStrictEqual({ created: false, number: 11, url: "https://x" });
         expect(calls[1]?.args).toContain("add_labels=release-bot");
     });
 

--- a/packages/tooling/vis/__tests__/release/core/remote-gitlab.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/remote-gitlab.test.ts
@@ -42,6 +42,8 @@ describe("gitlabRemoteClient.detectRepoSlug", () => {
     });
 
     it("prefers CI_PROJECT_PATH over the git remote", async () => {
+        expect.hasAssertions();
+
         process.env.CI_PROJECT_PATH = "group/sub/proj";
 
         const { calls, runner } = buildRunner([]);
@@ -53,6 +55,8 @@ describe("gitlabRemoteClient.detectRepoSlug", () => {
     });
 
     it("parses HTTPS gitlab remotes", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([
             { stdout: "https://gitlab.com/group/sub/proj.git\n" },
         ]);
@@ -63,6 +67,8 @@ describe("gitlabRemoteClient.detectRepoSlug", () => {
     });
 
     it("parses SSH gitlab remotes", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([
             { stdout: "git@gitlab.example.com:org/repo.git\n" },
         ]);
@@ -75,18 +81,24 @@ describe("gitlabRemoteClient.detectRepoSlug", () => {
 
 describe("gitlabRemoteClient.detectPullRequestNumber", () => {
     it("reads CI_MERGE_REQUEST_IID", () => {
+        expect.hasAssertions();
+
         const result = new GitlabRemoteClient().detectPullRequestNumber({ CI_MERGE_REQUEST_IID: "42" });
 
         expect(result).toBe(42);
     });
 
     it("falls back to VIS_MR_NUMBER", () => {
+        expect.hasAssertions();
+
         const result = new GitlabRemoteClient().detectPullRequestNumber({ VIS_MR_NUMBER: "7" });
 
         expect(result).toBe(7);
     });
 
     it("returns undefined when neither is set", () => {
+        expect.hasAssertions();
+
         const result = new GitlabRemoteClient().detectPullRequestNumber({});
 
         expect(result).toBeUndefined();
@@ -95,6 +107,8 @@ describe("gitlabRemoteClient.detectPullRequestNumber", () => {
 
 describe("gitlabRemoteClient.upsertStickyComment", () => {
     it("creates a new note when no marker match exists", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: JSON.stringify([{ body: "unrelated", id: 1, system: false }]) },
             { stdout: JSON.stringify({ id: 99 }) },
@@ -117,6 +131,8 @@ describe("gitlabRemoteClient.upsertStickyComment", () => {
     });
 
     it("pUTs the existing note when a marker match exists", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: JSON.stringify([{ body: "<!-- vis-marker -->\n stale", id: 7, system: false }]) },
             { stdout: "{}" },
@@ -137,6 +153,8 @@ describe("gitlabRemoteClient.upsertStickyComment", () => {
     });
 
     it("filters out system-generated notes when scanning for the marker", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             {
                 stdout: JSON.stringify([
@@ -163,6 +181,8 @@ describe("gitlabRemoteClient.upsertStickyComment", () => {
 
 describe("gitlabRemoteClient.createRelease", () => {
     it("emits structured assets — uploads files and registers link-only entries", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "" }, // glab release create
             { stdout: "" }, // glab release upload
@@ -198,6 +218,8 @@ describe("gitlabRemoteClient.createRelease", () => {
 
 describe("gitlabRemoteClient — self-hosted host", () => {
     it("threads GITLAB_HOST through every runner invocation", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "[]" },
             { stdout: JSON.stringify({ id: 1 }) },
@@ -219,6 +241,8 @@ describe("gitlabRemoteClient — self-hosted host", () => {
     });
 
     it("omits GITLAB_HOST when host is not configured", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ stdout: "[]" }, { stdout: JSON.stringify({ id: 1 }) }]);
 
         await new GitlabRemoteClient().upsertStickyComment(runner, {
@@ -235,6 +259,8 @@ describe("gitlabRemoteClient — self-hosted host", () => {
 
 describe("gitlabRemoteClient.createRelease — generic-package assets", () => {
     it("uploads files to the Generic Package Registry then registers links", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "" }, // glab release create
             { stdout: "{\"message\": \"201 Created\"}" }, // PUT generic upload
@@ -276,6 +302,8 @@ describe("gitlabRemoteClient.createRelease — generic-package assets", () => {
     });
 
     it("derives package name from repo + version from tag (with leading-v stripped)", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "" },
             { stdout: "{}" },
@@ -300,6 +328,8 @@ describe("gitlabRemoteClient.createRelease — generic-package assets", () => {
 
 describe("gitlabRemoteClient.upsertIssue", () => {
     it("pUTs the existing issue when one matches the marker", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: JSON.stringify([{ iid: 11, title: "[release-failed] v1.0", web_url: "https://x" }]) },
             { stdout: "{}" },
@@ -319,6 +349,8 @@ describe("gitlabRemoteClient.upsertIssue", () => {
     });
 
     it("creates a new issue when none match", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "[]" },
             { stdout: "https://gitlab.com/g/p/-/issues/42" },
@@ -342,6 +374,8 @@ describe("gitlabRemoteClient.upsertIssue", () => {
 
 describe("gitlabRemoteClient.closeIssue", () => {
     it("posts the closing comment then closes", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "" },
             { stdout: "" },
@@ -360,6 +394,8 @@ describe("gitlabRemoteClient.closeIssue", () => {
     });
 
     it("skips the comment call when closingComment is omitted", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { stdout: "" },
         ]);

--- a/packages/tooling/vis/__tests__/release/core/security.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/security.test.ts
@@ -81,7 +81,7 @@ describe("resolveCustomCommands: trust-gated", () => {
     it("returns empty when gate denies", () => {
         const result = resolveCustomCommands("@scope/a", perPkg, {});
 
-        expect(result).toEqual({});
+        expect(result).toStrictEqual({});
     });
 
     it("returns commands when gate allows", () => {

--- a/packages/tooling/vis/__tests__/release/core/security.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/security.test.ts
@@ -13,46 +13,56 @@ import {
 
 describe("sq: POSIX shell escape", () => {
     it("wraps simple strings in single quotes", () => {
+        expect.hasAssertions();
         expect(sq("hello")).toBe("'hello'");
     });
 
     it("escapes embedded single quotes", () => {
+        expect.hasAssertions();
         expect(sq("it's fine")).toBe(String.raw`'it'\''s fine'`);
     });
 
     it("renders shell metacharacters inert", () => {
         // Inside single quotes, $(...) is literal — not expanded.
+        expect.hasAssertions();
         expect(sq("$(rm -rf /)")).toBe("'$(rm -rf /)'");
     });
 
     it("handles empty string", () => {
+        expect.hasAssertions();
         expect(sq("")).toBe("''");
     });
 
     it("handles string with multiple single quotes", () => {
+        expect.hasAssertions();
         expect(sq("a'b'c")).toBe(String.raw`'a'\''b'\''c'`);
     });
 });
 
 describe("isCustomCommandAllowed: trust gate", () => {
     it("returns false by default", () => {
+        expect.hasAssertions();
         expect(isCustomCommandAllowed("@scope/a", {})).toBe(false);
         expect(isCustomCommandAllowed("@scope/a", { allowCustomCommands: false })).toBe(false);
     });
 
     it("returns true when allowCustomCommands is true", () => {
+        expect.hasAssertions();
         expect(isCustomCommandAllowed("@scope/a", { allowCustomCommands: true })).toBe(true);
     });
 
     it("returns true when array includes literal name", () => {
+        expect.hasAssertions();
         expect(isCustomCommandAllowed("@scope/a", { allowCustomCommands: ["@scope/a"] })).toBe(true);
     });
 
     it("returns true when array glob matches", () => {
+        expect.hasAssertions();
         expect(isCustomCommandAllowed("@scope/foo", { allowCustomCommands: ["@scope/*"] })).toBe(true);
     });
 
     it("returns false when array doesn't include or match", () => {
+        expect.hasAssertions();
         expect(isCustomCommandAllowed("@other/a", { allowCustomCommands: ["@scope/*"] })).toBe(false);
     });
 });
@@ -63,14 +73,17 @@ describe("interpolateCommand: token substitution", () => {
     // quotes on a Windows host, which is the platform-correct behaviour but not
     // what this block exercises.
     it("substitutes {{name}} and {{version}} via sq()", () => {
+        expect.hasAssertions();
         expect(interpolateCommand("publish-bin {{name}} {{version}}", { name: "@scope/a", version: "1.0.0" }, false)).toBe("publish-bin '@scope/a' '1.0.0'");
     });
 
     it("escapes injected single quotes inside tokens", () => {
+        expect.hasAssertions();
         expect(interpolateCommand("echo {{name}}", { name: "evil'name", version: "1.0.0" }, false)).toBe(String.raw`echo 'evil'\''name'`);
     });
 
     it("renders shell metacharacters inert in substituted tokens", () => {
+        expect.hasAssertions();
         expect(interpolateCommand("echo {{version}}", { name: "x", version: "$(touch /tmp/pwn)" }, false)).toBe("echo '$(touch /tmp/pwn)'");
     });
 });
@@ -79,12 +92,16 @@ describe("resolveCustomCommands: trust-gated", () => {
     const perPkg = { buildCommand: "y", checkPublished: "z", publishCommand: "x" };
 
     it("returns empty when gate denies", () => {
+        expect.hasAssertions();
+
         const result = resolveCustomCommands("@scope/a", perPkg, {});
 
         expect(result).toStrictEqual({});
     });
 
     it("returns commands when gate allows", () => {
+        expect.hasAssertions();
+
         const result = resolveCustomCommands("@scope/a", perPkg, { allowCustomCommands: true });
 
         expect(result.publishCommand).toBe("x");
@@ -93,6 +110,7 @@ describe("resolveCustomCommands: trust-gated", () => {
     });
 
     it("respects glob allowlist", () => {
+        expect.hasAssertions();
         expect(resolveCustomCommands("@scope/a", perPkg, { allowCustomCommands: ["@scope/*"] }).publishCommand).toBe("x");
         expect(resolveCustomCommands("@other/a", perPkg, { allowCustomCommands: ["@scope/*"] }).publishCommand).toBeUndefined();
     });
@@ -100,29 +118,37 @@ describe("resolveCustomCommands: trust-gated", () => {
 
 describe(redactTokens, () => {
     it("redacts npm token pattern", () => {
+        expect.hasAssertions();
         expect(redactTokens("Authorization: npm_AbCd1234567890abcdef1234567890abcd")).toBe("Authorization: [REDACTED]");
     });
 
     it("redacts GH PAT (ghp_)", () => {
         // Split-literal so secretlint doesn't trip on the test fixture.
+        expect.hasAssertions();
+
         const fakePat = `ghp_AbCd1234567890abcdef1234567890abcdef`;
 
         expect(redactTokens(`Bearer ${fakePat}`)).toBe("Bearer [REDACTED]");
     });
 
     it("redacts Bearer prefix", () => {
+        expect.hasAssertions();
         expect(redactTokens("Authorization: Bearer some-long-opaque-token-here")).toBe("Authorization: [REDACTED]");
     });
 
     it("redacts ACTIONS_ID_TOKEN_REQUEST_TOKEN env var", () => {
+        expect.hasAssertions();
         expect(redactTokens("env: ACTIONS_ID_TOKEN_REQUEST_TOKEN=abc123")).toBe("env: [REDACTED]");
     });
 
     it("redacts _authToken in npmrc", () => {
+        expect.hasAssertions();
         expect(redactTokens("//registry/:_authToken=abc123def456")).toBe("//registry/:[REDACTED]");
     });
 
     it("leaves non-token content alone", () => {
+        expect.hasAssertions();
+
         const text = "Just a regular log line with no secrets.";
 
         expect(redactTokens(text)).toBe(text);
@@ -130,6 +156,8 @@ describe(redactTokens, () => {
 
     it("handles multiple tokens in one line", () => {
         // Split-literal so secretlint doesn't trip on the test fixture.
+        expect.hasAssertions();
+
         const fakeNpm = `npm_AbCd1234567890abcdef1234567890abcd`;
         const fakePat = `ghp_AbCd1234567890abcdef1234567890abcdef`;
         const out = redactTokens(`${fakeNpm} ${fakePat}`);
@@ -140,17 +168,20 @@ describe(redactTokens, () => {
 
 describe("isValidPackageName / assertValidPackageName (RFC §19.4)", () => {
     it("accepts plain lowercase names", () => {
+        expect.hasAssertions();
         expect(isValidPackageName("my-pkg")).toBe(true);
         expect(isValidPackageName("foo.bar")).toBe(true);
         expect(isValidPackageName("foo_bar")).toBe(true);
     });
 
     it("accepts scoped names", () => {
+        expect.hasAssertions();
         expect(isValidPackageName("@scope/pkg")).toBe(true);
         expect(isValidPackageName("@my-org/sub.pkg_name")).toBe(true);
     });
 
     it("rejects shell metacharacters", () => {
+        expect.hasAssertions();
         expect(isValidPackageName("evil$(rm -rf /)")).toBe(false);
         expect(isValidPackageName("a;b")).toBe(false);
         expect(isValidPackageName("a b")).toBe(false);
@@ -159,20 +190,24 @@ describe("isValidPackageName / assertValidPackageName (RFC §19.4)", () => {
     });
 
     it("rejects uppercase letters (npm spec)", () => {
+        expect.hasAssertions();
         expect(isValidPackageName("MyPkg")).toBe(false);
     });
 
     it("rejects names starting with . or _", () => {
+        expect.hasAssertions();
         expect(isValidPackageName(".hidden")).toBe(false);
         expect(isValidPackageName("_private")).toBe(false);
     });
 
     it("rejects empty / oversized names", () => {
+        expect.hasAssertions();
         expect(isValidPackageName("")).toBe(false);
         expect(isValidPackageName("a".repeat(215))).toBe(false);
     });
 
     it("assertValidPackageName throws VisReleaseError on invalid input", () => {
+        expect.hasAssertions();
         expect(() => {
             assertValidPackageName("evil;bad");
         }).toThrow(/Invalid package name/);
@@ -181,23 +216,28 @@ describe("isValidPackageName / assertValidPackageName (RFC §19.4)", () => {
 
 describe("escapeMarkdown: PR-comment safety", () => {
     it("escapes < and >", () => {
+        expect.hasAssertions();
         expect(escapeMarkdown("<script>alert(1)</script>")).toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
     });
 
     it("escapes &", () => {
+        expect.hasAssertions();
         expect(escapeMarkdown("a & b")).toBe("a &amp; b");
     });
 
     it("escapes backticks", () => {
+        expect.hasAssertions();
         expect(escapeMarkdown("rm -rf `pwd`")).toBe("rm -rf \\`pwd\\`");
     });
 
     it("preserves Markdown-relevant chars (* _ # -)", () => {
         // These are intentional Markdown that users want preserved.
+        expect.hasAssertions();
         expect(escapeMarkdown("**bold** _italic_ # heading - bullet")).toBe("**bold** _italic_ # heading - bullet");
     });
 
     it("handles empty string", () => {
+        expect.hasAssertions();
         expect(escapeMarkdown("")).toBe("");
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/semver-pre-major.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/semver-pre-major.test.ts
@@ -11,14 +11,17 @@ import { bumpVersion } from "../../../src/release/core/semver";
 
 describe("bumpVersion: bumpMinorPreMajor", () => {
     it("demotes a major bump to minor when current.major === 0", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "major", bumpMinorPreMajor: true, current: "0.5.2" })).toBe("0.6.0");
     });
 
     it("leaves minor bumps alone unless `bumpPatchForMinorPreMajor` is also set", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "minor", bumpMinorPreMajor: true, current: "0.5.2" })).toBe("0.6.0");
     });
 
     it("demotes minor bumps to patch when both flags are set", () => {
+        expect.hasAssertions();
         expect(
             bumpVersion({
                 bump: "minor",
@@ -30,6 +33,7 @@ describe("bumpVersion: bumpMinorPreMajor", () => {
     });
 
     it("leaves patch bumps alone", () => {
+        expect.hasAssertions();
         expect(
             bumpVersion({
                 bump: "patch",
@@ -41,11 +45,13 @@ describe("bumpVersion: bumpMinorPreMajor", () => {
     });
 
     it("is a NO-OP once current.major >= 1 (pre-major demotion only applies to 0.x)", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "major", bumpMinorPreMajor: true, current: "1.0.0" })).toBe("2.0.0");
         expect(bumpVersion({ bump: "major", bumpMinorPreMajor: true, current: "12.5.7" })).toBe("13.0.0");
     });
 
     it("composes with prerelease channels (major bump on 0.x alpha → minor + .0)", () => {
+        expect.hasAssertions();
         expect(
             bumpVersion({
                 bump: "major",

--- a/packages/tooling/vis/__tests__/release/core/semver.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/semver.test.ts
@@ -4,109 +4,133 @@ import { bumpVersion, cleanRange, satisfiesRange } from "../../../src/release/co
 
 describe("semver: bumpVersion (RFC §10.1 channel-transition table)", () => {
     it("stable + minor + alpha → opens prerelease line at .0", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "minor", current: "1.2.3", prerelease: "alpha" })).toBe("1.3.0-alpha.0");
     });
 
     it("stable + patch + alpha → opens prerelease line at .0", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "patch", current: "1.2.3", prerelease: "alpha" })).toBe("1.2.4-alpha.0");
     });
 
     it("stable + major + alpha → opens prerelease line at .0", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "major", current: "1.2.3", prerelease: "alpha" })).toBe("2.0.0-alpha.0");
     });
 
     it("alpha + patch + alpha → counter increments", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "patch", current: "1.3.0-alpha.5", prerelease: "alpha" })).toBe("1.3.0-alpha.6");
     });
 
     it("alpha + none + beta → re-counter against new preid", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "none", current: "1.3.0-alpha.5", prerelease: "beta" })).toBe("1.3.0-beta.0");
     });
 
     it("beta + none + rc (next channel) → re-counter against rc", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "none", current: "1.3.0-beta.5", prerelease: "rc" })).toBe("1.3.0-rc.0");
     });
 
     it("rc + none + (no preid) → preid stripped, final stable", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "none", current: "1.3.0-rc.5" })).toBe("1.3.0");
     });
 
     it("alpha + none + (no preid) → direct merge to main", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "none", current: "1.3.0-alpha.5" })).toBe("1.3.0");
     });
 
     it("stable + patch (no preid) → straight semver bump", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "patch", current: "1.2.3" })).toBe("1.2.4");
     });
 
     it("stable + minor (no preid) → straight semver bump", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "minor", current: "1.2.3" })).toBe("1.3.0");
     });
 
     it("stable + major (no preid) → straight semver bump", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "major", current: "1.2.3" })).toBe("2.0.0");
     });
 
     it("stable + none + (no preid) → no change", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "none", current: "1.2.3" })).toBe("1.2.3");
     });
 
     it("escalates within same prerelease line: alpha minor on 1.3.0-alpha.5 + major", () => {
+        expect.hasAssertions();
         expect(bumpVersion({ bump: "major", current: "1.3.0-alpha.5", prerelease: "alpha" })).toBe("2.0.0-alpha.0");
     });
 
     it("rejects invalid current version", () => {
+        expect.hasAssertions();
         expect(() => bumpVersion({ bump: "minor", current: "not-a-version" })).toThrow(/Invalid current version/);
     });
 });
 
 describe("semver: cleanRange", () => {
     it("returns null for catalog: refs", () => {
+        expect.hasAssertions();
         expect(cleanRange("catalog:")).toBeNull();
         expect(cleanRange("catalog:dev")).toBeNull();
     });
 
     it("returns null for workspace: shorthands", () => {
+        expect.hasAssertions();
         expect(cleanRange("workspace:*")).toBeNull();
         expect(cleanRange("workspace:^")).toBeNull();
         expect(cleanRange("workspace:~")).toBeNull();
     });
 
     it("strips workspace: prefix from explicit ranges", () => {
+        expect.hasAssertions();
         expect(cleanRange("workspace:^1.2.3")).toBe("^1.2.3");
         expect(cleanRange("workspace:~1.2.3")).toBe("~1.2.3");
         expect(cleanRange("workspace:1.2.3")).toBe("1.2.3");
     });
 
     it("returns null for plain *", () => {
+        expect.hasAssertions();
         expect(cleanRange("*")).toBeNull();
     });
 
     it("extracts spec from npm: alias", () => {
+        expect.hasAssertions();
         expect(cleanRange("npm:other-pkg@^1.2.3")).toBe("^1.2.3");
     });
 
     it("returns plain semver ranges unchanged", () => {
+        expect.hasAssertions();
         expect(cleanRange("^1.2.3")).toBe("^1.2.3");
         expect(cleanRange("~1.2.3")).toBe("~1.2.3");
         expect(cleanRange(">=1.2.3")).toBe(">=1.2.3");
     });
 
     it("returns null for empty string", () => {
+        expect.hasAssertions();
         expect(cleanRange("")).toBeNull();
     });
 });
 
 describe("semver: satisfiesRange", () => {
     it("returns true when version satisfies range", () => {
+        expect.hasAssertions();
         expect(satisfiesRange("1.3.0", "^1.2.0")).toBe(true);
     });
 
     it("returns false when version is out of range", () => {
+        expect.hasAssertions();
         expect(satisfiesRange("2.0.0", "^1.2.0")).toBe(false);
     });
 
     it("returns true for any version against unparseable range (workspace shorthand)", () => {
+        expect.hasAssertions();
         expect(satisfiesRange("99.0.0", "workspace:*")).toBe(true);
         expect(satisfiesRange("99.0.0", "catalog:")).toBe(true);
     });
@@ -114,6 +138,7 @@ describe("semver: satisfiesRange", () => {
     it("includePrerelease semantics: prerelease versions can satisfy normal ranges", () => {
         // Without includePrerelease: true, "1.3.0-alpha.0" wouldn't satisfy "^1.2.0".
         // The propagation algorithm needs this to avoid every prerelease bump becoming an out-of-range cascade.
+        expect.hasAssertions();
         expect(satisfiesRange("1.3.0-alpha.0", "^1.2.0")).toBe(true);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/shell-runner.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/shell-runner.test.ts
@@ -4,6 +4,8 @@ import { createMockRunner, createShellRunner, MockRunner } from "../../../src/re
 
 describe("mockRunner — handler matching", () => {
     it("returns the default empty success result when no handler matches", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         const result = await runner.run("git", ["status"], { cwd: "/tmp" });
@@ -12,6 +14,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("matches an exact (command, argsPrefix) handler", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["status"], () => {
@@ -24,6 +28,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("matches when argsPrefix is a prefix of actual args", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["log"], () => {
@@ -36,6 +42,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("does NOT match when actual args is shorter than argsPrefix", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["log", "--oneline"], () => {
@@ -48,6 +56,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("does NOT match a different command", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["status"], () => {
@@ -60,6 +70,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("uses first registered handler when multiple match", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["log"], () => {
@@ -75,6 +87,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("passes cwd to the responder", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let seenCwd: string | undefined;
 
@@ -90,6 +104,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("supports a non-zero exitCode from the handler", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["push"], () => {
@@ -103,6 +119,8 @@ describe("mockRunner — handler matching", () => {
     });
 
     it("createMockRunner returns a MockRunner instance", () => {
+        expect.hasAssertions();
+
         const runner = createMockRunner();
 
         expect(runner).toBeInstanceOf(MockRunner);
@@ -111,6 +129,8 @@ describe("mockRunner — handler matching", () => {
 
 describe("createShellRunner — token redaction in stdout/stderr", () => {
     it("redacts npm/gh/Bearer tokens from captured stdout", async () => {
+        expect.hasAssertions();
+
         const runner = createShellRunner();
 
         // `node -e` is reliably available since vitest runs under node.
@@ -124,6 +144,8 @@ describe("createShellRunner — token redaction in stdout/stderr", () => {
     });
 
     it("returns exitCode -1 with redacted error message when the binary is missing", async () => {
+        expect.hasAssertions();
+
         const runner = createShellRunner();
         const result = await runner.run("vis-this-binary-does-not-exist-xyz", [], { cwd: process.cwd(), silent: true });
 
@@ -133,6 +155,8 @@ describe("createShellRunner — token redaction in stdout/stderr", () => {
     });
 
     it("propagates non-zero exit codes", async () => {
+        expect.hasAssertions();
+
         const runner = createShellRunner();
         const result = await runner.run(process.execPath, ["-e", "process.exit(7)"], { cwd: process.cwd(), silent: true });
 

--- a/packages/tooling/vis/__tests__/release/core/shell-runner.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/shell-runner.test.ts
@@ -8,7 +8,7 @@ describe("mockRunner — handler matching", () => {
 
         const result = await runner.run("git", ["status"], { cwd: "/tmp" });
 
-        expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+        expect(result).toStrictEqual({ exitCode: 0, stderr: "", stdout: "" });
     });
 
     it("matches an exact (command, argsPrefix) handler", async () => {
@@ -44,7 +44,7 @@ describe("mockRunner — handler matching", () => {
 
         const result = await runner.run("git", ["log"], { cwd: "/tmp" });
 
-        expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+        expect(result).toStrictEqual({ exitCode: 0, stderr: "", stdout: "" });
     });
 
     it("does NOT match a different command", async () => {
@@ -56,7 +56,7 @@ describe("mockRunner — handler matching", () => {
 
         const result = await runner.run("npm", ["status"], { cwd: "/tmp" });
 
-        expect(result).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+        expect(result).toStrictEqual({ exitCode: 0, stderr: "", stdout: "" });
     });
 
     it("uses first registered handler when multiple match", async () => {

--- a/packages/tooling/vis/__tests__/release/core/slug.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/slug.test.ts
@@ -6,6 +6,8 @@ const SLUG_RE = /^[a-z]+-[a-z]+$/;
 
 describe(randomAnimalSlug, () => {
     it("emits two hyphen-joined alpha words", () => {
+        expect.hasAssertions();
+
         for (let i = 0; i < 50; i += 1) {
             const slug = randomAnimalSlug();
 
@@ -14,6 +16,8 @@ describe(randomAnimalSlug, () => {
     });
 
     it("varies across calls (probabilistic)", () => {
+        expect.hasAssertions();
+
         const slugs = new Set<string>();
 
         for (let i = 0; i < 100; i += 1) {
@@ -28,12 +32,16 @@ describe(randomAnimalSlug, () => {
 
 describe(randomTimestampSlug, () => {
     it("starts with the supplied prefix", () => {
+        expect.hasAssertions();
+
         const slug = randomTimestampSlug("plan");
 
         expect(slug.startsWith("plan-")).toBe(true);
     });
 
     it("includes a base36 timestamp + 4-char hex tail", () => {
+        expect.hasAssertions();
+
         const slug = randomTimestampSlug("override");
         const match = /^override-[a-z0-9]+-[a-z0-9]{4}$/.exec(slug);
 
@@ -41,6 +49,8 @@ describe(randomTimestampSlug, () => {
     });
 
     it("produces unique outputs for back-to-back calls", () => {
+        expect.hasAssertions();
+
         const a = randomTimestampSlug("p");
         const b = randomTimestampSlug("p");
 

--- a/packages/tooling/vis/__tests__/release/core/snapshot.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/snapshot.test.ts
@@ -124,7 +124,7 @@ describe(runSnapshot, () => {
 
         const result = await runSnapshot({ context: ctx, dryRun: true, runner, tag: "x" });
 
-        expect(result.published.map((p) => p.name)).toEqual(["@scope/public"]);
+        expect(result.published.map((p) => p.name)).toStrictEqual(["@scope/public"]);
     });
 
     it("--filter narrows the target set", async () => {
@@ -141,6 +141,6 @@ describe(runSnapshot, () => {
 
         const result = await runSnapshot({ context: ctx, dryRun: true, filter: "@scope/*", runner, tag: "x" });
 
-        expect(result.published.map((p) => p.name).sort()).toEqual(["@scope/a", "@scope/b"]);
+        expect(result.published.map((p) => p.name).sort()).toStrictEqual(["@scope/a", "@scope/b"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/snapshot.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/snapshot.test.ts
@@ -66,6 +66,8 @@ describe(runSnapshot, () => {
     });
 
     it("requires a working git repo (throws when sha is unresolvable)", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         // No git handlers → getCurrentSha returns undefined.
 
@@ -75,6 +77,8 @@ describe(runSnapshot, () => {
     });
 
     it("computes the snapshot version from the configured template", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {
@@ -92,6 +96,8 @@ describe(runSnapshot, () => {
     });
 
     it("supports custom version templates with all placeholders", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {
@@ -111,6 +117,8 @@ describe(runSnapshot, () => {
     });
 
     it("excludes private packages from snapshot publishing", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {
@@ -128,6 +136,8 @@ describe(runSnapshot, () => {
     });
 
     it("--filter narrows the target set", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
 
         runner.on("git", ["rev-parse", "HEAD"], () => {

--- a/packages/tooling/vis/__tests__/release/core/stage-guardrail.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/stage-guardrail.test.ts
@@ -339,7 +339,7 @@ describe.skipIf(isWindows)("stage guardrail: assertNoConflictingPendingStages (p
             // Verb in the message differs by phase so logs are
             // unambiguous when the guard fires in mixed flows.
             expect(error.message).toContain("Refusing to publish");
-            expect(error.hint).toBeTruthy();
+            expect(error.hint).toBeDefined();
         }
     });
 

--- a/packages/tooling/vis/__tests__/release/core/stage-guardrail.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/stage-guardrail.test.ts
@@ -73,6 +73,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     });
 
     it("throws STAGE_PENDING when staged.json holds an entry for a planned package", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -96,6 +98,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     it("blocks even when the staged version is older than the planned bump (would orphan the prior tarball)", async () => {
         // Staged 1.2.0 (timed out); plan would bump to 1.2.1 — without the
         // guard, we'd publish 1.2.1 leaving 1.2.0 pending on npm forever.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -117,6 +121,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     });
 
     it("includes the package + stage id + reason in the error message", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -150,6 +156,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     });
 
     it("does NOT block when staged.json holds an entry for an UNRELATED package", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-other",
@@ -171,6 +179,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     });
 
     it("does NOT block when staged.json is absent", async () => {
+        expect.hasAssertions();
+
         const ctx = await buildContext({ cwd });
 
         await expect(applyContext(ctx, { dryRun: true })).resolves.toBeDefined();
@@ -179,6 +189,8 @@ describe.skipIf(isWindows)("stage guardrail: applyContext refuses to re-version 
     it("does NOT block when staged.json has an empty pending array", async () => {
         // Write directly to the file path so writeStagedRegistry doesn't
         // delete it for being empty.
+        expect.hasAssertions();
+
         const { mkdir, writeFile } = await import("node:fs/promises");
 
         await mkdir(join(cwd, ".vis", "release"), { recursive: true });
@@ -210,6 +222,8 @@ describe.skipIf(isWindows)("stage guardrail: RESUME case (same name + same versi
         // the in-memory plan matches the pending stage, which is the
         // resume case — we want to resume waiting on the existing stage,
         // not refuse the operation.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -233,6 +247,8 @@ describe.skipIf(isWindows)("stage guardrail: RESUME case (same name + same versi
     it("bLOCKS when the pending stage's version is below the planned version (orphan-risk)", async () => {
         // Pending at 1.2.0; plan bumps to 1.2.1. If we let this through,
         // 1.2.0 would never be tagged and the pending tarball orphans.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -256,6 +272,8 @@ describe.skipIf(isWindows)("stage guardrail: RESUME case (same name + same versi
     it("bLOCKS when the pending stage's version is ABOVE the planned version (would orphan the newer stage)", async () => {
         // Pending at 1.3.0 (somehow); plan only bumps to 1.2.1. Letting
         // this through would still leave 1.3.0 orphaned. Block.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -277,6 +295,8 @@ describe.skipIf(isWindows)("stage guardrail: RESUME case (same name + same versi
     });
 
     it("aLLOWS resume when MULTIPLE pending entries all match planned versions", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [
                 {
@@ -312,6 +332,8 @@ describe.skipIf(isWindows)("stage guardrail: assertNoConflictingPendingStages (p
     });
 
     it("throws STAGE_PENDING with hint when called for the publish phase", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -344,6 +366,8 @@ describe.skipIf(isWindows)("stage guardrail: assertNoConflictingPendingStages (p
     });
 
     it("uses the `version` verb when phase is version", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -384,6 +408,8 @@ describe.skipIf(isWindows)("stage guardrail: self-heal for out-of-band approvals
     });
 
     it("drains a pending entry whose version is already on the registry (operator approved via npmjs.com UI)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -423,6 +449,8 @@ describe.skipIf(isWindows)("stage guardrail: self-heal for out-of-band approvals
     });
 
     it("does NOT drain when `npm view` returns no tarball (still pending)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",
@@ -463,6 +491,8 @@ describe.skipIf(isWindows)("stage guardrail: self-heal for out-of-band approvals
         // Two pending entries — one already live (approved out-of-band),
         // one still pending. Guard should drain the live one and still
         // throw for the other.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [
                 {
@@ -529,6 +559,8 @@ describe.skipIf(isWindows)("stage guardrail: self-heal for out-of-band approvals
     });
 
     it("respects skipSelfHeal — no npm-view round-trips, straight to throw", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, ".vis/release", {
             pending: [{
                 id: "stage-xyz",

--- a/packages/tooling/vis/__tests__/release/core/stage-publisher.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/stage-publisher.test.ts
@@ -34,6 +34,8 @@ const buildRunner = (
 
 describe(waitForStageDecision, () => {
     it("returns 'approved' when the stage view 404s and `npm view` reports the version live", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             // First poll: still staged.
             { stdout: JSON.stringify({ id: "stage-xyz", package: "x", version: "1.0.0" }) },
@@ -61,6 +63,8 @@ describe(waitForStageDecision, () => {
     });
 
     it("returns 'rejected' when the stage record is gone and the version isn't on the registry", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([
             // First poll: empty stdout → decision made.
             { exitCode: 0, stdout: "" },
@@ -83,6 +87,8 @@ describe(waitForStageDecision, () => {
 
     it("returns 'timeout' when timeoutMs elapses with the stage record still present", async () => {
         // Every poll returns "still staged".
+        expect.hasAssertions();
+
         const responses = Array.from({ length: 20 }, () => {
             return {
                 stdout: JSON.stringify({ id: "stage-xyz", package: "x", version: "1.0.0" }),
@@ -104,6 +110,8 @@ describe(waitForStageDecision, () => {
     });
 
     it("fires onProgress while polling", async () => {
+        expect.hasAssertions();
+
         const responses = [
             { stdout: JSON.stringify({ id: "stage-xyz" }) },
             { stdout: JSON.stringify({ id: "stage-xyz" }) },
@@ -130,6 +138,8 @@ describe(waitForStageDecision, () => {
 
 describe(refuseRestrictedOidc, () => {
     it("throws CONFIG_INVALID when both restricted + OIDC are present", () => {
+        expect.hasAssertions();
+
         const env = { ACTIONS_ID_TOKEN_REQUEST_URL: "https://example/oidc" };
 
         expect(() => { refuseRestrictedOidc("restricted", env); }).toThrow(VisReleaseError);
@@ -137,6 +147,8 @@ describe(refuseRestrictedOidc, () => {
     });
 
     it("passes when only OIDC is set (public package)", () => {
+        expect.hasAssertions();
+
         const env = { ACTIONS_ID_TOKEN_REQUEST_URL: "https://example/oidc" };
 
         expect(() => { refuseRestrictedOidc("public", env); }).not.toThrow();
@@ -144,10 +156,13 @@ describe(refuseRestrictedOidc, () => {
     });
 
     it("passes when only restricted is set (no OIDC)", () => {
+        expect.hasAssertions();
         expect(() => { refuseRestrictedOidc("restricted", {}); }).not.toThrow();
     });
 
     it("passes when NPM_TOKEN is also set alongside OIDC (operator has the fallback)", () => {
+        expect.hasAssertions();
+
         const env = {
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://example/oidc",
             NPM_TOKEN: "npm_xxx",

--- a/packages/tooling/vis/__tests__/release/core/staged-registry.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/staged-registry.test.ts
@@ -32,6 +32,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("returns an empty registry when staged.json is absent", async () => {
+        expect.hasAssertions();
+
         const registry = await readStagedRegistry(cwd, CHANGES_DIR);
 
         expect(registry.version).toBe(1);
@@ -40,6 +42,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("writes the file when there's at least one pending entry", async () => {
+        expect.hasAssertions();
+
         const entry: PendingStage = {
             id: "stage-xyz",
             name: "@scope/pkg",
@@ -67,6 +71,8 @@ describe("staged-registry: read/write round-trip", () => {
 
     it("deletes the file when the registry becomes empty", async () => {
         // Seed a non-empty file first.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [{
                 id: "stage-xyz",
@@ -92,6 +98,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("does not touch the worktree when an empty registry was already empty on disk", async () => {
+        expect.hasAssertions();
+
         const result = await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [],
             updatedAt: "now",
@@ -103,6 +111,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("reports `changed: false` when the registry is identical to disk", async () => {
+        expect.hasAssertions();
+
         const registry: StagedRegistryFile = {
             pending: [{
                 id: "stage-xyz",
@@ -127,6 +137,8 @@ describe("staged-registry: read/write round-trip", () => {
         // pendingSetsEqual, a second write with the same pending set but
         // a fresh `updatedAt` would falsely report `changed: true` and
         // trigger a noise commit every wave.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [{
                 id: "stage-xyz",
@@ -156,6 +168,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("reports `changed: true` when the pending set changes (id swap)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [{
                 id: "stage-a",
@@ -184,6 +198,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("reports `changed: true` when the same entry's reason flips (timeout → rejected)", async () => {
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [{
                 id: "stage-xyz",
@@ -212,6 +228,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("throws STATE_FILE_CORRUPT when staged.json is malformed JSON", async () => {
+        expect.hasAssertions();
+
         const path = stagedRegistryPath(cwd, CHANGES_DIR);
         const { mkdir } = await import("node:fs/promises");
 
@@ -224,6 +242,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("throws STATE_FILE_CORRUPT for unknown schema versions", async () => {
+        expect.hasAssertions();
+
         const path = stagedRegistryPath(cwd, CHANGES_DIR);
         const { mkdir } = await import("node:fs/promises");
 
@@ -236,6 +256,8 @@ describe("staged-registry: read/write round-trip", () => {
     });
 
     it("throws STATE_FILE_CORRUPT when `pending` is not an array", async () => {
+        expect.hasAssertions();
+
         const path = stagedRegistryPath(cwd, CHANGES_DIR);
         const { mkdir } = await import("node:fs/promises");
 
@@ -261,12 +283,16 @@ describe("staged-registry: pure helpers", () => {
 
     describe(upsertPendingStages, () => {
         it("returns the input registry unchanged when next[] is empty", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = { pending: [], updatedAt: "now", version: 1 };
 
             expect(upsertPendingStages(registry, [])).toBe(registry);
         });
 
         it("adds new entries", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = { pending: [], updatedAt: "now", version: 1 };
             const entry = buildEntry({ id: "stage-xyz" });
 
@@ -276,6 +302,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("replaces an existing entry by id, preserving the rest", () => {
+            expect.hasAssertions();
+
             const a = buildEntry({ id: "stage-a", reason: "timeout" });
             const b = buildEntry({ id: "stage-b", name: "@scope/other" });
             const updated = buildEntry({ id: "stage-a", reason: "rejected" });
@@ -289,6 +317,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("dedupes within a single upsert call", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = { pending: [], updatedAt: "now", version: 1 };
             const first = buildEntry({ id: "stage-a", version: "1.0.0" });
             const second = buildEntry({ id: "stage-a", version: "1.0.1" });
@@ -302,6 +332,8 @@ describe("staged-registry: pure helpers", () => {
 
     describe(removePendingStages, () => {
         it("returns the input when ids[] is empty", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [buildEntry({ id: "x" })],
                 updatedAt: "now",
@@ -312,6 +344,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("returns the input when nothing matches", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [buildEntry({ id: "x" })],
                 updatedAt: "now",
@@ -322,6 +356,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("drops only matching ids", () => {
+            expect.hasAssertions();
+
             const a = buildEntry({ id: "a" });
             const b = buildEntry({ id: "b" });
             const c = buildEntry({ id: "c" });
@@ -333,6 +369,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("treats the empty list of ids as a no-op even when registry has entries", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [buildEntry({ id: "x" })],
                 updatedAt: "now",
@@ -345,12 +383,16 @@ describe("staged-registry: pure helpers", () => {
 
     describe(findConflictingPendingStages, () => {
         it("returns an empty list when the registry is empty", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = { pending: [], updatedAt: "now", version: 1 };
 
             expect(findConflictingPendingStages(registry, ["@scope/pkg"])).toStrictEqual([]);
         });
 
         it("returns an empty list when no package matches", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [buildEntry({ name: "@scope/a" })],
                 updatedAt: "now",
@@ -364,6 +406,8 @@ describe("staged-registry: pure helpers", () => {
             // Important behaviour: the guard blocks on *package*, not
             // (package, version). A pending pkg@1.2.0 blocks both a
             // re-publish of 1.2.0 AND a re-version to 1.2.1.
+            expect.hasAssertions();
+
             const blocked = buildEntry({ id: "stage-old", name: "@scope/a", version: "1.0.0" });
             const allowed = buildEntry({ id: "stage-other", name: "@scope/b", version: "2.0.0" });
 
@@ -374,6 +418,8 @@ describe("staged-registry: pure helpers", () => {
         });
 
         it("matches multiple packages in one call", () => {
+            expect.hasAssertions();
+
             const a = buildEntry({ id: "stage-a", name: "@scope/a" });
             const b = buildEntry({ id: "stage-b", name: "@scope/b" });
             const c = buildEntry({ id: "stage-c", name: "@scope/c" });
@@ -398,6 +444,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
     });
 
     it("round-trips recentlyNotified + recentlyWalked through write + read", async () => {
+        expect.hasAssertions();
+
         const registry: StagedRegistryFile = {
             pending: [],
             recentlyNotified: [{ at: new Date().toISOString(), key: "@scope/a@1.0.0" }],
@@ -421,6 +469,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
     it("preserves the file when pending is empty but recentlyNotified has entries", async () => {
         // Seed a registry with ONLY recentlyNotified.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [],
             recentlyNotified: [{ at: new Date().toISOString(), key: "@scope/a@1.0.0" }],
@@ -436,6 +486,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
     it("deletes the file ONLY when pending + recentlyNotified + recentlyWalked are all empty", async () => {
         // Seed with recents present.
+        expect.hasAssertions();
+
         await writeStagedRegistry(cwd, CHANGES_DIR, {
             pending: [],
             recentlyNotified: [{ at: new Date().toISOString(), key: "@scope/a@1.0.0" }],
@@ -456,6 +508,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
     });
 
     it("prunes entries older than 30 days on write", async () => {
+        expect.hasAssertions();
+
         const now = Date.now();
         const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
         const fresh = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
@@ -478,6 +532,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
     });
 
     it("caps recentlyNotified at 100 entries (keeping the most recent)", async () => {
+        expect.hasAssertions();
+
         const now = Date.now();
         const entries = Array.from({ length: 150 }, (_, idx) => {
             return {
@@ -506,6 +562,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
     });
 
     it("does not produce a noise write when only the in-memory updatedAt changed", async () => {
+        expect.hasAssertions();
+
         const initial: StagedRegistryFile = {
             pending: [],
             recentlyNotified: [{ at: "2026-05-22T14:00:00.000Z", key: "@scope/a@1.0.0" }],
@@ -525,11 +583,14 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
     describe(pruneOldEntries, () => {
         it("returns an empty array when input is undefined or empty", () => {
+            expect.hasAssertions();
             expect(pruneOldEntries(undefined)).toStrictEqual([]);
             expect(pruneOldEntries([])).toStrictEqual([]);
         });
 
         it("drops entries older than 30 days", () => {
+            expect.hasAssertions();
+
             const now = Date.now();
             const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
             const fresh = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
@@ -546,6 +607,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
         });
 
         it("caps the result to 100 entries even when all are within the 30-day window", () => {
+            expect.hasAssertions();
+
             const now = Date.now();
             const entries = Array.from({ length: 150 }, (_, idx) => {
                 return {
@@ -560,6 +623,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
         });
 
         it("treats bad-timestamp entries as expired (defensive)", () => {
+            expect.hasAssertions();
+
             const now = Date.now();
             const result = pruneOldEntries(
                 [
@@ -575,6 +640,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
     describe("recordRecentlyNotified / recordRecentlyWalked", () => {
         it("appends new keys with the supplied timestamp", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [],
                 updatedAt: "old",
@@ -588,6 +655,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
         });
 
         it("dedupes against existing entries (same wave, same key)", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [],
                 recentlyNotified: [{ at: "earlier", key: "@scope/a@1.0.0" }],
@@ -606,6 +675,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
         });
 
         it("returns the input unchanged when keys[] is empty", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = { pending: [], updatedAt: "old", version: 1 };
 
             expect(recordRecentlyNotified(registry, [])).toBe(registry);
@@ -613,6 +684,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
         });
 
         it("returns the input unchanged when nothing new to add", () => {
+            expect.hasAssertions();
+
             const registry: StagedRegistryFile = {
                 pending: [],
                 recentlyWalked: [{ at: "earlier", key: "@scope/a@1.0.0" }],

--- a/packages/tooling/vis/__tests__/release/core/staged-registry.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/staged-registry.test.ts
@@ -35,7 +35,7 @@ describe("staged-registry: read/write round-trip", () => {
         const registry = await readStagedRegistry(cwd, CHANGES_DIR);
 
         expect(registry.version).toBe(1);
-        expect(registry.pending).toEqual([]);
+        expect(registry.pending).toStrictEqual([]);
         expect(registry.updatedAt).toBeTypeOf("string");
     });
 
@@ -272,7 +272,7 @@ describe("staged-registry: pure helpers", () => {
 
             const next = upsertPendingStages(registry, [entry]);
 
-            expect(next.pending).toEqual([entry]);
+            expect(next.pending).toStrictEqual([entry]);
         });
 
         it("replaces an existing entry by id, preserving the rest", () => {
@@ -285,7 +285,7 @@ describe("staged-registry: pure helpers", () => {
 
             expect(next.pending).toHaveLength(2);
             expect(next.pending.find((entry) => entry.id === "stage-a")?.reason).toBe("rejected");
-            expect(next.pending.find((entry) => entry.id === "stage-b")).toEqual(b);
+            expect(next.pending.find((entry) => entry.id === "stage-b")).toStrictEqual(b);
         });
 
         it("dedupes within a single upsert call", () => {
@@ -329,7 +329,7 @@ describe("staged-registry: pure helpers", () => {
             const registry: StagedRegistryFile = { pending: [a, b, c], updatedAt: "now", version: 1 };
             const next = removePendingStages(registry, ["a", "c"]);
 
-            expect(next.pending).toEqual([b]);
+            expect(next.pending).toStrictEqual([b]);
         });
 
         it("treats the empty list of ids as a no-op even when registry has entries", () => {
@@ -347,7 +347,7 @@ describe("staged-registry: pure helpers", () => {
         it("returns an empty list when the registry is empty", () => {
             const registry: StagedRegistryFile = { pending: [], updatedAt: "now", version: 1 };
 
-            expect(findConflictingPendingStages(registry, ["@scope/pkg"])).toEqual([]);
+            expect(findConflictingPendingStages(registry, ["@scope/pkg"])).toStrictEqual([]);
         });
 
         it("returns an empty list when no package matches", () => {
@@ -357,7 +357,7 @@ describe("staged-registry: pure helpers", () => {
                 version: 1,
             };
 
-            expect(findConflictingPendingStages(registry, ["@scope/b"])).toEqual([]);
+            expect(findConflictingPendingStages(registry, ["@scope/b"])).toStrictEqual([]);
         });
 
         it("returns entries whose package name matches, regardless of version", () => {
@@ -370,7 +370,7 @@ describe("staged-registry: pure helpers", () => {
             const registry: StagedRegistryFile = { pending: [blocked, allowed], updatedAt: "now", version: 1 };
             const conflicts = findConflictingPendingStages(registry, ["@scope/a"]);
 
-            expect(conflicts).toEqual([blocked]);
+            expect(conflicts).toStrictEqual([blocked]);
         });
 
         it("matches multiple packages in one call", () => {
@@ -381,7 +381,7 @@ describe("staged-registry: pure helpers", () => {
             const registry: StagedRegistryFile = { pending: [a, b, c], updatedAt: "now", version: 1 };
             const conflicts = findConflictingPendingStages(registry, ["@scope/a", "@scope/c"]);
 
-            expect(conflicts.map((entry) => entry.id)).toEqual(["stage-a", "stage-c"]);
+            expect(conflicts.map((entry) => entry.id)).toStrictEqual(["stage-a", "stage-c"]);
         });
     });
 });
@@ -415,8 +415,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
         const read = await readStagedRegistry(cwd, CHANGES_DIR);
 
-        expect(read.recentlyNotified).toEqual(registry.recentlyNotified);
-        expect(read.recentlyWalked).toEqual(registry.recentlyWalked);
+        expect(read.recentlyNotified).toStrictEqual(registry.recentlyNotified);
+        expect(read.recentlyWalked).toStrictEqual(registry.recentlyWalked);
     });
 
     it("preserves the file when pending is empty but recentlyNotified has entries", async () => {
@@ -525,8 +525,8 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
     describe(pruneOldEntries, () => {
         it("returns an empty array when input is undefined or empty", () => {
-            expect(pruneOldEntries(undefined)).toEqual([]);
-            expect(pruneOldEntries([])).toEqual([]);
+            expect(pruneOldEntries(undefined)).toStrictEqual([]);
+            expect(pruneOldEntries([])).toStrictEqual([]);
         });
 
         it("drops entries older than 30 days", () => {
@@ -542,7 +542,7 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
                 now,
             );
 
-            expect(result).toEqual([{ at: fresh, key: "fresh" }]);
+            expect(result).toStrictEqual([{ at: fresh, key: "fresh" }]);
         });
 
         it("caps the result to 100 entries even when all are within the 30-day window", () => {
@@ -569,7 +569,7 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
                 now,
             );
 
-            expect(result.map((entry) => entry.key)).toEqual(["good"]);
+            expect(result.map((entry) => entry.key)).toStrictEqual(["good"]);
         });
     });
 
@@ -583,7 +583,7 @@ describe("staged-registry: cross-runner notify/walk dedupe", () => {
 
             const next = recordRecentlyNotified(registry, ["@scope/a@1.0.0"], "2026-05-22T14:00:00.000Z");
 
-            expect(next.recentlyNotified).toEqual([{ at: "2026-05-22T14:00:00.000Z", key: "@scope/a@1.0.0" }]);
+            expect(next.recentlyNotified).toStrictEqual([{ at: "2026-05-22T14:00:00.000Z", key: "@scope/a@1.0.0" }]);
             expect(next.updatedAt).toBe("2026-05-22T14:00:00.000Z");
         });
 

--- a/packages/tooling/vis/__tests__/release/core/state-lock.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/state-lock.test.ts
@@ -45,7 +45,7 @@ describe("state — process-level lock (RFC §19.1)", () => {
 
         const fs = await import("node:fs/promises");
 
-        await expect(fs.access(lockFilePath(cwd, changesDir))).rejects.toThrow();
+        await expect(fs.access(lockFilePath(cwd, changesDir))).rejects.toThrow(/ENOENT/);
     });
 
     it("releaseLock is a no-op when no lock exists", async () => {

--- a/packages/tooling/vis/__tests__/release/core/state-lock.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/state-lock.test.ts
@@ -22,6 +22,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
     });
 
     it("writes a lock file with current PID + timestamp", async () => {
+        expect.hasAssertions();
+
         const path = await acquireLock(cwd, changesDir);
 
         expect(path).toBe(lockFilePath(cwd, changesDir));
@@ -36,6 +38,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
     });
 
     it("releaseLock removes the file", async () => {
+        expect.hasAssertions();
+
         await acquireLock(cwd, changesDir);
         await releaseLock(cwd, changesDir);
 
@@ -45,10 +49,13 @@ describe("state — process-level lock (RFC §19.1)", () => {
     });
 
     it("releaseLock is a no-op when no lock exists", async () => {
+        expect.hasAssertions();
         await expect(releaseLock(cwd, changesDir)).resolves.toBeUndefined();
     });
 
     it("refuses to acquire when held by a live PID (current process)", async () => {
+        expect.hasAssertions();
+
         await acquireLock(cwd, changesDir);
 
         await expect(acquireLock(cwd, changesDir)).rejects.toThrow(VisReleaseError);
@@ -59,6 +66,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
 
     it("takes over a stale lock (dead PID)", async () => {
         // Pick a PID that's almost certainly not running.
+        expect.hasAssertions();
+
         const fakeDeadPid = 999_999;
 
         mkdirSync(join(cwd, changesDir), { recursive: true });
@@ -77,6 +86,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
 
     it("takes over an old lock (older than 1h) even if PID is live", async () => {
         // Use a definitely-live PID (us) but timestamp from 2 hours ago.
+        expect.hasAssertions();
+
         const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
 
         mkdirSync(join(cwd, changesDir), { recursive: true });
@@ -94,6 +105,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
     });
 
     it("takes over an unparseable lock (treats as stale)", async () => {
+        expect.hasAssertions();
+
         mkdirSync(join(cwd, changesDir), { recursive: true });
         writeFileSync(lockFilePath(cwd, changesDir), "not valid json");
 
@@ -107,6 +120,8 @@ describe("state — process-level lock (RFC §19.1)", () => {
     it("uses O_EXCL: only one of two parallel acquires can succeed (RFC §19.1)", async () => {
         // Race two acquires at the same instant. With O_EXCL, exactly one
         // should succeed; the loser sees the live PID lock and throws.
+        expect.hasAssertions();
+
         const results = await Promise.allSettled([
             acquireLock(cwd, changesDir),
             acquireLock(cwd, changesDir),

--- a/packages/tooling/vis/__tests__/release/core/state.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/state.test.ts
@@ -51,9 +51,9 @@ describe("state — file lifecycle", () => {
         expect(read?.version).toBe(1);
         expect(read?.channel).toBe("alpha");
         expect(read?.plan).toHaveLength(2);
-        expect(read?.applied).toEqual([]);
-        expect(read?.published).toEqual([]);
-        expect(read?.tagged).toEqual([]);
+        expect(read?.applied).toStrictEqual([]);
+        expect(read?.published).toStrictEqual([]);
+        expect(read?.tagged).toStrictEqual([]);
         expect(read?.pushed).toBe(false);
     });
 

--- a/packages/tooling/vis/__tests__/release/core/state.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/state.test.ts
@@ -37,12 +37,16 @@ describe("state — file lifecycle", () => {
     });
 
     it("returns undefined when no state file exists", async () => {
+        expect.hasAssertions();
+
         const state = await readState(cwd, changesDir);
 
         expect(state).toBeUndefined();
     });
 
     it("write → read round-trip preserves shape", async () => {
+        expect.hasAssertions();
+
         const state = newState("alpha", [mkRelease("a", "1.1.0"), mkRelease("b", "2.1.0")]);
 
         await writeState(cwd, changesDir, state);
@@ -58,6 +62,8 @@ describe("state — file lifecycle", () => {
     });
 
     it("clearState removes the file", async () => {
+        expect.hasAssertions();
+
         await writeState(cwd, changesDir, newState(undefined, [mkRelease("a", "1.1.0")]));
 
         await expect(readState(cwd, changesDir)).resolves.toBeDefined();
@@ -68,14 +74,18 @@ describe("state — file lifecycle", () => {
     });
 
     it("clearState is a no-op when file is absent", async () => {
+        expect.hasAssertions();
         await expect(clearState(cwd, changesDir)).resolves.toBeUndefined();
     });
 
     it("stateFilePath joins cwd + changesDir + .state.json", () => {
+        expect.hasAssertions();
         expect(stateFilePath("/r", ".vis/release")).toBe(join("/r", ".vis/release", ".state.json"));
     });
 
     it("throws STATE_FILE_CORRUPT on unknown schema version", async () => {
+        expect.hasAssertions();
+
         const fs = await import("node:fs/promises");
 
         await fs.mkdir(join(cwd, changesDir), { recursive: true });
@@ -87,6 +97,8 @@ describe("state — file lifecycle", () => {
 
 describe("state — filterPlanByState", () => {
     it("filters out already-published packages", () => {
+        expect.hasAssertions();
+
         const plan = [mkRelease("a", "1.1.0"), mkRelease("b", "2.1.0"), mkRelease("c", "3.1.0")];
         const state: StateFile = {
             applied: ["a@1.1.0", "b@2.1.0", "c@3.1.0"],
@@ -105,6 +117,8 @@ describe("state — filterPlanByState", () => {
     });
 
     it("returns full plan when nothing is published", () => {
+        expect.hasAssertions();
+
         const plan = [mkRelease("a", "1.1.0"), mkRelease("b", "2.1.0")];
         const state: StateFile = {
             applied: [],

--- a/packages/tooling/vis/__tests__/release/core/sticky-comment.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/sticky-comment.test.ts
@@ -4,30 +4,37 @@ import { detectPullRequestNumber } from "../../../src/release/core/sticky-commen
 
 describe(detectPullRequestNumber, () => {
     it("parses pull_request event GITHUB_REF (refs/pull/N/merge)", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ GITHUB_REF: "refs/pull/1234/merge" })).toBe(1234);
     });
 
     it("parses refs/pull/N/head form", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ GITHUB_REF: "refs/pull/9999/head" })).toBe(9999);
     });
 
     it("falls back to PR_NUMBER env var", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ PR_NUMBER: "42" })).toBe(42);
     });
 
     it("falls back to VIS_PR_NUMBER env var", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ VIS_PR_NUMBER: "7" })).toBe(7);
     });
 
     it("returns undefined for non-PR refs (push events)", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ GITHUB_REF: "refs/heads/main" })).toBeUndefined();
     });
 
     it("returns undefined when no signal is present", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({})).toBeUndefined();
     });
 
     it("ignores garbage in PR_NUMBER", () => {
+        expect.hasAssertions();
         expect(detectPullRequestNumber({ PR_NUMBER: "abc" })).toBeUndefined();
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/success-walk.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/success-walk.test.ts
@@ -143,14 +143,18 @@ const noopFormatter = async () => "";
 
 describe(extractReferences, () => {
     it("picks up bare `#123` references", () => {
+        expect.hasAssertions();
         expect(extractReferences("Closes #123 and #456.")).toStrictEqual([123, 456]);
     });
 
     it("picks up `gh-123` (case-insensitive) references", () => {
+        expect.hasAssertions();
         expect(extractReferences("Resolves gh-7 and GH-12 and Gh-9.")).toStrictEqual([7, 9, 12]);
     });
 
     it("picks up forge URLs (/pull/N, /issues/N, /-/merge_requests/N) when no repo gate is supplied", () => {
+        expect.hasAssertions();
+
         const body = `
             See https://github.com/x/y/pull/45 and
             https://gitlab.com/x/y/-/merge_requests/77
@@ -160,14 +164,17 @@ describe(extractReferences, () => {
     });
 
     it("deduplicates references appearing multiple times", () => {
+        expect.hasAssertions();
         expect(extractReferences("#42 and #42 again, and gh-42 too")).toStrictEqual([42]);
     });
 
     it("does not match colour hex codes like #ff00ff", () => {
+        expect.hasAssertions();
         expect(extractReferences("color: #ff00ff;")).toStrictEqual([]);
     });
 
     it("ignores numbers without a # prefix", () => {
+        expect.hasAssertions();
         expect(extractReferences("version 123.456 is shipped")).toStrictEqual([]);
     });
 
@@ -176,18 +183,21 @@ describe(extractReferences, () => {
     describe("m-9 — cross-repo URL guard", () => {
         it("drops URL refs pointing at a different repo", () => {
             // `#42` in a competitor's URL must not get applied locally.
+            expect.hasAssertions();
             expect(
                 extractReferences("See https://github.com/competitor/repo/pull/42 for context", "owner/repo"),
             ).toStrictEqual([]);
         });
 
         it("keeps URL refs that match the local repo", () => {
+            expect.hasAssertions();
             expect(
                 extractReferences("See https://github.com/owner/repo/pull/42 for context", "owner/repo"),
             ).toStrictEqual([42]);
         });
 
         it("keeps GitLab URLs (`-/merge_requests/N`) that match the local repo", () => {
+            expect.hasAssertions();
             expect(
                 extractReferences("See https://gitlab.com/owner/repo/-/merge_requests/77", "owner/repo"),
             ).toStrictEqual([77]);
@@ -196,18 +206,23 @@ describe(extractReferences, () => {
         it("keeps bare `#123` refs even when a cross-repo URL is present", () => {
             // Bare refs always apply locally by convention. The URL pointing
             // at competitor/repo is dropped, but `#7` is kept.
+            expect.hasAssertions();
+
             const body = "Closes #7. See https://github.com/competitor/repo/pull/42 for prior art.";
 
             expect(extractReferences(body, "owner/repo")).toStrictEqual([7]);
         });
 
         it("keeps bare `gh-123` refs even when a cross-repo URL is present", () => {
+            expect.hasAssertions();
+
             const body = "Resolves gh-9. Compare https://github.com/competitor/repo/issues/100.";
 
             expect(extractReferences(body, "owner/repo")).toStrictEqual([9]);
         });
 
         it("treats the repo comparison as case-insensitive (GitHub repo slugs are too)", () => {
+            expect.hasAssertions();
             expect(
                 extractReferences("See https://github.com/Owner/Repo/pull/42", "owner/repo"),
             ).toStrictEqual([42]);
@@ -215,6 +230,7 @@ describe(extractReferences, () => {
 
         it("drops a URL whose path partially overlaps but doesn't match exactly", () => {
             // `owner/repo-other` must not match `owner/repo`.
+            expect.hasAssertions();
             expect(
                 extractReferences("See https://github.com/owner/repo-other/pull/42", "owner/repo"),
             ).toStrictEqual([]);
@@ -224,6 +240,8 @@ describe(extractReferences, () => {
 
 describe(walkSuccessfulRelease, () => {
     it("extracts PR refs from a changelog body and posts a sticky comment per ref", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const release = mkRelease("@scope/pkg", "1.2.0", ["Closes #100 and #200."]);
         const context = mkContext({}, [release]);
@@ -241,6 +259,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("dedupes references across multiple packages in the wave", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const releases = [
             mkRelease("@scope/a", "1.0.0", ["See #42."]),
@@ -266,6 +286,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("adds the configured labels via client.addLabels", async () => {
+        expect.hasAssertions();
+
         const { addLabelsCalls, client } = buildMockClient();
         const context = mkContext({
             config: { successWalk: { labels: ["released", "shipped"] } },
@@ -282,6 +304,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("uses default `[\"released\"]` labels when not configured", async () => {
+        expect.hasAssertions();
+
         const { addLabelsCalls, client } = buildMockClient();
         const context = mkContext({}, [mkRelease("@scope/pkg", "1.0.0", ["#5"])]);
         const result = mkResult([{ name: "@scope/pkg", version: "1.0.0" }]);
@@ -297,6 +321,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("skips the walk entirely on prerelease channels by default", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext(
             { channel: { mode: "auto-publish", prerelease: "beta", tag: "beta" } },
@@ -314,6 +340,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("honours `skipPrerelease: false` to walk prerelease channels", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext(
             {
@@ -335,6 +363,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("soft-fails a single bad ref without aborting the rest", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient({
             upsertCommentFail: (n) => n === 100,
         });
@@ -355,6 +385,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("renders `{version}` / `{name}` / `{tag}` in the comment template", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext(
             {
@@ -383,6 +415,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("substitutes `{url}` when a release URL was recorded by createRemoteReleases", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext(
             { config: { successWalk: { commentBody: "url={url}" } } },
@@ -402,6 +436,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("returns early (no walk) when `enabled: false`", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext(
             { config: { successWalk: { enabled: false } } },
@@ -419,6 +455,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("returns early when `repo` is undefined (no remote detected)", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext({}, [mkRelease("@scope/pkg", "1.0.0", ["#1"])]);
         const result = mkResult([{ name: "@scope/pkg", version: "1.0.0" }]);
@@ -433,6 +471,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("skips the label call when configured `labels: []`", async () => {
+        expect.hasAssertions();
+
         const { addLabelsCalls, client, commentCalls } = buildMockClient();
         const context = mkContext(
             { config: { successWalk: { labels: [] } } },
@@ -451,6 +491,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("uses the default comment template when none is configured", async () => {
+        expect.hasAssertions();
+
         const { client, commentCalls } = buildMockClient();
         const context = mkContext({}, [mkRelease("@scope/pkg", "9.9.9", ["Closes #11."])]);
         const result = mkResult([
@@ -471,6 +513,8 @@ describe(walkSuccessfulRelease, () => {
     });
 
     it("soft-fails a single bad label call without aborting the rest", async () => {
+        expect.hasAssertions();
+
         const { addLabelsCalls, client } = buildMockClient({
             addLabelsFail: (n) => n === 1,
         });
@@ -494,6 +538,8 @@ describe(walkSuccessfulRelease, () => {
     //    third-party PRs referenced in changelog bodies. ─────────────────
     describe("c-1 — default OFF when `successWalk` is undefined", () => {
         it("is a no-op when `config.successWalk` is `undefined`", async () => {
+            expect.hasAssertions();
+
             const { addLabelsCalls, client, commentCalls } = buildMockClient();
             // Override the helper default (`{}`) back to explicit "not set".
             const context = mkContext({ config: {} }, [mkRelease("@scope/pkg", "1.0.0", ["Closes #1 and #2."])]);
@@ -512,6 +558,8 @@ describe(walkSuccessfulRelease, () => {
 
         it("walks when `config.successWalk` is an empty object (opt-in with defaults)", async () => {
             // Sanity-check the other half of the gate: `{}` opts in.
+            expect.hasAssertions();
+
             const { client, commentCalls } = buildMockClient();
             const context = mkContext({ config: { successWalk: {} } }, [mkRelease("@scope/pkg", "1.0.0", ["Closes #1."])]);
             const result = mkResult([{ name: "@scope/pkg", version: "1.0.0" }]);
@@ -529,6 +577,8 @@ describe(walkSuccessfulRelease, () => {
     // ── M-8 regression: concurrency cap + 429 retry. ──────────────────
     describe("m-8 — concurrency limit + 429 retry", () => {
         it("caps in-flight upsert calls at 4 even when 20 refs are processed", async () => {
+            expect.hasAssertions();
+
             let active = 0;
             let peak = 0;
 
@@ -575,6 +625,8 @@ describe(walkSuccessfulRelease, () => {
         });
 
         it("retries a 429-failed upsert once after the Retry-After delay", async () => {
+            expect.hasAssertions();
+
             let attempts = 0;
 
             const flakyClient: RemoteReleaseClient = {
@@ -618,6 +670,8 @@ describe(walkSuccessfulRelease, () => {
         });
 
         it("gives up after one 429 retry and records a warning", async () => {
+            expect.hasAssertions();
+
             const persistentClient: RemoteReleaseClient = {
                 addLabels: async () => true,
                 closeIssue: async () => true,
@@ -647,6 +701,8 @@ describe(walkSuccessfulRelease, () => {
         });
 
         it("does NOT retry non-429 errors (preserves soft-fail behaviour)", async () => {
+            expect.hasAssertions();
+
             let attempts = 0;
             const grumpyClient: RemoteReleaseClient = {
                 addLabels: async () => true,
@@ -684,6 +740,8 @@ describe(walkSuccessfulRelease, () => {
     //    bodies must not produce comment / label calls. ─────────────────
     describe("m-9 — cross-repo URL refs are dropped during the walk", () => {
         it("does not comment on a #N from a competitor's URL", async () => {
+            expect.hasAssertions();
+
             const { addLabelsCalls, client, commentCalls } = buildMockClient();
             const body = "Closes https://github.com/competitor/repo/pull/42.";
             const context = mkContext({}, [mkRelease("@scope/pkg", "1.0.0", [body])]);
@@ -700,6 +758,8 @@ describe(walkSuccessfulRelease, () => {
         });
 
         it("comments on a same-repo URL ref and skips a same-body cross-repo URL", async () => {
+            expect.hasAssertions();
+
             const { client, commentCalls } = buildMockClient();
             const body = ""
                 + "Same-repo: https://github.com/owner/repo/pull/10. "
@@ -722,6 +782,8 @@ describe(walkSuccessfulRelease, () => {
 //    but useful to validate in isolation so regressions surface fast. ──
 describe(pLimit, () => {
     it("never runs more than `n` tasks in flight", async () => {
+        expect.hasAssertions();
+
         let active = 0;
         let peak = 0;
         const limit = pLimit<number>(3);
@@ -747,6 +809,8 @@ describe(pLimit, () => {
     });
 
     it("propagates rejections without crashing the limiter", async () => {
+        expect.hasAssertions();
+
         const limit = pLimit<number>(2);
 
         const tasks = [
@@ -767,6 +831,8 @@ describe(pLimit, () => {
 
 describe(withRateLimitRetry, () => {
     it("returns the value on first success without sleeping", async () => {
+        expect.hasAssertions();
+
         const before = Date.now();
         const value = await withRateLimitRetry(async () => "ok");
 
@@ -776,6 +842,8 @@ describe(withRateLimitRetry, () => {
     });
 
     it("retries once on a 429-tagged error and returns the second result", async () => {
+        expect.hasAssertions();
+
         let attempts = 0;
         const value = await withRateLimitRetry(async () => {
             attempts += 1;
@@ -792,6 +860,8 @@ describe(withRateLimitRetry, () => {
     });
 
     it("does not retry non-429 errors", async () => {
+        expect.hasAssertions();
+
         let attempts = 0;
 
         await expect(
@@ -806,6 +876,8 @@ describe(withRateLimitRetry, () => {
     });
 
     it("only retries once — a second 429 propagates", async () => {
+        expect.hasAssertions();
+
         let attempts = 0;
 
         await expect(

--- a/packages/tooling/vis/__tests__/release/core/success-walk.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/success-walk.test.ts
@@ -143,11 +143,11 @@ const noopFormatter = async () => "";
 
 describe(extractReferences, () => {
     it("picks up bare `#123` references", () => {
-        expect(extractReferences("Closes #123 and #456.")).toEqual([123, 456]);
+        expect(extractReferences("Closes #123 and #456.")).toStrictEqual([123, 456]);
     });
 
     it("picks up `gh-123` (case-insensitive) references", () => {
-        expect(extractReferences("Resolves gh-7 and GH-12 and Gh-9.")).toEqual([7, 9, 12]);
+        expect(extractReferences("Resolves gh-7 and GH-12 and Gh-9.")).toStrictEqual([7, 9, 12]);
     });
 
     it("picks up forge URLs (/pull/N, /issues/N, /-/merge_requests/N) when no repo gate is supplied", () => {
@@ -156,19 +156,19 @@ describe(extractReferences, () => {
             https://gitlab.com/x/y/-/merge_requests/77
             and https://github.com/x/y/issues/100 for context.`;
 
-        expect(extractReferences(body)).toEqual([45, 77, 100]);
+        expect(extractReferences(body)).toStrictEqual([45, 77, 100]);
     });
 
     it("deduplicates references appearing multiple times", () => {
-        expect(extractReferences("#42 and #42 again, and gh-42 too")).toEqual([42]);
+        expect(extractReferences("#42 and #42 again, and gh-42 too")).toStrictEqual([42]);
     });
 
     it("does not match colour hex codes like #ff00ff", () => {
-        expect(extractReferences("color: #ff00ff;")).toEqual([]);
+        expect(extractReferences("color: #ff00ff;")).toStrictEqual([]);
     });
 
     it("ignores numbers without a # prefix", () => {
-        expect(extractReferences("version 123.456 is shipped")).toEqual([]);
+        expect(extractReferences("version 123.456 is shipped")).toStrictEqual([]);
     });
 
     // ── M-9 regression: URL refs pointing at a different repo must be
@@ -178,19 +178,19 @@ describe(extractReferences, () => {
             // `#42` in a competitor's URL must not get applied locally.
             expect(
                 extractReferences("See https://github.com/competitor/repo/pull/42 for context", "owner/repo"),
-            ).toEqual([]);
+            ).toStrictEqual([]);
         });
 
         it("keeps URL refs that match the local repo", () => {
             expect(
                 extractReferences("See https://github.com/owner/repo/pull/42 for context", "owner/repo"),
-            ).toEqual([42]);
+            ).toStrictEqual([42]);
         });
 
         it("keeps GitLab URLs (`-/merge_requests/N`) that match the local repo", () => {
             expect(
                 extractReferences("See https://gitlab.com/owner/repo/-/merge_requests/77", "owner/repo"),
-            ).toEqual([77]);
+            ).toStrictEqual([77]);
         });
 
         it("keeps bare `#123` refs even when a cross-repo URL is present", () => {
@@ -198,26 +198,26 @@ describe(extractReferences, () => {
             // at competitor/repo is dropped, but `#7` is kept.
             const body = "Closes #7. See https://github.com/competitor/repo/pull/42 for prior art.";
 
-            expect(extractReferences(body, "owner/repo")).toEqual([7]);
+            expect(extractReferences(body, "owner/repo")).toStrictEqual([7]);
         });
 
         it("keeps bare `gh-123` refs even when a cross-repo URL is present", () => {
             const body = "Resolves gh-9. Compare https://github.com/competitor/repo/issues/100.";
 
-            expect(extractReferences(body, "owner/repo")).toEqual([9]);
+            expect(extractReferences(body, "owner/repo")).toStrictEqual([9]);
         });
 
         it("treats the repo comparison as case-insensitive (GitHub repo slugs are too)", () => {
             expect(
                 extractReferences("See https://github.com/Owner/Repo/pull/42", "owner/repo"),
-            ).toEqual([42]);
+            ).toStrictEqual([42]);
         });
 
         it("drops a URL whose path partially overlaps but doesn't match exactly", () => {
             // `owner/repo-other` must not match `owner/repo`.
             expect(
                 extractReferences("See https://github.com/owner/repo-other/pull/42", "owner/repo"),
-            ).toEqual([]);
+            ).toStrictEqual([]);
         });
     });
 });
@@ -236,7 +236,7 @@ describe(walkSuccessfulRelease, () => {
         });
 
         expect(commentCalls).toHaveLength(2);
-        expect(commentCalls.map((c) => c.issueNumber).sort()).toEqual([100, 200]);
+        expect(commentCalls.map((c) => c.issueNumber).sort()).toStrictEqual([100, 200]);
         expect(commentCalls[0]!.body).toContain(SUCCESS_WALK_MARKER);
     });
 
@@ -262,7 +262,7 @@ describe(walkSuccessfulRelease, () => {
         // two packages' change-file bodies.
         const refs = commentCalls.map((c) => c.issueNumber).sort();
 
-        expect(refs).toEqual([42, 43]);
+        expect(refs).toStrictEqual([42, 43]);
     });
 
     it("adds the configured labels via client.addLabels", async () => {
@@ -278,7 +278,7 @@ describe(walkSuccessfulRelease, () => {
             repo: "owner/repo",
         });
 
-        expect(addLabelsCalls).toEqual([{ issueNumber: 1, labels: ["released", "shipped"] }]);
+        expect(addLabelsCalls).toStrictEqual([{ issueNumber: 1, labels: ["released", "shipped"] }]);
     });
 
     it("uses default `[\"released\"]` labels when not configured", async () => {
@@ -292,8 +292,8 @@ describe(walkSuccessfulRelease, () => {
             repo: "owner/repo",
         });
 
-        expect(addLabelsCalls[0]!.labels).toEqual(DEFAULT_SUCCESS_WALK_LABELS);
-        expect(DEFAULT_SUCCESS_WALK_LABELS).toEqual(["released"]);
+        expect(addLabelsCalls[0]!.labels).toStrictEqual(DEFAULT_SUCCESS_WALK_LABELS);
+        expect(DEFAULT_SUCCESS_WALK_LABELS).toStrictEqual(["released"]);
     });
 
     it("skips the walk entirely on prerelease channels by default", async () => {
@@ -350,7 +350,7 @@ describe(walkSuccessfulRelease, () => {
 
         // #100 attempted, #200 succeeded
         expect(commentCalls).toHaveLength(2);
-        expect(out.commented).toEqual([200]);
+        expect(out.commented).toStrictEqual([200]);
         expect(out.warnings.some((w) => w.includes("#100"))).toBe(true);
     });
 
@@ -485,7 +485,7 @@ describe(walkSuccessfulRelease, () => {
         });
 
         expect(addLabelsCalls).toHaveLength(2);
-        expect(out.labeled).toEqual([2]);
+        expect(out.labeled).toStrictEqual([2]);
         expect(out.warnings.some((w) => w.includes("#1"))).toBe(true);
     });
 
@@ -505,9 +505,9 @@ describe(walkSuccessfulRelease, () => {
                 repo: "owner/repo",
             });
 
-            expect(commentCalls).toEqual([]);
-            expect(addLabelsCalls).toEqual([]);
-            expect(out).toEqual({ commented: [], labeled: [], warnings: [] });
+            expect(commentCalls).toStrictEqual([]);
+            expect(addLabelsCalls).toStrictEqual([]);
+            expect(out).toStrictEqual({ commented: [], labeled: [], warnings: [] });
         });
 
         it("walks when `config.successWalk` is an empty object (opt-in with defaults)", async () => {
@@ -612,9 +612,9 @@ describe(walkSuccessfulRelease, () => {
 
             // First call failed, second succeeded.
             expect(attempts).toBe(2);
-            expect(out.commented).toEqual([1]);
+            expect(out.commented).toStrictEqual([1]);
             // No warning was recorded — the retry was successful.
-            expect(out.warnings).toEqual([]);
+            expect(out.warnings).toStrictEqual([]);
         });
 
         it("gives up after one 429 retry and records a warning", async () => {
@@ -642,7 +642,7 @@ describe(walkSuccessfulRelease, () => {
                 repo: "owner/repo",
             });
 
-            expect(out.commented).toEqual([]);
+            expect(out.commented).toStrictEqual([]);
             expect(out.warnings.some((w) => w.includes("#1") && /429|rate/i.test(w))).toBe(true);
         });
 
@@ -695,8 +695,8 @@ describe(walkSuccessfulRelease, () => {
                 repo: "owner/repo",
             });
 
-            expect(commentCalls).toEqual([]);
-            expect(addLabelsCalls).toEqual([]);
+            expect(commentCalls).toStrictEqual([]);
+            expect(addLabelsCalls).toStrictEqual([]);
         });
 
         it("comments on a same-repo URL ref and skips a same-body cross-repo URL", async () => {
@@ -713,7 +713,7 @@ describe(walkSuccessfulRelease, () => {
                 repo: "owner/repo",
             });
 
-            expect(commentCalls.map((c) => c.issueNumber).sort()).toEqual([10]);
+            expect(commentCalls.map((c) => c.issueNumber).sort()).toStrictEqual([10]);
         });
     });
 });
@@ -743,7 +743,7 @@ describe(pLimit, () => {
         expect(peak).toBeLessThanOrEqual(3);
         // Sanity-check that *some* parallelism happened.
         expect(peak).toBeGreaterThan(1);
-        expect(results).toEqual(Array.from({ length: 20 }, (_, i) => i));
+        expect(results).toStrictEqual(Array.from({ length: 20 }, (_, i) => i));
     });
 
     it("propagates rejections without crashing the limiter", async () => {
@@ -759,9 +759,9 @@ describe(pLimit, () => {
 
         const settled = await Promise.allSettled(tasks);
 
-        expect(settled[0]).toEqual({ status: "fulfilled", value: 1 });
+        expect(settled[0]).toStrictEqual({ status: "fulfilled", value: 1 });
         expect(settled[1]!.status).toBe("rejected");
-        expect(settled[2]).toEqual({ status: "fulfilled", value: 3 });
+        expect(settled[2]).toStrictEqual({ status: "fulfilled", value: 3 });
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
@@ -137,468 +137,470 @@ let workspace: string;
 let originalFetch: typeof globalThis.fetch;
 let originalEnv: NodeJS.ProcessEnv;
 
-beforeEach(() => {
-    workspace = mkdtempSync(join(tmpdir(), "vis-cargo-test-"));
-    originalFetch = globalThis.fetch;
-    originalEnv = { ...process.env };
-    // Wipe ambient auth so tests don't depend on the dev machine's env.
-    delete process.env["CARGO_REGISTRY_TOKEN"];
-    delete process.env["ACTIONS_ID_TOKEN_REQUEST_URL"];
-    delete process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
-});
-
-afterEach(() => {
-    globalThis.fetch = originalFetch;
-    process.env = originalEnv;
-});
-
-describe("cargoVersionActions: identity", () => {
-    it("has stable id `cargo`", () => {
-        expect.hasAssertions();
-        expect(new CargoVersionActions().id).toBe("cargo");
-    });
-});
-
-describe("cargoVersionActions: readPublishedVersion", () => {
-    it("returns crates.io max_stable_version on a 200 happy path", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
-        stubFetch({ body: { crate: { max_stable_version: "1.2.3", max_version: "2.0.0-beta.1" } } });
-
-        const actions = new CargoVersionActions();
-        const result = await actions.readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBe("1.2.3");
+describe("cargo version actions", () => {
+    beforeEach(() => {
+        workspace = mkdtempSync(join(tmpdir(), "vis-cargo-test-"));
+        originalFetch = globalThis.fetch;
+        originalEnv = { ...process.env };
+        // Wipe ambient auth so tests don't depend on the dev machine's env.
+        delete process.env["CARGO_REGISTRY_TOKEN"];
+        delete process.env["ACTIONS_ID_TOKEN_REQUEST_URL"];
+        delete process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
     });
 
-    it("falls back to max_version when max_stable_version is absent", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "0.1.0"\n`);
-        stubFetch({ body: { crate: { max_version: "0.5.0" } } });
-
-        const result = await new CargoVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBe("0.5.0");
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        process.env = originalEnv;
     });
 
-    it("returns undefined on 404 (crate doesn't exist yet)", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "fresh-crate"\nversion = "0.1.0"\n`);
-        stubFetch({ ok: false, status: 404 });
-
-        const result = await new CargoVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
-    });
-
-    it("returns undefined when fetch throws (network unreachable)", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
-        stubFetch({ throws: true });
-
-        const result = await new CargoVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
-    });
-
-    it("returns undefined when Cargo.toml cannot be read (preserves publish-anyway path)", async () => {
-        // No Cargo.toml at the workspace.
-        expect.hasAssertions();
-
-        stubFetch({ body: { crate: { max_version: "1.2.3" } } });
-
-        const result = await new CargoVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
-    });
-});
-
-describe("cargoVersionActions: readCargoToml (parse helper)", () => {
-    it("parses [package].version directly", async () => {
-        expect.hasAssertions();
-
-        const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "2.5.1"\n`);
-        const result = await __testing.readCargoToml(path);
-
-        expect(result).toStrictEqual({ name: "my-crate", version: "2.5.1" });
-    });
-
-    it("resolves version.workspace = true via [workspace.package]", async () => {
-        expect.hasAssertions();
-
-        const path = writeCargoToml(
-            workspace,
-            `[package]\nname = "member"\nversion.workspace = true\n\n[workspace.package]\nversion = "3.0.0"\n`,
-        );
-
-        const result = await __testing.readCargoToml(path);
-
-        expect(result).toStrictEqual({ name: "member", version: "3.0.0" });
-    });
-
-    it("throws CONFIG_INVALID when [package] is absent (workspace root pointed at directly)", async () => {
-        expect.hasAssertions();
-
-        const path = writeCargoToml(workspace, `[workspace]\nmembers = ["crate-a", "crate-b"]\n`);
-
-        await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            file: path,
+    describe("cargoVersionActions: identity", () => {
+        it("has stable id `cargo`", () => {
+            expect.hasAssertions();
+            expect(new CargoVersionActions().id).toBe("cargo");
         });
     });
 
-    it("throws CONFIG_INVALID when [package].version is missing", async () => {
-        expect.hasAssertions();
+    describe("cargoVersionActions: readPublishedVersion", () => {
+        it("returns crates.io max_stable_version on a 200 happy path", async () => {
+            expect.hasAssertions();
 
-        const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\n`);
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
+            stubFetch({ body: { crate: { max_stable_version: "1.2.3", max_version: "2.0.0-beta.1" } } });
 
-        await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
+            const actions = new CargoVersionActions();
+            const result = await actions.readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBe("1.2.3");
+        });
+
+        it("falls back to max_version when max_stable_version is absent", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "0.1.0"\n`);
+            stubFetch({ body: { crate: { max_version: "0.5.0" } } });
+
+            const result = await new CargoVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBe("0.5.0");
+        });
+
+        it("returns undefined on 404 (crate doesn't exist yet)", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "fresh-crate"\nversion = "0.1.0"\n`);
+            stubFetch({ ok: false, status: 404 });
+
+            const result = await new CargoVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when fetch throws (network unreachable)", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
+            stubFetch({ throws: true });
+
+            const result = await new CargoVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when Cargo.toml cannot be read (preserves publish-anyway path)", async () => {
+            // No Cargo.toml at the workspace.
+            expect.hasAssertions();
+
+            stubFetch({ body: { crate: { max_version: "1.2.3" } } });
+
+            const result = await new CargoVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
         });
     });
 
-    it("throws CONFIG_INVALID when the file is missing entirely", async () => {
-        expect.hasAssertions();
-        await expect(__testing.readCargoToml(join(workspace, "no-such-file.toml"))).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
+    describe("cargoVersionActions: readCargoToml (parse helper)", () => {
+        it("parses [package].version directly", async () => {
+            expect.hasAssertions();
+
+            const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "2.5.1"\n`);
+            const result = await __testing.readCargoToml(path);
+
+            expect(result).toStrictEqual({ name: "my-crate", version: "2.5.1" });
+        });
+
+        it("resolves version.workspace = true via [workspace.package]", async () => {
+            expect.hasAssertions();
+
+            const path = writeCargoToml(
+                workspace,
+                `[package]\nname = "member"\nversion.workspace = true\n\n[workspace.package]\nversion = "3.0.0"\n`,
+            );
+
+            const result = await __testing.readCargoToml(path);
+
+            expect(result).toStrictEqual({ name: "member", version: "3.0.0" });
+        });
+
+        it("throws CONFIG_INVALID when [package] is absent (workspace root pointed at directly)", async () => {
+            expect.hasAssertions();
+
+            const path = writeCargoToml(workspace, `[workspace]\nmembers = ["crate-a", "crate-b"]\n`);
+
+            await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                file: path,
+            });
+        });
+
+        it("throws CONFIG_INVALID when [package].version is missing", async () => {
+            expect.hasAssertions();
+
+            const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\n`);
+
+            await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+            });
+        });
+
+        it("throws CONFIG_INVALID when the file is missing entirely", async () => {
+            expect.hasAssertions();
+            await expect(__testing.readCargoToml(join(workspace, "no-such-file.toml"))).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+            });
         });
     });
-});
 
-describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
-    it("returns true with OIDC env + no static token", () => {
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({
-            ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
-        })).toBe(true);
-    });
+    describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
+        it("returns true with OIDC env + no static token", () => {
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({
+                ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
+            })).toBe(true);
+        });
 
-    it("returns true even when CARGO_REGISTRY_TOKEN is set (OIDC wins by default)", () => {
-        // M-3: OIDC precedence aligned with python.ts. A leftover
-        // static token in the env shouldn't silently downgrade the
-        // operator's choice when the OIDC env signal is present.
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({
-            ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
-            CARGO_REGISTRY_TOKEN: "cio_abc123",
-        })).toBe(true);
-    });
-
-    it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
-        // M-3 escape hatch: explicit operator opt-in flips the
-        // precedence so static wins even with OIDC env present.
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing(
-            {
+        it("returns true even when CARGO_REGISTRY_TOKEN is set (OIDC wins by default)", () => {
+            // M-3: OIDC precedence aligned with python.ts. A leftover
+            // static token in the env shouldn't silently downgrade the
+            // operator's choice when the OIDC env signal is present.
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({
                 ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
                 CARGO_REGISTRY_TOKEN: "cio_abc123",
-            },
-            { publish: { preferStaticToken: true } },
-        )).toBe(false);
-    });
-
-    it("returns true with preferStaticToken: true but no static token (degenerate — falls back to OIDC)", () => {
-        // Escape hatch only matters when both signals are present.
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing(
-            { ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com" },
-            { publish: { preferStaticToken: true } },
-        )).toBe(true);
-    });
-
-    it("returns false without OIDC env (developer machine, no token)", () => {
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
-    });
-});
-
-describe("cargoVersionActions: publish — dryRun", () => {
-    it("returns published: true without invoking cargo or fetch", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        const { calls, runner } = buildRunner([]);
-        const fetchSpy = stubFetch({ body: {} });
-
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            dryRun: true,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("[dry-run / cargo]");
-        expect(calls).toHaveLength(0);
-        expect(fetchSpy).not.toHaveBeenCalled();
-    });
-});
-
-describe("cargoVersionActions: publish — happy path", () => {
-    it("invokes `cargo publish --allow-dirty` when crates.io has an older version", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy_static_token";
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "uploaded" }]);
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.alreadyPublished).not.toBe(true);
-        expect(calls).toHaveLength(1);
-        expect(calls[0]!.command).toBe("cargo");
-        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
-    });
-
-    it("never passes --trusted-publishing (M-7: not a real cargo flag)", async () => {
-        // M-7 regression guard: cargo's trusted-publishing config is
-        // in `Cargo.toml` / `~/.cargo/config.toml` — there is NO
-        // `cargo publish --trusted-publishing` flag (as of cargo
-        // 1.85 / late 2025). vis must let cargo's own auth resolution
-        // pick up OIDC without adding a bogus CLI arg.
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
-        process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
-        // CARGO_REGISTRY_TOKEN deliberately absent — OIDC path.
-
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0 }]);
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("trusted publishing");
-        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
-        // Explicitly assert the bogus flag is gone.
-        expect(calls[0]!.args).not.toContain("--trusted-publishing");
-    });
-
-    it("prefers OIDC when BOTH OIDC env AND a static token are set (M-3)", async () => {
-        // M-3 alignment with python.ts: OIDC wins by default. A
-        // leftover CARGO_REGISTRY_TOKEN in the env shouldn't silently
-        // downgrade an operator who configured trusted publishing.
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_stale_token_from_last_year";
-
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        const { runner } = buildRunner([{ exitCode: 0 }]);
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        // Output flags the OIDC path so operators can see in CI logs
-        // which auth mode was actually used.
-        expect(result.output).toContain("trusted publishing");
-    });
-
-    it("preferStaticToken: true flips precedence — static wins when both signals are present (M-3 escape hatch)", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_token_operator_chose";
-
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        const { runner } = buildRunner([{ exitCode: 0 }]);
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-            workspaceConfig: { publish: { preferStaticToken: true } },
-        }));
-
-        expect(result.published).toBe(true);
-        // No "trusted publishing" suffix — we're on the static path.
-        expect(result.output).not.toContain("trusted publishing");
-    });
-});
-
-describe("cargoVersionActions: publish — idempotency", () => {
-    it("short-circuits with alreadyPublished when crates.io max_version === new version", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
-        stubFetch({ body: { crate: { max_version: "1.0.1" } } });
-
-        const { calls, runner } = buildRunner([]);
-        const result = await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.alreadyPublished).toBe(true);
-        expect(result.published).toBe(false);
-        expect(result.output).toContain("already on crates.io");
-        // No cargo invocation — short-circuit before publish.
-        expect(calls).toHaveLength(0);
-    });
-});
-
-describe("cargoVersionActions: publish — failure modes", () => {
-    it("throws AUTH_MISSING when neither CARGO_REGISTRY_TOKEN nor OIDC is available", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        // No env set in beforeEach.
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        await expect(new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner: buildRunner([]).runner,
-        }))).rejects.toMatchObject({ code: "AUTH_MISSING" });
-    });
-
-    it("throws PUBLISH_FAILED when cargo publish exits non-zero", async () => {
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        const { runner } = buildRunner([{ exitCode: 101, stderr: "error: 401 Unauthorized" }]);
-
-        await expect(new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
-    });
-
-    it("throws CONFIG_INVALID when Cargo.toml version doesn't match planned release version", async () => {
-        // Simulates the extra-files bump skipping a misconfigured file —
-        // we publish 1.0.1 but disk says 1.0.0. Catching it pre-publish
-        // saves a misleading "already published" or "not yet uploaded"
-        // confusion downstream.
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
-        stubFetch({ body: { crate: { max_version: "0.9.0" } } });
-
-        await expect(new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            newVersion: "1.0.1",
-            runner: buildRunner([]).runner,
-        }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
-    });
-});
-
-describe("cargoVersionActions: publish — pre-publish secret scan", () => {
-    it("throws PUBLISH_FAILED when packSecretScan finds a leaked secret", async () => {
-        // Layout: a .crate file that would carry an env file.
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        writeFileSync(join(workspace, "Cargo.lock"), "");
-        writeFileSync(
-            join(workspace, "leaked.env"),
-            // A synthetic-but-realistic AWS key pair the secret-scanner flags.
-            // NB: the canonical `AKIAIOSFODNN7EXAMPLE` doc key is deliberately
-            // allowlisted by the scanner as a known false-positive, so it must
-            // NOT be used here — pick a non-"EXAMPLE" access-key id.
-            `AWS_ACCESS_KEY_ID=AKIA2E0A8F3B244C9986\nAWS_SECRET_ACCESS_KEY=wJalr7Utn3EMz9K7MDfNG2bPxR1iCYz4aKp9Lq8x\n`,
-        );
-
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        // `cargo package --list` is the first call; subsequent `cargo publish`
-        // must NOT happen because the scanner aborts.
-        const { calls, runner } = buildRunner([
-            { exitCode: 0, stdout: "Cargo.toml\nCargo.lock\nleaked.env\n" }, // cargo package --list
-        ]);
-
-        await expect(new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-            workspaceConfig: { publish: { guards: { packSecretScan: true } } },
-        }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
-
-        // Only the file-list call ran — the actual publish was aborted.
-        expect(calls).toHaveLength(1);
-        expect(calls[0]!.args).toStrictEqual(["package", "--list", "--allow-dirty"]);
-    });
-});
-
-describe("cargoVersionActions: User-Agent header (B-3)", () => {
-    it("stamps a vis-release User-Agent on crates.io metadata requests", async () => {
-        // B-3: crates.io's policy asks for a contact UA. vis routes
-        // all registry probes through `safeFetchVersionMetadata`,
-        // which auto-injects the header.
-        expect.hasAssertions();
-
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
-
-        const fetchSpy = stubFetch({ body: { crate: { max_version: "1.0.0" } } });
-
-        await new CargoVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/native" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
+            })).toBe(true);
         });
 
-        // First call to fetch — verify the headers carry a UA.
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
+            // M-3 escape hatch: explicit operator opt-in flips the
+            // precedence so static wins even with OIDC env present.
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing(
+                {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
+                    CARGO_REGISTRY_TOKEN: "cio_abc123",
+                },
+                { publish: { preferStaticToken: true } },
+            )).toBe(false);
+        });
 
-        const callArgs = fetchSpy.mock.calls[0]!;
-        const init = callArgs[1] as RequestInit | undefined;
-        const headers = init?.headers as Record<string, string> | undefined;
+        it("returns true with preferStaticToken: true but no static token (degenerate — falls back to OIDC)", () => {
+            // Escape hatch only matters when both signals are present.
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing(
+                { ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com" },
+                { publish: { preferStaticToken: true } },
+            )).toBe(true);
+        });
 
-        expect(headers).toBeDefined();
-        expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
-        expect(headers!["User-Agent"]).toContain("github.com/visulima/visulima");
+        it("returns false without OIDC env (developer machine, no token)", () => {
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
+        });
     });
-});
 
-describe("cargoVersionActions: publish — alternative registry", () => {
-    it("passes --registry when context.registry is set to a non-crates.io URL", async () => {
-        expect.hasAssertions();
+    describe("cargoVersionActions: publish — dryRun", () => {
+        it("returns published: true without invoking cargo or fetch", async () => {
+            expect.hasAssertions();
 
-        writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
-        process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
-        stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            const { calls, runner } = buildRunner([]);
+            const fetchSpy = stubFetch({ body: {} });
 
-        const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                dryRun: true,
+                runner,
+            }));
 
-        await new CargoVersionActions().publish(ctx({
-            dir: workspace,
-            registry: "internal",
-            runner,
-        }));
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("[dry-run / cargo]");
+            expect(calls).toHaveLength(0);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
 
-        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty", "--registry", "internal"]);
+    describe("cargoVersionActions: publish — happy path", () => {
+        it("invokes `cargo publish --allow-dirty` when crates.io has an older version", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy_static_token";
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "uploaded" }]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            expect(result.alreadyPublished).not.toBe(true);
+            expect(calls).toHaveLength(1);
+            expect(calls[0]!.command).toBe("cargo");
+            expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
+        });
+
+        it("never passes --trusted-publishing (M-7: not a real cargo flag)", async () => {
+            // M-7 regression guard: cargo's trusted-publishing config is
+            // in `Cargo.toml` / `~/.cargo/config.toml` — there is NO
+            // `cargo publish --trusted-publishing` flag (as of cargo
+            // 1.85 / late 2025). vis must let cargo's own auth resolution
+            // pick up OIDC without adding a bogus CLI arg.
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
+            process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
+            // CARGO_REGISTRY_TOKEN deliberately absent — OIDC path.
+
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("trusted publishing");
+            expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
+            // Explicitly assert the bogus flag is gone.
+            expect(calls[0]!.args).not.toContain("--trusted-publishing");
+        });
+
+        it("prefers OIDC when BOTH OIDC env AND a static token are set (M-3)", async () => {
+            // M-3 alignment with python.ts: OIDC wins by default. A
+            // leftover CARGO_REGISTRY_TOKEN in the env shouldn't silently
+            // downgrade an operator who configured trusted publishing.
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_stale_token_from_last_year";
+
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { runner } = buildRunner([{ exitCode: 0 }]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            // Output flags the OIDC path so operators can see in CI logs
+            // which auth mode was actually used.
+            expect(result.output).toContain("trusted publishing");
+        });
+
+        it("preferStaticToken: true flips precedence — static wins when both signals are present (M-3 escape hatch)", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_token_operator_chose";
+
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { runner } = buildRunner([{ exitCode: 0 }]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+                workspaceConfig: { publish: { preferStaticToken: true } },
+            }));
+
+            expect(result.published).toBe(true);
+            // No "trusted publishing" suffix — we're on the static path.
+            expect(result.output).not.toContain("trusted publishing");
+        });
+    });
+
+    describe("cargoVersionActions: publish — idempotency", () => {
+        it("short-circuits with alreadyPublished when crates.io max_version === new version", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
+            stubFetch({ body: { crate: { max_version: "1.0.1" } } });
+
+            const { calls, runner } = buildRunner([]);
+            const result = await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.alreadyPublished).toBe(true);
+            expect(result.published).toBe(false);
+            expect(result.output).toContain("already on crates.io");
+            // No cargo invocation — short-circuit before publish.
+            expect(calls).toHaveLength(0);
+        });
+    });
+
+    describe("cargoVersionActions: publish — failure modes", () => {
+        it("throws AUTH_MISSING when neither CARGO_REGISTRY_TOKEN nor OIDC is available", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            // No env set in beforeEach.
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            await expect(new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner: buildRunner([]).runner,
+            }))).rejects.toMatchObject({ code: "AUTH_MISSING" });
+        });
+
+        it("throws PUBLISH_FAILED when cargo publish exits non-zero", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { runner } = buildRunner([{ exitCode: 101, stderr: "error: 401 Unauthorized" }]);
+
+            await expect(new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
+        });
+
+        it("throws CONFIG_INVALID when Cargo.toml version doesn't match planned release version", async () => {
+            // Simulates the extra-files bump skipping a misconfigured file —
+            // we publish 1.0.1 but disk says 1.0.0. Catching it pre-publish
+            // saves a misleading "already published" or "not yet uploaded"
+            // confusion downstream.
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
+            stubFetch({ body: { crate: { max_version: "0.9.0" } } });
+
+            await expect(new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                newVersion: "1.0.1",
+                runner: buildRunner([]).runner,
+            }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+        });
+    });
+
+    describe("cargoVersionActions: publish — pre-publish secret scan", () => {
+        it("throws PUBLISH_FAILED when packSecretScan finds a leaked secret", async () => {
+            // Layout: a .crate file that would carry an env file.
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            writeFileSync(join(workspace, "Cargo.lock"), "");
+            writeFileSync(
+                join(workspace, "leaked.env"),
+                // A synthetic-but-realistic AWS key pair the secret-scanner flags.
+                // NB: the canonical `AKIAIOSFODNN7EXAMPLE` doc key is deliberately
+                // allowlisted by the scanner as a known false-positive, so it must
+                // NOT be used here — pick a non-"EXAMPLE" access-key id.
+                `AWS_ACCESS_KEY_ID=AKIA2E0A8F3B244C9986\nAWS_SECRET_ACCESS_KEY=wJalr7Utn3EMz9K7MDfNG2bPxR1iCYz4aKp9Lq8x\n`,
+            );
+
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            // `cargo package --list` is the first call; subsequent `cargo publish`
+            // must NOT happen because the scanner aborts.
+            const { calls, runner } = buildRunner([
+                { exitCode: 0, stdout: "Cargo.toml\nCargo.lock\nleaked.env\n" }, // cargo package --list
+            ]);
+
+            await expect(new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+                workspaceConfig: { publish: { guards: { packSecretScan: true } } },
+            }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
+
+            // Only the file-list call ran — the actual publish was aborted.
+            expect(calls).toHaveLength(1);
+            expect(calls[0]!.args).toStrictEqual(["package", "--list", "--allow-dirty"]);
+        });
+    });
+
+    describe("cargoVersionActions: User-Agent header (B-3)", () => {
+        it("stamps a vis-release User-Agent on crates.io metadata requests", async () => {
+            // B-3: crates.io's policy asks for a contact UA. vis routes
+            // all registry probes through `safeFetchVersionMetadata`,
+            // which auto-injects the header.
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
+
+            const fetchSpy = stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            await new CargoVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/native" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            // First call to fetch — verify the headers carry a UA.
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            const callArgs = fetchSpy.mock.calls[0]!;
+            const init = callArgs[1] as RequestInit | undefined;
+            const headers = init?.headers as Record<string, string> | undefined;
+
+            expect(headers).toBeDefined();
+            expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
+            expect(headers!["User-Agent"]).toContain("github.com/visulima/visulima");
+        });
+    });
+
+    describe("cargoVersionActions: publish — alternative registry", () => {
+        it("passes --registry when context.registry is set to a non-crates.io URL", async () => {
+            expect.hasAssertions();
+
+            writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
+            process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
+            stubFetch({ body: { crate: { max_version: "1.0.0" } } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+
+            await new CargoVersionActions().publish(ctx({
+                dir: workspace,
+                registry: "internal",
+                runner,
+            }));
+
+            expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty", "--registry", "internal"]);
+        });
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
@@ -154,12 +154,15 @@ afterEach(() => {
 
 describe("cargoVersionActions: identity", () => {
     it("has stable id `cargo`", () => {
+        expect.hasAssertions();
         expect(new CargoVersionActions().id).toBe("cargo");
     });
 });
 
 describe("cargoVersionActions: readPublishedVersion", () => {
     it("returns crates.io max_stable_version on a 200 happy path", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
         stubFetch({ body: { crate: { max_stable_version: "1.2.3", max_version: "2.0.0-beta.1" } } });
 
@@ -173,6 +176,8 @@ describe("cargoVersionActions: readPublishedVersion", () => {
     });
 
     it("falls back to max_version when max_stable_version is absent", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "0.1.0"\n`);
         stubFetch({ body: { crate: { max_version: "0.5.0" } } });
 
@@ -185,6 +190,8 @@ describe("cargoVersionActions: readPublishedVersion", () => {
     });
 
     it("returns undefined on 404 (crate doesn't exist yet)", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "fresh-crate"\nversion = "0.1.0"\n`);
         stubFetch({ ok: false, status: 404 });
 
@@ -197,6 +204,8 @@ describe("cargoVersionActions: readPublishedVersion", () => {
     });
 
     it("returns undefined when fetch throws (network unreachable)", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
         stubFetch({ throws: true });
 
@@ -210,6 +219,8 @@ describe("cargoVersionActions: readPublishedVersion", () => {
 
     it("returns undefined when Cargo.toml cannot be read (preserves publish-anyway path)", async () => {
         // No Cargo.toml at the workspace.
+        expect.hasAssertions();
+
         stubFetch({ body: { crate: { max_version: "1.2.3" } } });
 
         const result = await new CargoVersionActions().readPublishedVersion({
@@ -223,6 +234,8 @@ describe("cargoVersionActions: readPublishedVersion", () => {
 
 describe("cargoVersionActions: readCargoToml (parse helper)", () => {
     it("parses [package].version directly", async () => {
+        expect.hasAssertions();
+
         const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "2.5.1"\n`);
         const result = await __testing.readCargoToml(path);
 
@@ -230,6 +243,8 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
     });
 
     it("resolves version.workspace = true via [workspace.package]", async () => {
+        expect.hasAssertions();
+
         const path = writeCargoToml(
             workspace,
             `[package]\nname = "member"\nversion.workspace = true\n\n[workspace.package]\nversion = "3.0.0"\n`,
@@ -241,6 +256,8 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
     });
 
     it("throws CONFIG_INVALID when [package] is absent (workspace root pointed at directly)", async () => {
+        expect.hasAssertions();
+
         const path = writeCargoToml(workspace, `[workspace]\nmembers = ["crate-a", "crate-b"]\n`);
 
         await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
@@ -250,6 +267,8 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
     });
 
     it("throws CONFIG_INVALID when [package].version is missing", async () => {
+        expect.hasAssertions();
+
         const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\n`);
 
         await expect(__testing.readCargoToml(path)).rejects.toMatchObject({
@@ -258,6 +277,7 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
     });
 
     it("throws CONFIG_INVALID when the file is missing entirely", async () => {
+        expect.hasAssertions();
         await expect(__testing.readCargoToml(join(workspace, "no-such-file.toml"))).rejects.toMatchObject({
             code: "CONFIG_INVALID",
         });
@@ -266,6 +286,7 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
 
 describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
     it("returns true with OIDC env + no static token", () => {
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
         })).toBe(true);
@@ -275,6 +296,7 @@ describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
         // M-3: OIDC precedence aligned with python.ts. A leftover
         // static token in the env shouldn't silently downgrade the
         // operator's choice when the OIDC env signal is present.
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
             CARGO_REGISTRY_TOKEN: "cio_abc123",
@@ -284,6 +306,7 @@ describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
     it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
         // M-3 escape hatch: explicit operator opt-in flips the
         // precedence so static wins even with OIDC env present.
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing(
             {
                 ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
@@ -295,6 +318,7 @@ describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
 
     it("returns true with preferStaticToken: true but no static token (degenerate — falls back to OIDC)", () => {
         // Escape hatch only matters when both signals are present.
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing(
             { ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com" },
             { publish: { preferStaticToken: true } },
@@ -302,12 +326,15 @@ describe("cargoVersionActions: shouldUseTrustedPublishing (M-3)", () => {
     });
 
     it("returns false without OIDC env (developer machine, no token)", () => {
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
     });
 });
 
 describe("cargoVersionActions: publish — dryRun", () => {
     it("returns published: true without invoking cargo or fetch", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         const { calls, runner } = buildRunner([]);
         const fetchSpy = stubFetch({ body: {} });
@@ -327,6 +354,8 @@ describe("cargoVersionActions: publish — dryRun", () => {
 
 describe("cargoVersionActions: publish — happy path", () => {
     it("invokes `cargo publish --allow-dirty` when crates.io has an older version", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy_static_token";
         stubFetch({ body: { crate: { max_version: "1.0.0" } } });
@@ -350,6 +379,8 @@ describe("cargoVersionActions: publish — happy path", () => {
         // `cargo publish --trusted-publishing` flag (as of cargo
         // 1.85 / late 2025). vis must let cargo's own auth resolution
         // pick up OIDC without adding a bogus CLI arg.
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
         process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
@@ -374,6 +405,8 @@ describe("cargoVersionActions: publish — happy path", () => {
         // M-3 alignment with python.ts: OIDC wins by default. A
         // leftover CARGO_REGISTRY_TOKEN in the env shouldn't silently
         // downgrade an operator who configured trusted publishing.
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_stale_token_from_last_year";
@@ -393,6 +426,8 @@ describe("cargoVersionActions: publish — happy path", () => {
     });
 
     it("preferStaticToken: true flips precedence — static wins when both signals are present (M-3 escape hatch)", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_token_operator_chose";
@@ -414,6 +449,8 @@ describe("cargoVersionActions: publish — happy path", () => {
 
 describe("cargoVersionActions: publish — idempotency", () => {
     it("short-circuits with alreadyPublished when crates.io max_version === new version", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
         stubFetch({ body: { crate: { max_version: "1.0.1" } } });
@@ -434,6 +471,8 @@ describe("cargoVersionActions: publish — idempotency", () => {
 
 describe("cargoVersionActions: publish — failure modes", () => {
     it("throws AUTH_MISSING when neither CARGO_REGISTRY_TOKEN nor OIDC is available", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         // No env set in beforeEach.
         stubFetch({ body: { crate: { max_version: "1.0.0" } } });
@@ -445,6 +484,8 @@ describe("cargoVersionActions: publish — failure modes", () => {
     });
 
     it("throws PUBLISH_FAILED when cargo publish exits non-zero", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
         stubFetch({ body: { crate: { max_version: "1.0.0" } } });
@@ -462,6 +503,8 @@ describe("cargoVersionActions: publish — failure modes", () => {
         // we publish 1.0.1 but disk says 1.0.0. Catching it pre-publish
         // saves a misleading "already published" or "not yet uploaded"
         // confusion downstream.
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
         stubFetch({ body: { crate: { max_version: "0.9.0" } } });
@@ -477,6 +520,8 @@ describe("cargoVersionActions: publish — failure modes", () => {
 describe("cargoVersionActions: publish — pre-publish secret scan", () => {
     it("throws PUBLISH_FAILED when packSecretScan finds a leaked secret", async () => {
         // Layout: a .crate file that would carry an env file.
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         writeFileSync(join(workspace, "Cargo.lock"), "");
         writeFileSync(
@@ -514,6 +559,8 @@ describe("cargoVersionActions: User-Agent header (B-3)", () => {
         // B-3: crates.io's policy asks for a contact UA. vis routes
         // all registry probes through `safeFetchVersionMetadata`,
         // which auto-injects the header.
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.0"\n`);
 
         const fetchSpy = stubFetch({ body: { crate: { max_version: "1.0.0" } } });
@@ -538,6 +585,8 @@ describe("cargoVersionActions: User-Agent header (B-3)", () => {
 
 describe("cargoVersionActions: publish — alternative registry", () => {
     it("passes --registry when context.registry is set to a non-crates.io URL", async () => {
+        expect.hasAssertions();
+
         writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "1.0.1"\n`);
         process.env["CARGO_REGISTRY_TOKEN"] = "cio_dummy";
         stubFetch({ body: { crate: { max_version: "1.0.0" } } });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
@@ -226,7 +226,7 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
         const path = writeCargoToml(workspace, `[package]\nname = "my-crate"\nversion = "2.5.1"\n`);
         const result = await __testing.readCargoToml(path);
 
-        expect(result).toEqual({ name: "my-crate", version: "2.5.1" });
+        expect(result).toStrictEqual({ name: "my-crate", version: "2.5.1" });
     });
 
     it("resolves version.workspace = true via [workspace.package]", async () => {
@@ -237,7 +237,7 @@ describe("cargoVersionActions: readCargoToml (parse helper)", () => {
 
         const result = await __testing.readCargoToml(path);
 
-        expect(result).toEqual({ name: "member", version: "3.0.0" });
+        expect(result).toStrictEqual({ name: "member", version: "3.0.0" });
     });
 
     it("throws CONFIG_INVALID when [package] is absent (workspace root pointed at directly)", async () => {
@@ -341,7 +341,7 @@ describe("cargoVersionActions: publish — happy path", () => {
         expect(result.alreadyPublished).not.toBe(true);
         expect(calls).toHaveLength(1);
         expect(calls[0]!.command).toBe("cargo");
-        expect(calls[0]!.args).toEqual(["publish", "--allow-dirty"]);
+        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
     });
 
     it("never passes --trusted-publishing (M-7: not a real cargo flag)", async () => {
@@ -365,7 +365,7 @@ describe("cargoVersionActions: publish — happy path", () => {
 
         expect(result.published).toBe(true);
         expect(result.output).toContain("trusted publishing");
-        expect(calls[0]!.args).toEqual(["publish", "--allow-dirty"]);
+        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty"]);
         // Explicitly assert the bogus flag is gone.
         expect(calls[0]!.args).not.toContain("--trusted-publishing");
     });
@@ -505,7 +505,7 @@ describe("cargoVersionActions: publish — pre-publish secret scan", () => {
 
         // Only the file-list call ran — the actual publish was aborted.
         expect(calls).toHaveLength(1);
-        expect(calls[0]!.args).toEqual(["package", "--list", "--allow-dirty"]);
+        expect(calls[0]!.args).toStrictEqual(["package", "--list", "--allow-dirty"]);
     });
 });
 
@@ -550,6 +550,6 @@ describe("cargoVersionActions: publish — alternative registry", () => {
             runner,
         }));
 
-        expect(calls[0]!.args).toEqual(["publish", "--allow-dirty", "--registry", "internal"]);
+        expect(calls[0]!.args).toStrictEqual(["publish", "--allow-dirty", "--registry", "internal"]);
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-cargo.test.ts
@@ -338,7 +338,7 @@ describe("cargoVersionActions: publish — happy path", () => {
         }));
 
         expect(result.published).toBe(true);
-        expect(result.alreadyPublished).toBeFalsy();
+        expect(result.alreadyPublished).not.toBe(true);
         expect(calls).toHaveLength(1);
         expect(calls[0]!.command).toBe("cargo");
         expect(calls[0]!.args).toEqual(["publish", "--allow-dirty"]);
@@ -524,7 +524,7 @@ describe("cargoVersionActions: User-Agent header (B-3)", () => {
         });
 
         // First call to fetch — verify the headers carry a UA.
-        expect(fetchSpy).toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
 
         const callArgs = fetchSpy.mock.calls[0]!;
         const init = callArgs[1] as RequestInit | undefined;

--- a/packages/tooling/vis/__tests__/release/core/version-actions-container.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-container.test.ts
@@ -112,7 +112,7 @@ describe("validateContainerConfig (N-4)", () => {
         );
 
         expect(result.containerImage).toBe("ghcr.io/scope/foo");
-        expect(result.containerPlatforms).toEqual(["linux/amd64"]);
+        expect(result.containerPlatforms).toStrictEqual(["linux/amd64"]);
     });
 
     it("throws CONFIG_INVALID when containerImage is missing entirely", () => {
@@ -157,25 +157,25 @@ describe(parseImageRef, () => {
     it("splits GHCR refs (registry contains a dot)", () => {
         const result = parseImageRef("ghcr.io/scope/foo");
 
-        expect(result).toEqual({ registry: "ghcr.io", repository: "scope/foo" });
+        expect(result).toStrictEqual({ registry: "ghcr.io", repository: "scope/foo" });
     });
 
     it("recognises localhost as a registry", () => {
         const result = parseImageRef("localhost:5000/foo");
 
-        expect(result).toEqual({ registry: "localhost:5000", repository: "foo" });
+        expect(result).toStrictEqual({ registry: "localhost:5000", repository: "foo" });
     });
 
     it("defaults the registry to docker.io and adds library/ for single-segment images", () => {
         const result = parseImageRef("nginx");
 
-        expect(result).toEqual({ registry: "docker.io", repository: "library/nginx" });
+        expect(result).toStrictEqual({ registry: "docker.io", repository: "library/nginx" });
     });
 
     it("treats two-segment images without a hostname as docker.io", () => {
         const result = parseImageRef("myorg/myimage");
 
-        expect(result).toEqual({ registry: "docker.io", repository: "myorg/myimage" });
+        expect(result).toStrictEqual({ registry: "docker.io", repository: "myorg/myimage" });
     });
 });
 
@@ -207,7 +207,7 @@ describe(buildBuildxCommand, () => {
         const { command } = buildBuildxCommand(minPkg, { containerImage: "ghcr.io/scope/app" });
 
         expect(command[0]).toBe("docker");
-        expect(command.slice(1, 3)).toEqual(["buildx", "build"]);
+        expect(command.slice(1, 3)).toStrictEqual(["buildx", "build"]);
         expect(command).toContain("--platform");
         expect(command[command.indexOf("--platform") + 1]).toBe("linux/amd64,linux/arm64");
         expect(command).toContain("ghcr.io/scope/app:1.1.0");
@@ -422,7 +422,7 @@ describe("containerActions.publish", () => {
         expect(result.output).toContain("cosign");
         expect(calls).toHaveLength(2);
         expect(calls[1]!.command).toBe("cosign");
-        expect(calls[1]!.args).toEqual(["sign", "--yes", "ghcr.io/scope/app:1.1.0"]);
+        expect(calls[1]!.args).toStrictEqual(["sign", "--yes", "ghcr.io/scope/app:1.1.0"]);
     });
 
     it("throws PUBLISH_FAILED when docker buildx exits non-zero with auth hints", async () => {

--- a/packages/tooling/vis/__tests__/release/core/version-actions-container.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-container.test.ts
@@ -106,6 +106,8 @@ describe("validateContainerConfig (N-4)", () => {
     // into buildBuildxCommand where it would throw a confusing internal
     // error.
     it("returns a narrowed struct on a valid containerImage", () => {
+        expect.hasAssertions();
+
         const result = validateContainerConfig(
             { containerImage: "ghcr.io/scope/foo", containerPlatforms: ["linux/amd64"] },
             "@scope/foo",
@@ -116,6 +118,7 @@ describe("validateContainerConfig (N-4)", () => {
     });
 
     it("throws CONFIG_INVALID when containerImage is missing entirely", () => {
+        expect.hasAssertions();
         expect(() => validateContainerConfig({}, "@scope/foo")).toThrow(
             expect.objectContaining({
                 code: "CONFIG_INVALID",
@@ -125,6 +128,7 @@ describe("validateContainerConfig (N-4)", () => {
     });
 
     it("throws CONFIG_INVALID when containerImage is an empty string", () => {
+        expect.hasAssertions();
         expect(() => validateContainerConfig({ containerImage: "" }, "@scope/foo")).toThrow(
             expect.objectContaining({
                 code: "CONFIG_INVALID",
@@ -137,6 +141,7 @@ describe("validateContainerConfig (N-4)", () => {
         // A user mis-configuring `containerImage: 42` via a templated
         // config tool previously slipped through the `as` cast; now it
         // surfaces clearly.
+        expect.hasAssertions();
         expect(() =>
             validateContainerConfig(
                 { containerImage: 42 as unknown as string },
@@ -147,6 +152,7 @@ describe("validateContainerConfig (N-4)", () => {
     });
 
     it("treats undefined perPkg as missing-image (not a TypeError)", () => {
+        expect.hasAssertions();
         expect(() => validateContainerConfig(undefined, "@scope/foo")).toThrow(
             expect.objectContaining({ code: "CONFIG_INVALID" }),
         );
@@ -155,24 +161,32 @@ describe("validateContainerConfig (N-4)", () => {
 
 describe(parseImageRef, () => {
     it("splits GHCR refs (registry contains a dot)", () => {
+        expect.hasAssertions();
+
         const result = parseImageRef("ghcr.io/scope/foo");
 
         expect(result).toStrictEqual({ registry: "ghcr.io", repository: "scope/foo" });
     });
 
     it("recognises localhost as a registry", () => {
+        expect.hasAssertions();
+
         const result = parseImageRef("localhost:5000/foo");
 
         expect(result).toStrictEqual({ registry: "localhost:5000", repository: "foo" });
     });
 
     it("defaults the registry to docker.io and adds library/ for single-segment images", () => {
+        expect.hasAssertions();
+
         const result = parseImageRef("nginx");
 
         expect(result).toStrictEqual({ registry: "docker.io", repository: "library/nginx" });
     });
 
     it("treats two-segment images without a hostname as docker.io", () => {
+        expect.hasAssertions();
+
         const result = parseImageRef("myorg/myimage");
 
         expect(result).toStrictEqual({ registry: "docker.io", repository: "myorg/myimage" });
@@ -181,18 +195,21 @@ describe(parseImageRef, () => {
 
 describe(ociManifestUrl, () => {
     it("composes the v2 manifest URL for GHCR", () => {
+        expect.hasAssertions();
         expect(ociManifestUrl("ghcr.io/scope/foo", "1.2.3")).toBe(
             "https://ghcr.io/v2/scope/foo/manifests/1.2.3",
         );
     });
 
     it("uses registry-1.docker.io for Docker Hub", () => {
+        expect.hasAssertions();
         expect(ociManifestUrl("nginx", "stable")).toBe(
             "https://registry-1.docker.io/v2/library/nginx/manifests/stable",
         );
     });
 
     it("uRL-encodes tag values with special chars", () => {
+        expect.hasAssertions();
         expect(ociManifestUrl("ghcr.io/s/f", "1.0.0+build")).toContain("%2B");
     });
 });
@@ -204,6 +221,8 @@ describe(buildBuildxCommand, () => {
     };
 
     it("includes --platform, both tags, --push, and OCI labels by default", () => {
+        expect.hasAssertions();
+
         const { command } = buildBuildxCommand(minPkg, { containerImage: "ghcr.io/scope/app" });
 
         expect(command[0]).toBe("docker");
@@ -217,6 +236,8 @@ describe(buildBuildxCommand, () => {
     });
 
     it("omits :latest when containerSkipLatest is true", () => {
+        expect.hasAssertions();
+
         const { command } = buildBuildxCommand(minPkg, {
             containerImage: "ghcr.io/scope/app",
             containerSkipLatest: true,
@@ -227,6 +248,8 @@ describe(buildBuildxCommand, () => {
     });
 
     it("respects a custom containerPlatforms array", () => {
+        expect.hasAssertions();
+
         const { command } = buildBuildxCommand(minPkg, {
             containerImage: "ghcr.io/scope/app",
             containerPlatforms: ["linux/amd64"],
@@ -236,6 +259,8 @@ describe(buildBuildxCommand, () => {
     });
 
     it("forwards containerBuildArgs as --build-arg KEY=VALUE pairs", () => {
+        expect.hasAssertions();
+
         const { command } = buildBuildxCommand(minPkg, {
             containerBuildArgs: { BUILD_DATE: "2025-01-01", VERSION: "1.1.0" },
             containerImage: "ghcr.io/scope/app",
@@ -248,6 +273,8 @@ describe(buildBuildxCommand, () => {
     });
 
     it("uses buildContext as the final positional arg", () => {
+        expect.hasAssertions();
+
         const { command } = buildBuildxCommand(minPkg, {
             buildContext: "./images/app",
             containerImage: "ghcr.io/scope/app",
@@ -265,6 +292,8 @@ describe("containerActions.readPublishedVersion", () => {
     });
 
     it("returns the current version when HEAD returns 200", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockResolvedValue({ status: 200 }) as never;
 
         const actions = new ContainerActions();
@@ -282,6 +311,8 @@ describe("containerActions.readPublishedVersion", () => {
     });
 
     it("returns undefined when HEAD is 404", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 }) as never;
 
         const actions = new ContainerActions();
@@ -295,6 +326,8 @@ describe("containerActions.readPublishedVersion", () => {
     });
 
     it("returns undefined when containerImage is missing", async () => {
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn();
 
         globalThis.fetch = fetchSpy as never;
@@ -310,6 +343,8 @@ describe("containerActions.readPublishedVersion", () => {
     });
 
     it("stamps a vis-release User-Agent and uses manual redirects (B-3 + M-4)", async () => {
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn().mockResolvedValue({
             headers: new Headers(),
             ok: true,
@@ -347,6 +382,8 @@ describe("containerActions.publish", () => {
     });
 
     it("throws CONFIG_INVALID when containerImage is missing", async () => {
+        expect.hasAssertions();
+
         const actions = new ContainerActions();
 
         await expect(actions.publish(buildContext())).rejects.toMatchObject({
@@ -356,6 +393,8 @@ describe("containerActions.publish", () => {
     });
 
     it("emits a dry-run preview without invoking docker", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([]);
         const actions = new ContainerActions();
 
@@ -372,6 +411,8 @@ describe("containerActions.publish", () => {
     });
 
     it("short-circuits with alreadyPublished when the manifest HEAD is 200", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockResolvedValue({ status: 200 }) as never;
         const { calls, runner } = buildRunner([]);
         const actions = new ContainerActions();
@@ -387,6 +428,8 @@ describe("containerActions.publish", () => {
     });
 
     it("invokes docker buildx with the constructed command on a fresh publish", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ exitCode: 0 }]);
         const actions = new ContainerActions();
 
@@ -404,6 +447,8 @@ describe("containerActions.publish", () => {
     });
 
     it("runs cosign sign after a successful push when containerSigning is set", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 0 }, // buildx
             { exitCode: 0 }, // cosign
@@ -426,6 +471,8 @@ describe("containerActions.publish", () => {
     });
 
     it("throws PUBLISH_FAILED when docker buildx exits non-zero with auth hints", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([{ exitCode: 1, stderr: "unauthorized: authentication required" }]);
         const actions = new ContainerActions();
 
@@ -439,6 +486,8 @@ describe("containerActions.publish", () => {
     });
 
     it("throws PUBLISH_FAILED when cosign sign fails", async () => {
+        expect.hasAssertions();
+
         const { runner } = buildRunner([
             { exitCode: 0 }, // buildx
             { exitCode: 1, stderr: "no OIDC token available" }, // cosign
@@ -458,6 +507,7 @@ describe("containerActions.publish", () => {
     });
 
     it("stable id is `container`", () => {
+        expect.hasAssertions();
         expect(new ContainerActions().id).toBe("container");
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
@@ -241,7 +241,7 @@ describe("jsrVersionActions: parseJsrManifest", () => {
         const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "2.5.1" });
         const result = await __testing.parseJsrManifest(path);
 
-        expect(result).toEqual({ name: "@acme/sdk", version: "2.5.1" });
+        expect(result).toStrictEqual({ name: "@acme/sdk", version: "2.5.1" });
     });
 
     it("parses a deno.json manifest (same shape as jsr.json for the fields we read)", async () => {
@@ -254,7 +254,7 @@ describe("jsrVersionActions: parseJsrManifest", () => {
 
         const result = await __testing.parseJsrManifest(path);
 
-        expect(result).toEqual({ name: "@acme/deno-pkg", version: "0.3.0" });
+        expect(result).toStrictEqual({ name: "@acme/deno-pkg", version: "0.3.0" });
     });
 
     it("throws CONFIG_INVALID when name has no @scope/ prefix (JSR refuses unscoped publishes)", async () => {
@@ -370,7 +370,7 @@ describe("jsrVersionActions: publish — happy path", () => {
         expect(result.alreadyPublished).not.toBe(true);
         expect(calls).toHaveLength(1);
         expect(calls[0]!.command).toBe("npx");
-        expect(calls[0]!.args).toEqual(["jsr", "publish", "--allow-dirty"]);
+        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
     });
 
     it("flags OIDC trusted-publishing in the output when ACTIONS_ID_TOKEN_REQUEST_URL is set", async () => {
@@ -388,7 +388,7 @@ describe("jsrVersionActions: publish — happy path", () => {
 
         expect(result.published).toBe(true);
         expect(result.output).toContain("trusted publishing");
-        expect(calls[0]!.args).toEqual(["jsr", "publish", "--allow-dirty"]);
+        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
     });
 
     it("forwards jsrPublishArgs (e.g. --allow-slow-types) after the built-in flags", async () => {
@@ -404,7 +404,7 @@ describe("jsrVersionActions: publish — happy path", () => {
             runner,
         }));
 
-        expect(calls[0]!.args).toEqual(["jsr", "publish", "--allow-dirty", "--allow-slow-types"]);
+        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--allow-slow-types"]);
     });
 
     it("passes --config when jsrConfigPath points at a non-default file (e.g. deno.json)", async () => {
@@ -421,7 +421,7 @@ describe("jsrVersionActions: publish — happy path", () => {
             runner,
         }));
 
-        expect(calls[0]!.args).toEqual(["jsr", "publish", "--allow-dirty", "--config", "deno.json"]);
+        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--config", "deno.json"]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
@@ -367,7 +367,7 @@ describe("jsrVersionActions: publish — happy path", () => {
         }));
 
         expect(result.published).toBe(true);
-        expect(result.alreadyPublished).toBeFalsy();
+        expect(result.alreadyPublished).not.toBe(true);
         expect(calls).toHaveLength(1);
         expect(calls[0]!.command).toBe("npx");
         expect(calls[0]!.args).toEqual(["jsr", "publish", "--allow-dirty"]);

--- a/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
@@ -140,465 +140,467 @@ let workspace: string;
 let originalFetch: typeof globalThis.fetch;
 let originalEnv: NodeJS.ProcessEnv;
 
-beforeEach(() => {
-    workspace = mkdtempSync(join(tmpdir(), "vis-jsr-test-"));
-    originalFetch = globalThis.fetch;
-    originalEnv = { ...process.env };
-    // Wipe ambient auth so tests don't depend on the dev machine's env.
-    delete process.env["JSR_API_KEY"];
-    delete process.env["ACTIONS_ID_TOKEN_REQUEST_URL"];
-    delete process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
-});
-
-afterEach(() => {
-    globalThis.fetch = originalFetch;
-    process.env = originalEnv;
-});
-
-describe("jsrVersionActions: identity", () => {
-    it("has stable id `jsr`", () => {
-        expect.hasAssertions();
-        expect(new JsrVersionActions().id).toBe("jsr");
-    });
-});
-
-describe("jsrVersionActions: readPublishedVersion", () => {
-    it("returns jsr.io `latest` on the 200 happy path", async () => {
-        // Manifest must be present so the actions can resolve the JSR
-        // package name (it's not the JS package.json name — JSR uses
-        // its own scoped identifier in jsr.json).
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
-        const fetchSpy = stubFetch({ body: { latest: "1.2.3", versions: { "1.0.0": {}, "1.2.3": {} } } });
-
-        const result = await new JsrVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBe("1.2.3");
-
-        // Verify the URL targets jsr.io's meta.json endpoint with the
-        // manifest's scoped name (NOT the JS package name).
-        const calledUrl = fetchSpy.mock.calls[0]![0] as string;
-
-        expect(calledUrl).toBe("https://jsr.io/@acme/sdk/meta.json");
+describe("jsr version actions", () => {
+    beforeEach(() => {
+        workspace = mkdtempSync(join(tmpdir(), "vis-jsr-test-"));
+        originalFetch = globalThis.fetch;
+        originalEnv = { ...process.env };
+        // Wipe ambient auth so tests don't depend on the dev machine's env.
+        delete process.env["JSR_API_KEY"];
+        delete process.env["ACTIONS_ID_TOKEN_REQUEST_URL"];
+        delete process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
     });
 
-    it("returns undefined on 404 (package never published)", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/fresh", version: "0.1.0" });
-        stubFetch({ ok: false, status: 404 });
-
-        const result = await new JsrVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        process.env = originalEnv;
     });
 
-    it("returns undefined when fetch throws (network unreachable)", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
-        stubFetch({ throws: true });
-
-        const result = await new JsrVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
-    });
-
-    it("returns undefined when manifest is unreadable (preserves publish-anyway path)", async () => {
-        // No jsr.json at the workspace.
-        expect.hasAssertions();
-
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const result = await new JsrVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        expect(result).toBeUndefined();
-    });
-
-    it("stamps a vis-release User-Agent on jsr.io metadata requests (B-3 parity)", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
-        const fetchSpy = stubFetch({ body: { latest: "1.0.0" } });
-
-        await new JsrVersionActions().readPublishedVersion({
-            pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
-            pm: { runner: buildRunner([]).runner } as never,
-        });
-
-        const init = fetchSpy.mock.calls[0]![1] as RequestInit | undefined;
-        const headers = init?.headers as Record<string, string> | undefined;
-
-        expect(headers).toBeDefined();
-        expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
-    });
-});
-
-describe("jsrVersionActions: parseJsrManifest", () => {
-    it("parses a valid @scope/name + version", async () => {
-        expect.hasAssertions();
-
-        const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "2.5.1" });
-        const result = await __testing.parseJsrManifest(path);
-
-        expect(result).toStrictEqual({ name: "@acme/sdk", version: "2.5.1" });
-    });
-
-    it("parses a deno.json manifest (same shape as jsr.json for the fields we read)", async () => {
-        expect.hasAssertions();
-
-        const path = writeJsrManifest(workspace, "deno.json", {
-            exports: "./mod.ts",
-            name: "@acme/deno-pkg",
-            tasks: { test: "deno test" },
-            version: "0.3.0",
-        });
-
-        const result = await __testing.parseJsrManifest(path);
-
-        expect(result).toStrictEqual({ name: "@acme/deno-pkg", version: "0.3.0" });
-    });
-
-    it("throws CONFIG_INVALID when name has no @scope/ prefix (JSR refuses unscoped publishes)", async () => {
-        expect.hasAssertions();
-
-        const path = writeJsrManifest(workspace, "jsr.json", { name: "no-scope", version: "1.0.0" });
-
-        await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            file: path,
-            hint: expect.stringContaining("@scope/name"),
+    describe("jsrVersionActions: identity", () => {
+        it("has stable id `jsr`", () => {
+            expect.hasAssertions();
+            expect(new JsrVersionActions().id).toBe("jsr");
         });
     });
 
-    it("throws CONFIG_INVALID when name is missing entirely", async () => {
-        expect.hasAssertions();
+    describe("jsrVersionActions: readPublishedVersion", () => {
+        it("returns jsr.io `latest` on the 200 happy path", async () => {
+            // Manifest must be present so the actions can resolve the JSR
+            // package name (it's not the JS package.json name — JSR uses
+            // its own scoped identifier in jsr.json).
+            expect.hasAssertions();
 
-        const path = writeJsrManifest(workspace, "jsr.json", { version: "1.0.0" });
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
+            const fetchSpy = stubFetch({ body: { latest: "1.2.3", versions: { "1.0.0": {}, "1.2.3": {} } } });
 
-        await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            file: path,
+            const result = await new JsrVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBe("1.2.3");
+
+            // Verify the URL targets jsr.io's meta.json endpoint with the
+            // manifest's scoped name (NOT the JS package name).
+            const calledUrl = fetchSpy.mock.calls[0]![0] as string;
+
+            expect(calledUrl).toBe("https://jsr.io/@acme/sdk/meta.json");
+        });
+
+        it("returns undefined on 404 (package never published)", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/fresh", version: "0.1.0" });
+            stubFetch({ ok: false, status: 404 });
+
+            const result = await new JsrVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when fetch throws (network unreachable)", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
+            stubFetch({ throws: true });
+
+            const result = await new JsrVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when manifest is unreadable (preserves publish-anyway path)", async () => {
+            // No jsr.json at the workspace.
+            expect.hasAssertions();
+
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const result = await new JsrVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            expect(result).toBeUndefined();
+        });
+
+        it("stamps a vis-release User-Agent on jsr.io metadata requests (B-3 parity)", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
+            const fetchSpy = stubFetch({ body: { latest: "1.0.0" } });
+
+            await new JsrVersionActions().readPublishedVersion({
+                pkg: { dir: workspace, name: "@scope/sdk-jsr" } as never,
+                pm: { runner: buildRunner([]).runner } as never,
+            });
+
+            const init = fetchSpy.mock.calls[0]![1] as RequestInit | undefined;
+            const headers = init?.headers as Record<string, string> | undefined;
+
+            expect(headers).toBeDefined();
+            expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
         });
     });
 
-    it("throws CONFIG_INVALID when version is missing", async () => {
-        expect.hasAssertions();
+    describe("jsrVersionActions: parseJsrManifest", () => {
+        it("parses a valid @scope/name + version", async () => {
+            expect.hasAssertions();
 
-        const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk" });
+            const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "2.5.1" });
+            const result = await __testing.parseJsrManifest(path);
 
-        await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            file: path,
+            expect(result).toStrictEqual({ name: "@acme/sdk", version: "2.5.1" });
+        });
+
+        it("parses a deno.json manifest (same shape as jsr.json for the fields we read)", async () => {
+            expect.hasAssertions();
+
+            const path = writeJsrManifest(workspace, "deno.json", {
+                exports: "./mod.ts",
+                name: "@acme/deno-pkg",
+                tasks: { test: "deno test" },
+                version: "0.3.0",
+            });
+
+            const result = await __testing.parseJsrManifest(path);
+
+            expect(result).toStrictEqual({ name: "@acme/deno-pkg", version: "0.3.0" });
+        });
+
+        it("throws CONFIG_INVALID when name has no @scope/ prefix (JSR refuses unscoped publishes)", async () => {
+            expect.hasAssertions();
+
+            const path = writeJsrManifest(workspace, "jsr.json", { name: "no-scope", version: "1.0.0" });
+
+            await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                file: path,
+                hint: expect.stringContaining("@scope/name"),
+            });
+        });
+
+        it("throws CONFIG_INVALID when name is missing entirely", async () => {
+            expect.hasAssertions();
+
+            const path = writeJsrManifest(workspace, "jsr.json", { version: "1.0.0" });
+
+            await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                file: path,
+            });
+        });
+
+        it("throws CONFIG_INVALID when version is missing", async () => {
+            expect.hasAssertions();
+
+            const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk" });
+
+            await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                file: path,
+            });
+        });
+
+        it("throws CONFIG_INVALID when the file is missing entirely", async () => {
+            expect.hasAssertions();
+            await expect(__testing.parseJsrManifest(join(workspace, "no-such-file.json"))).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+            });
+        });
+
+        it("throws CONFIG_INVALID on malformed JSON", async () => {
+            expect.hasAssertions();
+
+            const path = join(workspace, "jsr.json");
+
+            writeFileSync(path, "{ not valid json ");
+
+            await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                file: path,
+            });
         });
     });
 
-    it("throws CONFIG_INVALID when the file is missing entirely", async () => {
-        expect.hasAssertions();
-        await expect(__testing.parseJsrManifest(join(workspace, "no-such-file.json"))).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
+    describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
+        it("returns true with OIDC env + no static token", () => {
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({
+                ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
+            })).toBe(true);
         });
-    });
 
-    it("throws CONFIG_INVALID on malformed JSON", async () => {
-        expect.hasAssertions();
-
-        const path = join(workspace, "jsr.json");
-
-        writeFileSync(path, "{ not valid json ");
-
-        await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            file: path,
-        });
-    });
-});
-
-describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
-    it("returns true with OIDC env + no static token", () => {
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({
-            ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
-        })).toBe(true);
-    });
-
-    it("returns true even when JSR_API_KEY is set (OIDC wins by default)", () => {
-        // Aligned with cargo / python: OIDC env presence means the
-        // operator wired up trusted publishing; a leftover static token
-        // shouldn't silently downgrade.
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({
-            ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
-            JSR_API_KEY: "jsr_abc123",
-        })).toBe(true);
-    });
-
-    it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing(
-            {
+        it("returns true even when JSR_API_KEY is set (OIDC wins by default)", () => {
+            // Aligned with cargo / python: OIDC env presence means the
+            // operator wired up trusted publishing; a leftover static token
+            // shouldn't silently downgrade.
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({
                 ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
                 JSR_API_KEY: "jsr_abc123",
-            },
-            { publish: { preferStaticToken: true } },
-        )).toBe(false);
-    });
-
-    it("returns false without OIDC env (developer machine, no key)", () => {
-        expect.hasAssertions();
-        expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
-    });
-});
-
-describe("jsrVersionActions: publish — dryRun", () => {
-    it("returns published: true without invoking npx or fetch", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        const { calls, runner } = buildRunner([]);
-        const fetchSpy = stubFetch({ body: {} });
-
-        const result = await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            dryRun: true,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("[dry-run / jsr]");
-        expect(calls).toHaveLength(0);
-        expect(fetchSpy).not.toHaveBeenCalled();
-    });
-});
-
-describe("jsrVersionActions: publish — happy path", () => {
-    it("invokes `npx jsr publish --allow-dirty` when jsr.io has an older version", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy_static_token";
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "uploaded" }]);
-        const result = await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.alreadyPublished).not.toBe(true);
-        expect(calls).toHaveLength(1);
-        expect(calls[0]!.command).toBe("npx");
-        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
-    });
-
-    it("flags OIDC trusted-publishing in the output when ACTIONS_ID_TOKEN_REQUEST_URL is set", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
-        process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
-
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0 }]);
-        const result = await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("trusted publishing");
-        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
-    });
-
-    it("forwards jsrPublishArgs (e.g. --allow-slow-types) after the built-in flags", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0 }]);
-
-        await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            jsrPublishArgs: ["--allow-slow-types"],
-            runner,
-        }));
-
-        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--allow-slow-types"]);
-    });
-
-    it("passes --config when jsrConfigPath points at a non-default file (e.g. deno.json)", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "deno.json", { name: "@acme/deno-pkg", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const { calls, runner } = buildRunner([{ exitCode: 0 }]);
-
-        await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            jsrConfigPath: "deno.json",
-            pkgName: "@scope/deno-pkg",
-            runner,
-        }));
-
-        expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--config", "deno.json"]);
-    });
-});
-
-describe("jsrVersionActions: publish — idempotency", () => {
-    it("short-circuits with alreadyPublished when jsr.io latest === new version", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "1.0.1" } });
-
-        const { calls, runner } = buildRunner([]);
-        const result = await new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }));
-
-        expect(result.alreadyPublished).toBe(true);
-        expect(result.published).toBe(false);
-        expect(result.output).toContain("already on jsr.io");
-        expect(calls).toHaveLength(0);
-    });
-});
-
-describe("jsrVersionActions: publish — failure modes", () => {
-    it("throws AUTH_MISSING when neither JSR_API_KEY nor OIDC is available", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        await expect(new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner: buildRunner([]).runner,
-        }))).rejects.toMatchObject({ code: "AUTH_MISSING" });
-    });
-
-    it("throws CONFIG_INVALID when the manifest's name is unscoped", async () => {
-        // The manifest gets past the read step (extra-files would
-        // already have bumped it to newVersion in a real run); the
-        // publish path re-validates and surfaces the scoped-name rule.
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "unscoped", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        await expect(new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner: buildRunner([]).runner,
-        }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
-    });
-
-    it("throws CONFIG_INVALID when manifest version differs from planned release version", async () => {
-        // Simulates a misconfigured extra-files rule that didn't bump
-        // the manifest — we want to publish 1.0.1 but disk says 1.0.0.
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "0.9.0" } });
-
-        await expect(new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            newVersion: "1.0.1",
-            runner: buildRunner([]).runner,
-        }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
-    });
-
-    it("throws PUBLISH_FAILED when jsr publish exits non-zero", async () => {
-        expect.hasAssertions();
-
-        writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
-        process.env["JSR_API_KEY"] = "jsr_dummy";
-        stubFetch({ body: { latest: "1.0.0" } });
-
-        const { runner } = buildRunner([{ exitCode: 1, stderr: "error: 401 Unauthorized" }]);
-
-        await expect(new JsrVersionActions().publish(ctx({
-            dir: workspace,
-            runner,
-        }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
-    });
-});
-
-describe("jsr() preset integration", () => {
-    it("returns a PerPackageReleaseConfig with versionActions: 'jsr' and matching jsrConfigPath", () => {
-        expect.hasAssertions();
-
-        const cfg = jsr();
-
-        expect(cfg.versionActions).toBe("jsr");
-        expect(cfg.jsrConfigPath).toBe("jsr.json");
-        expect(cfg.extraFiles).toBeDefined();
-        expect(cfg.extraFiles).toHaveLength(1);
-        expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
-    });
-
-    it("supports `manifestPath: 'deno.json'` for Deno-flavoured packages", () => {
-        expect.hasAssertions();
-
-        const cfg = jsr({ manifestPath: "deno.json" });
-
-        expect(cfg.versionActions).toBe("jsr");
-        expect(cfg.jsrConfigPath).toBe("deno.json");
-        expect(cfg.extraFiles![0]!.path).toBe("deno.json");
-    });
-
-    it("emits a second extra-files rule against deno.json when `deno: true` is passed", () => {
-        expect.hasAssertions();
-
-        const cfg = jsr({ deno: true });
-
-        expect(cfg.extraFiles).toHaveLength(2);
-        expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
-        expect(cfg.extraFiles![1]!.path).toBe("deno.json");
-    });
-
-    it("does NOT duplicate the rule when `deno: true` is paired with `manifestPath: 'deno.json'`", () => {
-        // Edge case: operator passed both flags. The manifestPath
-        // already targets deno.json, so there's no second file to
-        // rewrite — the preset must not emit a duplicate rule.
-        expect.hasAssertions();
-
-        const cfg = jsr({ deno: true, manifestPath: "deno.json" });
-
-        expect(cfg.extraFiles).toHaveLength(1);
-        expect(cfg.extraFiles![0]!.path).toBe("deno.json");
-    });
-
-    it("merges operator-supplied extraFiles after the manifest rule", () => {
-        expect.hasAssertions();
-
-        const cfg = jsr({
-            extraFiles: [{ path: "src/version.ts", search: "VERSION = \"[^\"]+\"" }],
+            })).toBe(true);
         });
 
-        expect(cfg.extraFiles).toHaveLength(2);
-        expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
-        expect(cfg.extraFiles![1]!.path).toBe("src/version.ts");
+        it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing(
+                {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
+                    JSR_API_KEY: "jsr_abc123",
+                },
+                { publish: { preferStaticToken: true } },
+            )).toBe(false);
+        });
+
+        it("returns false without OIDC env (developer machine, no key)", () => {
+            expect.hasAssertions();
+            expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
+        });
+    });
+
+    describe("jsrVersionActions: publish — dryRun", () => {
+        it("returns published: true without invoking npx or fetch", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            const { calls, runner } = buildRunner([]);
+            const fetchSpy = stubFetch({ body: {} });
+
+            const result = await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                dryRun: true,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("[dry-run / jsr]");
+            expect(calls).toHaveLength(0);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("jsrVersionActions: publish — happy path", () => {
+        it("invokes `npx jsr publish --allow-dirty` when jsr.io has an older version", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy_static_token";
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "uploaded" }]);
+            const result = await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            expect(result.alreadyPublished).not.toBe(true);
+            expect(calls).toHaveLength(1);
+            expect(calls[0]!.command).toBe("npx");
+            expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
+        });
+
+        it("flags OIDC trusted-publishing in the output when ACTIONS_ID_TOKEN_REQUEST_URL is set", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
+            process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
+
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+            const result = await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("trusted publishing");
+            expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty"]);
+        });
+
+        it("forwards jsrPublishArgs (e.g. --allow-slow-types) after the built-in flags", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+
+            await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                jsrPublishArgs: ["--allow-slow-types"],
+                runner,
+            }));
+
+            expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--allow-slow-types"]);
+        });
+
+        it("passes --config when jsrConfigPath points at a non-default file (e.g. deno.json)", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "deno.json", { name: "@acme/deno-pkg", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const { calls, runner } = buildRunner([{ exitCode: 0 }]);
+
+            await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                jsrConfigPath: "deno.json",
+                pkgName: "@scope/deno-pkg",
+                runner,
+            }));
+
+            expect(calls[0]!.args).toStrictEqual(["jsr", "publish", "--allow-dirty", "--config", "deno.json"]);
+        });
+    });
+
+    describe("jsrVersionActions: publish — idempotency", () => {
+        it("short-circuits with alreadyPublished when jsr.io latest === new version", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "1.0.1" } });
+
+            const { calls, runner } = buildRunner([]);
+            const result = await new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }));
+
+            expect(result.alreadyPublished).toBe(true);
+            expect(result.published).toBe(false);
+            expect(result.output).toContain("already on jsr.io");
+            expect(calls).toHaveLength(0);
+        });
+    });
+
+    describe("jsrVersionActions: publish — failure modes", () => {
+        it("throws AUTH_MISSING when neither JSR_API_KEY nor OIDC is available", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            await expect(new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner: buildRunner([]).runner,
+            }))).rejects.toMatchObject({ code: "AUTH_MISSING" });
+        });
+
+        it("throws CONFIG_INVALID when the manifest's name is unscoped", async () => {
+            // The manifest gets past the read step (extra-files would
+            // already have bumped it to newVersion in a real run); the
+            // publish path re-validates and surfaces the scoped-name rule.
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "unscoped", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            await expect(new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner: buildRunner([]).runner,
+            }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+        });
+
+        it("throws CONFIG_INVALID when manifest version differs from planned release version", async () => {
+            // Simulates a misconfigured extra-files rule that didn't bump
+            // the manifest — we want to publish 1.0.1 but disk says 1.0.0.
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "0.9.0" } });
+
+            await expect(new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                newVersion: "1.0.1",
+                runner: buildRunner([]).runner,
+            }))).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+        });
+
+        it("throws PUBLISH_FAILED when jsr publish exits non-zero", async () => {
+            expect.hasAssertions();
+
+            writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
+            process.env["JSR_API_KEY"] = "jsr_dummy";
+            stubFetch({ body: { latest: "1.0.0" } });
+
+            const { runner } = buildRunner([{ exitCode: 1, stderr: "error: 401 Unauthorized" }]);
+
+            await expect(new JsrVersionActions().publish(ctx({
+                dir: workspace,
+                runner,
+            }))).rejects.toMatchObject({ code: "PUBLISH_FAILED" });
+        });
+    });
+
+    describe("jsr() preset integration", () => {
+        it("returns a PerPackageReleaseConfig with versionActions: 'jsr' and matching jsrConfigPath", () => {
+            expect.hasAssertions();
+
+            const cfg = jsr();
+
+            expect(cfg.versionActions).toBe("jsr");
+            expect(cfg.jsrConfigPath).toBe("jsr.json");
+            expect(cfg.extraFiles).toBeDefined();
+            expect(cfg.extraFiles).toHaveLength(1);
+            expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
+        });
+
+        it("supports `manifestPath: 'deno.json'` for Deno-flavoured packages", () => {
+            expect.hasAssertions();
+
+            const cfg = jsr({ manifestPath: "deno.json" });
+
+            expect(cfg.versionActions).toBe("jsr");
+            expect(cfg.jsrConfigPath).toBe("deno.json");
+            expect(cfg.extraFiles![0]!.path).toBe("deno.json");
+        });
+
+        it("emits a second extra-files rule against deno.json when `deno: true` is passed", () => {
+            expect.hasAssertions();
+
+            const cfg = jsr({ deno: true });
+
+            expect(cfg.extraFiles).toHaveLength(2);
+            expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
+            expect(cfg.extraFiles![1]!.path).toBe("deno.json");
+        });
+
+        it("does NOT duplicate the rule when `deno: true` is paired with `manifestPath: 'deno.json'`", () => {
+            // Edge case: operator passed both flags. The manifestPath
+            // already targets deno.json, so there's no second file to
+            // rewrite — the preset must not emit a duplicate rule.
+            expect.hasAssertions();
+
+            const cfg = jsr({ deno: true, manifestPath: "deno.json" });
+
+            expect(cfg.extraFiles).toHaveLength(1);
+            expect(cfg.extraFiles![0]!.path).toBe("deno.json");
+        });
+
+        it("merges operator-supplied extraFiles after the manifest rule", () => {
+            expect.hasAssertions();
+
+            const cfg = jsr({
+                extraFiles: [{ path: "src/version.ts", search: "VERSION = \"[^\"]+\"" }],
+            });
+
+            expect(cfg.extraFiles).toHaveLength(2);
+            expect(cfg.extraFiles![0]!.path).toBe("jsr.json");
+            expect(cfg.extraFiles![1]!.path).toBe("src/version.ts");
+        });
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-jsr.test.ts
@@ -157,6 +157,7 @@ afterEach(() => {
 
 describe("jsrVersionActions: identity", () => {
     it("has stable id `jsr`", () => {
+        expect.hasAssertions();
         expect(new JsrVersionActions().id).toBe("jsr");
     });
 });
@@ -166,6 +167,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
         // Manifest must be present so the actions can resolve the JSR
         // package name (it's not the JS package.json name — JSR uses
         // its own scoped identifier in jsr.json).
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
         const fetchSpy = stubFetch({ body: { latest: "1.2.3", versions: { "1.0.0": {}, "1.2.3": {} } } });
 
@@ -184,6 +187,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
     });
 
     it("returns undefined on 404 (package never published)", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/fresh", version: "0.1.0" });
         stubFetch({ ok: false, status: 404 });
 
@@ -196,6 +201,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
     });
 
     it("returns undefined when fetch throws (network unreachable)", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
         stubFetch({ throws: true });
 
@@ -209,6 +216,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
 
     it("returns undefined when manifest is unreadable (preserves publish-anyway path)", async () => {
         // No jsr.json at the workspace.
+        expect.hasAssertions();
+
         stubFetch({ body: { latest: "1.0.0" } });
 
         const result = await new JsrVersionActions().readPublishedVersion({
@@ -220,6 +229,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
     });
 
     it("stamps a vis-release User-Agent on jsr.io metadata requests (B-3 parity)", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
         const fetchSpy = stubFetch({ body: { latest: "1.0.0" } });
 
@@ -238,6 +249,8 @@ describe("jsrVersionActions: readPublishedVersion", () => {
 
 describe("jsrVersionActions: parseJsrManifest", () => {
     it("parses a valid @scope/name + version", async () => {
+        expect.hasAssertions();
+
         const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "2.5.1" });
         const result = await __testing.parseJsrManifest(path);
 
@@ -245,6 +258,8 @@ describe("jsrVersionActions: parseJsrManifest", () => {
     });
 
     it("parses a deno.json manifest (same shape as jsr.json for the fields we read)", async () => {
+        expect.hasAssertions();
+
         const path = writeJsrManifest(workspace, "deno.json", {
             exports: "./mod.ts",
             name: "@acme/deno-pkg",
@@ -258,6 +273,8 @@ describe("jsrVersionActions: parseJsrManifest", () => {
     });
 
     it("throws CONFIG_INVALID when name has no @scope/ prefix (JSR refuses unscoped publishes)", async () => {
+        expect.hasAssertions();
+
         const path = writeJsrManifest(workspace, "jsr.json", { name: "no-scope", version: "1.0.0" });
 
         await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
@@ -268,6 +285,8 @@ describe("jsrVersionActions: parseJsrManifest", () => {
     });
 
     it("throws CONFIG_INVALID when name is missing entirely", async () => {
+        expect.hasAssertions();
+
         const path = writeJsrManifest(workspace, "jsr.json", { version: "1.0.0" });
 
         await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
@@ -277,6 +296,8 @@ describe("jsrVersionActions: parseJsrManifest", () => {
     });
 
     it("throws CONFIG_INVALID when version is missing", async () => {
+        expect.hasAssertions();
+
         const path = writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk" });
 
         await expect(__testing.parseJsrManifest(path)).rejects.toMatchObject({
@@ -286,12 +307,15 @@ describe("jsrVersionActions: parseJsrManifest", () => {
     });
 
     it("throws CONFIG_INVALID when the file is missing entirely", async () => {
+        expect.hasAssertions();
         await expect(__testing.parseJsrManifest(join(workspace, "no-such-file.json"))).rejects.toMatchObject({
             code: "CONFIG_INVALID",
         });
     });
 
     it("throws CONFIG_INVALID on malformed JSON", async () => {
+        expect.hasAssertions();
+
         const path = join(workspace, "jsr.json");
 
         writeFileSync(path, "{ not valid json ");
@@ -305,6 +329,7 @@ describe("jsrVersionActions: parseJsrManifest", () => {
 
 describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
     it("returns true with OIDC env + no static token", () => {
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
         })).toBe(true);
@@ -314,6 +339,7 @@ describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
         // Aligned with cargo / python: OIDC env presence means the
         // operator wired up trusted publishing; a leftover static token
         // shouldn't silently downgrade.
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
             JSR_API_KEY: "jsr_abc123",
@@ -321,6 +347,7 @@ describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
     });
 
     it("returns false when preferStaticToken: true AND a static token is set (escape hatch)", () => {
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing(
             {
                 ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.com",
@@ -331,12 +358,15 @@ describe("jsrVersionActions: shouldUseTrustedPublishing", () => {
     });
 
     it("returns false without OIDC env (developer machine, no key)", () => {
+        expect.hasAssertions();
         expect(__testing.shouldUseTrustedPublishing({})).toBe(false);
     });
 });
 
 describe("jsrVersionActions: publish — dryRun", () => {
     it("returns published: true without invoking npx or fetch", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         const { calls, runner } = buildRunner([]);
         const fetchSpy = stubFetch({ body: {} });
@@ -356,6 +386,8 @@ describe("jsrVersionActions: publish — dryRun", () => {
 
 describe("jsrVersionActions: publish — happy path", () => {
     it("invokes `npx jsr publish --allow-dirty` when jsr.io has an older version", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy_static_token";
         stubFetch({ body: { latest: "1.0.0" } });
@@ -374,6 +406,8 @@ describe("jsrVersionActions: publish — happy path", () => {
     });
 
     it("flags OIDC trusted-publishing in the output when ACTIONS_ID_TOKEN_REQUEST_URL is set", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         process.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://token.actions.githubusercontent.com";
         process.env["ACTIONS_ID_TOKEN_REQUEST_TOKEN"] = "ghs_dummy";
@@ -392,6 +426,8 @@ describe("jsrVersionActions: publish — happy path", () => {
     });
 
     it("forwards jsrPublishArgs (e.g. --allow-slow-types) after the built-in flags", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "1.0.0" } });
@@ -408,6 +444,8 @@ describe("jsrVersionActions: publish — happy path", () => {
     });
 
     it("passes --config when jsrConfigPath points at a non-default file (e.g. deno.json)", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "deno.json", { name: "@acme/deno-pkg", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "1.0.0" } });
@@ -427,6 +465,8 @@ describe("jsrVersionActions: publish — happy path", () => {
 
 describe("jsrVersionActions: publish — idempotency", () => {
     it("short-circuits with alreadyPublished when jsr.io latest === new version", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "1.0.1" } });
@@ -446,6 +486,8 @@ describe("jsrVersionActions: publish — idempotency", () => {
 
 describe("jsrVersionActions: publish — failure modes", () => {
     it("throws AUTH_MISSING when neither JSR_API_KEY nor OIDC is available", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         stubFetch({ body: { latest: "1.0.0" } });
 
@@ -459,6 +501,8 @@ describe("jsrVersionActions: publish — failure modes", () => {
         // The manifest gets past the read step (extra-files would
         // already have bumped it to newVersion in a real run); the
         // publish path re-validates and surfaces the scoped-name rule.
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "unscoped", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "1.0.0" } });
@@ -472,6 +516,8 @@ describe("jsrVersionActions: publish — failure modes", () => {
     it("throws CONFIG_INVALID when manifest version differs from planned release version", async () => {
         // Simulates a misconfigured extra-files rule that didn't bump
         // the manifest — we want to publish 1.0.1 but disk says 1.0.0.
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.0" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "0.9.0" } });
@@ -484,6 +530,8 @@ describe("jsrVersionActions: publish — failure modes", () => {
     });
 
     it("throws PUBLISH_FAILED when jsr publish exits non-zero", async () => {
+        expect.hasAssertions();
+
         writeJsrManifest(workspace, "jsr.json", { name: "@acme/sdk", version: "1.0.1" });
         process.env["JSR_API_KEY"] = "jsr_dummy";
         stubFetch({ body: { latest: "1.0.0" } });
@@ -499,6 +547,8 @@ describe("jsrVersionActions: publish — failure modes", () => {
 
 describe("jsr() preset integration", () => {
     it("returns a PerPackageReleaseConfig with versionActions: 'jsr' and matching jsrConfigPath", () => {
+        expect.hasAssertions();
+
         const cfg = jsr();
 
         expect(cfg.versionActions).toBe("jsr");
@@ -509,6 +559,8 @@ describe("jsr() preset integration", () => {
     });
 
     it("supports `manifestPath: 'deno.json'` for Deno-flavoured packages", () => {
+        expect.hasAssertions();
+
         const cfg = jsr({ manifestPath: "deno.json" });
 
         expect(cfg.versionActions).toBe("jsr");
@@ -517,6 +569,8 @@ describe("jsr() preset integration", () => {
     });
 
     it("emits a second extra-files rule against deno.json when `deno: true` is passed", () => {
+        expect.hasAssertions();
+
         const cfg = jsr({ deno: true });
 
         expect(cfg.extraFiles).toHaveLength(2);
@@ -528,6 +582,8 @@ describe("jsr() preset integration", () => {
         // Edge case: operator passed both flags. The manifestPath
         // already targets deno.json, so there's no second file to
         // rewrite — the preset must not emit a duplicate rule.
+        expect.hasAssertions();
+
         const cfg = jsr({ deno: true, manifestPath: "deno.json" });
 
         expect(cfg.extraFiles).toHaveLength(1);
@@ -535,6 +591,8 @@ describe("jsr() preset integration", () => {
     });
 
     it("merges operator-supplied extraFiles after the manifest rule", () => {
+        expect.hasAssertions();
+
         const cfg = jsr({
             extraFiles: [{ path: "src/version.ts", search: "VERSION = \"[^\"]+\"" }],
         });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
@@ -643,7 +643,7 @@ describe("parsePomCoordinates regex sharing (B-4)", () => {
         const results = Array.from({ length: 100 }, () => parsePomCoordinates(xml));
 
         for (const result of results) {
-            expect(result).toEqual({
+            expect(result).toStrictEqual({
                 artifactId: "c",
                 groupId: "a.b",
                 hasModules: false,

--- a/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
@@ -135,6 +135,8 @@ const buildPublishContext = (overrides: { dryRun?: boolean; newVersion?: string;
 
 describe(parsePomCoordinates, () => {
     it("extracts groupId / artifactId / version from a simple pom", () => {
+        expect.hasAssertions();
+
         const result = parsePomCoordinates(POM_SIMPLE);
 
         expect(result.groupId).toBe("io.visulima");
@@ -144,6 +146,8 @@ describe(parsePomCoordinates, () => {
     });
 
     it("skips <parent> + <dependency> version tags and finds the project version", () => {
+        expect.hasAssertions();
+
         const result = parsePomCoordinates(POM_WITH_PARENT);
 
         // 1.2.3 is the project version; 3.2.0 / 9.9.9 are the parent + dep
@@ -154,6 +158,8 @@ describe(parsePomCoordinates, () => {
     });
 
     it("flags multi-module reactor projects via hasModules", () => {
+        expect.hasAssertions();
+
         const result = parsePomCoordinates(POM_MULTI_MODULE);
 
         expect(result.hasModules).toBe(true);
@@ -161,6 +167,8 @@ describe(parsePomCoordinates, () => {
     });
 
     it("ignores commented-out version tags", () => {
+        expect.hasAssertions();
+
         const xml = `<project>
             <groupId>a.b</groupId>
             <artifactId>c</artifactId>
@@ -176,20 +184,24 @@ describe(parsePomCoordinates, () => {
 
 describe(parseMavenMetadataLatest, () => {
     it("prefers <latest>", () => {
+        expect.hasAssertions();
         expect(parseMavenMetadataLatest(METADATA_WITH_LATEST)).toBe("1.2.4");
     });
 
     it("falls back to the last <version> in <versions> when <latest> is missing", () => {
+        expect.hasAssertions();
         expect(parseMavenMetadataLatest(METADATA_NO_LATEST)).toBe("1.0.0");
     });
 
     it("returns undefined for malformed metadata", () => {
+        expect.hasAssertions();
         expect(parseMavenMetadataLatest("<metadata />")).toBeUndefined();
     });
 });
 
 describe(mavenCentralMetadataUrl, () => {
     it("translates dotted groupId into slash path", () => {
+        expect.hasAssertions();
         expect(mavenCentralMetadataUrl("io.visulima", "vis-jvm")).toBe(
             "https://repo1.maven.org/maven2/io/visulima/vis-jvm/maven-metadata.xml",
         );
@@ -211,6 +223,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("returns the metadata <latest> for an existing artifact", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockResolvedValue({
             ok: true,
             status: 200,
@@ -231,6 +245,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("returns undefined on 404 (fresh artifact)", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockResolvedValue({
             ok: false,
             status: 404,
@@ -247,6 +263,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("returns undefined when the network errors (fail-open)", async () => {
+        expect.hasAssertions();
+
         globalThis.fetch = vi.fn().mockRejectedValue(new Error("ENOTFOUND")) as never;
 
         const actions = new MavenVersionActions();
@@ -259,6 +277,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("returns undefined when the pom is missing", async () => {
+        expect.hasAssertions();
+
         const emptyDir = mkdtempSync(join(tmpdir(), "vis-maven-empty-"));
 
         try {
@@ -275,6 +295,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("warns to stderr when the pom declares <modules>", async () => {
+        expect.hasAssertions();
+
         writeFileSync(join(pkgDir, "pom.xml"), POM_MULTI_MODULE);
         globalThis.fetch = vi.fn().mockResolvedValue({
             ok: true,
@@ -300,6 +322,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     });
 
     it("honours mavenMetadataUrl: \"\" to disable the metadata check", async () => {
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn();
 
         globalThis.fetch = fetchSpy as never;
@@ -317,6 +341,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
 
     it("stamps a vis-release User-Agent on the metadata request (B-3)", async () => {
         // B-3: every registry-probe fetch carries a contact UA.
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn().mockResolvedValue({
             headers: new Headers(),
             ok: true,
@@ -347,6 +373,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     it("follows up to 2 same-host redirects (M-4 SSRF guard)", async () => {
         // M-4: when Maven Central's CDN normalises a path with a 301,
         // we want to follow IF the target stays on the same host.
+        expect.hasAssertions();
+
         let call = 0;
         const fetchSpy = vi.fn().mockImplementation(async (_url: string) => {
             call += 1;
@@ -393,6 +421,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
         // treated as a 404 rather than silently following the 30x.
         // This protects against cloud-metadata exfil, intranet
         // probing, etc.
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn().mockResolvedValueOnce({
             headers: new Headers({
                 // Cross-host redirect → SSRF risk → reject.
@@ -420,6 +450,8 @@ describe("mavenVersionActions.readPublishedVersion", () => {
     it("stops after 2 same-host redirects to bound chains (M-4 SSRF guard)", async () => {
         // Bounded chain — at most 2 follows. The 3rd 301 in a row
         // surfaces as "unknown" rather than continuing indefinitely.
+        expect.hasAssertions();
+
         const fetchSpy = vi.fn().mockResolvedValue({
             headers: new Headers({
                 location: "https://repo1.maven.org/maven2/io/visulima/vis-jvm/loop/maven-metadata.xml",
@@ -457,6 +489,8 @@ describe("mavenVersionActions.publish", () => {
     });
 
     it("returns published: true in dryRun mode without throwing", async () => {
+        expect.hasAssertions();
+
         const actions = new MavenVersionActions();
         const result = await actions.publish(buildPublishContext({ dryRun: true, pkg: buildPkg(pkgDir) }));
 
@@ -465,6 +499,8 @@ describe("mavenVersionActions.publish", () => {
     });
 
     it("throws CONFIG_INVALID with the shell-path workaround hint", async () => {
+        expect.hasAssertions();
+
         const actions = new MavenVersionActions();
 
         await expect(actions.publish(buildPublishContext({ pkg: buildPkg(pkgDir) }))).rejects.toMatchObject({
@@ -474,6 +510,8 @@ describe("mavenVersionActions.publish", () => {
     });
 
     it("error mentions the docs guide for the full operator setup", async () => {
+        expect.hasAssertions();
+
         const actions = new MavenVersionActions();
 
         await expect(actions.publish(buildPublishContext({ pkg: buildPkg(pkgDir) }))).rejects.toMatchObject({
@@ -482,6 +520,7 @@ describe("mavenVersionActions.publish", () => {
     });
 
     it("stable id is `maven`", () => {
+        expect.hasAssertions();
         expect(new MavenVersionActions().id).toBe("maven");
     });
 
@@ -490,6 +529,8 @@ describe("mavenVersionActions.publish", () => {
         // across the workspace to find the offending pom. The publish
         // error now stamps `groupId:artifactId` (and the resolved pom
         // path) so the log line points straight at the source.
+        expect.hasAssertions();
+
         const actions = new MavenVersionActions();
         const pkg = buildPkg(pkgDir);
 
@@ -504,6 +545,8 @@ describe("mavenVersionActions.publish", () => {
         // Best-effort pom read: a missing/malformed pom doesn't change
         // the error class, but the coordinate label degrades to the
         // package name so the operator still has SOMETHING to grep.
+        expect.hasAssertions();
+
         const emptyDir = mkdtempSync(join(tmpdir(), "vis-maven-no-pom-"));
 
         try {
@@ -520,6 +563,8 @@ describe("mavenVersionActions.publish", () => {
     });
 
     it("includes the resolved pom path in the hint (B-1)", async () => {
+        expect.hasAssertions();
+
         const actions = new MavenVersionActions();
         const pkg = buildPkg(pkgDir);
 
@@ -565,6 +610,8 @@ describe("mavenVersionActions instance state (N-5)", () => {
     });
 
     it("emits the multi-module warning once per actions instance", async () => {
+        expect.hasAssertions();
+
         const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
         const actions = new MavenVersionActions();
@@ -595,6 +642,8 @@ describe("mavenVersionActions instance state (N-5)", () => {
         // long-running daemon, REPL session, or test harness reusing
         // module imports) gets the warning again. Previously the
         // module-level WeakSet ate it.
+        expect.hasAssertions();
+
         const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
         const pkg = buildPkg(pkgDir);
@@ -634,6 +683,8 @@ describe("parsePomCoordinates regex sharing (B-4)", () => {
     // times must produce identical results without state contamination
     // (the hoisted regexes are stateless — no `g` flag — so safe to share).
     it("yields identical coordinates across repeated calls (regex statelessness)", () => {
+        expect.hasAssertions();
+
         const xml = `<project>
             <groupId>a.b</groupId>
             <artifactId>c</artifactId>

--- a/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-maven.test.ts
@@ -333,7 +333,7 @@ describe("mavenVersionActions.readPublishedVersion", () => {
             pm: { runner: {} as CommandRunner } as never,
         });
 
-        expect(fetchSpy).toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
 
         const init = fetchSpy.mock.calls[0]![1] as RequestInit | undefined;
         const headers = init?.headers as Record<string, string> | undefined;

--- a/packages/tooling/vis/__tests__/release/core/version-actions-private.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-private.test.ts
@@ -32,6 +32,8 @@ const mkPkg = (name: string, version: string, isPrivate: boolean): WorkspacePack
 
 describe(PrivateVersionActions, () => {
     it("readPublishedVersion always returns undefined", async () => {
+        expect.hasAssertions();
+
         const actions = new PrivateVersionActions();
         const pm = new NpmAdapter(new MockRunner());
 
@@ -44,6 +46,8 @@ describe(PrivateVersionActions, () => {
     });
 
     it("publish returns published: false with diagnostic output", async () => {
+        expect.hasAssertions();
+
         const actions = new PrivateVersionActions();
         const pm = new NpmAdapter(new MockRunner());
 
@@ -61,6 +65,7 @@ describe(PrivateVersionActions, () => {
     });
 
     it("has stable id `private`", () => {
+        expect.hasAssertions();
         expect(new PrivateVersionActions().id).toBe("private");
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
@@ -442,7 +442,7 @@ describe("pythonVersionActions: PyPI User-Agent header (B-3)", () => {
 
         await fetchPyPiVersion("any-pkg");
 
-        expect(fetchSpy).toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
 
         const init = fetchSpy.mock.calls[0]![1];
         const headers = init?.headers as Record<string, string> | undefined;

--- a/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
@@ -101,287 +101,288 @@ const stubPypiResponse = (body: unknown, status = 200): Response => ({
     statusText: status === 200 ? "OK" : status === 404 ? "Not Found" : "Error",
 } as Response);
 
-beforeEach(() => {
-    // Clear PyPI auth env between tests so the detect-auth path is
-    // deterministic — leaking from a previous test would silently
-    // pass AUTH_MISSING assertions.
-    delete process.env.TWINE_USERNAME;
-    delete process.env.TWINE_PASSWORD;
-    delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-});
-
-afterEach(() => {
-    vi.restoreAllMocks();
-});
-
-// ── identity + dry-run ──────────────────────────────────────────────
-
-describe("pythonVersionActions: identity", () => {
-    it("has stable id `python`", () => {
-        expect.hasAssertions();
-        expect(new PythonVersionActions().id).toBe("python");
+describe("python version actions", () => {
+    beforeEach(() => {
+        // Clear PyPI auth env between tests so the detect-auth path is
+        // deterministic — leaking from a previous test would silently
+        // pass AUTH_MISSING assertions.
+        delete process.env.TWINE_USERNAME;
+        delete process.env.TWINE_PASSWORD;
+        delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
     });
 
-    it("dry-run returns published: true without invoking anything", async () => {
-        expect.hasAssertions();
-
-        const runner = new MockRunner();
-        let invoked = false;
-        const wrapped: CommandRunner = {
-            run: async (...args) => {
-                invoked = true;
-
-                return runner.run(...args);
-            },
-        };
-
-        const actions = new PythonVersionActions();
-        const result = await actions.publish(mkContext({ dryRun: true, runner: wrapped }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("[dry-run / python]");
-        expect(invoked).toBe(false);
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
-});
 
-// ── readPublishedVersion (PyPI HTTP API) ───────────────────────────
+    // ── identity + dry-run ──────────────────────────────────────────────
 
-describe("pythonVersionActions: readPublishedVersion", () => {
-    it("parses .info.version from PyPI JSON on 200", async () => {
-        expect.hasAssertions();
+    describe("pythonVersionActions: identity", () => {
+        it("has stable id `python`", () => {
+            expect.hasAssertions();
+            expect(new PythonVersionActions().id).toBe("python");
+        });
 
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-            stubPypiResponse({ info: { version: "2.3.4" } }),
-        );
+        it("dry-run returns published: true without invoking anything", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-"));
+            const runner = new MockRunner();
+            let invoked = false;
+            const wrapped: CommandRunner = {
+                run: async (...args) => {
+                    invoked = true;
 
-        writePyProject(tmp, `
+                    return runner.run(...args);
+                },
+            };
+
+            const actions = new PythonVersionActions();
+            const result = await actions.publish(mkContext({ dryRun: true, runner: wrapped }));
+
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("[dry-run / python]");
+            expect(invoked).toBe(false);
+        });
+    });
+
+    // ── readPublishedVersion (PyPI HTTP API) ───────────────────────────
+
+    describe("pythonVersionActions: readPublishedVersion", () => {
+        it("parses .info.version from PyPI JSON on 200", async () => {
+            expect.hasAssertions();
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                stubPypiResponse({ info: { version: "2.3.4" } }),
+            );
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-"));
+
+            writePyProject(tmp, `
 [project]
 name = "demo-pkg"
 version = "1.0.0"
 `);
 
-        const actions = new PythonVersionActions();
-        const result = await actions.readPublishedVersion({
-            perPackageConfig: { pythonProjectDir: undefined },
-            pkg: {
-                dir: tmp,
-                manifest: { name: "@scope/demo-pkg", version: "1.0.0" },
-                manifestPath: `${tmp}/package.json`,
-                name: "@scope/demo-pkg",
-                private: false,
-                version: "1.0.0",
-            },
-            pm: { id: "npm", minVersion: "8.0.0", runner: new MockRunner() } as never,
+            const actions = new PythonVersionActions();
+            const result = await actions.readPublishedVersion({
+                perPackageConfig: { pythonProjectDir: undefined },
+                pkg: {
+                    dir: tmp,
+                    manifest: { name: "@scope/demo-pkg", version: "1.0.0" },
+                    manifestPath: `${tmp}/package.json`,
+                    name: "@scope/demo-pkg",
+                    private: false,
+                    version: "1.0.0",
+                },
+                pm: { id: "npm", minVersion: "8.0.0", runner: new MockRunner() } as never,
+            });
+
+            expect(result).toBe("2.3.4");
+
+            const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+
+            // Must lowercase + URL-encode the dist name from pyproject.toml.
+            expect(calledUrl).toBe("https://pypi.org/pypi/demo-pkg/json");
         });
 
-        expect(result).toBe("2.3.4");
+        it("returns undefined on 404 (package not on PyPI yet)", async () => {
+            expect.hasAssertions();
 
-        const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
-        // Must lowercase + URL-encode the dist name from pyproject.toml.
-        expect(calledUrl).toBe("https://pypi.org/pypi/demo-pkg/json");
+            const result = await fetchPyPiVersion("brand-new-pkg");
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined on network failure", async () => {
+            expect.hasAssertions();
+
+            vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+            const result = await fetchPyPiVersion("any-pkg");
+
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined on malformed JSON / missing info.version", async () => {
+            expect.hasAssertions();
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({ /* no info */ }));
+
+            const result = await fetchPyPiVersion("partial-pkg");
+
+            expect(result).toBeUndefined();
+        });
     });
 
-    it("returns undefined on 404 (package not on PyPI yet)", async () => {
-        expect.hasAssertions();
+    // ── dynamic-version refusal ─────────────────────────────────────────
 
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+    describe("pythonVersionActions: dynamic versioning refusal", () => {
+        it("throws CONFIG_INVALID when pyproject declares dynamic = [\"version\"]", async () => {
+            expect.hasAssertions();
 
-        const result = await fetchPyPiVersion("brand-new-pkg");
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-dyn-"));
 
-        expect(result).toBeUndefined();
-    });
-
-    it("returns undefined on network failure", async () => {
-        expect.hasAssertions();
-
-        vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
-
-        const result = await fetchPyPiVersion("any-pkg");
-
-        expect(result).toBeUndefined();
-    });
-
-    it("returns undefined on malformed JSON / missing info.version", async () => {
-        expect.hasAssertions();
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({ /* no info */ }));
-
-        const result = await fetchPyPiVersion("partial-pkg");
-
-        expect(result).toBeUndefined();
-    });
-});
-
-// ── dynamic-version refusal ─────────────────────────────────────────
-
-describe("pythonVersionActions: dynamic versioning refusal", () => {
-    it("throws CONFIG_INVALID when pyproject declares dynamic = [\"version\"]", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-dyn-"));
-
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "scm-pkg"
 dynamic = ["version"]
 `);
 
-        // OIDC set so auth-missing isn't the failure path.
-        process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
+            // OIDC set so auth-missing isn't the failure path.
+            process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
 
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
-        const actions = new PythonVersionActions();
+            const actions = new PythonVersionActions();
 
-        await expect(actions.publish(mkContext({ cwd: tmp }))).rejects.toMatchObject({
-            code: "CONFIG_INVALID",
-            hint: expect.stringContaining("Dynamic versioning"),
+            await expect(actions.publish(mkContext({ cwd: tmp }))).rejects.toMatchObject({
+                code: "CONFIG_INVALID",
+                hint: expect.stringContaining("Dynamic versioning"),
+            });
         });
     });
-});
 
-// ── build backend detection ────────────────────────────────────────
+    // ── build backend detection ────────────────────────────────────────
 
-describe("pythonVersionActions: detectBackend", () => {
-    it("detects hatchling.build → hatch", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "hatchling.build" } })).toBe("hatch");
+    describe("pythonVersionActions: detectBackend", () => {
+        it("detects hatchling.build → hatch", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "hatchling.build" } })).toBe("hatch");
+        });
+
+        it("detects poetry.core.masonry.api → poetry", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "poetry.core.masonry.api" } })).toBe("poetry");
+        });
+
+        it("detects pdm.backend → pdm", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "pdm.backend" } })).toBe("pdm");
+        });
+
+        it("detects setuptools.build_meta → setuptools", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "setuptools.build_meta" } })).toBe("setuptools");
+        });
+
+        it("detects uv_build → uv", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "uv_build" } })).toBe("uv");
+        });
+
+        it("returns 'unknown' for unrecognized / missing backend", () => {
+            expect.hasAssertions();
+            expect(detectBackend({ "build-system": { "build-backend": "weird.thing" } })).toBe("unknown");
+            expect(detectBackend({ "build-system": {} })).toBe("unknown");
+            expect(detectBackend(undefined)).toBe("unknown");
+        });
     });
 
-    it("detects poetry.core.masonry.api → poetry", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "poetry.core.masonry.api" } })).toBe("poetry");
+    // ── build-env resolution (which CLIs to invoke) ────────────────────
+
+    describe("pythonVersionActions: resolveBuildEnv", () => {
+        it("prefers uv when backend is 'uv' regardless of PATH detection", () => {
+            expect.hasAssertions();
+
+            const env = resolveBuildEnv("uv", false);
+
+            expect(env.buildCommand).toStrictEqual({ args: ["build"], binary: "uv" });
+            expect(env.publishCommand).toStrictEqual({ args: ["publish"], binary: "uv" });
+        });
+
+        it("prefers uv when backend is 'unknown' AND uv is on PATH", () => {
+            expect.hasAssertions();
+
+            const env = resolveBuildEnv("unknown", true);
+
+            expect(env.buildCommand.binary).toBe("uv");
+            expect(env.publishCommand.binary).toBe("uv");
+        });
+
+        it("uses python -m build + twine upload for hatch", () => {
+            expect.hasAssertions();
+
+            const env = resolveBuildEnv("hatch", false);
+
+            expect(env.buildCommand).toStrictEqual({ args: ["-m", "build"], binary: "python" });
+            expect(env.publishCommand).toStrictEqual({ args: ["upload", "dist/*"], binary: "twine" });
+        });
+
+        it("uses python -m build for poetry / pdm / setuptools (PEP 517 universal)", () => {
+            expect.hasAssertions();
+
+            for (const backend of ["poetry", "pdm", "setuptools"] as const) {
+                const env = resolveBuildEnv(backend, false);
+
+                expect(env.buildCommand.binary).toBe("python");
+                expect(env.buildCommand.args).toStrictEqual(["-m", "build"]);
+                expect(env.publishCommand.binary).toBe("twine");
+            }
+        });
     });
 
-    it("detects pdm.backend → pdm", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "pdm.backend" } })).toBe("pdm");
+    // ── auth-mode detection ────────────────────────────────────────────
+
+    describe("pythonVersionActions: detectAuthMode (M-3)", () => {
+        it("returns 'token' when only TWINE_PASSWORD is set", () => {
+            expect.hasAssertions();
+            expect(detectAuthMode({ TWINE_PASSWORD: "pypi-token" })).toBe("token");
+        });
+
+        it("returns 'oidc' when only ACTIONS_ID_TOKEN_REQUEST_URL is set", () => {
+            expect.hasAssertions();
+            expect(detectAuthMode({ ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" })).toBe("oidc");
+        });
+
+        it("prefers 'oidc' over 'token' when both are present (M-3)", () => {
+            // M-3 alignment: OIDC env signal means the operator wired up
+            // trusted publishing; a leftover TWINE_PASSWORD shouldn't
+            // silently downgrade. (Previous behaviour was the inverse —
+            // that was the bug.)
+            expect.hasAssertions();
+            expect(detectAuthMode({
+                ACTIONS_ID_TOKEN_REQUEST_URL: "https://x",
+                TWINE_PASSWORD: "tok",
+            })).toBe("oidc");
+        });
+
+        it("returns 'token' when preferStaticToken: true AND both signals are present (escape hatch)", () => {
+            // M-3 escape hatch for operators migrating off OIDC or
+            // running a shadow publish.
+            expect.hasAssertions();
+            expect(detectAuthMode(
+                { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x", TWINE_PASSWORD: "tok" },
+                { publish: { preferStaticToken: true } },
+            )).toBe("token");
+        });
+
+        it("returns 'oidc' when preferStaticToken: true but no static token is present", () => {
+            // Escape hatch only fires when there's actually a static
+            // token to fall back to.
+            expect.hasAssertions();
+            expect(detectAuthMode(
+                { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" },
+                { publish: { preferStaticToken: true } },
+            )).toBe("oidc");
+        });
+
+        it("returns 'missing' when neither is set", () => {
+            expect.hasAssertions();
+            expect(detectAuthMode({})).toBe("missing");
+        });
     });
 
-    it("detects setuptools.build_meta → setuptools", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "setuptools.build_meta" } })).toBe("setuptools");
-    });
+    // ── end-to-end publish (mocked runner + fetch) ─────────────────────
 
-    it("detects uv_build → uv", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "uv_build" } })).toBe("uv");
-    });
+    describe("pythonVersionActions: publish via twine (no uv)", () => {
+        it("invokes python -m build then twine upload dist/*", async () => {
+            expect.hasAssertions();
 
-    it("returns 'unknown' for unrecognized / missing backend", () => {
-        expect.hasAssertions();
-        expect(detectBackend({ "build-system": { "build-backend": "weird.thing" } })).toBe("unknown");
-        expect(detectBackend({ "build-system": {} })).toBe("unknown");
-        expect(detectBackend(undefined)).toBe("unknown");
-    });
-});
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-twine-"));
 
-// ── build-env resolution (which CLIs to invoke) ────────────────────
-
-describe("pythonVersionActions: resolveBuildEnv", () => {
-    it("prefers uv when backend is 'uv' regardless of PATH detection", () => {
-        expect.hasAssertions();
-
-        const env = resolveBuildEnv("uv", false);
-
-        expect(env.buildCommand).toStrictEqual({ args: ["build"], binary: "uv" });
-        expect(env.publishCommand).toStrictEqual({ args: ["publish"], binary: "uv" });
-    });
-
-    it("prefers uv when backend is 'unknown' AND uv is on PATH", () => {
-        expect.hasAssertions();
-
-        const env = resolveBuildEnv("unknown", true);
-
-        expect(env.buildCommand.binary).toBe("uv");
-        expect(env.publishCommand.binary).toBe("uv");
-    });
-
-    it("uses python -m build + twine upload for hatch", () => {
-        expect.hasAssertions();
-
-        const env = resolveBuildEnv("hatch", false);
-
-        expect(env.buildCommand).toStrictEqual({ args: ["-m", "build"], binary: "python" });
-        expect(env.publishCommand).toStrictEqual({ args: ["upload", "dist/*"], binary: "twine" });
-    });
-
-    it("uses python -m build for poetry / pdm / setuptools (PEP 517 universal)", () => {
-        expect.hasAssertions();
-
-        for (const backend of ["poetry", "pdm", "setuptools"] as const) {
-            const env = resolveBuildEnv(backend, false);
-
-            expect(env.buildCommand.binary).toBe("python");
-            expect(env.buildCommand.args).toStrictEqual(["-m", "build"]);
-            expect(env.publishCommand.binary).toBe("twine");
-        }
-    });
-});
-
-// ── auth-mode detection ────────────────────────────────────────────
-
-describe("pythonVersionActions: detectAuthMode (M-3)", () => {
-    it("returns 'token' when only TWINE_PASSWORD is set", () => {
-        expect.hasAssertions();
-        expect(detectAuthMode({ TWINE_PASSWORD: "pypi-token" })).toBe("token");
-    });
-
-    it("returns 'oidc' when only ACTIONS_ID_TOKEN_REQUEST_URL is set", () => {
-        expect.hasAssertions();
-        expect(detectAuthMode({ ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" })).toBe("oidc");
-    });
-
-    it("prefers 'oidc' over 'token' when both are present (M-3)", () => {
-        // M-3 alignment: OIDC env signal means the operator wired up
-        // trusted publishing; a leftover TWINE_PASSWORD shouldn't
-        // silently downgrade. (Previous behaviour was the inverse —
-        // that was the bug.)
-        expect.hasAssertions();
-        expect(detectAuthMode({
-            ACTIONS_ID_TOKEN_REQUEST_URL: "https://x",
-            TWINE_PASSWORD: "tok",
-        })).toBe("oidc");
-    });
-
-    it("returns 'token' when preferStaticToken: true AND both signals are present (escape hatch)", () => {
-        // M-3 escape hatch for operators migrating off OIDC or
-        // running a shadow publish.
-        expect.hasAssertions();
-        expect(detectAuthMode(
-            { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x", TWINE_PASSWORD: "tok" },
-            { publish: { preferStaticToken: true } },
-        )).toBe("token");
-    });
-
-    it("returns 'oidc' when preferStaticToken: true but no static token is present", () => {
-        // Escape hatch only fires when there's actually a static
-        // token to fall back to.
-        expect.hasAssertions();
-        expect(detectAuthMode(
-            { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" },
-            { publish: { preferStaticToken: true } },
-        )).toBe("oidc");
-    });
-
-    it("returns 'missing' when neither is set", () => {
-        expect.hasAssertions();
-        expect(detectAuthMode({})).toBe("missing");
-    });
-});
-
-// ── end-to-end publish (mocked runner + fetch) ─────────────────────
-
-describe("pythonVersionActions: publish via twine (no uv)", () => {
-    it("invokes python -m build then twine upload dist/*", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-twine-"));
-
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "demo"
 version = "1.0.1"
@@ -391,478 +392,478 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 `);
 
-        process.env.TWINE_PASSWORD = "pypi-token";
+            process.env.TWINE_PASSWORD = "pypi-token";
 
-        // PyPI JSON returns older version — proceed with publish.
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-            stubPypiResponse({ info: { version: "1.0.0" } }),
-        );
+            // PyPI JSON returns older version — proceed with publish.
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                stubPypiResponse({ info: { version: "1.0.0" } }),
+            );
 
-        const runner = new MockRunner();
+            const runner = new MockRunner();
 
-        // uv probe → fail (not installed)
-        runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "uv: not found", stdout: "" }; });
-        runner.on("python", ["-m", "build"], () => { return { exitCode: 0, stderr: "", stdout: "build ok" }; });
-        runner.on("twine", ["upload", "dist/*"], () => { return { exitCode: 0, stderr: "", stdout: "upload ok" }; });
+            // uv probe → fail (not installed)
+            runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "uv: not found", stdout: "" }; });
+            runner.on("python", ["-m", "build"], () => { return { exitCode: 0, stderr: "", stdout: "build ok" }; });
+            runner.on("twine", ["upload", "dist/*"], () => { return { exitCode: 0, stderr: "", stdout: "upload ok" }; });
 
-        const actions = new PythonVersionActions();
-        const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+            const actions = new PythonVersionActions();
+            const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
 
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("[python/hatch]");
-        expect(result.output).toContain("demo@1.0.1");
-    });
-});
-
-describe("pythonVersionActions: publish via uv", () => {
-    it("invokes uv build + uv publish when uv is on PATH", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-uv-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        process.env.TWINE_PASSWORD = "pypi-token";
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        const calls: { args: ReadonlyArray<string>; command: string }[] = [];
-        const runner: CommandRunner = {
-            run: async (command, args) => {
-                calls.push({ args, command });
-
-                if (command === "uv" && args[0] === "--version") {
-                    return { exitCode: 0, stderr: "", stdout: "uv 0.5.0" };
-                }
-
-                if (command === "uv" && args[0] === "build") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                if (command === "uv" && args[0] === "publish") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                return { exitCode: 1, stderr: "unexpected", stdout: "" };
-            },
-        };
-
-        const actions = new PythonVersionActions();
-        const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
-
-        expect(result.published).toBe(true);
-        expect(result.output).toContain("+uv");
-
-        const cmdShape = calls.map((c) => `${c.command} ${c.args.join(" ")}`);
-
-        expect(cmdShape).toContain("uv --version");
-        expect(cmdShape).toContain("uv build");
-        expect(cmdShape).toContain("uv publish");
-        // twine MUST NOT have been invoked.
-        expect(cmdShape.some((c) => c.startsWith("twine"))).toBe(false);
-    });
-});
-
-// ── User-Agent stamping (B-3) ──────────────────────────────────────
-
-describe("pythonVersionActions: PyPI User-Agent header (B-3)", () => {
-    it("stamps a vis-release User-Agent on PyPI metadata requests", async () => {
-        // PyPI explicitly asks for a contact UA; vis routes the
-        // JSON-API probe through `safeFetchVersionMetadata`.
-        expect.hasAssertions();
-
-        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-            stubPypiResponse({ info: { version: "1.0.0" } }),
-        );
-
-        await fetchPyPiVersion("any-pkg");
-
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
-
-        const init = fetchSpy.mock.calls[0]![1];
-        const headers = init?.headers as Record<string, string> | undefined;
-
-        expect(headers).toBeDefined();
-        expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
-        expect(headers!["User-Agent"]).toContain("github.com/visulima/visulima");
-    });
-});
-
-// ── trusted-publishing detection ───────────────────────────────────
-
-describe("pythonVersionActions: OIDC trusted publishing", () => {
-    it("proceeds when ACTIONS_ID_TOKEN_REQUEST_URL is set even with no TWINE_PASSWORD", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-oidc-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        let twineRan = false;
-        const runner: CommandRunner = {
-            run: async (command, args, options) => {
-                if (command === "uv") {
-                    return { exitCode: 127, stderr: "", stdout: "" };
-                }
-
-                if (command === "python") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                if (command === "twine") {
-                    twineRan = true;
-
-                    // TWINE_USERNAME should NOT be injected when we're on
-                    // the OIDC path — the env var is only for the static-
-                    // token flow.
-                    expect(options.env?.TWINE_USERNAME).toBeUndefined();
-
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                return { exitCode: 1, stderr: "", stdout: "" };
-            },
-        };
-
-        const actions = new PythonVersionActions();
-        const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
-
-        expect(result.published).toBe(true);
-        expect(twineRan).toBe(true);
-    });
-
-    it("injects TWINE_USERNAME=__token__ for the static-token flow when not already set", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-tok-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        process.env.TWINE_PASSWORD = "pypi-token";
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        let observedUsername: string | undefined;
-        const runner: CommandRunner = {
-            run: async (command, args, options) => {
-                if (command === "uv") {
-                    return { exitCode: 127, stderr: "", stdout: "" };
-                }
-
-                if (command === "python") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                if (command === "twine") {
-                    observedUsername = options.env?.TWINE_USERNAME;
-
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                return { exitCode: 1, stderr: "", stdout: "" };
-            },
-        };
-
-        const actions = new PythonVersionActions();
-
-        await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
-
-        expect(observedUsername).toBe("__token__");
-    });
-});
-
-// ── M-3 end-to-end: OIDC vs token precedence in publish() ─────────
-
-describe("pythonVersionActions: M-3 OIDC precedence in publish()", () => {
-    it("uses OIDC (no TWINE_USERNAME injection) when both env vars are present", async () => {
-        // M-3: OIDC wins by default even with TWINE_PASSWORD set.
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-oidc-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        process.env.TWINE_PASSWORD = "stale-token-from-last-year";
-        process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        let observedUsername: string | undefined;
-        let twineRan = false;
-
-        const runner: CommandRunner = {
-            run: async (command, args, options) => {
-                if (command === "uv") {
-                    return { exitCode: 127, stderr: "", stdout: "" };
-                }
-
-                if (command === "python") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                if (command === "twine") {
-                    twineRan = true;
-                    observedUsername = options.env?.TWINE_USERNAME;
-
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                return { exitCode: 1, stderr: "", stdout: "" };
-            },
-        };
-
-        await new PythonVersionActions().publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
-
-        expect(twineRan).toBe(true);
-        // OIDC path: TWINE_USERNAME=__token__ is NOT injected (only
-        // the static-token path needs it). The leftover TWINE_PASSWORD
-        // is left in the env for the trusted-publishing helper to
-        // ignore.
-        expect(observedUsername).toBeUndefined();
-    });
-
-    it("preferStaticToken: true flips precedence — TWINE_USERNAME=__token__ is injected (M-3 escape hatch)", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-escape-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        process.env.TWINE_PASSWORD = "operator-chose-static";
-        process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        let observedUsername: string | undefined;
-
-        const runner: CommandRunner = {
-            run: async (command, args, options) => {
-                if (command === "uv") {
-                    return { exitCode: 127, stderr: "", stdout: "" };
-                }
-
-                if (command === "python") {
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                if (command === "twine") {
-                    observedUsername = options.env?.TWINE_USERNAME;
-
-                    return { exitCode: 0, stderr: "", stdout: "" };
-                }
-
-                return { exitCode: 1, stderr: "", stdout: "" };
-            },
-        };
-
-        const ctxWithEscape = mkContext({ cwd: tmp, runner, version: "1.0.1" });
-
-        // Inject workspaceConfig with the escape hatch.
-        (ctxWithEscape as { workspaceConfig: unknown }).workspaceConfig = {
-            publish: { preferStaticToken: true },
-        };
-
-        await new PythonVersionActions().publish(ctxWithEscape);
-
-        // Static-token path → __token__ injection.
-        expect(observedUsername).toBe("__token__");
-    });
-});
-
-// ── auth missing ───────────────────────────────────────────────────
-
-describe("pythonVersionActions: AUTH_MISSING", () => {
-    it("throws AUTH_MISSING when neither TWINE_PASSWORD nor OIDC env is set", async () => {
-        expect.hasAssertions();
-
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-noauth-"));
-
-        writePyProject(tmp, `
-[project]
-name = "demo"
-version = "1.0.1"
-`);
-
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
-
-        const runner = new MockRunner();
-
-        runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "", stdout: "" }; });
-
-        const actions = new PythonVersionActions();
-
-        await expect(actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }))).rejects.toMatchObject({
-            code: "AUTH_MISSING",
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("[python/hatch]");
+            expect(result.output).toContain("demo@1.0.1");
         });
     });
-});
 
-// ── build failure ─────────────────────────────────────────────────
+    describe("pythonVersionActions: publish via uv", () => {
+        it("invokes uv build + uv publish when uv is on PATH", async () => {
+            expect.hasAssertions();
 
-describe("pythonVersionActions: build failure", () => {
-    it("throws PUBLISH_FAILED when python -m build exits non-zero", async () => {
-        expect.hasAssertions();
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-uv-"));
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-buildfail-"));
-
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "demo"
 version = "1.0.1"
 `);
 
-        process.env.TWINE_PASSWORD = "pypi-token";
+            process.env.TWINE_PASSWORD = "pypi-token";
 
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
-        const runner = new MockRunner();
+            const calls: { args: ReadonlyArray<string>; command: string }[] = [];
+            const runner: CommandRunner = {
+                run: async (command, args) => {
+                    calls.push({ args, command });
 
-        runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "", stdout: "" }; });
-        runner.on("python", ["-m", "build"], () => {
-            return {
-                exitCode: 1,
-                stderr: "ImportError: build module missing",
-                stdout: "",
+                    if (command === "uv" && args[0] === "--version") {
+                        return { exitCode: 0, stderr: "", stdout: "uv 0.5.0" };
+                    }
+
+                    if (command === "uv" && args[0] === "build") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "uv" && args[0] === "publish") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    return { exitCode: 1, stderr: "unexpected", stdout: "" };
+                },
             };
-        });
 
-        const actions = new PythonVersionActions();
+            const actions = new PythonVersionActions();
+            const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
 
-        await expect(actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }))).rejects.toMatchObject({
-            code: "PUBLISH_FAILED",
-            message: expect.stringContaining("build failed"),
+            expect(result.published).toBe(true);
+            expect(result.output).toContain("+uv");
+
+            const cmdShape = calls.map((c) => `${c.command} ${c.args.join(" ")}`);
+
+            expect(cmdShape).toContain("uv --version");
+            expect(cmdShape).toContain("uv build");
+            expect(cmdShape).toContain("uv publish");
+            // twine MUST NOT have been invoked.
+            expect(cmdShape.some((c) => c.startsWith("twine"))).toBe(false);
         });
     });
-});
 
-// ── already-published short-circuit ────────────────────────────────
+    // ── User-Agent stamping (B-3) ──────────────────────────────────────
 
-describe("pythonVersionActions: already-published short-circuit", () => {
-    it("returns alreadyPublished without invoking build/twine when PyPI reports the new version", async () => {
-        expect.hasAssertions();
+    describe("pythonVersionActions: PyPI User-Agent header (B-3)", () => {
+        it("stamps a vis-release User-Agent on PyPI metadata requests", async () => {
+            // PyPI explicitly asks for a contact UA; vis routes the
+            // JSON-API probe through `safeFetchVersionMetadata`.
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-already-"));
+            const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                stubPypiResponse({ info: { version: "1.0.0" } }),
+            );
 
-        writePyProject(tmp, `
+            await fetchPyPiVersion("any-pkg");
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            const init = fetchSpy.mock.calls[0]![1];
+            const headers = init?.headers as Record<string, string> | undefined;
+
+            expect(headers).toBeDefined();
+            expect(headers!["User-Agent"]).toMatch(/^vis-release\//);
+            expect(headers!["User-Agent"]).toContain("github.com/visulima/visulima");
+        });
+    });
+
+    // ── trusted-publishing detection ───────────────────────────────────
+
+    describe("pythonVersionActions: OIDC trusted publishing", () => {
+        it("proceeds when ACTIONS_ID_TOKEN_REQUEST_URL is set even with no TWINE_PASSWORD", async () => {
+            expect.hasAssertions();
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-oidc-"));
+
+            writePyProject(tmp, `
 [project]
 name = "demo"
 version = "1.0.1"
 `);
 
-        process.env.TWINE_PASSWORD = "pypi-token";
+            process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
 
-        // PyPI already has 1.0.1 — vis must skip.
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-            stubPypiResponse({ info: { version: "1.0.1" } }),
-        );
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
-        const calls: string[] = [];
-        const runner: CommandRunner = {
-            run: async (command, args) => {
-                calls.push(`${command} ${args.join(" ")}`);
+            let twineRan = false;
+            const runner: CommandRunner = {
+                run: async (command, args, options) => {
+                    if (command === "uv") {
+                        return { exitCode: 127, stderr: "", stdout: "" };
+                    }
 
-                return { exitCode: 0, stderr: "", stdout: "" };
-            },
-        };
+                    if (command === "python") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
 
-        const actions = new PythonVersionActions();
-        const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+                    if (command === "twine") {
+                        twineRan = true;
 
-        expect(result.alreadyPublished).toBe(true);
-        expect(result.published).toBe(false);
-        // No build / publish invocation — only the (no) uv probe is
-        // permitted (and we don't even reach that since the already-
-        // published gate triggers before backend resolution).
-        expect(calls.filter((c) => c.startsWith("python") || c.startsWith("twine") || c.startsWith("uv "))).toHaveLength(0);
+                        // TWINE_USERNAME should NOT be injected when we're on
+                        // the OIDC path — the env var is only for the static-
+                        // token flow.
+                        expect(options.env?.TWINE_USERNAME).toBeUndefined();
+
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    return { exitCode: 1, stderr: "", stdout: "" };
+                },
+            };
+
+            const actions = new PythonVersionActions();
+            const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+
+            expect(result.published).toBe(true);
+            expect(twineRan).toBe(true);
+        });
+
+        it("injects TWINE_USERNAME=__token__ for the static-token flow when not already set", async () => {
+            expect.hasAssertions();
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-tok-"));
+
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
+
+            process.env.TWINE_PASSWORD = "pypi-token";
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+
+            let observedUsername: string | undefined;
+            const runner: CommandRunner = {
+                run: async (command, args, options) => {
+                    if (command === "uv") {
+                        return { exitCode: 127, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "python") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "twine") {
+                        observedUsername = options.env?.TWINE_USERNAME;
+
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    return { exitCode: 1, stderr: "", stdout: "" };
+                },
+            };
+
+            const actions = new PythonVersionActions();
+
+            await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+
+            expect(observedUsername).toBe("__token__");
+        });
     });
-});
 
-// ── version-mismatch guard ─────────────────────────────────────────
+    // ── M-3 end-to-end: OIDC vs token precedence in publish() ─────────
 
-// ── uv lockfile + workspace (release-please #2560 / #2561) ─────────
+    describe("pythonVersionActions: M-3 OIDC precedence in publish()", () => {
+        it("uses OIDC (no TWINE_USERNAME injection) when both env vars are present", async () => {
+            // M-3: OIDC wins by default even with TWINE_PASSWORD set.
+            expect.hasAssertions();
 
-describe("pythonVersionActions: resolveUvLockPath", () => {
-    it("returns <pkg.dir>/uv.lock when no per-package override is set", () => {
-        expect.hasAssertions();
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-oidc-"));
 
-        const result = resolveUvLockPath(
-            { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
-        );
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
 
-        expect(result).toBe(join("/repo/py/sdk", "uv.lock"));
+            process.env.TWINE_PASSWORD = "stale-token-from-last-year";
+            process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+
+            let observedUsername: string | undefined;
+            let twineRan = false;
+
+            const runner: CommandRunner = {
+                run: async (command, args, options) => {
+                    if (command === "uv") {
+                        return { exitCode: 127, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "python") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "twine") {
+                        twineRan = true;
+                        observedUsername = options.env?.TWINE_USERNAME;
+
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    return { exitCode: 1, stderr: "", stdout: "" };
+                },
+            };
+
+            await new PythonVersionActions().publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+
+            expect(twineRan).toBe(true);
+            // OIDC path: TWINE_USERNAME=__token__ is NOT injected (only
+            // the static-token path needs it). The leftover TWINE_PASSWORD
+            // is left in the env for the trusted-publishing helper to
+            // ignore.
+            expect(observedUsername).toBeUndefined();
+        });
+
+        it("preferStaticToken: true flips precedence — TWINE_USERNAME=__token__ is injected (M-3 escape hatch)", async () => {
+            expect.hasAssertions();
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-escape-"));
+
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
+
+            process.env.TWINE_PASSWORD = "operator-chose-static";
+            process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "https://token-url";
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+
+            let observedUsername: string | undefined;
+
+            const runner: CommandRunner = {
+                run: async (command, args, options) => {
+                    if (command === "uv") {
+                        return { exitCode: 127, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "python") {
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    if (command === "twine") {
+                        observedUsername = options.env?.TWINE_USERNAME;
+
+                        return { exitCode: 0, stderr: "", stdout: "" };
+                    }
+
+                    return { exitCode: 1, stderr: "", stdout: "" };
+                },
+            };
+
+            const ctxWithEscape = mkContext({ cwd: tmp, runner, version: "1.0.1" });
+
+            // Inject workspaceConfig with the escape hatch.
+            (ctxWithEscape as { workspaceConfig: unknown }).workspaceConfig = {
+                publish: { preferStaticToken: true },
+            };
+
+            await new PythonVersionActions().publish(ctxWithEscape);
+
+            // Static-token path → __token__ injection.
+            expect(observedUsername).toBe("__token__");
+        });
     });
 
-    it("honours perPackageConfig.uvLockPath (relative to pkg.dir)", () => {
-        // Operators point this at `../uv.lock` when uv manages the
-        // lockfile at the workspace root rather than per-package.
-        expect.hasAssertions();
+    // ── auth missing ───────────────────────────────────────────────────
 
-        const result = resolveUvLockPath(
-            { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
-            { uvLockPath: "../uv.lock" },
-        );
+    describe("pythonVersionActions: AUTH_MISSING", () => {
+        it("throws AUTH_MISSING when neither TWINE_PASSWORD nor OIDC env is set", async () => {
+            expect.hasAssertions();
 
-        expect(result).toBe(join("/repo/py/sdk", "../uv.lock"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-noauth-"));
+
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+
+            const runner = new MockRunner();
+
+            runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "", stdout: "" }; });
+
+            const actions = new PythonVersionActions();
+
+            await expect(actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }))).rejects.toMatchObject({
+                code: "AUTH_MISSING",
+            });
+        });
     });
-});
 
-describe("pythonVersionActions: checkUvWorkspaceMembership", () => {
-    it("returns 'no-root-pyproject' when the root has no pyproject.toml", async () => {
-        expect.hasAssertions();
+    // ── build failure ─────────────────────────────────────────────────
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-empty-"));
+    describe("pythonVersionActions: build failure", () => {
+        it("throws PUBLISH_FAILED when python -m build exits non-zero", async () => {
+            expect.hasAssertions();
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-buildfail-"));
 
-        expect(result).toBe("no-root-pyproject");
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
+
+            process.env.TWINE_PASSWORD = "pypi-token";
+
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+
+            const runner = new MockRunner();
+
+            runner.on("uv", ["--version"], () => { return { exitCode: 127, stderr: "", stdout: "" }; });
+            runner.on("python", ["-m", "build"], () => {
+                return {
+                    exitCode: 1,
+                    stderr: "ImportError: build module missing",
+                    stdout: "",
+                };
+            });
+
+            const actions = new PythonVersionActions();
+
+            await expect(actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }))).rejects.toMatchObject({
+                code: "PUBLISH_FAILED",
+                message: expect.stringContaining("build failed"),
+            });
+        });
     });
 
-    it("returns 'no-workspace' when the root pyproject has no [tool.uv.workspace] block", async () => {
-        expect.hasAssertions();
+    // ── already-published short-circuit ────────────────────────────────
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-no-ws-"));
+    describe("pythonVersionActions: already-published short-circuit", () => {
+        it("returns alreadyPublished without invoking build/twine when PyPI reports the new version", async () => {
+            expect.hasAssertions();
 
-        writePyProject(tmp, `
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-already-"));
+
+            writePyProject(tmp, `
+[project]
+name = "demo"
+version = "1.0.1"
+`);
+
+            process.env.TWINE_PASSWORD = "pypi-token";
+
+            // PyPI already has 1.0.1 — vis must skip.
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                stubPypiResponse({ info: { version: "1.0.1" } }),
+            );
+
+            const calls: string[] = [];
+            const runner: CommandRunner = {
+                run: async (command, args) => {
+                    calls.push(`${command} ${args.join(" ")}`);
+
+                    return { exitCode: 0, stderr: "", stdout: "" };
+                },
+            };
+
+            const actions = new PythonVersionActions();
+            const result = await actions.publish(mkContext({ cwd: tmp, runner, version: "1.0.1" }));
+
+            expect(result.alreadyPublished).toBe(true);
+            expect(result.published).toBe(false);
+            // No build / publish invocation — only the (no) uv probe is
+            // permitted (and we don't even reach that since the already-
+            // published gate triggers before backend resolution).
+            expect(calls.filter((c) => c.startsWith("python") || c.startsWith("twine") || c.startsWith("uv "))).toHaveLength(0);
+        });
+    });
+
+    // ── version-mismatch guard ─────────────────────────────────────────
+
+    // ── uv lockfile + workspace (release-please #2560 / #2561) ─────────
+
+    describe("pythonVersionActions: resolveUvLockPath", () => {
+        it("returns <pkg.dir>/uv.lock when no per-package override is set", () => {
+            expect.hasAssertions();
+
+            const result = resolveUvLockPath(
+                { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
+            );
+
+            expect(result).toBe(join("/repo/py/sdk", "uv.lock"));
+        });
+
+        it("honours perPackageConfig.uvLockPath (relative to pkg.dir)", () => {
+            // Operators point this at `../uv.lock` when uv manages the
+            // lockfile at the workspace root rather than per-package.
+            expect.hasAssertions();
+
+            const result = resolveUvLockPath(
+                { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
+                { uvLockPath: "../uv.lock" },
+            );
+
+            expect(result).toBe(join("/repo/py/sdk", "../uv.lock"));
+        });
+    });
+
+    describe("pythonVersionActions: checkUvWorkspaceMembership", () => {
+        it("returns 'no-root-pyproject' when the root has no pyproject.toml", async () => {
+            expect.hasAssertions();
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-empty-"));
+
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
+
+            expect(result).toBe("no-root-pyproject");
+        });
+
+        it("returns 'no-workspace' when the root pyproject has no [tool.uv.workspace] block", async () => {
+            expect.hasAssertions();
+
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-no-ws-"));
+
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
 
-        expect(result).toBe("no-workspace");
-    });
+            expect(result).toBe("no-workspace");
+        });
 
-    it("returns 'member' when the relative path matches a literal members entry", async () => {
-        expect.hasAssertions();
+        it("returns 'member' when the relative path matches a literal members entry", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-literal-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-literal-"));
 
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
@@ -871,17 +872,17 @@ version = "0.0.0"
 members = ["py/sdk", "py/cli"]
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
 
-        expect(result).toBe("member");
-    });
+            expect(result).toBe("member");
+        });
 
-    it("returns 'member' for a glob entry (`py/*`)", async () => {
-        expect.hasAssertions();
+        it("returns 'member' for a glob entry (`py/*`)", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-glob-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-glob-"));
 
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
@@ -890,17 +891,17 @@ version = "0.0.0"
 members = ["py/*"]
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
 
-        expect(result).toBe("member");
-    });
+            expect(result).toBe("member");
+        });
 
-    it("returns 'member' for a recursive glob entry (`py/**`)", async () => {
-        expect.hasAssertions();
+        it("returns 'member' for a recursive glob entry (`py/**`)", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-recursive-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-recursive-"));
 
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
@@ -909,17 +910,17 @@ version = "0.0.0"
 members = ["py/**"]
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk/nested");
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk/nested");
 
-        expect(result).toBe("member");
-    });
+            expect(result).toBe("member");
+        });
 
-    it("returns 'missing' when the path doesn't match any member entry", async () => {
-        expect.hasAssertions();
+        it("returns 'missing' when the path doesn't match any member entry", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-missing-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-missing-"));
 
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
@@ -928,20 +929,20 @@ version = "0.0.0"
 members = ["py/sdk"]
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/cli");
+            const result = await checkUvWorkspaceMembership(tmp, "py/cli");
 
-        expect(result).toBe("missing");
-    });
+            expect(result).toBe("missing");
+        });
 
-    it("`py/*` does NOT match nested paths beyond a single segment", async () => {
-        // Regression guard: a non-recursive glob shouldn't accept
-        // arbitrarily-deep paths. Operators on a deep tree should
-        // use `py/**` instead.
-        expect.hasAssertions();
+        it("`py/*` does NOT match nested paths beyond a single segment", async () => {
+            // Regression guard: a non-recursive glob shouldn't accept
+            // arbitrarily-deep paths. Operators on a deep tree should
+            // use `py/**` instead.
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-uv-nonrecursive-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-uv-nonrecursive-"));
 
-        writePyProject(tmp, `
+            writePyProject(tmp, `
 [project]
 name = "monorepo-root"
 version = "0.0.0"
@@ -950,34 +951,35 @@ version = "0.0.0"
 members = ["py/*"]
 `);
 
-        const result = await checkUvWorkspaceMembership(tmp, "py/sdk/sub");
+            const result = await checkUvWorkspaceMembership(tmp, "py/sdk/sub");
 
-        expect(result).toBe("missing");
+            expect(result).toBe("missing");
+        });
     });
-});
 
-describe("pythonVersionActions: pyproject version drift", () => {
-    it("throws BUMP_FILE_INVALID when the on-disk version differs from planned", async () => {
-        expect.hasAssertions();
+    describe("pythonVersionActions: pyproject version drift", () => {
+        it("throws BUMP_FILE_INVALID when the on-disk version differs from planned", async () => {
+            expect.hasAssertions();
 
-        const tmp = mkdtempSync(join(tmpdir(), "vis-py-drift-"));
+            const tmp = mkdtempSync(join(tmpdir(), "vis-py-drift-"));
 
-        // On-disk pyproject has 0.9.0 but plan says 1.0.1 — preset
-        // didn't run / was misconfigured.
-        writePyProject(tmp, `
+            // On-disk pyproject has 0.9.0 but plan says 1.0.1 — preset
+            // didn't run / was misconfigured.
+            writePyProject(tmp, `
 [project]
 name = "demo"
 version = "0.9.0"
 `);
 
-        process.env.TWINE_PASSWORD = "pypi-token";
+            process.env.TWINE_PASSWORD = "pypi-token";
 
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
-        const actions = new PythonVersionActions();
+            const actions = new PythonVersionActions();
 
-        await expect(actions.publish(mkContext({ cwd: tmp, version: "1.0.1" }))).rejects.toMatchObject({
-            code: "BUMP_FILE_INVALID",
+            await expect(actions.publish(mkContext({ cwd: tmp, version: "1.0.1" }))).rejects.toMatchObject({
+                code: "BUMP_FILE_INVALID",
+            });
         });
     });
 });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
@@ -118,10 +118,13 @@ afterEach(() => {
 
 describe("pythonVersionActions: identity", () => {
     it("has stable id `python`", () => {
+        expect.hasAssertions();
         expect(new PythonVersionActions().id).toBe("python");
     });
 
     it("dry-run returns published: true without invoking anything", async () => {
+        expect.hasAssertions();
+
         const runner = new MockRunner();
         let invoked = false;
         const wrapped: CommandRunner = {
@@ -145,6 +148,8 @@ describe("pythonVersionActions: identity", () => {
 
 describe("pythonVersionActions: readPublishedVersion", () => {
     it("parses .info.version from PyPI JSON on 200", async () => {
+        expect.hasAssertions();
+
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             stubPypiResponse({ info: { version: "2.3.4" } }),
         );
@@ -180,6 +185,8 @@ version = "1.0.0"
     });
 
     it("returns undefined on 404 (package not on PyPI yet)", async () => {
+        expect.hasAssertions();
+
         vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({}, 404));
 
         const result = await fetchPyPiVersion("brand-new-pkg");
@@ -188,6 +195,8 @@ version = "1.0.0"
     });
 
     it("returns undefined on network failure", async () => {
+        expect.hasAssertions();
+
         vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
 
         const result = await fetchPyPiVersion("any-pkg");
@@ -196,6 +205,8 @@ version = "1.0.0"
     });
 
     it("returns undefined on malformed JSON / missing info.version", async () => {
+        expect.hasAssertions();
+
         vi.spyOn(globalThis, "fetch").mockResolvedValue(stubPypiResponse({ /* no info */ }));
 
         const result = await fetchPyPiVersion("partial-pkg");
@@ -208,6 +219,8 @@ version = "1.0.0"
 
 describe("pythonVersionActions: dynamic versioning refusal", () => {
     it("throws CONFIG_INVALID when pyproject declares dynamic = [\"version\"]", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-dyn-"));
 
         writePyProject(tmp, `
@@ -234,26 +247,32 @@ dynamic = ["version"]
 
 describe("pythonVersionActions: detectBackend", () => {
     it("detects hatchling.build → hatch", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "hatchling.build" } })).toBe("hatch");
     });
 
     it("detects poetry.core.masonry.api → poetry", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "poetry.core.masonry.api" } })).toBe("poetry");
     });
 
     it("detects pdm.backend → pdm", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "pdm.backend" } })).toBe("pdm");
     });
 
     it("detects setuptools.build_meta → setuptools", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "setuptools.build_meta" } })).toBe("setuptools");
     });
 
     it("detects uv_build → uv", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "uv_build" } })).toBe("uv");
     });
 
     it("returns 'unknown' for unrecognized / missing backend", () => {
+        expect.hasAssertions();
         expect(detectBackend({ "build-system": { "build-backend": "weird.thing" } })).toBe("unknown");
         expect(detectBackend({ "build-system": {} })).toBe("unknown");
         expect(detectBackend(undefined)).toBe("unknown");
@@ -264,6 +283,8 @@ describe("pythonVersionActions: detectBackend", () => {
 
 describe("pythonVersionActions: resolveBuildEnv", () => {
     it("prefers uv when backend is 'uv' regardless of PATH detection", () => {
+        expect.hasAssertions();
+
         const env = resolveBuildEnv("uv", false);
 
         expect(env.buildCommand).toStrictEqual({ args: ["build"], binary: "uv" });
@@ -271,6 +292,8 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
     });
 
     it("prefers uv when backend is 'unknown' AND uv is on PATH", () => {
+        expect.hasAssertions();
+
         const env = resolveBuildEnv("unknown", true);
 
         expect(env.buildCommand.binary).toBe("uv");
@@ -278,6 +301,8 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
     });
 
     it("uses python -m build + twine upload for hatch", () => {
+        expect.hasAssertions();
+
         const env = resolveBuildEnv("hatch", false);
 
         expect(env.buildCommand).toStrictEqual({ args: ["-m", "build"], binary: "python" });
@@ -285,6 +310,8 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
     });
 
     it("uses python -m build for poetry / pdm / setuptools (PEP 517 universal)", () => {
+        expect.hasAssertions();
+
         for (const backend of ["poetry", "pdm", "setuptools"] as const) {
             const env = resolveBuildEnv(backend, false);
 
@@ -299,10 +326,12 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
 
 describe("pythonVersionActions: detectAuthMode (M-3)", () => {
     it("returns 'token' when only TWINE_PASSWORD is set", () => {
+        expect.hasAssertions();
         expect(detectAuthMode({ TWINE_PASSWORD: "pypi-token" })).toBe("token");
     });
 
     it("returns 'oidc' when only ACTIONS_ID_TOKEN_REQUEST_URL is set", () => {
+        expect.hasAssertions();
         expect(detectAuthMode({ ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" })).toBe("oidc");
     });
 
@@ -311,6 +340,7 @@ describe("pythonVersionActions: detectAuthMode (M-3)", () => {
         // trusted publishing; a leftover TWINE_PASSWORD shouldn't
         // silently downgrade. (Previous behaviour was the inverse —
         // that was the bug.)
+        expect.hasAssertions();
         expect(detectAuthMode({
             ACTIONS_ID_TOKEN_REQUEST_URL: "https://x",
             TWINE_PASSWORD: "tok",
@@ -320,6 +350,7 @@ describe("pythonVersionActions: detectAuthMode (M-3)", () => {
     it("returns 'token' when preferStaticToken: true AND both signals are present (escape hatch)", () => {
         // M-3 escape hatch for operators migrating off OIDC or
         // running a shadow publish.
+        expect.hasAssertions();
         expect(detectAuthMode(
             { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x", TWINE_PASSWORD: "tok" },
             { publish: { preferStaticToken: true } },
@@ -329,6 +360,7 @@ describe("pythonVersionActions: detectAuthMode (M-3)", () => {
     it("returns 'oidc' when preferStaticToken: true but no static token is present", () => {
         // Escape hatch only fires when there's actually a static
         // token to fall back to.
+        expect.hasAssertions();
         expect(detectAuthMode(
             { ACTIONS_ID_TOKEN_REQUEST_URL: "https://x" },
             { publish: { preferStaticToken: true } },
@@ -336,6 +368,7 @@ describe("pythonVersionActions: detectAuthMode (M-3)", () => {
     });
 
     it("returns 'missing' when neither is set", () => {
+        expect.hasAssertions();
         expect(detectAuthMode({})).toBe("missing");
     });
 });
@@ -344,6 +377,8 @@ describe("pythonVersionActions: detectAuthMode (M-3)", () => {
 
 describe("pythonVersionActions: publish via twine (no uv)", () => {
     it("invokes python -m build then twine upload dist/*", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-twine-"));
 
         writePyProject(tmp, `
@@ -381,6 +416,8 @@ build-backend = "hatchling.build"
 
 describe("pythonVersionActions: publish via uv", () => {
     it("invokes uv build + uv publish when uv is on PATH", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-uv-"));
 
         writePyProject(tmp, `
@@ -436,6 +473,8 @@ describe("pythonVersionActions: PyPI User-Agent header (B-3)", () => {
     it("stamps a vis-release User-Agent on PyPI metadata requests", async () => {
         // PyPI explicitly asks for a contact UA; vis routes the
         // JSON-API probe through `safeFetchVersionMetadata`.
+        expect.hasAssertions();
+
         const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
             stubPypiResponse({ info: { version: "1.0.0" } }),
         );
@@ -457,6 +496,8 @@ describe("pythonVersionActions: PyPI User-Agent header (B-3)", () => {
 
 describe("pythonVersionActions: OIDC trusted publishing", () => {
     it("proceeds when ACTIONS_ID_TOKEN_REQUEST_URL is set even with no TWINE_PASSWORD", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-oidc-"));
 
         writePyProject(tmp, `
@@ -503,6 +544,8 @@ version = "1.0.1"
     });
 
     it("injects TWINE_USERNAME=__token__ for the static-token flow when not already set", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-tok-"));
 
         writePyProject(tmp, `
@@ -549,6 +592,8 @@ version = "1.0.1"
 describe("pythonVersionActions: M-3 OIDC precedence in publish()", () => {
     it("uses OIDC (no TWINE_USERNAME injection) when both env vars are present", async () => {
         // M-3: OIDC wins by default even with TWINE_PASSWORD set.
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-oidc-"));
 
         writePyProject(tmp, `
@@ -597,6 +642,8 @@ version = "1.0.1"
     });
 
     it("preferStaticToken: true flips precedence — TWINE_USERNAME=__token__ is injected (M-3 escape hatch)", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-m3-escape-"));
 
         writePyProject(tmp, `
@@ -650,6 +697,8 @@ version = "1.0.1"
 
 describe("pythonVersionActions: AUTH_MISSING", () => {
     it("throws AUTH_MISSING when neither TWINE_PASSWORD nor OIDC env is set", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-noauth-"));
 
         writePyProject(tmp, `
@@ -676,6 +725,8 @@ version = "1.0.1"
 
 describe("pythonVersionActions: build failure", () => {
     it("throws PUBLISH_FAILED when python -m build exits non-zero", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-buildfail-"));
 
         writePyProject(tmp, `
@@ -712,6 +763,8 @@ version = "1.0.1"
 
 describe("pythonVersionActions: already-published short-circuit", () => {
     it("returns alreadyPublished without invoking build/twine when PyPI reports the new version", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-already-"));
 
         writePyProject(tmp, `
@@ -754,6 +807,8 @@ version = "1.0.1"
 
 describe("pythonVersionActions: resolveUvLockPath", () => {
     it("returns <pkg.dir>/uv.lock when no per-package override is set", () => {
+        expect.hasAssertions();
+
         const result = resolveUvLockPath(
             { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
         );
@@ -764,6 +819,8 @@ describe("pythonVersionActions: resolveUvLockPath", () => {
     it("honours perPackageConfig.uvLockPath (relative to pkg.dir)", () => {
         // Operators point this at `../uv.lock` when uv manages the
         // lockfile at the workspace root rather than per-package.
+        expect.hasAssertions();
+
         const result = resolveUvLockPath(
             { dir: "/repo/py/sdk", name: "@scope/sdk" } as never,
             { uvLockPath: "../uv.lock" },
@@ -775,6 +832,8 @@ describe("pythonVersionActions: resolveUvLockPath", () => {
 
 describe("pythonVersionActions: checkUvWorkspaceMembership", () => {
     it("returns 'no-root-pyproject' when the root has no pyproject.toml", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-empty-"));
 
         const result = await checkUvWorkspaceMembership(tmp, "py/sdk");
@@ -783,6 +842,8 @@ describe("pythonVersionActions: checkUvWorkspaceMembership", () => {
     });
 
     it("returns 'no-workspace' when the root pyproject has no [tool.uv.workspace] block", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-no-ws-"));
 
         writePyProject(tmp, `
@@ -797,6 +858,8 @@ version = "0.0.0"
     });
 
     it("returns 'member' when the relative path matches a literal members entry", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-literal-"));
 
         writePyProject(tmp, `
@@ -814,6 +877,8 @@ members = ["py/sdk", "py/cli"]
     });
 
     it("returns 'member' for a glob entry (`py/*`)", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-glob-"));
 
         writePyProject(tmp, `
@@ -831,6 +896,8 @@ members = ["py/*"]
     });
 
     it("returns 'member' for a recursive glob entry (`py/**`)", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-recursive-"));
 
         writePyProject(tmp, `
@@ -848,6 +915,8 @@ members = ["py/**"]
     });
 
     it("returns 'missing' when the path doesn't match any member entry", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-missing-"));
 
         writePyProject(tmp, `
@@ -868,6 +937,8 @@ members = ["py/sdk"]
         // Regression guard: a non-recursive glob shouldn't accept
         // arbitrarily-deep paths. Operators on a deep tree should
         // use `py/**` instead.
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-uv-nonrecursive-"));
 
         writePyProject(tmp, `
@@ -887,6 +958,8 @@ members = ["py/*"]
 
 describe("pythonVersionActions: pyproject version drift", () => {
     it("throws BUMP_FILE_INVALID when the on-disk version differs from planned", async () => {
+        expect.hasAssertions();
+
         const tmp = mkdtempSync(join(tmpdir(), "vis-py-drift-"));
 
         // On-disk pyproject has 0.9.0 but plan says 1.0.1 — preset

--- a/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-python.test.ts
@@ -266,8 +266,8 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
     it("prefers uv when backend is 'uv' regardless of PATH detection", () => {
         const env = resolveBuildEnv("uv", false);
 
-        expect(env.buildCommand).toEqual({ args: ["build"], binary: "uv" });
-        expect(env.publishCommand).toEqual({ args: ["publish"], binary: "uv" });
+        expect(env.buildCommand).toStrictEqual({ args: ["build"], binary: "uv" });
+        expect(env.publishCommand).toStrictEqual({ args: ["publish"], binary: "uv" });
     });
 
     it("prefers uv when backend is 'unknown' AND uv is on PATH", () => {
@@ -280,8 +280,8 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
     it("uses python -m build + twine upload for hatch", () => {
         const env = resolveBuildEnv("hatch", false);
 
-        expect(env.buildCommand).toEqual({ args: ["-m", "build"], binary: "python" });
-        expect(env.publishCommand).toEqual({ args: ["upload", "dist/*"], binary: "twine" });
+        expect(env.buildCommand).toStrictEqual({ args: ["-m", "build"], binary: "python" });
+        expect(env.publishCommand).toStrictEqual({ args: ["upload", "dist/*"], binary: "twine" });
     });
 
     it("uses python -m build for poetry / pdm / setuptools (PEP 517 universal)", () => {
@@ -289,7 +289,7 @@ describe("pythonVersionActions: resolveBuildEnv", () => {
             const env = resolveBuildEnv(backend, false);
 
             expect(env.buildCommand.binary).toBe("python");
-            expect(env.buildCommand.args).toEqual(["-m", "build"]);
+            expect(env.buildCommand.args).toStrictEqual(["-m", "build"]);
             expect(env.publishCommand.binary).toBe("twine");
         }
     });

--- a/packages/tooling/vis/__tests__/release/core/version-actions-shell.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-actions-shell.test.ts
@@ -94,6 +94,8 @@ const ctx = (overrides: {
 
 describe("shellPublishActions: trust-gate refusal", () => {
     it("throws CONFIG_INVALID when allowCustomCommands is missing", async () => {
+        expect.hasAssertions();
+
         const actions = new ShellPublishActions();
 
         await expect(actions.publish(ctx({
@@ -102,6 +104,8 @@ describe("shellPublishActions: trust-gate refusal", () => {
     });
 
     it("throws when package is not in the allow-list", async () => {
+        expect.hasAssertions();
+
         const actions = new ShellPublishActions();
 
         await expect(actions.publish(ctx({
@@ -111,6 +115,8 @@ describe("shellPublishActions: trust-gate refusal", () => {
     });
 
     it("throws when allowed but no publishCommand", async () => {
+        expect.hasAssertions();
+
         const actions = new ShellPublishActions();
 
         await expect(actions.publish(ctx({
@@ -121,6 +127,8 @@ describe("shellPublishActions: trust-gate refusal", () => {
 
 describe("shellPublishActions: dryRun", () => {
     it("returns published: true without invoking anything", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([]);
         const actions = new ShellPublishActions();
 
@@ -140,6 +148,8 @@ describe("shellPublishActions: dryRun", () => {
 describe("shellPublishActions: idempotency via checkPublished", () => {
     it("returns alreadyPublished: true when checkPublished reports the new version", async () => {
         // First runner call: checkPublished → stdout matches new version.
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 0, stdout: "1.0.1\n" },
         ]);
@@ -160,6 +170,8 @@ describe("shellPublishActions: idempotency via checkPublished", () => {
     });
 
     it("proceeds with publishCommand when checkPublished reports an older version", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 0, stdout: "1.0.0\n" }, // check
             { exitCode: 0, stdout: "" }, // publishCommand
@@ -179,6 +191,8 @@ describe("shellPublishActions: idempotency via checkPublished", () => {
     });
 
     it("ignores checkPublished failure (non-zero exit) and proceeds with publish", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 1, stderr: "registry unreachable" }, // check fails
             { exitCode: 0, stdout: "" }, // publishCommand
@@ -199,6 +213,8 @@ describe("shellPublishActions: idempotency via checkPublished", () => {
 
 describe("shellPublishActions: interpolation", () => {
     it("substitutes {{name}}/{{version}}/{{tag}}/{{registry}} in the publishCommand", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "" }]);
         const actions = new ShellPublishActions();
 
@@ -220,6 +236,8 @@ describe("shellPublishActions: interpolation", () => {
     });
 
     it("shell-quotes the substituted values (no injection)", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([{ exitCode: 0, stdout: "" }]);
         const actions = new ShellPublishActions();
 
@@ -244,6 +262,8 @@ describe("shellPublishActions: interpolation", () => {
 
 describe("shellPublishActions: buildCommand + sequential publishCommand", () => {
     it("runs buildCommand before publishCommand and stops at first non-zero exit", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 0, stdout: "" }, // buildCommand
             { exitCode: 0, stdout: "" }, // publishCommand[0]
@@ -263,6 +283,8 @@ describe("shellPublishActions: buildCommand + sequential publishCommand", () => 
     });
 
     it("does NOT run publishCommand if buildCommand fails", async () => {
+        expect.hasAssertions();
+
         const { calls, runner } = buildRunner([
             { exitCode: 1, stderr: "compile error" }, // buildCommand fails
         ]);

--- a/packages/tooling/vis/__tests__/release/core/version-pr-merge.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-pr-merge.test.ts
@@ -11,12 +11,16 @@ import { VisReleaseError } from "../../../src/release/errors";
 
 describe(mergeProtectedContent, () => {
     it("returns the new body unchanged when there is no existing body", () => {
+        expect.hasAssertions();
+
         const next = "## Pending releases\n\n- pkg: 1.0 -> 1.1";
 
         expect(mergeProtectedContent(undefined, next)).toBe(next);
     });
 
     it("returns the new body unchanged when the existing body has no markers", () => {
+        expect.hasAssertions();
+
         const existing = "Plain text I edited — but no markers.";
         const next = "## Pending releases\n\n- pkg: 1.0 -> 1.1";
 
@@ -24,6 +28,8 @@ describe(mergeProtectedContent, () => {
     });
 
     it("preserves a single operator-edited block verbatim", () => {
+        expect.hasAssertions();
+
         const existing = [
             "## Pending releases (old)",
             "",
@@ -49,6 +55,8 @@ describe(mergeProtectedContent, () => {
     });
 
     it("preserves multiple operator-edited blocks in order", () => {
+        expect.hasAssertions();
+
         const existing = [
             "<!-- vis:user-content -->",
             "BLOCK ONE",
@@ -70,6 +78,8 @@ describe(mergeProtectedContent, () => {
     });
 
     it("fills empty marker pairs in the new body before appending the rest", () => {
+        expect.hasAssertions();
+
         const existing = [
             "<!-- vis:user-content -->",
             "PRESERVED",
@@ -95,6 +105,8 @@ describe(mergeProtectedContent, () => {
     });
 
     it("rejects nested markers up-front (silent data loss otherwise)", () => {
+        expect.hasAssertions();
+
         const nested = [
             "<!-- vis:user-content -->",
             "outer",
@@ -111,6 +123,8 @@ describe(mergeProtectedContent, () => {
     // the CI handler can surface a clean CI-tail diagnostic instead of a
     // bare `Error`. Code is `CONFIG_INVALID` (RFC §19.4).
     it("f7: throws VisReleaseError with CONFIG_INVALID for nested markers", () => {
+        expect.hasAssertions();
+
         const nested = [
             "<!-- vis:user-content -->",
             "outer",
@@ -136,6 +150,8 @@ describe(mergeProtectedContent, () => {
     // partial edit because BLOCK_RE only matches well-formed pairs. We
     // count opens vs closes and refuse to merge when they're unbalanced.
     it("f18: rejects unbalanced markers (more opens than closes)", () => {
+        expect.hasAssertions();
+
         const orphan = [
             "<!-- vis:user-content -->",
             "first block — closed",
@@ -157,6 +173,8 @@ describe(mergeProtectedContent, () => {
     });
 
     it("f18: rejects unbalanced markers (more closes than opens)", () => {
+        expect.hasAssertions();
+
         const orphan = [
             "<!-- vis:user-content -->",
             "first",
@@ -182,6 +200,8 @@ describe(mergeProtectedContent, () => {
     // trip the balance check. The fenced occurrences are documentation,
     // not real markers — strip fences before counting.
     it("f18: ignores marker tokens inside fenced code blocks (``` fence)", () => {
+        expect.hasAssertions();
+
         const documented = [
             "## How protected blocks work",
             "",
@@ -217,6 +237,8 @@ describe(mergeProtectedContent, () => {
         // and the pre-strip code would throw. With the strip, the
         // fence is treated as documentation and only the real
         // well-formed pair below counts.
+        expect.hasAssertions();
+
         const documented = [
             "Example of the open marker:",
             "",
@@ -238,6 +260,8 @@ describe(mergeProtectedContent, () => {
         // Fence contains a balanced documentation pair; the body
         // OUTSIDE the fence is genuinely unbalanced (orphan open).
         // The strip must not mask the real imbalance.
+        expect.hasAssertions();
+
         const orphan = [
             "```",
             "<!-- vis:user-content -->",

--- a/packages/tooling/vis/__tests__/release/core/version-resolver.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/version-resolver.test.ts
@@ -60,6 +60,8 @@ const mkDepGraph = (pkgs: WorkspacePackage[]): DependencyGraph => new Dependency
 
 describe("resolveCurrentVersion — disk mode", () => {
     it("returns the manifest version verbatim and tags the result as resolvedFrom: disk", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/a", "1.2.3");
 
@@ -77,6 +79,8 @@ describe("resolveCurrentVersion — disk mode", () => {
 
 describe("resolveCurrentVersion — registry mode (npm package)", () => {
     it("returns the registry version when `npm view` answers with a semver", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/a", "1.2.3");
 
@@ -94,6 +98,8 @@ describe("resolveCurrentVersion — registry mode (npm package)", () => {
     });
 
     it("falls back to the manifest version when `npm view` returns a 404 (non-zero exit, empty stdout)", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/new-pkg", "0.0.1");
 
@@ -121,6 +127,8 @@ describe("resolveCurrentVersion — registry mode (npm package)", () => {
 
 describe("resolveCurrentVersion — git-tag mode", () => {
     it("happy path: finds the highest matching tag and returns its version", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/a", "1.0.0"); // manifest lags behind tags
 
@@ -145,6 +153,8 @@ describe("resolveCurrentVersion — git-tag mode", () => {
     });
 
     it("no matching tag → falls back to manifest, with a warning nudging toward --first-release", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/freshpkg", "0.0.1");
 
@@ -166,6 +176,8 @@ describe("resolveCurrentVersion — git-tag mode", () => {
 
 describe("resolveModeForPackage — precedence", () => {
     it("per-package override wins over workspace-level", () => {
+        expect.hasAssertions();
+
         const mode = resolveModeForPackage(
             { currentVersionResolver: "registry" },
             { currentVersionResolver: "git-tag" },
@@ -176,6 +188,8 @@ describe("resolveModeForPackage — precedence", () => {
     });
 
     it("workspace-level wins over the default disk", () => {
+        expect.hasAssertions();
+
         const mode = resolveModeForPackage(
             { currentVersionResolver: "registry" },
             undefined,
@@ -186,6 +200,8 @@ describe("resolveModeForPackage — precedence", () => {
     });
 
     it("`firstRelease` forces disk regardless of config", () => {
+        expect.hasAssertions();
+
         const mode = resolveModeForPackage(
             { currentVersionResolver: "registry" },
             { currentVersionResolver: "git-tag" },
@@ -196,6 +212,8 @@ describe("resolveModeForPackage — precedence", () => {
     });
 
     it("default is disk when nothing is configured", () => {
+        expect.hasAssertions();
+
         const mode = resolveModeForPackage(undefined, undefined, false);
 
         expect(mode).toBe("disk");
@@ -211,6 +229,8 @@ describe("resolveCurrentVersionsForWorkspace — batch resolution", () => {
     });
 
     it("resolves every package in parallel and surfaces per-package fallbacks as warnings", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const a = mkPkg("@scope/a", "1.0.0");
         const b = mkPkg("@scope/b", "2.0.0");
@@ -249,6 +269,8 @@ describe("resolveCurrentVersionsForWorkspace — batch resolution", () => {
     });
 
     it("`firstRelease: true` forces every package to disk even when config says otherwise", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const a = mkPkg("@scope/a", "1.0.0");
         const depGraph = mkDepGraph([a]);
@@ -336,6 +358,8 @@ describe("resolveCurrentVersionsForWorkspace — concurrency cap (C-3)", () => {
     }
 
     it("never exceeds REGISTRY_LOOKUP_CONCURRENCY in-flight registry probes (cap = 4 by default)", async () => {
+        expect.hasAssertions();
+
         const counting = new CountingRunner();
         // NpmAdapter's `readPublishedVersion` runs through `pm.runner.run`,
         // so the CountingRunner must be the adapter's runner — not just
@@ -385,6 +409,8 @@ describe("resolveCurrentVersionsForWorkspace — concurrency cap (C-3)", () => {
     });
 
     it("memoises repeat lookups within the same process — a second resolve hits the cache (one fetch only)", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const a = mkPkg("@scope/memoed", "1.0.0");
         const depGraph = mkDepGraph([a]);
@@ -420,6 +446,8 @@ describe("resolveCurrentVersionsForWorkspace — concurrency cap (C-3)", () => {
     });
 
     it("skipRegistryLookup: true falls back to disk for every package, never probing the registry", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const a = mkPkg("@scope/skip-a", "1.0.0");
         const b = mkPkg("@scope/skip-b", "2.0.0");
@@ -460,6 +488,8 @@ describe("resolveCurrentVersionsForWorkspace — concurrency cap (C-3)", () => {
  */
 describe("git-tag mode — releaseTagPattern compilation (N-7)", () => {
     it("compileReleaseTagRegex: a custom pattern 'v{version}' matches 'v1.2.3' but not random 'v1'", () => {
+        expect.hasAssertions();
+
         const re = compileReleaseTagRegex("v{version}", { name: "@scope/foo" });
 
         const m = re.exec("v1.2.3");
@@ -476,6 +506,8 @@ describe("git-tag mode — releaseTagPattern compilation (N-7)", () => {
     });
 
     it("compileReleaseTagRegex: a name-prefix pattern '{name}-v{version}' anchors on the package name", () => {
+        expect.hasAssertions();
+
         const re = compileReleaseTagRegex("{name}-v{version}", { name: "cerebro" });
 
         expect(re.exec("cerebro-v3.0.0")![1]).toBe("3.0.0");
@@ -484,6 +516,8 @@ describe("git-tag mode — releaseTagPattern compilation (N-7)", () => {
     });
 
     it("git-tag mode honours a workspace-configured releaseTagPattern: 'v{version}' (no literal name@ fallback)", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/a", "0.0.1");
 
@@ -508,6 +542,8 @@ describe("git-tag mode — releaseTagPattern compilation (N-7)", () => {
     });
 
     it("git-tag mode rejects tags that don't match the configured pattern (no second-chance literal-prefix fallback)", async () => {
+        expect.hasAssertions();
+
         const runner = mkRunner();
         const pkg = mkPkg("@scope/a", "0.0.1");
 

--- a/packages/tooling/vis/__tests__/release/core/workflow-templates.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workflow-templates.test.ts
@@ -7,7 +7,7 @@ describe("generateWorkflowFiles — GitHub", () => {
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "github" });
 
         expect(files).toHaveLength(3);
-        expect(files.map((f) => f.path).sort()).toEqual([
+        expect(files.map((f) => f.path).sort()).toStrictEqual([
             ".github/workflows/vis-release-check.yml",
             ".github/workflows/vis-release-snapshot.yml",
             ".github/workflows/vis-release.yml",

--- a/packages/tooling/vis/__tests__/release/core/workflow-templates.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workflow-templates.test.ts
@@ -4,6 +4,8 @@ import { generateWorkflowFiles } from "../../../src/release/core/workflow-templa
 
 describe("generateWorkflowFiles — GitHub", () => {
     it("emits 3 files (release + check + snapshot) by default", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "github" });
 
         expect(files).toHaveLength(3);
@@ -15,6 +17,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("uses configured branches in the on.push trigger", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, {
             branches: ["main", "alpha", "beta"],
             packageManager: "pnpm",
@@ -30,6 +34,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("derives branches from config.channels when not overridden", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({
             channels: { alpha: { prerelease: "alpha", tag: "alpha" }, main: { tag: "latest" } },
         }, { packageManager: "pnpm", provider: "github" });
@@ -41,6 +47,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("falls back to ['main'] when no channels are configured and no branches override", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { packageManager: "pnpm", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -48,6 +56,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("emits id-token: write when useOidc is true (default)", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "github", useOidc: true });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -56,6 +66,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("emits NPM_TOKEN env when useOidc is false", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "github", useOidc: false });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -64,6 +76,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("includes pnpm/action-setup for pnpm projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -71,6 +85,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("includes oven-sh/setup-bun for bun projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "bun", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -78,6 +94,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("uses npm-specific install + exec commands for npm projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "npm", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -87,6 +105,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("uses yarn-specific install + exec commands for yarn projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "yarn", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -97,6 +117,8 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("uses bun-specific install + exec commands for bun projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "bun", provider: "github" });
         const release = files.find((f) => f.path === ".github/workflows/vis-release.yml")!;
 
@@ -105,12 +127,16 @@ describe("generateWorkflowFiles — GitHub", () => {
     });
 
     it("respects includeSnapshot: false", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], includeSnapshot: false, packageManager: "pnpm", provider: "github" });
 
         expect(files.find((f) => f.path === ".github/workflows/vis-release-snapshot.yml")).toBeUndefined();
     });
 
     it("respects includeCheck: false", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], includeCheck: false, packageManager: "pnpm", provider: "github" });
 
         expect(files.find((f) => f.path === ".github/workflows/vis-release-check.yml")).toBeUndefined();
@@ -119,6 +145,8 @@ describe("generateWorkflowFiles — GitHub", () => {
 
 describe("generateWorkflowFiles — GitLab", () => {
     it("emits a single .gitlab-ci.yml at repo root", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "gitlab" });
 
         expect(files).toHaveLength(1);
@@ -126,6 +154,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("uses GitLab merge_request_event for check + snapshot stages", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("merge_request_event");
@@ -134,6 +164,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("uses GitLab branch rules for release stage", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main", "alpha"], packageManager: "pnpm", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("$CI_COMMIT_BRANCH == \"main\"");
@@ -141,6 +173,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("documents the GitLab token variables in the generated comment header", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("VIS_GH_TOKEN");
@@ -148,6 +182,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("emits corepack-based yarn bootstrap for yarn projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "yarn", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("corepack enable");
@@ -156,6 +192,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("emits npm install -g pnpm for pnpm projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "pnpm", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("npm install -g pnpm");
@@ -163,6 +201,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("emits npm install -g bun for bun projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "bun", provider: "gitlab" });
 
         expect(files[0]?.content).toContain("npm install -g bun");
@@ -170,6 +210,8 @@ describe("generateWorkflowFiles — GitLab", () => {
     });
 
     it("omits the bootstrap line entirely for npm projects", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({}, { branches: ["main"], packageManager: "npm", provider: "gitlab" });
 
         // No package-manager bootstrap needed — node:22 image already ships npm.
@@ -182,18 +224,24 @@ describe("generateWorkflowFiles — GitLab", () => {
 
 describe("generateWorkflowFiles — provider auto-detection from config", () => {
     it("uses config.provider when set to github", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({ provider: "github" }, { branches: ["main"], packageManager: "pnpm" });
 
         expect(files[0]?.path).toContain(".github/workflows/");
     });
 
     it("uses config.provider when set to gitlab", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({ provider: "gitlab" }, { branches: ["main"], packageManager: "pnpm" });
 
         expect(files[0]?.path).toBe(".gitlab-ci.yml");
     });
 
     it("defaults to github when config.provider is auto", () => {
+        expect.hasAssertions();
+
         const files = generateWorkflowFiles({ provider: "auto" }, { branches: ["main"], packageManager: "pnpm" });
 
         expect(files[0]?.path).toContain(".github/workflows/");

--- a/packages/tooling/vis/__tests__/release/core/workspace-reader.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workspace-reader.test.ts
@@ -50,6 +50,8 @@ describe(createVisWorkspaceReader, () => {
     });
 
     it("enumerates every workspace project that has a package.json", async () => {
+        expect.hasAssertions();
+
         const reader = createVisWorkspaceReader({ cwd });
         const result = await reader.listPackages();
 
@@ -57,6 +59,8 @@ describe(createVisWorkspaceReader, () => {
     });
 
     it("filters by project.json tag", async () => {
+        expect.hasAssertions();
+
         const reader = createVisWorkspaceReader({ cwd, tag: "type:package" });
         const result = await reader.listPackages();
 
@@ -64,6 +68,8 @@ describe(createVisWorkspaceReader, () => {
     });
 
     it("filters by projectType", async () => {
+        expect.hasAssertions();
+
         const reader = createVisWorkspaceReader({ cwd, projectType: "application" });
         const result = await reader.listPackages();
 
@@ -71,6 +77,8 @@ describe(createVisWorkspaceReader, () => {
     });
 
     it("composes tag + projectType filters", async () => {
+        expect.hasAssertions();
+
         const reader = createVisWorkspaceReader({ cwd, projectType: "library", tag: "category:internal" });
         const result = await reader.listPackages();
 
@@ -78,6 +86,8 @@ describe(createVisWorkspaceReader, () => {
     });
 
     it("returns absolute manifestPath usable by downstream consumers", async () => {
+        expect.hasAssertions();
+
         const reader = createVisWorkspaceReader({ cwd, tag: "type:package" });
         const result = await reader.listPackages();
         const a = result.find((r) => r.manifest.name === "@scope/a");

--- a/packages/tooling/vis/__tests__/release/core/workspace-reader.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workspace-reader.test.ts
@@ -53,28 +53,28 @@ describe(createVisWorkspaceReader, () => {
         const reader = createVisWorkspaceReader({ cwd });
         const result = await reader.listPackages();
 
-        expect(result.map((r) => r.manifest.name).sort()).toEqual(["@scope/a", "@scope/b", "@scope/web"]);
+        expect(result.map((r) => r.manifest.name).sort()).toStrictEqual(["@scope/a", "@scope/b", "@scope/web"]);
     });
 
     it("filters by project.json tag", async () => {
         const reader = createVisWorkspaceReader({ cwd, tag: "type:package" });
         const result = await reader.listPackages();
 
-        expect(result.map((r) => r.manifest.name).sort()).toEqual(["@scope/a", "@scope/b"]);
+        expect(result.map((r) => r.manifest.name).sort()).toStrictEqual(["@scope/a", "@scope/b"]);
     });
 
     it("filters by projectType", async () => {
         const reader = createVisWorkspaceReader({ cwd, projectType: "application" });
         const result = await reader.listPackages();
 
-        expect(result.map((r) => r.manifest.name)).toEqual(["@scope/web"]);
+        expect(result.map((r) => r.manifest.name)).toStrictEqual(["@scope/web"]);
     });
 
     it("composes tag + projectType filters", async () => {
         const reader = createVisWorkspaceReader({ cwd, projectType: "library", tag: "category:internal" });
         const result = await reader.listPackages();
 
-        expect(result.map((r) => r.manifest.name)).toEqual(["@scope/b"]);
+        expect(result.map((r) => r.manifest.name)).toStrictEqual(["@scope/b"]);
     });
 
     it("returns absolute manifestPath usable by downstream consumers", async () => {

--- a/packages/tooling/vis/__tests__/release/core/workspace.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workspace.test.ts
@@ -19,7 +19,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true });
 
-        expect(result.packages.map((p) => p.name).sort()).toEqual(["a", "b", "c"]);
+        expect(result.packages.map((p) => p.name).sort()).toStrictEqual(["a", "b", "c"]);
     });
 
     it("excludes native-addon platform packages under <parent>/npm/ (RFC §12.4)", async () => {
@@ -55,7 +55,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true });
 
-        expect(result.packages.map((p) => p.name)).toEqual(["@scope/native"]);
+        expect(result.packages.map((p) => p.name)).toStrictEqual(["@scope/native"]);
     });
 
     it("rejects duplicate package names", async () => {
@@ -84,7 +84,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true, ignore: ["@scope/internal-*"] });
 
-        expect(result.packages.map((p) => p.name).sort()).toEqual(["@scope/a", "@scope/c"]);
+        expect(result.packages.map((p) => p.name).sort()).toStrictEqual(["@scope/a", "@scope/c"]);
     });
 
     it("respects per-package managed: false override", async () => {
@@ -97,7 +97,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true });
 
-        expect(result.packages.map((p) => p.name)).toEqual(["a"]);
+        expect(result.packages.map((p) => p.name)).toStrictEqual(["a"]);
     });
 
     it("respects per-package managed: true override even when defaultManaged is false", async () => {
@@ -110,7 +110,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: false });
 
-        expect(result.packages.map((p) => p.name)).toEqual(["b"]);
+        expect(result.packages.map((p) => p.name)).toStrictEqual(["b"]);
     });
 
     it("skips private packages by default", async () => {
@@ -123,7 +123,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true });
 
-        expect(result.packages.map((p) => p.name)).toEqual(["a"]);
+        expect(result.packages.map((p) => p.name)).toStrictEqual(["a"]);
     });
 
     it("includes private packages when privatePackages.version is true", async () => {
@@ -136,7 +136,7 @@ describe("workspace: discoverPackages", () => {
 
         const result = await discoverPackages(reader, { defaultManaged: true, privatePackages: { tag: false, version: true } });
 
-        expect(result.packages.map((p) => p.name).sort()).toEqual(["a", "internal"]);
+        expect(result.packages.map((p) => p.name).sort()).toStrictEqual(["a", "internal"]);
     });
 
     it("rejects package names with shell metacharacters (RFC §19.4)", async () => {

--- a/packages/tooling/vis/__tests__/release/core/workspace.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/workspace.test.ts
@@ -13,6 +13,8 @@ const mkPkg = (name: string, extras: Partial<PackageManifest> = {}): { manifest:
 
 describe("workspace: discoverPackages", () => {
     it("returns packages from the reader", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [mkPkg("a"), mkPkg("b"), mkPkg("c")],
         };
@@ -23,6 +25,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("excludes native-addon platform packages under <parent>/npm/ (RFC §12.4)", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 // Native-addon parent (napi field) at packages/vis.
@@ -46,6 +50,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("excludes platform packages of an explicit native-addon parent (no napi field)", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 { manifest: { name: "@scope/native", version: "1.0.0", "vis-release": { versionActions: "native-addon" } } as unknown as PackageManifest, manifestPath: "/repo/packages/native/package.json" },
@@ -59,6 +65,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("rejects duplicate package names", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [mkPkg("a"), mkPkg("a")],
         };
@@ -67,6 +75,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("skips anonymous packages (missing name)", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [mkPkg("a"), { manifest: { name: "" as unknown as string, version: "1.0.0" }, manifestPath: "/x/p.json" }],
         };
@@ -78,6 +88,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("filters via release.ignore globs", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [mkPkg("@scope/a"), mkPkg("@scope/internal-b"), mkPkg("@scope/c")],
         };
@@ -88,6 +100,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("respects per-package managed: false override", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 mkPkg("a"),
@@ -101,6 +115,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("respects per-package managed: true override even when defaultManaged is false", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 mkPkg("a"),
@@ -114,6 +130,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("skips private packages by default", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 mkPkg("a"),
@@ -127,6 +145,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("includes private packages when privatePackages.version is true", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [
                 mkPkg("a"),
@@ -140,6 +160,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("rejects package names with shell metacharacters (RFC §19.4)", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [{
                 manifest: { name: "evil$(rm -rf /)", version: "1.0.0" } as PackageManifest,
@@ -151,6 +173,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("rejects package names exceeding 214 chars", async () => {
+        expect.hasAssertions();
+
         const longName = `@scope/${"a".repeat(214)}`;
         const reader = {
             listPackages: async () => [{
@@ -163,6 +187,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("rejects manifestPath outside the workspace cwd when cwd is provided", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [{
                 manifest: { name: "evil", version: "1.0.0" } as PackageManifest,
@@ -174,6 +200,8 @@ describe("workspace: discoverPackages", () => {
     });
 
     it("accepts manifestPath inside the workspace cwd", async () => {
+        expect.hasAssertions();
+
         const reader = {
             listPackages: async () => [{
                 manifest: { name: "a", version: "1.0.0" } as PackageManifest,
@@ -189,6 +217,8 @@ describe("workspace: discoverPackages", () => {
 
 describe("workspace: mergePerPackageConfig", () => {
     it("package.json wins over root config", () => {
+        expect.hasAssertions();
+
         const merged = mergePerPackageConfig(
             "a",
             { name: "a", version: "1.0.0", "vis-release": { versionActions: "native-addon" } },
@@ -199,6 +229,8 @@ describe("workspace: mergePerPackageConfig", () => {
     });
 
     it("root config supplies fields when package.json is absent", () => {
+        expect.hasAssertions();
+
         const merged = mergePerPackageConfig(
             "a",
             { name: "a", version: "1.0.0" },
@@ -223,24 +255,32 @@ describe("workspace: resolveVersionActionsId auto-detection", () => {
     };
 
     it("auto-detects native-addon via napi field", () => {
+        expect.hasAssertions();
+
         const id = resolveVersionActionsId(wsPkg({ name: "a", napi: { binaryName: "a" }, version: "1.0.0" }), {});
 
         expect(id).toBe("native-addon");
     });
 
     it("auto-detects private for private:true packages", () => {
+        expect.hasAssertions();
+
         const id = resolveVersionActionsId(wsPkg({ name: "a", version: "1.0.0" }, true), {});
 
         expect(id).toBe("private");
     });
 
     it("defaults to npm", () => {
+        expect.hasAssertions();
+
         const id = resolveVersionActionsId(wsPkg({ name: "a", version: "1.0.0" }), {});
 
         expect(id).toBe("npm");
     });
 
     it("explicit per-package config overrides auto-detection", () => {
+        expect.hasAssertions();
+
         const id = resolveVersionActionsId(wsPkg({ name: "a", napi: { binaryName: "a" }, version: "1.0.0" }), { versionActions: "npm" });
 
         expect(id).toBe("npm");
@@ -253,27 +293,33 @@ describe("workspace: isPackageManaged precedence (RFC §17.1 5-rule order)", () 
     };
 
     it("rule 1: explicit managed:false always wins", () => {
+        expect.hasAssertions();
         expect(isPackageManaged("a", m(), { managed: false }, { defaultManaged: true, include: ["a"] })).toBe(false);
     });
 
     it("rule 2: ignore glob wins over default", () => {
+        expect.hasAssertions();
         expect(isPackageManaged("a", m(), {}, { defaultManaged: true, ignore: ["a"] })).toBe(false);
     });
 
     it("rule 3: explicit managed:true overrides ignore", () => {
         // Note: bumpy's documented order has explicit managed:true after ignore; verify
+        expect.hasAssertions();
         expect(isPackageManaged("a", m(), { managed: true }, { defaultManaged: false, ignore: ["a"] })).toBe(true);
     });
 
     it("rule 4: include glob wins over private + default-false", () => {
+        expect.hasAssertions();
         expect(isPackageManaged("a", { ...m(), private: true }, {}, { defaultManaged: false, include: ["a"] })).toBe(true);
     });
 
     it("rule 5: private:true excluded when privatePackages.version is false", () => {
+        expect.hasAssertions();
         expect(isPackageManaged("a", { ...m(), private: true }, {}, { defaultManaged: true })).toBe(false);
     });
 
     it("rule 6: defaults to defaultManaged", () => {
+        expect.hasAssertions();
         expect(isPackageManaged("a", m(), {}, { defaultManaged: false })).toBe(false);
         expect(isPackageManaged("a", m(), {}, { defaultManaged: true })).toBe(true);
     });

--- a/packages/tooling/vis/__tests__/release/e2e/init-from-changesets.e2e.test.ts
+++ b/packages/tooling/vis/__tests__/release/e2e/init-from-changesets.e2e.test.ts
@@ -33,6 +33,8 @@ describe.skipIf(!visBuilt())("e2e: vis release init --from-changesets", () => {
     });
 
     it("auto-detects changesets and migrates the change file", () => {
+        expect.hasAssertions();
+
         const { exitCode, stdout } = result.runVisRelease(["init", "--from-changesets"]);
 
         expect(exitCode).toBe(0);
@@ -41,6 +43,8 @@ describe.skipIf(!visBuilt())("e2e: vis release init --from-changesets", () => {
     });
 
     it("aborts when changesets pre-release mode is active", async () => {
+        expect.hasAssertions();
+
         const fs = await import("node:fs/promises");
 
         await fs.writeFile(

--- a/packages/tooling/vis/__tests__/release/errors.test.ts
+++ b/packages/tooling/vis/__tests__/release/errors.test.ts
@@ -4,6 +4,8 @@ import { VisReleaseError, visReleaseError } from "../../src/release/errors";
 
 describe(VisReleaseError, () => {
     it("preserves the code on the constructed instance", () => {
+        expect.hasAssertions();
+
         const error = new VisReleaseError({ code: "CONFIG_INVALID", message: "bad" });
 
         expect(error.code).toBe("CONFIG_INVALID");
@@ -12,6 +14,8 @@ describe(VisReleaseError, () => {
     });
 
     it("is an instance of Error", () => {
+        expect.hasAssertions();
+
         const error = new VisReleaseError({ code: "CONFIG_INVALID", message: "x" });
 
         expect(error).toBeInstanceOf(Error);
@@ -19,6 +23,8 @@ describe(VisReleaseError, () => {
     });
 
     it("attaches hint/docsUrl/packageName/file/line when provided", () => {
+        expect.hasAssertions();
+
         const error = new VisReleaseError({
             code: "BUMP_FILE_INVALID",
             docsUrl: "https://example.com",
@@ -37,6 +43,8 @@ describe(VisReleaseError, () => {
     });
 
     it("leaves optional fields undefined when not passed", () => {
+        expect.hasAssertions();
+
         const error = new VisReleaseError({ code: "PUBLISH_FAILED", message: "x" });
 
         expect(error.hint).toBeUndefined();
@@ -47,6 +55,8 @@ describe(VisReleaseError, () => {
     });
 
     it("preserves `cause` for stack-trace continuity", () => {
+        expect.hasAssertions();
+
         const inner = new Error("inner");
         const error = new VisReleaseError({ cause: inner, code: "PUBLISH_FAILED", message: "outer" });
 
@@ -54,6 +64,8 @@ describe(VisReleaseError, () => {
     });
 
     it("is catchable as a plain Error", () => {
+        expect.hasAssertions();
+
         const fn = (): never => {
             throw new VisReleaseError({ code: "TAG_COLLISION", message: "boom" });
         };
@@ -73,6 +85,8 @@ describe(VisReleaseError, () => {
 
 describe("visReleaseError factory", () => {
     it("produces a VisReleaseError with identical shape to `new`", () => {
+        expect.hasAssertions();
+
         const a = visReleaseError({ code: "CONFIG_INVALID", hint: "fix it", message: "x" });
         const b = new VisReleaseError({ code: "CONFIG_INVALID", hint: "fix it", message: "x" });
 

--- a/packages/tooling/vis/__tests__/release/plugin-sdk.test.ts
+++ b/packages/tooling/vis/__tests__/release/plugin-sdk.test.ts
@@ -52,7 +52,7 @@ describe(defineNotificationChannel, () => {
             skipped: [],
         });
 
-        expect(captured).toEqual([{ name: "@scope/pkg" }]);
+        expect(captured).toStrictEqual([{ name: "@scope/pkg" }]);
     });
 });
 

--- a/packages/tooling/vis/__tests__/release/plugin-sdk.test.ts
+++ b/packages/tooling/vis/__tests__/release/plugin-sdk.test.ts
@@ -29,6 +29,8 @@ import {
 
 describe(defineNotificationChannel, () => {
     it("returns the input unchanged (identity)", () => {
+        expect.hasAssertions();
+
         const channel: NotificationChannel = {
             id: "teams",
             send: async () => undefined,
@@ -38,6 +40,8 @@ describe(defineNotificationChannel, () => {
     });
 
     it("preserves the `id` + `send` shape at runtime", async () => {
+        expect.hasAssertions();
+
         let captured: { name: string }[] = [];
         const channel = defineNotificationChannel({
             id: "test",
@@ -58,6 +62,8 @@ describe(defineNotificationChannel, () => {
 
 describe(defineVersionActions, () => {
     it("returns the same VersionActions instance (identity)", () => {
+        expect.hasAssertions();
+
         class FakeActions extends VersionActions {
             public readonly id = "fake" as const;
 
@@ -78,12 +84,16 @@ describe(defineVersionActions, () => {
 
 describe(defineChangelogFormatter, () => {
     it("returns the same function (identity)", () => {
+        expect.hasAssertions();
+
         const formatter: ChangelogFormatter = (context) => `# ${context.release.name}`;
 
         expect(defineChangelogFormatter(formatter)).toBe(formatter);
     });
 
     it("rendered output passes through verbatim", async () => {
+        expect.hasAssertions();
+
         const formatter = defineChangelogFormatter(async (context) => `release ${context.release.newVersion}`);
 
         const out = await formatter({
@@ -111,6 +121,8 @@ describe(defineChangelogFormatter, () => {
 describe("plugin-sdk — type-level guards (smoke tests)", () => {
     it("rejects channel missing `id` at compile-time", () => {
         // @ts-expect-error — `id` is required on NotificationChannel.
+        expect.hasAssertions();
+
         const invalid = defineNotificationChannel({ send: async () => undefined });
 
         // The runtime identity still returns whatever was passed; the
@@ -120,6 +132,8 @@ describe("plugin-sdk — type-level guards (smoke tests)", () => {
 
     it("rejects formatter with the wrong return type at compile-time", () => {
         // @ts-expect-error — formatter must return string | Promise<string>.
+        expect.hasAssertions();
+
         const invalid = defineChangelogFormatter(() => 42);
 
         expect(invalid).toBeDefined();

--- a/packages/tooling/vis/__tests__/release/presets.test.ts
+++ b/packages/tooling/vis/__tests__/release/presets.test.ts
@@ -23,7 +23,7 @@ describe("presets: jsr", () => {
     it("maps allowSlowTypes → --allow-slow-types and merges publishArgs", () => {
         const config = jsr({ allowSlowTypes: true, publishArgs: ["--no-provenance"] });
 
-        expect(config.jsrPublishArgs).toEqual(["--allow-slow-types", "--no-provenance"]);
+        expect(config.jsrPublishArgs).toStrictEqual(["--allow-slow-types", "--no-provenance"]);
     });
 
     it("points jsrConfigPath at a custom manifest", () => {
@@ -112,7 +112,7 @@ describe("presets: pyproject", () => {
     it("threads uvWorkspace through when set (release-please #2560)", () => {
         const config = pyproject({ uvWorkspace: { root: ".." } });
 
-        expect(config.uvWorkspace).toEqual({ root: ".." });
+        expect(config.uvWorkspace).toStrictEqual({ root: ".." });
     });
 
     it("omits uvLockPath / uvWorkspace fields when not requested (default config stays minimal)", () => {
@@ -175,7 +175,7 @@ describe("presets: pomXml", () => {
 
 describe("presets: goMod", () => {
     it("emits zero rules by default (Go uses git tags, not manifest versions)", () => {
-        expect(goMod().extraFiles).toEqual([]);
+        expect(goMod().extraFiles).toStrictEqual([]);
     });
 
     it("passes through extra rules when provided", () => {

--- a/packages/tooling/vis/__tests__/release/presets.test.ts
+++ b/packages/tooling/vis/__tests__/release/presets.test.ts
@@ -13,6 +13,8 @@ import { cargo, goMod, gradleProperties, jsr, pomXml, pyproject } from "../../sr
 
 describe("presets: jsr", () => {
     it("wires jsr versionActions + jsrConfigPath, no jsrPublishArgs by default", () => {
+        expect.hasAssertions();
+
         const config = jsr();
 
         expect(config.versionActions).toBe("jsr");
@@ -21,12 +23,16 @@ describe("presets: jsr", () => {
     });
 
     it("maps allowSlowTypes → --allow-slow-types and merges publishArgs", () => {
+        expect.hasAssertions();
+
         const config = jsr({ allowSlowTypes: true, publishArgs: ["--no-provenance"] });
 
         expect(config.jsrPublishArgs).toStrictEqual(["--allow-slow-types", "--no-provenance"]);
     });
 
     it("points jsrConfigPath at a custom manifest", () => {
+        expect.hasAssertions();
+
         const config = jsr({ manifestPath: "deno.json" });
 
         expect(config.jsrConfigPath).toBe("deno.json");
@@ -35,6 +41,8 @@ describe("presets: jsr", () => {
 
 describe("presets: cargo", () => {
     it("emits a Cargo.toml rule under the package root by default", () => {
+        expect.hasAssertions();
+
         const config = cargo();
 
         expect(config.extraFiles).toHaveLength(1);
@@ -45,12 +53,16 @@ describe("presets: cargo", () => {
     });
 
     it("places Cargo.toml under crateDir when provided", () => {
+        expect.hasAssertions();
+
         const config = cargo({ crateDir: "crates/native" });
 
         expect(config.extraFiles?.[0]?.path).toBe("crates/native/Cargo.toml");
     });
 
     it("appends user-provided extra rules after the preset's own", () => {
+        expect.hasAssertions();
+
         const config = cargo({
             extraFiles: [{ path: "README.md", search: String.raw`v\d+\.\d+\.\d+` }],
         });
@@ -60,6 +72,8 @@ describe("presets: cargo", () => {
     });
 
     it("regex matches a typical Cargo.toml [package] version line", () => {
+        expect.hasAssertions();
+
         const rule = cargo().extraFiles![0]!;
         const regex = new RegExp(rule.search, rule.flags);
 
@@ -77,18 +91,24 @@ describe("presets: cargo", () => {
 
 describe("presets: pyproject", () => {
     it("emits a pyproject.toml rule under the package root by default", () => {
+        expect.hasAssertions();
+
         const config = pyproject();
 
         expect(config.extraFiles?.[0]?.path).toBe("pyproject.toml");
     });
 
     it("places pyproject.toml under projectDir when provided", () => {
+        expect.hasAssertions();
+
         const config = pyproject({ projectDir: "py/sdk" });
 
         expect(config.extraFiles?.[0]?.path).toBe("py/sdk/pyproject.toml");
     });
 
     it("regex matches a PEP 621 [project] version line", () => {
+        expect.hasAssertions();
+
         const rule = pyproject().extraFiles![0]!;
         const regex = new RegExp(rule.search, rule.flags);
 
@@ -101,6 +121,8 @@ describe("presets: pyproject", () => {
         // The preset doesn't mutate uv.lock itself — uv regenerates it
         // on `uv sync`/`uv build`. The path is recorded so doctor can
         // warn when it's missing despite the operator opting in.
+        expect.hasAssertions();
+
         const config = pyproject({ uvLockPath: "../uv.lock" });
 
         expect(config.uvLockPath).toBe("../uv.lock");
@@ -110,12 +132,16 @@ describe("presets: pyproject", () => {
     });
 
     it("threads uvWorkspace through when set (release-please #2560)", () => {
+        expect.hasAssertions();
+
         const config = pyproject({ uvWorkspace: { root: ".." } });
 
         expect(config.uvWorkspace).toStrictEqual({ root: ".." });
     });
 
     it("omits uvLockPath / uvWorkspace fields when not requested (default config stays minimal)", () => {
+        expect.hasAssertions();
+
         const config = pyproject();
 
         expect(config.uvLockPath).toBeUndefined();
@@ -125,6 +151,8 @@ describe("presets: pyproject", () => {
 
 describe("presets: gradleProperties", () => {
     it("uses the `version` property by default", () => {
+        expect.hasAssertions();
+
         const config = gradleProperties();
         const rule = config.extraFiles![0]!;
 
@@ -133,6 +161,8 @@ describe("presets: gradleProperties", () => {
     });
 
     it("uses a custom property name when provided", () => {
+        expect.hasAssertions();
+
         const config = gradleProperties({ property: "projectVersion" });
         const rule = config.extraFiles![0]!;
 
@@ -141,6 +171,8 @@ describe("presets: gradleProperties", () => {
     });
 
     it("regex matches a gradle.properties version line", () => {
+        expect.hasAssertions();
+
         const rule = gradleProperties().extraFiles![0]!;
         const regex = new RegExp(rule.search, rule.flags);
 
@@ -152,6 +184,8 @@ describe("presets: gradleProperties", () => {
 
 describe("presets: pomXml", () => {
     it("emits a pom.xml rule WITHOUT the `g` flag (project version only)", () => {
+        expect.hasAssertions();
+
         const config = pomXml();
         const rule = config.extraFiles![0]!;
 
@@ -160,6 +194,8 @@ describe("presets: pomXml", () => {
     });
 
     it("regex matches the project version (first <version> tag)", () => {
+        expect.hasAssertions();
+
         const rule = pomXml().extraFiles![0]!;
         const regex = new RegExp(rule.search, rule.flags);
 
@@ -175,10 +211,13 @@ describe("presets: pomXml", () => {
 
 describe("presets: goMod", () => {
     it("emits zero rules by default (Go uses git tags, not manifest versions)", () => {
+        expect.hasAssertions();
         expect(goMod().extraFiles).toStrictEqual([]);
     });
 
     it("passes through extra rules when provided", () => {
+        expect.hasAssertions();
+
         const config = goMod({
             extraFiles: [{ path: "version.go", replace: "Version = \"{version}\"", search: "Version = \"[^\"]+\"" }],
         });

--- a/packages/tooling/vis/__tests__/runtime/__fixtures__/ts-loader/.gitattributes
+++ b/packages/tooling/vis/__tests__/runtime/__fixtures__/ts-loader/.gitattributes
@@ -1,0 +1,4 @@
+# data.txt is read verbatim by the ts-loader ".txt" test, which asserts the raw
+# string with LF newlines. Pin it to LF so Windows checkouts (core.autocrlf)
+# don't rewrite it to CRLF and break the assertion.
+data.txt text eol=lf

--- a/packages/tooling/vis/__tests__/runtime/polyfills.test.ts
+++ b/packages/tooling/vis/__tests__/runtime/polyfills.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable n/no-unsupported-features/node-builtins, prefer-destructuring, vitest/no-conditional-expect -- this suite exercises the experimental-global shims (navigator.locks, Float16Array, …) via dynamic property access, and guards a few assertions on the host Node version. */
+/* eslint-disable n/no-unsupported-features/node-builtins, prefer-destructuring, vitest/no-conditional-expect, vitest/no-conditional-in-test -- this suite exercises the experimental-global shims (navigator.locks, Float16Array, …) via dynamic property access, and guards a few assertions on the host Node version. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { installPolyfills } from "../../src/runtime/polyfills";

--- a/packages/tooling/vis/__tests__/runtime/ts-loader.test.ts
+++ b/packages/tooling/vis/__tests__/runtime/ts-loader.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable vitest/require-hook, vitest/require-top-level-describe -- single-subject loader suite: setup and `it` cases run at the top level without a wrapping describe. */
+
 /**
  * Tests for the runtime data-file imports and tsconfig `paths` resolution wired
  * into the `module.registerHooks` load/resolve hooks (see `src/runtime/ts-loader.ts`).

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -279,10 +279,6 @@ export default createConfig(
             // `expect.assertions(n)`. Not autofixable (no count to infer); enabling means
             // hand-annotating every test for no behavioural gain.
             "vitest/prefer-expect-assertions": "off",
-            // `toBe`/`toEqual` are deliberate (referential or loose shape checks);
-            // `toStrictEqual` would over-constrain fixture comparisons. ~224 sites and the
-            // fixer is suggestion-only (not applied by `--fix`), so it'd be manual churn.
-            "vitest/prefer-strict-equal": "off",
             // Top-level `it`/setup without a wrapping `describe` is fine for
             // these single-subject release command suites.
             "vitest/require-hook": "off",

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -278,8 +278,6 @@ export default createConfig(
             // Top-level `it`/setup without a wrapping `describe` is fine for
             // these single-subject release command suites.
             "vitest/require-hook": "off",
-            "vitest/require-to-throw-message": "off",
-            "vitest/require-top-level-describe": "off",
         },
     },
 );

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -7,7 +7,7 @@ export default createConfig(
             "dist",
             "node_modules",
             "coverage",
-            "__fixtures__",
+            "**/__fixtures__/**",
             "__docs__",
             "__bench__",
             "vitest.config.ts",

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -276,15 +276,21 @@ export default createConfig(
             // intentional in these integration-style suites.
             "vitest/no-conditional-in-test": "off",
             // Asserting a mock was called (without pinning every argument) is
-            // sufficient for these orchestration tests.
+            // sufficient for these orchestration tests. NOTE: the rule's autofix
+            // rewrites `toHaveBeenCalled()` → `toHaveBeenCalledWith()`, which asserts a
+            // *zero-argument* call and breaks every spy invoked with args — don't enable.
             "vitest/prefer-called-with": "off",
-            // These integration-style release tests assert via mock call
-            // expectations and error catches rather than a leading
-            // `expect.assertions(n)`; the count would be noise to maintain.
+            // ~1180 sites assert via mock expectations / error catches, not a leading
+            // `expect.assertions(n)`. Not autofixable (no count to infer); enabling means
+            // hand-annotating every test for no behavioural gain.
             "vitest/prefer-expect-assertions": "off",
-            // `toBe`/`toEqual` are deliberate here (referential or loose shape
-            // checks); `toStrictEqual` would over-constrain fixture comparisons.
+            // The autofix rewrites `toBeTruthy()` → `toBe(true)`, wrong wherever the value
+            // is truthy-but-not-`true` (e.g. a string `error.hint`); these tests assert
+            // truthiness, not identity.
             "vitest/prefer-strict-boolean-matchers": "off",
+            // `toBe`/`toEqual` are deliberate (referential or loose shape checks);
+            // `toStrictEqual` would over-constrain fixture comparisons. ~224 sites and the
+            // fixer is suggestion-only (not applied by `--fix`), so it'd be manual churn.
             "vitest/prefer-strict-equal": "off",
             // Top-level `it`/setup without a wrapping `describe` is fine for
             // these single-subject release command suites.

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -275,19 +275,10 @@ export default createConfig(
             // Branching over fixture/platform variants inside a test is
             // intentional in these integration-style suites.
             "vitest/no-conditional-in-test": "off",
-            // Asserting a mock was called (without pinning every argument) is
-            // sufficient for these orchestration tests. NOTE: the rule's autofix
-            // rewrites `toHaveBeenCalled()` → `toHaveBeenCalledWith()`, which asserts a
-            // *zero-argument* call and breaks every spy invoked with args — don't enable.
-            "vitest/prefer-called-with": "off",
             // ~1180 sites assert via mock expectations / error catches, not a leading
             // `expect.assertions(n)`. Not autofixable (no count to infer); enabling means
             // hand-annotating every test for no behavioural gain.
             "vitest/prefer-expect-assertions": "off",
-            // The autofix rewrites `toBeTruthy()` → `toBe(true)`, wrong wherever the value
-            // is truthy-but-not-`true` (e.g. a string `error.hint`); these tests assert
-            // truthiness, not identity.
-            "vitest/prefer-strict-boolean-matchers": "off",
             // `toBe`/`toEqual` are deliberate (referential or loose shape checks);
             // `toStrictEqual` would over-constrain fixture comparisons. ~224 sites and the
             // fixer is suggestion-only (not applied by `--fix`), so it'd be manual churn.

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -134,11 +134,7 @@ export default createConfig(
         // The remote clients also co-locate small private helpers next to
         // the public method that uses them — easier to read than enforcing
         // strict public-first ordering across a ~600-line class.
-        files: [
-            "src/release/core/package-managers/**/*.ts",
-            "src/release/core/remote/**/*.ts",
-            "src/release/core/version-actions/**/*.ts",
-        ],
+        files: ["src/release/core/package-managers/**/*.ts", "src/release/core/remote/**/*.ts", "src/release/core/version-actions/**/*.ts"],
         rules: {
             "@typescript-eslint/member-ordering": "off",
             "class-methods-use-this": "off",
@@ -276,7 +272,25 @@ export default createConfig(
             // The try/catch + `expect` on the caught error is the idiomatic way
             // to assert on a specific error type/code/message here.
             "vitest/no-conditional-expect": "off",
+            // Branching over fixture/platform variants inside a test is
+            // intentional in these integration-style suites.
+            "vitest/no-conditional-in-test": "off",
+            // Asserting a mock was called (without pinning every argument) is
+            // sufficient for these orchestration tests.
+            "vitest/prefer-called-with": "off",
+            // These integration-style release tests assert via mock call
+            // expectations and error catches rather than a leading
+            // `expect.assertions(n)`; the count would be noise to maintain.
+            "vitest/prefer-expect-assertions": "off",
+            // `toBe`/`toEqual` are deliberate here (referential or loose shape
+            // checks); `toStrictEqual` would over-constrain fixture comparisons.
+            "vitest/prefer-strict-boolean-matchers": "off",
+            "vitest/prefer-strict-equal": "off",
+            // Top-level `it`/setup without a wrapping `describe` is fine for
+            // these single-subject release command suites.
+            "vitest/require-hook": "off",
             "vitest/require-to-throw-message": "off",
+            "vitest/require-top-level-describe": "off",
         },
     },
 );

--- a/packages/tooling/vis/eslint.config.js
+++ b/packages/tooling/vis/eslint.config.js
@@ -275,10 +275,6 @@ export default createConfig(
             // Branching over fixture/platform variants inside a test is
             // intentional in these integration-style suites.
             "vitest/no-conditional-in-test": "off",
-            // ~1180 sites assert via mock expectations / error catches, not a leading
-            // `expect.assertions(n)`. Not autofixable (no count to infer); enabling means
-            // hand-annotating every test for no behavioural gain.
-            "vitest/prefer-expect-assertions": "off",
             // Top-level `it`/setup without a wrapping `describe` is fine for
             // these single-subject release command suites.
             "vitest/require-hook": "off",

--- a/packages/tooling/vis/native/Cargo.toml
+++ b/packages/tooling/vis/native/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT"
 # always builds a package's library when building one of its binaries. Shared
 # logic ported off Node lives in the `core` crate, which the CLI depends on.
 [workspace]
-members = [ "cli", "core" ]
+members = [
+  "cli",
+  "core"
+]
 
 # `rlib` is added alongside `cdylib` so the in-crate criterion benches
 # (native/benches/) can link the pure transpile/sort logic. `napi build` still

--- a/packages/tooling/vis/npm/darwin-arm64/package.json
+++ b/packages/tooling/vis/npm/darwin-arm64/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.darwin-arm64.node",
     "files": [
-        "vis-native.darwin-arm64.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.darwin-arm64.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/darwin-x64/package.json
+++ b/packages/tooling/vis/npm/darwin-x64/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.darwin-x64.node",
     "files": [
-        "vis-native.darwin-x64.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.darwin-x64.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/linux-arm64-gnu/package.json
+++ b/packages/tooling/vis/npm/linux-arm64-gnu/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.linux-arm64-gnu.node",
     "files": [
-        "vis-native.linux-arm64-gnu.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.linux-arm64-gnu.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/linux-arm64-musl/package.json
+++ b/packages/tooling/vis/npm/linux-arm64-musl/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.linux-arm64-musl.node",
     "files": [
-        "vis-native.linux-arm64-musl.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.linux-arm64-musl.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/linux-x64-gnu/package.json
+++ b/packages/tooling/vis/npm/linux-x64-gnu/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.linux-x64-gnu.node",
     "files": [
-        "vis-native.linux-x64-gnu.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.linux-x64-gnu.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/linux-x64-musl/package.json
+++ b/packages/tooling/vis/npm/linux-x64-musl/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.linux-x64-musl.node",
     "files": [
-        "vis-native.linux-x64-musl.node",
-        "vis-native-cli"
+        "vis-native-cli",
+        "vis-native.linux-x64-musl.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/win32-arm64-msvc/package.json
+++ b/packages/tooling/vis/npm/win32-arm64-msvc/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.win32-arm64-msvc.node",
     "files": [
-        "vis-native.win32-arm64-msvc.node",
-        "vis-native-cli.exe"
+        "vis-native-cli.exe",
+        "vis-native.win32-arm64-msvc.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/npm/win32-x64-msvc/package.json
+++ b/packages/tooling/vis/npm/win32-x64-msvc/package.json
@@ -15,8 +15,8 @@
     },
     "main": "vis-native.win32-x64-msvc.node",
     "files": [
-        "vis-native.win32-x64-msvc.node",
-        "vis-native-cli.exe"
+        "vis-native-cli.exe",
+        "vis-native.win32-x64-msvc.node"
     ],
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/tooling/vis/packem.config.ts
+++ b/packages/tooling/vis/packem.config.ts
@@ -49,10 +49,16 @@ export default defineConfig({
         // The release changelog loader uses a runtime-resolved `import(url)` to
         // load a user-supplied formatter module. The default
         // @rollup/plugin-dynamic-import-vars rejects that pattern as
-        // statically un-analyzable, so we downgrade its errors to warnings —
-        // the variable import survives untransformed and is handled by Node
-        // at runtime.
+        // statically un-analyzable. `warnOnError` downgrades the throw to a
+        // warning, but packem's `failOnWarn` then turns that warning fatal —
+        // so we also `exclude` every module whose `import(variable)` is a
+        // deliberate runtime-resolved import (a user-supplied changelog
+        // formatter, the runtime TS/ESM module loaders, and the project-local
+        // prettier resolution). The plugin skips them entirely, the import
+        // stays a native dynamic import handled by Node at runtime, and no
+        // warning is emitted to trip `failOnWarn`.
         dynamicVars: {
+            exclude: ["**/release/core/changelog/dynamic-import.ts", "**/release/core/orchestrator.ts", "**/runtime/polyfills.ts", "**/runtime/ts-loader.ts"],
             warnOnError: true,
         },
         license: {

--- a/packages/tooling/vis/src/release/core/success-walk.ts
+++ b/packages/tooling/vis/src/release/core/success-walk.ts
@@ -517,6 +517,7 @@ export const walkSuccessfulRelease = async (
     }
 
     const channelTag = context.channel?.tag ?? "";
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- pLimit's type parameter is the task return type; these tasks resolve to void.
     const limit = pLimit<void>(4);
 
     const tasks = refs.map((ref) => limit(async () => {


### PR DESCRIPTION
## Problem

The full Nx build is **red on alpha** since PR #697 (native Rust CLI front-end). #697 added modules with deliberate runtime-resolved `import(variable)` calls. `@rollup/plugin-dynamic-import-vars` cannot statically analyze those; `warnOnError: true` (already set) downgrades the throw to a **warning**, but packem's `failOnWarn` then turns that warning **fatal** → `[packem] Exiting with code (1)` / exit 130.

Because the Tests workflow does a full 54-project Nx rebuild, **any PR that changes the lockfile drags `vis` into the build and fails** — this surfaced while fixing CI on the notification/workflow PRs (#698/#705), none of which touch `vis`.

## Affected modules (variable `import()`)

| File | Import |
|---|---|
| `src/release/core/changelog/dynamic-import.ts` | `import(url)` — user-supplied changelog formatter |
| `src/runtime/polyfills.ts` | `import(pathToFileURL(resolved).href)` — runtime module loader |
| `src/runtime/ts-loader.ts` | `import(url)` / `import(pathToFileURL(...).href)` — runtime TS/ESM loader |
| `src/release/core/orchestrator.ts` | `import(pathToFileURL(...resolve("prettier")).href)` — project-local prettier |

## Fix

Add an `exclude` filter to the `dynamicVars` plugin config for exactly these four modules. The plugin skips them, so the imports stay **native runtime dynamic imports** (the intended behavior) and emit **no warning** to trip `failOnWarn`. Analyzable variable imports elsewhere are still transformed; warning-gating is otherwise unchanged.

String-literal dynamic imports (`sdk-loader.ts`, `sigstore/loader.ts`) are analyzable and intentionally left in.

## Verification

A full local build is blocked by an unrelated cold-worktree toolchain artifact (cerebro's nested `@visulima/pail` dist), so I verified the exclude globs directly against `@rollup/pluginutils` `createFilter` — the engine the plugin uses:

```
PASS  release/core/changelog/dynamic-import.ts -> SKIPS
PASS  release/core/orchestrator.ts             -> SKIPS
PASS  runtime/polyfills.ts                      -> SKIPS
PASS  runtime/ts-loader.ts                      -> SKIPS
PASS  ai/sdk-loader.ts                          -> PROCESSES
PASS  security/sigstore/loader.ts               -> PROCESSES
PASS  index.ts                                  -> PROCESSES
```

CI's full vis build is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Rollup dynamic import variable handling by excluding selected runtime-resolved modules to prevent build warnings from being escalated to fatal errors.
  * Updated ESLint configuration to better fit fixture- and test-heavy code, including additional Vitest rule relaxations and a targeted lint suppression.
  * Reordered native package manifest `files` listings consistently across all platform builds (CLI before the native node binary).
  * Reformatted the native workspace member list for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->