### PR TITLE
perf(vis): fast-path local .bin in exec command

### DIFF
--- a/packages/tooling/vis/__bench__/cli/dispatch-internals.bench.ts
+++ b/packages/tooling/vis/__bench__/cli/dispatch-internals.bench.ts
@@ -13,14 +13,16 @@
  *
  * Run with `pnpm --filter @visulima/vis run bench`.
  */
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterAll, bench, describe } from "vitest";
 
-import { detectLockfileDrift, detectPm, resolveInstaller } from "../../src/pm/pm-runner";
+import { detectLockfileDrift, detectPm, pmRunnerInternals, resolveInstaller } from "../../src/pm/pm-runner";
 import { satisfies } from "../../src/runtime/toolchain";
+
+const { resolveLocalBin } = pmRunnerInternals;
 
 // ── Fixtures: isolated single-lockfile workspaces, built once. ───────────────
 // detectPm/resolveInstaller read the lockfile family on disk, so each PM gets a
@@ -44,6 +46,17 @@ const npmDir = makeWorkspace("package-lock.json", JSON.stringify({ lockfileVersi
 // An aube installer over a dir carrying a foreign (pnpm) lockfile — the only
 // shape for which detectLockfileDrift does real work (it early-returns otherwise).
 const aubeInstaller = { name: "aube" as const, useCorepack: false, version: "latest" };
+
+// ── Fixture: a nested package carrying a workspace-local `.bin`. ─────────────
+// `vis exec`'s fast path calls `resolveLocalBin` on every single-package
+// invocation — it walks `node_modules/.bin` from cwd up to the filesystem root
+// looking for the binary. The nested cwd makes the "miss" walk several ancestor
+// `.bin` dirs (realistic monorepo depth), which is the worst case the fast path
+// pays before falling back to the package manager.
+const binNestedDir = join(makeWorkspace("pnpm-lock.yaml", "lockfileVersion: '9.0'\n"), "packages", "app");
+
+mkdirSync(join(binNestedDir, "node_modules", ".bin"), { recursive: true });
+writeFileSync(join(binNestedDir, "node_modules", ".bin", "widget"), "#!/bin/sh\nexit 0\n");
 
 // A representative batch of semver checks, mirroring engines/devEngines gating.
 const SEMVER_CASES: ReadonlyArray<readonly [string, string]> = [
@@ -94,6 +107,16 @@ describe("dispatch internals · installer resolution", () => {
 describe("dispatch internals · lockfile-drift detection", () => {
     bench("detectLockfileDrift · aube over foreign lockfile", () => {
         detectLockfileDrift(pnpmDir, aubeInstaller);
+    });
+});
+
+describe("dispatch internals · exec fast-path bin resolution", () => {
+    bench("resolveLocalBin · local hit (nearest .bin)", () => {
+        resolveLocalBin("widget", binNestedDir);
+    });
+
+    bench("resolveLocalBin · miss (full ancestor walk → PM fallback)", () => {
+        resolveLocalBin("not-installed-binary", binNestedDir);
     });
 });
 

--- a/packages/tooling/vis/__tests__/pm/local-exec.test.ts
+++ b/packages/tooling/vis/__tests__/pm/local-exec.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -71,5 +71,25 @@ describe("runLocalExec", () => {
 
         expect(runLocalExec("ok", [], workspace)).toBe(0);
         expect(runLocalExec("boom", [], workspace)).toBe(3);
+    });
+
+    it.skipIf(process.platform === "win32")("passes arguments as argv without shell re-tokenization", () => {
+        expect.assertions(2);
+
+        const sentinel = join(workspace, "captured.txt");
+        const injected = join(workspace, "injected.txt");
+
+        // Writes its raw first argument to a file. If the spawn went through
+        // a shell, the `&` would split the argument and run a second command.
+        writeBin("capture", `#!/bin/sh\nprintf '%s' "$1" > ${JSON.stringify(sentinel)}\nexit 0\n`);
+
+        const evil = `a & echo pwned > ${injected}`;
+
+        runLocalExec("capture", [evil], workspace);
+
+        // The whole metacharacter-laden string arrives as a single argv entry…
+        expect(readFileSync(sentinel, "utf8")).toBe(evil);
+        // …and the injected command never executed.
+        expect(existsSync(injected)).toBe(false);
     });
 });

--- a/packages/tooling/vis/__tests__/pm/local-exec.test.ts
+++ b/packages/tooling/vis/__tests__/pm/local-exec.test.ts
@@ -1,0 +1,75 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { pmRunnerInternals, runLocalExec } from "../../src/pm/pm-runner";
+
+const { resolveLocalBin } = pmRunnerInternals;
+
+let workspace: string;
+let binDir: string;
+
+const writeBin = (name: string, body: string): string => {
+    const file = join(binDir, name);
+
+    writeFileSync(file, body);
+    chmodSync(file, 0o755);
+
+    return file;
+};
+
+beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "vis-local-exec-"));
+    binDir = join(workspace, "node_modules", ".bin");
+    mkdirSync(binDir, { recursive: true });
+});
+
+afterEach(() => {
+    rmSync(workspace, { force: true, recursive: true });
+});
+
+describe("resolveLocalBin", () => {
+    it("resolves a binary that exists in the workspace node_modules/.bin", () => {
+        expect.assertions(1);
+
+        const file = writeBin("widget", "#!/bin/sh\nexit 0\n");
+
+        expect(resolveLocalBin("widget", workspace)).toBe(file);
+    });
+
+    it("returns undefined when the binary is not locally installed", () => {
+        expect.assertions(1);
+
+        expect(resolveLocalBin("does-not-exist", workspace)).toBeUndefined();
+    });
+
+    it("returns undefined for a command that contains a path separator", () => {
+        expect.assertions(1);
+
+        writeBin("widget", "#!/bin/sh\nexit 0\n");
+
+        // A path-bearing command is the caller's explicit path — left for
+        // the package manager / shell, never resolved against `.bin`.
+        expect(resolveLocalBin("./widget", workspace)).toBeUndefined();
+    });
+});
+
+describe("runLocalExec", () => {
+    it("returns null when the binary is not local, so the caller falls back to the PM", () => {
+        expect.assertions(1);
+
+        expect(runLocalExec("does-not-exist", [], workspace)).toBeNull();
+    });
+
+    it.skipIf(process.platform === "win32")("runs a local binary directly and forwards its exit code", () => {
+        expect.assertions(2);
+
+        writeBin("ok", "#!/bin/sh\nexit 0\n");
+        writeBin("boom", "#!/bin/sh\nexit 3\n");
+
+        expect(runLocalExec("ok", [], workspace)).toBe(0);
+        expect(runLocalExec("boom", [], workspace)).toBe(3);
+    });
+});

--- a/packages/tooling/vis/__tests__/pm/local-exec.test.ts
+++ b/packages/tooling/vis/__tests__/pm/local-exec.test.ts
@@ -8,88 +8,90 @@ import { pmRunnerInternals, runLocalExec } from "../../src/pm/pm-runner";
 
 const { resolveLocalBin } = pmRunnerInternals;
 
-let workspace: string;
-let binDir: string;
+describe("exec fast path", () => {
+    let workspace: string;
+    let binDir: string;
 
-const writeBin = (name: string, body: string): string => {
-    const file = join(binDir, name);
+    const writeBin = (name: string, body: string): string => {
+        const file = join(binDir, name);
 
-    writeFileSync(file, body);
-    chmodSync(file, 0o755);
+        writeFileSync(file, body);
+        chmodSync(file, 0o755);
 
-    return file;
-};
+        return file;
+    };
 
-beforeEach(() => {
-    workspace = mkdtempSync(join(tmpdir(), "vis-local-exec-"));
-    binDir = join(workspace, "node_modules", ".bin");
-    mkdirSync(binDir, { recursive: true });
-});
-
-afterEach(() => {
-    rmSync(workspace, { force: true, recursive: true });
-});
-
-describe("resolveLocalBin", () => {
-    it("resolves a binary that exists in the workspace node_modules/.bin", () => {
-        expect.assertions(1);
-
-        const file = writeBin("widget", "#!/bin/sh\nexit 0\n");
-
-        expect(resolveLocalBin("widget", workspace)).toBe(file);
+    beforeEach(() => {
+        workspace = mkdtempSync(join(tmpdir(), "vis-local-exec-"));
+        binDir = join(workspace, "node_modules", ".bin");
+        mkdirSync(binDir, { recursive: true });
     });
 
-    it("returns undefined when the binary is not locally installed", () => {
-        expect.assertions(1);
-
-        expect(resolveLocalBin("does-not-exist", workspace)).toBeUndefined();
+    afterEach(() => {
+        rmSync(workspace, { force: true, recursive: true });
     });
 
-    it("returns undefined for a command that contains a path separator", () => {
-        expect.assertions(1);
+    describe(resolveLocalBin, () => {
+        it("resolves a binary that exists in the workspace node_modules/.bin", () => {
+            expect.assertions(1);
 
-        writeBin("widget", "#!/bin/sh\nexit 0\n");
+            const file = writeBin("widget", "#!/bin/sh\nexit 0\n");
 
-        // A path-bearing command is the caller's explicit path — left for
-        // the package manager / shell, never resolved against `.bin`.
-        expect(resolveLocalBin("./widget", workspace)).toBeUndefined();
-    });
-});
+            expect(resolveLocalBin("widget", workspace)).toBe(file);
+        });
 
-describe("runLocalExec", () => {
-    it("returns null when the binary is not local, so the caller falls back to the PM", () => {
-        expect.assertions(1);
+        it("returns undefined when the binary is not locally installed", () => {
+            expect.assertions(1);
 
-        expect(runLocalExec("does-not-exist", [], workspace)).toBeNull();
-    });
+            expect(resolveLocalBin("does-not-exist", workspace)).toBeUndefined();
+        });
 
-    it.skipIf(process.platform === "win32")("runs a local binary directly and forwards its exit code", () => {
-        expect.assertions(2);
+        it("returns undefined for a command that contains a path separator", () => {
+            expect.assertions(1);
 
-        writeBin("ok", "#!/bin/sh\nexit 0\n");
-        writeBin("boom", "#!/bin/sh\nexit 3\n");
+            writeBin("widget", "#!/bin/sh\nexit 0\n");
 
-        expect(runLocalExec("ok", [], workspace)).toBe(0);
-        expect(runLocalExec("boom", [], workspace)).toBe(3);
+            // A path-bearing command is the caller's explicit path — left for
+            // the package manager / shell, never resolved against `.bin`.
+            expect(resolveLocalBin("./widget", workspace)).toBeUndefined();
+        });
     });
 
-    it.skipIf(process.platform === "win32")("passes arguments as argv without shell re-tokenization", () => {
-        expect.assertions(2);
+    describe(runLocalExec, () => {
+        it("returns null when the binary is not local, so the caller falls back to the PM", () => {
+            expect.assertions(1);
 
-        const sentinel = join(workspace, "captured.txt");
-        const injected = join(workspace, "injected.txt");
+            expect(runLocalExec("does-not-exist", [], workspace)).toBeNull();
+        });
 
-        // Writes its raw first argument to a file. If the spawn went through
-        // a shell, the `&` would split the argument and run a second command.
-        writeBin("capture", `#!/bin/sh\nprintf '%s' "$1" > ${JSON.stringify(sentinel)}\nexit 0\n`);
+        it.skipIf(process.platform === "win32")("runs a local binary directly and forwards its exit code", () => {
+            expect.assertions(2);
 
-        const evil = `a & echo pwned > ${injected}`;
+            writeBin("ok", "#!/bin/sh\nexit 0\n");
+            writeBin("boom", "#!/bin/sh\nexit 3\n");
 
-        runLocalExec("capture", [evil], workspace);
+            expect(runLocalExec("ok", [], workspace)).toBe(0);
+            expect(runLocalExec("boom", [], workspace)).toBe(3);
+        });
 
-        // The whole metacharacter-laden string arrives as a single argv entry…
-        expect(readFileSync(sentinel, "utf8")).toBe(evil);
-        // …and the injected command never executed.
-        expect(existsSync(injected)).toBe(false);
+        it.skipIf(process.platform === "win32")("passes arguments as argv without shell re-tokenization", () => {
+            expect.assertions(2);
+
+            const sentinel = join(workspace, "captured.txt");
+            const injected = join(workspace, "injected.txt");
+
+            // Writes its raw first argument to a file. If the spawn went through
+            // a shell, the `&` would split the argument and run a second command.
+            writeBin("capture", `#!/bin/sh\nprintf '%s' "$1" > ${JSON.stringify(sentinel)}\nexit 0\n`);
+
+            const evil = `a & echo pwned > ${injected}`;
+
+            runLocalExec("capture", [evil], workspace);
+
+            // The whole metacharacter-laden string arrives as a single argv entry…
+            expect(readFileSync(sentinel, "utf8")).toBe(evil);
+            // …and the injected command never executed.
+            expect(existsSync(injected)).toBe(false);
+        });
     });
 });

--- a/packages/tooling/vis/src/commands/exec/handler.ts
+++ b/packages/tooling/vis/src/commands/exec/handler.ts
@@ -1,6 +1,6 @@
 import type { CommandExecute, Toolbox } from "@visulima/cerebro";
 
-import { resolveInstaller, runExec } from "../../pm/pm-runner";
+import { resolveInstaller, runExec, runLocalExec } from "../../pm/pm-runner";
 import { resolveCommandRuntime, runtimeInstallerBackend } from "../../runtime/command-runtime";
 import { toStringArray } from "../../util/utils";
 import type { ExecOptions } from "./index";
@@ -26,28 +26,43 @@ const execute = async ({ argument, logger, options, rawUnknown, visConfig, works
     const rest = unknown[0] === "--" ? positionalRest : [...positionalRest, ...unknown];
 
     const cwd = wsRoot ?? process.cwd();
-    const runtime = resolveCommandRuntime({ logger, options, visConfig }, cwd);
-    const pm = resolveInstaller(cwd, {
-        backend: runtimeInstallerBackend(runtime),
-        configBackend: visConfig?.install?.backend,
-        configCorepack: visConfig?.install?.corepack,
-    });
+    const filter = toStringArray(options.filter);
 
-    const code = runExec(
-        pm,
-        {
-            args: rest,
-            command: command as string,
-            filter: toStringArray(options.filter),
-            parallel: options.parallel || false,
-            recursive: options.recursive || false,
-            reverse: options.reverse || false,
-            shellMode: options.shellMode || false,
-            workspaceRoot: options.workspaceRoot || false,
-        },
-        cwd,
-        logger,
-    );
+    // Fast path: when the invocation targets a single package (no
+    // recursive / filter / workspace-root / shell mode) and the binary is
+    // already in `node_modules/.bin`, launch it directly and skip the
+    // package manager's `exec`/`x` wrapper start-up. `runLocalExec`
+    // returns `null` when the binary is not local, so we fall through to
+    // the PM, which can still resolve workspace-aware or globally-linked
+    // binaries.
+    const singlePackage = !options.recursive && !options.workspaceRoot && !options.parallel && !options.reverse && !options.shellMode && filter.length === 0;
+
+    let code = singlePackage ? runLocalExec(command as string, rest, cwd) : null;
+
+    if (code === null) {
+        const runtime = resolveCommandRuntime({ logger, options, visConfig }, cwd);
+        const pm = resolveInstaller(cwd, {
+            backend: runtimeInstallerBackend(runtime),
+            configBackend: visConfig?.install?.backend,
+            configCorepack: visConfig?.install?.corepack,
+        });
+
+        code = runExec(
+            pm,
+            {
+                args: rest,
+                command: command as string,
+                filter,
+                parallel: options.parallel || false,
+                recursive: options.recursive || false,
+                reverse: options.reverse || false,
+                shellMode: options.shellMode || false,
+                workspaceRoot: options.workspaceRoot || false,
+            },
+            cwd,
+            logger,
+        );
+    }
 
     if (code !== 0) {
         process.exitCode = code;

--- a/packages/tooling/vis/src/pm/pm-runner.ts
+++ b/packages/tooling/vis/src/pm/pm-runner.ts
@@ -1106,7 +1106,10 @@ const resolveLocalBin = (command: string, cwd: string): string | undefined => {
             const candidate = join(binDir, `${command}${extension}`);
 
             if (isAccessibleSync(candidate)) {
-                return candidate;
+                // `@visulima/path` always joins with `/`, even on Windows.
+                // Hand callers (and `spawnSync`) an OS-native path so the
+                // separator matches the rest of the platform's tooling.
+                return isWindows ? candidate.replaceAll("/", "\\") : candidate;
             }
         }
     }

--- a/packages/tooling/vis/src/pm/pm-runner.ts
+++ b/packages/tooling/vis/src/pm/pm-runner.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 
 import { isAccessibleSync, readFileSync } from "@visulima/fs";
 import { dirname, join, parse as parsePath } from "@visulima/path";
+import { collectNodeModulesBinDirs, withEnhancedPath } from "@visulima/task-runner";
 import { coerce, lt } from "semver";
 
 import type { AddOptions, DlxOptions, ExecOptions, InstallOptions, RemoveOptions, ResolvedCommand, WhyOptions } from "#native";
@@ -1077,6 +1078,78 @@ const runDlx = (pm: InstallerInfo, options: DlxOptions, cwd: string, logger: Con
     return runResolved(pm, resolved, cwd, logger, { dry: extras.dry, env: extras.env });
 };
 
+const isWindows = process.platform === "win32";
+
+/**
+ * Extensions a `node_modules/.bin` shim can carry. On Windows the shim
+ * is a `.cmd`/`.exe`/`.bat`/`.ps1` (or the extension-less shell script);
+ * on POSIX it is an extension-less executable. Mirrors the lookup
+ * npm/pnpm perform when they place `.bin` on PATH.
+ */
+const LOCAL_BIN_EXTENSIONS = isWindows ? ["", ".cmd", ".exe", ".bat", ".ps1"] : [""];
+
+/**
+ * Resolve `command` against the workspace-local `node_modules/.bin`
+ * chain (nearest-first), returning the matched shim path or undefined.
+ * Bare names only — a command containing a path separator is the
+ * caller's explicit path and is left for the package manager / shell.
+ */
+const resolveLocalBin = (command: string, cwd: string): string | undefined => {
+    if (command.includes("/") || command.includes("\\")) {
+        return undefined;
+    }
+
+    for (const binDir of collectNodeModulesBinDirs(cwd)) {
+        for (const extension of LOCAL_BIN_EXTENSIONS) {
+            const candidate = join(binDir, `${command}${extension}`);
+
+            if (isAccessibleSync(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Fast path for `vis exec <bin>`: when the binary already lives in the
+ * workspace's `node_modules/.bin`, launch it directly with that chain
+ * prepended to PATH instead of booting the package manager's
+ * `exec`/`x` wrapper. The PM wrapper costs hundreds of milliseconds of
+ * Node/PM start-up before it does the same `.bin` resolution we do here.
+ *
+ * Returns the child's exit code, or `null` when the binary is not
+ * locally installed — the caller then falls back to {@link runExec} so
+ * the PM can still resolve workspace-aware or globally-linked binaries.
+ *
+ * Only valid for a single-package, non-shell invocation; recursive /
+ * filtered / workspace-root runs need the PM's workspace topology, and
+ * shell mode hands a shell string (not a binary) to the PM.
+ */
+const runLocalExec = (command: string, args: string[], cwd: string): number | null => {
+    if (resolveLocalBin(command, cwd) === undefined) {
+        return null;
+    }
+
+    // Pass the bare command and let the spawn resolve it through the
+    // enhanced PATH: on POSIX an argv spawn keeps user arguments free of
+    // shell-quoting; on Windows `.cmd`/`.bat` shims can only be launched
+    // through a shell, which also resolves the extension via PATHEXT.
+    const result = spawnSync(command, args, {
+        cwd,
+        env: withEnhancedPath({ ...process.env }, cwd),
+        shell: isWindows,
+        stdio: "inherit",
+    });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    return result.status ?? 1;
+};
+
 const runExec = (pm: InstallerInfo, options: ExecOptions, cwd: string, logger: Console, extras: RunOverrides = {}): number => {
     if (pm.name === "aube") {
         return runResolved(pm, resolveAubeExec(options), cwd, logger, extras);
@@ -1123,6 +1196,7 @@ export {
     runInstall,
     runInstallCaptured,
     runLink,
+    runLocalExec,
     runPmSubcommand,
     runRemove,
     runUnlink,
@@ -1140,6 +1214,7 @@ export const pmRunnerInternals = {
     applyDryRun,
     applyImmutableCache,
     applySilent,
+    resolveLocalBin,
     shouldUseCorepack,
     spawnResolved,
 };

--- a/packages/tooling/vis/src/pm/pm-runner.ts
+++ b/packages/tooling/vis/src/pm/pm-runner.ts
@@ -1115,7 +1115,7 @@ const resolveLocalBin = (command: string, cwd: string): string | undefined => {
 };
 
 /**
- * Fast path for `vis exec <bin>`: when the binary already lives in the
+ * Fast path for `vis exec &lt;bin>`: when the binary already lives in the
  * workspace's `node_modules/.bin`, launch it directly with that chain
  * prepended to PATH instead of booting the package manager's
  * `exec`/`x` wrapper. The PM wrapper costs hundreds of milliseconds of

--- a/packages/tooling/vis/src/pm/pm-runner.ts
+++ b/packages/tooling/vis/src/pm/pm-runner.ts
@@ -1084,9 +1084,11 @@ const isWindows = process.platform === "win32";
  * Extensions a `node_modules/.bin` shim can carry. On Windows the shim
  * is a `.cmd`/`.exe`/`.bat`/`.ps1` (or the extension-less shell script);
  * on POSIX it is an extension-less executable. Mirrors the lookup
- * npm/pnpm perform when they place `.bin` on PATH.
+ * npm/pnpm perform when they place `.bin` on PATH. On Windows `.exe` is
+ * listed first so the fast path prefers the one shim it can spawn
+ * directly (without a shell) — see {@link runLocalExec}.
  */
-const LOCAL_BIN_EXTENSIONS = isWindows ? ["", ".cmd", ".exe", ".bat", ".ps1"] : [""];
+const LOCAL_BIN_EXTENSIONS = isWindows ? [".exe", ".cmd", ".bat", ".ps1", ""] : [""];
 
 /**
  * Resolve `command` against the workspace-local `node_modules/.bin`
@@ -1128,18 +1130,26 @@ const resolveLocalBin = (command: string, cwd: string): string | undefined => {
  * shell mode hands a shell string (not a binary) to the PM.
  */
 const runLocalExec = (command: string, args: string[], cwd: string): number | null => {
-    if (resolveLocalBin(command, cwd) === undefined) {
+    const binary = resolveLocalBin(command, cwd);
+
+    if (binary === undefined) {
         return null;
     }
 
-    // Pass the bare command and let the spawn resolve it through the
-    // enhanced PATH: on POSIX an argv spawn keeps user arguments free of
-    // shell-quoting; on Windows `.cmd`/`.bat` shims can only be launched
-    // through a shell, which also resolves the extension via PATHEXT.
-    const result = spawnSync(command, args, {
+    // Never spawn through a shell: handing `args` to /bin/sh or cmd.exe
+    // would let them be re-tokenized (an argument such as `a & b` could
+    // inject a second command). Spawning the resolved path directly
+    // passes each argument as a distinct argv entry, which the OS does
+    // not re-parse. On Windows only a `.exe` is directly spawnable —
+    // `.cmd`/`.bat`/shell shims require a shell, so skip the fast path
+    // for them and let the package manager run them safely.
+    if (isWindows && !binary.toLowerCase().endsWith(".exe")) {
+        return null;
+    }
+
+    const result = spawnSync(binary, args, {
         cwd,
         env: withEnhancedPath({ ...process.env }, cwd),
-        shell: isWindows,
         stdio: "inherit",
     });
 


### PR DESCRIPTION
## Summary

`vis exec <bin>` always routed through the package manager's `exec`/`x` wrapper (`pnpm exec`, `npm exec`, `bun x`, …), paying the PM's Node start-up before it resolved the same `node_modules/.bin` entry. This adds a local-binary fast path: for a single-package, non-shell invocation whose binary is already installed locally, the binary is launched directly with the `.bin` chain on `PATH`, skipping the wrapper.

It also makes the command match its documented description — _"Execute a local node_modules/.bin command"_ — which previously didn't reflect the `pnpm exec` routing.

## Changes

- **`src/pm/pm-runner.ts`**
  - `resolveLocalBin` — walks the `node_modules/.bin` chain nearest-first (bare names only; a path-bearing command is left for the PM/shell), with Windows shim extensions (`.cmd`/`.exe`/`.bat`/`.ps1`).
  - `runLocalExec` — spawns the resolved binary directly with `withEnhancedPath` (the same helper `vis run` / services / staged already use). Returns `null` when the binary is not local so the caller can fall back.
- **`src/commands/exec/handler.ts`** — try the fast path first for single-package, non-shell invocations; on `null`, run the existing PM `exec` path unchanged. PM/installer resolution is deferred into the fallback branch, so the fast path skips it entirely.
- **`__tests__/pm/local-exec.test.ts`** — local resolution, the missing-binary `null` contract, path-bearing command rejection, and exit-code forwarding.

## Behavior preserved

Recursive / filter / workspace-root / shell (`-c`) modes, aube, corepack, and globally-linked binaries all continue to route through the package manager. Only single-package invocations of an already-installed local binary take the fast path.

## Verification

The package test suite and typecheck could not be run in the authoring environment (no `node_modules`; `pnpm install` is blocked by an egress-proxy 403 on `npm.jsr.io` during pnpm's supply-chain check). To compensate, the exact `resolveLocalBin` / `runLocalExec` logic was extracted into a standalone pure-Node reproduction and all assertions passed: bin resolution, the `null`→PM-fallback contract, non-zero exit-code forwarding, and argv passthrough preserving arguments with spaces.

**Please run `pnpm --filter @visulima/vis test` and `lint:types` with dependencies installed before merging** — the standalone check validates the algorithm, not the real imports/types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gnphssuka92vvq2FHYtkwx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `vis exec` performance by running locally installed `node_modules/.bin` commands directly when conditions allow.
  * Enhanced workspace binary resolution on Windows, including shim `.exe` handling.

* **Bug Fixes**
  * Reduced fallback to package-manager execution wrappers for simple single-package runs without `--filter`.
  * More reliably finds (or correctly misses) local `.bin` shims by walking nearest workspace `.bin` locations.

* **Tests / Benchmarks**
  * Updated benchmarks to measure `.bin` resolution hit and miss behavior in monorepo-like fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->