### PR TITLE
feat(find-ai-runner): detect the AI agent session driving a process

### DIFF
--- a/packages/tooling/find-ai-runner/README.md
+++ b/packages/tooling/find-ai-runner/README.md
@@ -230,6 +230,31 @@ Providers are detected using three strategies (tried in order):
 2. **`which`/`where` command** — checks system PATH
 3. **Known paths** — `/opt/homebrew/bin/`, `~/.local/bin/`, `~/.cargo/bin/`, etc.
 
+## Session Detection
+
+Binary detection answers "which AI CLIs are installed?". Session detection answers the complementary question: **is an AI agent driving _this_ process right now?** — what dev servers, scaffolders, and destructive CLIs ask before switching to machine-readable output, backgrounding themselves, or requiring explicit human consent.
+
+```ts
+import { detectAiSession, isAiSession } from "@visulima/find-ai-runner";
+
+const session = detectAiSession();
+
+if (session) {
+    console.log(`Driven by ${session.agent} (via ${session.variable})`);
+    // e.g. { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDECODE" }
+}
+
+if (isAiSession()) {
+    // emit JSON logs, skip interactive prompts, …
+}
+```
+
+Detection is by environment markers the agent harnesses set in the shells they spawn (Claude Code, Cursor Agent, Codex, Gemini CLI / Qwen Code, GitHub Copilot CLI, opencode, Amp, Cline, Aider, Antigravity, Augment, Replit Agent), plus the self-describing `AI_AGENT` variable, which wins over the marker table. Every marker is sourced from a shipping implementation — a false positive silently changes a tool's behavior under a human's fingers.
+
+Markers that only prove the **platform** (a Cursor editor terminal via `CURSOR_TRACE_ID`, a Replit workspace via `REPL_ID`) — where a human may well be the one typing — are reported with `confidence: "ambient"` and only consulted with `detectAiSession(process.env, { includeAmbient: true })`. Use ambient detection for telemetry, never for behavior switches.
+
+Both functions accept a custom env object for testing: `detectAiSession({ CLAUDECODE: "1" })`.
+
 ## API
 
 ### `detectAllProviders(options?: AiDetectOptions): AiProviderInfo[]`
@@ -255,6 +280,14 @@ Returns the first available provider in preference order, stopping at the first 
 ### `buildCliArgs(name: AiProviderName, prompt: string, options?: AiRunOptions): string[]`
 
 Build the CLI arguments array for a provider without executing.
+
+### `detectAiSession(env?: EnvLike, options?: AiSessionOptions): AiSessionInfo | undefined`
+
+Detects the AI agent session the current process runs inside via environment markers (see [Session Detection](#session-detection)). Pure; pass a custom `env` in tests.
+
+### `isAiSession(env?: EnvLike, options?: AiSessionOptions): boolean`
+
+Convenience predicate over `detectAiSession`.
 
 ### `runProvider(provider: AiProviderInfo, prompt: string, options?: AiRunOptions): Promise<AiRunResult>`
 

--- a/packages/tooling/find-ai-runner/README.md
+++ b/packages/tooling/find-ai-runner/README.md
@@ -249,7 +249,7 @@ if (isAiSession()) {
 }
 ```
 
-Detection is by environment markers the agent harnesses set in the shells they spawn (Claude Code, Cursor Agent, Codex, Gemini CLI / Qwen Code, GitHub Copilot CLI, opencode, Amp, Cline, Aider, Antigravity, Augment, Replit Agent), plus the self-describing `AI_AGENT` variable, which wins over the marker table. Every marker is sourced from a shipping implementation — a false positive silently changes a tool's behavior under a human's fingers.
+Detection is by environment markers the agent harnesses set in the shells they spawn (Claude Code, Cursor Agent, Codex, Gemini CLI / Qwen Code, GitHub Copilot CLI, opencode, Amp, Cline, Aider, Antigravity, Augment, Replit Agent), plus the self-describing `AI_AGENT` variable, which wins over the marker table. Markers for invokable providers are declared on each provider's config (`sessionMarkers` in `src/providers/*.ts`); non-invokable agents live in `src/session.ts`. Every marker is sourced from a shipping implementation — a false positive silently changes a tool's behavior under a human's fingers.
 
 Markers that only prove the **platform** (a Cursor editor terminal via `CURSOR_TRACE_ID`, a Replit workspace via `REPL_ID`) — where a human may well be the one typing — are reported with `confidence: "ambient"` and only consulted with `detectAiSession(process.env, { includeAmbient: true })`. Use ambient detection for telemetry, never for behavior switches.
 

--- a/packages/tooling/find-ai-runner/__tests__/session.test.ts
+++ b/packages/tooling/find-ai-runner/__tests__/session.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { detectAiSession, isAiSession } from "../src/session";
+
+describe(detectAiSession, () => {
+    it("returns undefined for a plain human environment", () => {
+        expect.assertions(2);
+
+        expect(detectAiSession({ HOME: "/home/dev", TERM: "xterm-256color" })).toBeUndefined();
+        expect(isAiSession({ HOME: "/home/dev" })).toBe(false);
+    });
+
+    it("detects definite harness markers and maps them to providers", () => {
+        expect.assertions(4);
+
+        expect(detectAiSession({ CLAUDECODE: "1" })).toStrictEqual({
+            agent: "Claude Code",
+            confidence: "definite",
+            provider: "claude",
+            variable: "CLAUDECODE",
+        });
+        expect(detectAiSession({ CURSOR_AGENT: "1" })?.provider).toBe("cursor");
+        expect(detectAiSession({ CODEX_THREAD_ID: "abc123" })?.provider).toBe("codex");
+        expect(detectAiSession({ COPILOT_ALLOW_ALL: "true" })?.provider).toBe("copilot");
+    });
+
+    it("detects agents that are not invokable providers without a provider mapping", () => {
+        expect.assertions(2);
+
+        const cline = detectAiSession({ CLINE_ACTIVE: "true" });
+
+        expect(cline?.agent).toBe("Cline");
+        expect(cline?.provider).toBeUndefined();
+    });
+
+    it("matches value-scoped markers only on the exact value", () => {
+        expect.assertions(3);
+
+        expect(detectAiSession({ AGENT: "amp" })?.agent).toBe("Amp");
+        // A generic AGENT variable with another value must not read as Amp.
+        expect(detectAiSession({ AGENT: "buildkite" })).toBeUndefined();
+        expect(detectAiSession({ OR_APP_NAME: "Aider" })?.agent).toBe("Aider");
+    });
+
+    it("honors the self-describing AI_AGENT variable first", () => {
+        expect.assertions(2);
+
+        expect(detectAiSession({ AI_AGENT: "github-copilot-cli", CLAUDECODE: "1" })).toStrictEqual({
+            agent: "github-copilot-cli",
+            confidence: "definite",
+            variable: "AI_AGENT",
+        });
+        // A disabled AI_AGENT falls through to the marker table.
+        expect(detectAiSession({ AI_AGENT: "0", CLAUDECODE: "1" })?.agent).toBe("Claude Code");
+    });
+
+    it("ignores empty and explicitly-disabled marker values", () => {
+        expect.assertions(2);
+
+        expect(detectAiSession({ CLAUDECODE: "" })).toBeUndefined();
+        expect(detectAiSession({ CLAUDECODE: "false" })).toBeUndefined();
+    });
+
+    it("reports ambient platform markers only when opted in", () => {
+        expect.assertions(3);
+
+        // A Cursor editor terminal hosts a human — not an agent session by default.
+        expect(detectAiSession({ CURSOR_TRACE_ID: "trace-1" })).toBeUndefined();
+
+        const ambient = detectAiSession({ CURSOR_TRACE_ID: "trace-1" }, { includeAmbient: true });
+
+        expect(ambient).toStrictEqual({ agent: "Cursor editor", confidence: "ambient", provider: "cursor", variable: "CURSOR_TRACE_ID" });
+        // A definite marker shadows an ambient one even with ambient enabled.
+        expect(detectAiSession({ CURSOR_AGENT: "1", CURSOR_TRACE_ID: "trace-1" }, { includeAmbient: true })?.confidence).toBe("definite");
+    });
+});

--- a/packages/tooling/find-ai-runner/src/index.ts
+++ b/packages/tooling/find-ai-runner/src/index.ts
@@ -505,6 +505,8 @@ const runProvider = async (provider: AiProviderInfo, prompt: string, options: Ai
 export { buildCliArgs, detectAllProviders, detectAllProvidersAsync, detectAvailableProviders, detectProvider, findRunner, PROVIDERS, runProvider };
 
 export { PROVIDER_NAMES } from "./constants";
+export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS } from "./session";
+export { type AiSessionConfidence, type AiSessionInfo, type AiSessionMarker, type AiSessionOptions } from "./session";
 export { AiRunError } from "./types";
 export {
     type AiBuildArgsOptions,

--- a/packages/tooling/find-ai-runner/src/index.ts
+++ b/packages/tooling/find-ai-runner/src/index.ts
@@ -506,7 +506,7 @@ export { buildCliArgs, detectAllProviders, detectAllProvidersAsync, detectAvaila
 
 export { PROVIDER_NAMES } from "./constants";
 export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS } from "./session";
-export { type AiSessionConfidence, type AiSessionInfo, type AiSessionMarker, type AiSessionOptions } from "./session";
+export { type AiSessionConfidence, type AiSessionInfo, type AiSessionMarker, type AiSessionOptions, type EnvLike } from "./session";
 export { AiRunError } from "./types";
 export {
     type AiBuildArgsOptions,

--- a/packages/tooling/find-ai-runner/src/index.ts
+++ b/packages/tooling/find-ai-runner/src/index.ts
@@ -6,37 +6,12 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 
 import { DEFAULT_MAX_TOKENS, DEFAULT_RUN_TIMEOUT, DETECTION_TIMEOUT, IS_WINDOWS, PROVIDER_NAMES, VERSION_REGEX, VERSION_TIMEOUT } from "./constants";
-import amp from "./providers/amp";
-import claude from "./providers/claude";
-import codex from "./providers/codex";
-import copilot from "./providers/copilot";
-import crush from "./providers/crush";
-import cursor from "./providers/cursor";
-import droid from "./providers/droid";
-import gemini from "./providers/gemini";
-import kimi from "./providers/kimi";
-import opencode from "./providers/opencode";
-import qwen from "./providers/qwen";
-import type { AiDetectAsyncOptions, AiDetectOptions, AiProviderConfig, AiProviderInfo, AiProviderName, AiRunOptions, AiRunResult } from "./types";
+import PROVIDERS from "./providers";
+import type { AiDetectAsyncOptions, AiDetectOptions, AiProviderInfo, AiProviderName, AiRunOptions, AiRunResult } from "./types";
 import { AiRunError } from "./types"; // used as a value inside runProvider
 
 /** Promisified `execFile`, used by the async/parallel detection path. */
 const execFileAsync = promisify(execFile);
-
-/** All supported AI CLI provider configurations, keyed by name. */
-const PROVIDERS: Record<AiProviderName, AiProviderConfig> = {
-    amp,
-    claude,
-    codex,
-    copilot,
-    crush,
-    cursor,
-    droid,
-    gemini,
-    kimi,
-    opencode,
-    qwen,
-};
 
 /** Matches Windows `.cmd`/`.bat` shim extensions. */
 const WINDOWS_SHIM_REGEX = /\.(?:bat|cmd)$/i;
@@ -502,11 +477,12 @@ const runProvider = async (provider: AiProviderInfo, prompt: string, options: Ai
     });
 };
 
-export { buildCliArgs, detectAllProviders, detectAllProvidersAsync, detectAvailableProviders, detectProvider, findRunner, PROVIDERS, runProvider };
+export { buildCliArgs, detectAllProviders, detectAllProvidersAsync, detectAvailableProviders, detectProvider, findRunner, runProvider };
 
 export { PROVIDER_NAMES } from "./constants";
+export { default as PROVIDERS } from "./providers";
 export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS } from "./session";
-export { type AiSessionConfidence, type AiSessionInfo, type AiSessionMarker, type AiSessionOptions, type EnvLike } from "./session";
+export { type AiSessionInfo, type AiSessionMarker, type AiSessionOptions, type EnvLike } from "./session";
 export { AiRunError } from "./types";
 export {
     type AiBuildArgsOptions,
@@ -517,4 +493,6 @@ export {
     type AiProviderName,
     type AiRunOptions,
     type AiRunResult,
+    type AiSessionConfidence,
+    type AiSessionMarkerConfig,
 } from "./types";

--- a/packages/tooling/find-ai-runner/src/providers/amp.ts
+++ b/packages/tooling/find-ai-runner/src/providers/amp.ts
@@ -14,7 +14,9 @@ const amp: AiProviderConfig = {
     },
     command: "amp",
     defaultModel: "",
+    displayName: "Amp",
     envVariable: "AMP_PATH",
+    sessionMarkers: [{ confidence: "definite", equals: "amp", variable: "AGENT" }],
     supportsMaxTokens: false,
     supportsModel: false,
 };

--- a/packages/tooling/find-ai-runner/src/providers/claude.ts
+++ b/packages/tooling/find-ai-runner/src/providers/claude.ts
@@ -21,7 +21,12 @@ const claude: AiProviderConfig = {
     command: "claude",
     // Empty default = provider-default model, avoids pinning a stale snapshot.
     defaultModel: "",
+    displayName: "Claude Code",
     envVariable: "CLAUDE_PATH",
+    sessionMarkers: [
+        { confidence: "definite", variable: "CLAUDECODE" },
+        { confidence: "definite", variable: "CLAUDE_CODE" },
+    ],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/codex.ts
+++ b/packages/tooling/find-ai-runner/src/providers/codex.ts
@@ -22,7 +22,13 @@ const codex: AiProviderConfig = {
     },
     command: "codex",
     defaultModel: "",
+    displayName: "Codex",
     envVariable: "CODEX_PATH",
+    sessionMarkers: [
+        { confidence: "definite", variable: "CODEX_SANDBOX" },
+        { confidence: "definite", variable: "CODEX_THREAD_ID" },
+        { confidence: "definite", variable: "CODEX_CI" },
+    ],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/copilot.ts
+++ b/packages/tooling/find-ai-runner/src/providers/copilot.ts
@@ -18,7 +18,13 @@ const copilot: AiProviderConfig = {
     },
     command: "copilot",
     defaultModel: "",
+    displayName: "GitHub Copilot CLI",
     envVariable: "COPILOT_PATH",
+    sessionMarkers: [
+        { confidence: "definite", variable: "COPILOT_MODEL" },
+        { confidence: "definite", variable: "COPILOT_ALLOW_ALL" },
+        { confidence: "definite", variable: "COPILOT_GITHUB_TOKEN" },
+    ],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/crush.ts
+++ b/packages/tooling/find-ai-runner/src/providers/crush.ts
@@ -20,7 +20,10 @@ const crush: AiProviderConfig = {
     },
     command: "crush",
     defaultModel: "",
+    displayName: "Crush",
     envVariable: "CRUSH_PATH",
+    // No verified session marker yet — crush does not mark the shells it spawns.
+    sessionMarkers: [],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/cursor.ts
+++ b/packages/tooling/find-ai-runner/src/providers/cursor.ts
@@ -22,7 +22,13 @@ const cursor: AiProviderConfig = {
     },
     command: "agent",
     defaultModel: "",
+    displayName: "Cursor Agent",
     envVariable: "CURSOR_PATH",
+    sessionMarkers: [
+        { confidence: "definite", variable: "CURSOR_AGENT" },
+        // The editor sets this in EVERY integrated terminal — a human may be typing.
+        { agent: "Cursor editor", confidence: "ambient", variable: "CURSOR_TRACE_ID" },
+    ],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/droid.ts
+++ b/packages/tooling/find-ai-runner/src/providers/droid.ts
@@ -20,7 +20,10 @@ const droid: AiProviderConfig = {
     },
     command: "droid",
     defaultModel: "",
+    displayName: "Droid",
     envVariable: "DROID_PATH",
+    // No verified session marker yet — droid does not mark the shells it spawns.
+    sessionMarkers: [],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/gemini.ts
+++ b/packages/tooling/find-ai-runner/src/providers/gemini.ts
@@ -22,7 +22,10 @@ const gemini: AiProviderConfig = {
     },
     command: "gemini",
     defaultModel: "gemini-2.5-pro",
+    displayName: "Gemini CLI",
     envVariable: "GEMINI_PATH",
+    // Qwen Code (a gemini-cli fork) sets the same variable; detection attributes it here.
+    sessionMarkers: [{ confidence: "definite", variable: "GEMINI_CLI" }],
     supportsMaxTokens: true,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/index.ts
+++ b/packages/tooling/find-ai-runner/src/providers/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Barrel assembling the provider configs into the `PROVIDERS` record. Lives
+ * here (not in the package entrypoint) so both the binary-detection code in
+ * `../index.ts` and the session detection in `../session.ts` can consume the
+ * same table without a circular import.
+ */
+import type { AiProviderConfig, AiProviderName } from "../types";
+import amp from "./amp";
+import claude from "./claude";
+import codex from "./codex";
+import copilot from "./copilot";
+import crush from "./crush";
+import cursor from "./cursor";
+import droid from "./droid";
+import gemini from "./gemini";
+import kimi from "./kimi";
+import opencode from "./opencode";
+import qwen from "./qwen";
+
+/** All supported AI CLI provider configurations, keyed by name. */
+const PROVIDERS: Record<AiProviderName, AiProviderConfig> = {
+    amp,
+    claude,
+    codex,
+    copilot,
+    crush,
+    cursor,
+    droid,
+    gemini,
+    kimi,
+    opencode,
+    qwen,
+};
+
+export default PROVIDERS;

--- a/packages/tooling/find-ai-runner/src/providers/kimi.ts
+++ b/packages/tooling/find-ai-runner/src/providers/kimi.ts
@@ -14,7 +14,10 @@ const kimi: AiProviderConfig = {
     },
     command: "kimi",
     defaultModel: "",
+    displayName: "Kimi CLI",
     envVariable: "KIMI_PATH",
+    // No verified session marker yet — kimi does not mark the shells it spawns.
+    sessionMarkers: [],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/opencode.ts
+++ b/packages/tooling/find-ai-runner/src/providers/opencode.ts
@@ -15,7 +15,9 @@ const opencode: AiProviderConfig = {
     command: "opencode",
     // Empty default = provider-default model, avoids pinning a stale snapshot.
     defaultModel: "",
+    displayName: "opencode",
     envVariable: "OPENCODE_PATH",
+    sessionMarkers: [{ confidence: "definite", variable: "OPENCODE_CLIENT" }],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/providers/qwen.ts
+++ b/packages/tooling/find-ai-runner/src/providers/qwen.ts
@@ -20,7 +20,10 @@ const qwen: AiProviderConfig = {
     },
     command: "qwen",
     defaultModel: "",
+    displayName: "Qwen Code",
     envVariable: "QWEN_PATH",
+    // Qwen Code sets gemini-cli's GEMINI_CLI (it is a fork); the marker lives on the gemini provider.
+    sessionMarkers: [],
     supportsMaxTokens: false,
     supportsModel: true,
 };

--- a/packages/tooling/find-ai-runner/src/session.ts
+++ b/packages/tooling/find-ai-runner/src/session.ts
@@ -7,28 +7,23 @@
  * output, backgrounding themselves, or demanding explicit human consent.
  *
  * Detection is by environment-variable markers the agent harnesses set in the
- * shells they spawn. The table is deliberately conservative and every entry is
+ * shells they spawn. Markers for invokable providers live on each provider's
+ * config (`sessionMarkers` in `providers/*.ts`); agents that are not
+ * invokable CLIs (their harness spawns shells but exposes no promptable
+ * binary) are listed in {@link EXTRA_AGENT_MARKERS} here. Every entry is
  * sourced from a shipping implementation (the Vercel CLI / Next.js
  * `detect-agent`, Prisma's `ai-safety`, or the harness's own documentation):
- * a false positive here silently changes a tool's behavior under a human's
+ * a false positive silently changes a tool's behavior under a human's
  * fingers. Markers that only prove the PLATFORM (e.g. a Cursor editor
- * terminal, a Replit workspace) — where a human may well be typing — are
- * reported with `confidence: "ambient"` and excluded from detection unless
- * explicitly opted into.
+ * terminal, a Replit workspace) — where a human may well be typing — carry
+ * `confidence: "ambient"` and are excluded from detection unless explicitly
+ * opted into.
  */
-import type { AiProviderName } from "./types";
+import PROVIDERS from "./providers";
+import type { AiProviderConfig, AiProviderName, AiSessionConfidence } from "./types";
 
 /** Minimal env shape accepted by {@link detectAiSession} / {@link isAiSession} — `process.env` structurally, injectable for tests. */
 type EnvLike = Readonly<Record<string, string | undefined>>;
-
-/**
- * How strongly a marker implies an agent is driving the process.
- *
- * `definite` markers are set only in agent-spawned shells. `ambient` markers
- * prove the surrounding platform (editor, cloud workspace) but not that an
- * agent — rather than a human — is issuing commands.
- */
-type AiSessionConfidence = "ambient" | "definite";
 
 /** One detected agent session: which agent, how sure, and which env var gave it away. */
 interface AiSessionInfo {
@@ -36,7 +31,7 @@ interface AiSessionInfo {
     agent: string;
     /** See {@link AiSessionConfidence}. */
     confidence: AiSessionConfidence;
-    /** The matching invokable provider from `index.ts`, when the agent is one. */
+    /** The matching invokable provider from `providers/`, when the agent is one. */
     provider?: AiProviderName;
     /** The environment variable that matched. */
     variable: string;
@@ -54,7 +49,7 @@ interface AiSessionOptions {
     includeAmbient?: boolean;
 }
 
-/** One marker table entry. Matches when the variable is set non-empty (and not `0`/`false`), or exactly `equals` when given. */
+/** A fully resolved marker table entry: a provider's `sessionMarkers` entry (or an extra agent's) with display name and provider attached. */
 interface AiSessionMarker {
     agent: string;
     confidence: AiSessionConfidence;
@@ -71,36 +66,47 @@ interface AiSessionMarker {
 const AI_AGENT_ENV = "AI_AGENT";
 
 /**
- * Known session markers, first match wins; `definite` entries listed before
- * `ambient` ones so a definite signal always shadows an ambient one.
- *
- * Sources: Vercel CLI / Next.js `detect-agent.ts`, Prisma `ai-safety.ts`, and
- * the respective harness docs. When adding an entry, cite where it ships —
- * an unverified marker is a behavior bug waiting for a human to hit it.
+ * Session markers for agents that are NOT invokable providers — their harness
+ * spawns shells, but there is no promptable CLI for `providers/` to model.
+ * Sources: Vercel CLI / Next.js `detect-agent.ts`, Prisma `ai-safety.ts`.
  */
-const SESSION_MARKERS: ReadonlyArray<AiSessionMarker> = [
-    { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDECODE" },
-    { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDE_CODE" },
-    { agent: "Cursor Agent", confidence: "definite", provider: "cursor", variable: "CURSOR_AGENT" },
-    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_SANDBOX" },
-    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_THREAD_ID" },
-    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_CI" },
-    // Qwen Code is a gemini-cli fork and sets the same variable.
-    { agent: "Gemini CLI", confidence: "definite", provider: "gemini", variable: "GEMINI_CLI" },
-    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_MODEL" },
-    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_ALLOW_ALL" },
-    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_GITHUB_TOKEN" },
-    { agent: "opencode", confidence: "definite", provider: "opencode", variable: "OPENCODE_CLIENT" },
-    { agent: "Amp", confidence: "definite", equals: "amp", provider: "amp", variable: "AGENT" },
+const EXTRA_AGENT_MARKERS: ReadonlyArray<AiSessionMarker> = [
     { agent: "Cline", confidence: "definite", variable: "CLINE_ACTIVE" },
     { agent: "Aider", confidence: "definite", equals: "Aider", variable: "OR_APP_NAME" },
     { agent: "Antigravity", confidence: "definite", variable: "ANTIGRAVITY_AGENT" },
     { agent: "Augment", confidence: "definite", variable: "AUGMENT_AGENT" },
     { agent: "Replit Agent", confidence: "definite", variable: "REPLIT_CLI" },
     // Ambient: the platform is present, but a human may be the one typing.
-    { agent: "Cursor editor", confidence: "ambient", provider: "cursor", variable: "CURSOR_TRACE_ID" },
     { agent: "Replit workspace", confidence: "ambient", variable: "REPL_ID" },
 ];
+
+/** Resolve one provider's `sessionMarkers` into full table entries. */
+const resolveProviderMarkers = (name: AiProviderName, config: AiProviderConfig): AiSessionMarker[] =>
+    config.sessionMarkers.map((marker): AiSessionMarker => {
+        return {
+            agent: marker.agent ?? config.displayName,
+            confidence: marker.confidence,
+            equals: marker.equals,
+            provider: name,
+            variable: marker.variable,
+        };
+    });
+
+/**
+ * The full marker table, assembled from every provider's `sessionMarkers`
+ * plus {@link EXTRA_AGENT_MARKERS}, ordered `definite` before `ambient` so a
+ * definite signal always shadows an ambient one. First match wins.
+ */
+const SESSION_MARKERS: ReadonlyArray<AiSessionMarker> = [
+    ...(Object.keys(PROVIDERS) as AiProviderName[]).flatMap((name) => resolveProviderMarkers(name, PROVIDERS[name])),
+    ...EXTRA_AGENT_MARKERS,
+].toSorted((a, b) => {
+    if (a.confidence === b.confidence) {
+        return 0;
+    }
+
+    return a.confidence === "definite" ? -1 : 1;
+});
 
 /** True when the env value spells an explicit "off" (`0` / `false`). */
 const isDisabledValue = (value: string): boolean => value === "0" || value === "false";
@@ -151,4 +157,4 @@ const detectAiSession = (env: EnvLike = process.env, options: AiSessionOptions =
 const isAiSession = (env: EnvLike = process.env, options: AiSessionOptions = {}): boolean => detectAiSession(env, options) !== undefined;
 
 export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS };
-export type { AiSessionConfidence, AiSessionInfo, AiSessionMarker, AiSessionOptions, EnvLike };
+export type { AiSessionInfo, AiSessionMarker, AiSessionOptions, EnvLike };

--- a/packages/tooling/find-ai-runner/src/session.ts
+++ b/packages/tooling/find-ai-runner/src/session.ts
@@ -18,7 +18,7 @@
  */
 import type { AiProviderName } from "./types";
 
-/** Minimal env shape — `process.env` structurally, injectable for tests. */
+/** Minimal env shape accepted by {@link detectAiSession} / {@link isAiSession} — `process.env` structurally, injectable for tests. */
 type EnvLike = Readonly<Record<string, string | undefined>>;
 
 /**
@@ -151,4 +151,4 @@ const detectAiSession = (env: EnvLike = process.env, options: AiSessionOptions =
 const isAiSession = (env: EnvLike = process.env, options: AiSessionOptions = {}): boolean => detectAiSession(env, options) !== undefined;
 
 export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS };
-export type { AiSessionConfidence, AiSessionInfo, AiSessionMarker, AiSessionOptions };
+export type { AiSessionConfidence, AiSessionInfo, AiSessionMarker, AiSessionOptions, EnvLike };

--- a/packages/tooling/find-ai-runner/src/session.ts
+++ b/packages/tooling/find-ai-runner/src/session.ts
@@ -1,0 +1,154 @@
+/**
+ * Detection of the AI agent SESSION the current process runs inside — the
+ * complement to the binary detection in `index.ts`. Binary detection answers
+ * "which AI CLIs are installed on this machine?"; session detection answers
+ * "is an AI agent driving THIS process right now?" — the question dev servers,
+ * scaffolders, and destructive CLIs ask before switching to machine-readable
+ * output, backgrounding themselves, or demanding explicit human consent.
+ *
+ * Detection is by environment-variable markers the agent harnesses set in the
+ * shells they spawn. The table is deliberately conservative and every entry is
+ * sourced from a shipping implementation (the Vercel CLI / Next.js
+ * `detect-agent`, Prisma's `ai-safety`, or the harness's own documentation):
+ * a false positive here silently changes a tool's behavior under a human's
+ * fingers. Markers that only prove the PLATFORM (e.g. a Cursor editor
+ * terminal, a Replit workspace) — where a human may well be typing — are
+ * reported with `confidence: "ambient"` and excluded from detection unless
+ * explicitly opted into.
+ */
+import type { AiProviderName } from "./types";
+
+/** Minimal env shape — `process.env` structurally, injectable for tests. */
+type EnvLike = Readonly<Record<string, string | undefined>>;
+
+/**
+ * How strongly a marker implies an agent is driving the process.
+ *
+ * `definite` markers are set only in agent-spawned shells. `ambient` markers
+ * prove the surrounding platform (editor, cloud workspace) but not that an
+ * agent — rather than a human — is issuing commands.
+ */
+type AiSessionConfidence = "ambient" | "definite";
+
+/** One detected agent session: which agent, how sure, and which env var gave it away. */
+interface AiSessionInfo {
+    /** Human-readable agent name (e.g. `"Claude Code"`). */
+    agent: string;
+    /** See {@link AiSessionConfidence}. */
+    confidence: AiSessionConfidence;
+    /** The matching invokable provider from `index.ts`, when the agent is one. */
+    provider?: AiProviderName;
+    /** The environment variable that matched. */
+    variable: string;
+}
+
+/** Options for {@link detectAiSession} / {@link isAiSession}. */
+interface AiSessionOptions {
+    /**
+     * Also report `ambient` markers (Cursor editor terminals, Replit
+     * workspaces, …). Off by default: ambient environments host humans too,
+     * and behavior switches (JSON output, auto-backgrounding) keyed on them
+     * surprise those humans. Turn on for telemetry-style consumers where a
+     * false positive is harmless.
+     */
+    includeAmbient?: boolean;
+}
+
+/** One marker table entry. Matches when the variable is set non-empty (and not `0`/`false`), or exactly `equals` when given. */
+interface AiSessionMarker {
+    agent: string;
+    confidence: AiSessionConfidence;
+    /** Require this exact value (for shared variables like `AGENT`). */
+    equals?: string;
+    provider?: AiProviderName;
+    variable: string;
+}
+
+/**
+ * Generic marker some harnesses (and the Vercel CLI convention) set with the
+ * agent's name as the value — checked first, since it is self-describing.
+ */
+const AI_AGENT_ENV = "AI_AGENT";
+
+/**
+ * Known session markers, first match wins; `definite` entries listed before
+ * `ambient` ones so a definite signal always shadows an ambient one.
+ *
+ * Sources: Vercel CLI / Next.js `detect-agent.ts`, Prisma `ai-safety.ts`, and
+ * the respective harness docs. When adding an entry, cite where it ships —
+ * an unverified marker is a behavior bug waiting for a human to hit it.
+ */
+const SESSION_MARKERS: ReadonlyArray<AiSessionMarker> = [
+    { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDECODE" },
+    { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDE_CODE" },
+    { agent: "Cursor Agent", confidence: "definite", provider: "cursor", variable: "CURSOR_AGENT" },
+    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_SANDBOX" },
+    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_THREAD_ID" },
+    { agent: "Codex", confidence: "definite", provider: "codex", variable: "CODEX_CI" },
+    // Qwen Code is a gemini-cli fork and sets the same variable.
+    { agent: "Gemini CLI", confidence: "definite", provider: "gemini", variable: "GEMINI_CLI" },
+    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_MODEL" },
+    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_ALLOW_ALL" },
+    { agent: "GitHub Copilot CLI", confidence: "definite", provider: "copilot", variable: "COPILOT_GITHUB_TOKEN" },
+    { agent: "opencode", confidence: "definite", provider: "opencode", variable: "OPENCODE_CLIENT" },
+    { agent: "Amp", confidence: "definite", equals: "amp", provider: "amp", variable: "AGENT" },
+    { agent: "Cline", confidence: "definite", variable: "CLINE_ACTIVE" },
+    { agent: "Aider", confidence: "definite", equals: "Aider", variable: "OR_APP_NAME" },
+    { agent: "Antigravity", confidence: "definite", variable: "ANTIGRAVITY_AGENT" },
+    { agent: "Augment", confidence: "definite", variable: "AUGMENT_AGENT" },
+    { agent: "Replit Agent", confidence: "definite", variable: "REPLIT_CLI" },
+    // Ambient: the platform is present, but a human may be the one typing.
+    { agent: "Cursor editor", confidence: "ambient", provider: "cursor", variable: "CURSOR_TRACE_ID" },
+    { agent: "Replit workspace", confidence: "ambient", variable: "REPL_ID" },
+];
+
+/** True when the env value spells an explicit "off" (`0` / `false`). */
+const isDisabledValue = (value: string): boolean => value === "0" || value === "false";
+
+/** The marker's effective value in `env`, or `undefined` when unset/empty/disabled/mismatched. */
+const markerValue = (marker: AiSessionMarker, env: EnvLike): string | undefined => {
+    const value = env[marker.variable];
+
+    if (value === undefined || value === "" || isDisabledValue(value)) {
+        return undefined;
+    }
+
+    if (marker.equals !== undefined && value !== marker.equals) {
+        return undefined;
+    }
+
+    return value;
+};
+
+/**
+ * Detect the AI agent session the current process runs inside, or `undefined`
+ * when none is detected. Pure — pass a custom `env` in tests.
+ *
+ * The self-describing `AI_AGENT` variable wins over the marker table; ambient
+ * markers are only consulted with `includeAmbient: true`.
+ */
+const detectAiSession = (env: EnvLike = process.env, options: AiSessionOptions = {}): AiSessionInfo | undefined => {
+    const generic = env[AI_AGENT_ENV]?.trim();
+
+    if (generic !== undefined && generic !== "" && !isDisabledValue(generic)) {
+        return { agent: generic, confidence: "definite", variable: AI_AGENT_ENV };
+    }
+
+    for (const marker of SESSION_MARKERS) {
+        if (marker.confidence === "ambient" && options.includeAmbient !== true) {
+            continue;
+        }
+
+        if (markerValue(marker, env) !== undefined) {
+            return { agent: marker.agent, confidence: marker.confidence, provider: marker.provider, variable: marker.variable };
+        }
+    }
+
+    return undefined;
+};
+
+/** Convenience predicate over {@link detectAiSession}. */
+const isAiSession = (env: EnvLike = process.env, options: AiSessionOptions = {}): boolean => detectAiSession(env, options) !== undefined;
+
+export { AI_AGENT_ENV, detectAiSession, isAiSession, SESSION_MARKERS };
+export type { AiSessionConfidence, AiSessionInfo, AiSessionMarker, AiSessionOptions };

--- a/packages/tooling/find-ai-runner/src/types.ts
+++ b/packages/tooling/find-ai-runner/src/types.ts
@@ -25,6 +25,34 @@ interface AiBuildArgsOptions {
     model: string;
 }
 
+/**
+ * How strongly a session marker implies an agent is driving the process.
+ *
+ * `definite` markers are set only in agent-spawned shells. `ambient` markers
+ * prove the surrounding platform (editor, cloud workspace) but not that an
+ * agent — rather than a human — is issuing commands.
+ */
+type AiSessionConfidence = "ambient" | "definite";
+
+/**
+ * One environment marker a provider's harness sets in the shells it spawns,
+ * declared on the provider's config and consumed by `detectAiSession`.
+ * Matches when the variable is set non-empty (and not `0`/`false`), or
+ * exactly `equals` when given. Only add markers that ship in a production
+ * implementation — an unverified marker is a behavior bug waiting for a
+ * human to hit it.
+ */
+interface AiSessionMarkerConfig {
+    /** Display-name override for this marker (e.g. `"Cursor editor"` for the ambient Cursor marker); defaults to the provider's `displayName`. */
+    agent?: string;
+    /** See {@link AiSessionConfidence}. */
+    confidence: AiSessionConfidence;
+    /** Require this exact value (for shared variables like `AGENT`). */
+    equals?: string;
+    /** The environment variable to check. */
+    variable: string;
+}
+
 /** Configuration for an AI CLI provider, including how to build CLI arguments. */
 interface AiProviderConfig {
     /** Alternate CLI command names to try (e.g., `gemini-cli` for `gemini`). */
@@ -40,8 +68,12 @@ interface AiProviderConfig {
     command: string;
     /** Default model to use if none specified. Empty string means provider-default. */
     defaultModel: string;
+    /** Human-readable provider name (e.g. `"Claude Code"`), used in session-detection results. */
+    displayName: string;
     /** Environment variable that can override the CLI path (e.g., `CLAUDE_PATH`). */
     envVariable: string;
+    /** Env markers this provider's harness sets in agent-spawned shells (see {@link AiSessionMarkerConfig}); empty when none are verified. */
+    sessionMarkers: AiSessionMarkerConfig[];
     /** Whether the provider honors the `maxTokens` option in its CLI invocation. */
     supportsMaxTokens: boolean;
     /** Whether the provider honors the `model` option in its CLI invocation. */
@@ -204,4 +236,4 @@ class AiRunError extends Error {
 }
 
 export { AiRunError };
-export type { AiBuildArgsOptions, AiDetectAsyncOptions, AiDetectOptions, AiProviderConfig, AiProviderInfo, AiProviderName, AiRunOptions, AiRunResult };
+export type { AiBuildArgsOptions, AiDetectAsyncOptions, AiDetectOptions, AiProviderConfig, AiProviderInfo, AiProviderName, AiRunOptions, AiRunResult, AiSessionConfidence, AiSessionMarkerConfig };


### PR DESCRIPTION
## What

Adds **session detection** to `@visulima/find-ai-runner` — the complement to the existing binary detection. Binary detection answers *"which AI CLIs are installed on this machine?"*; the new `detectAiSession()` / `isAiSession()` answer *"is an AI agent driving **this** process right now?"* — the question dev servers, scaffolders, and destructive CLIs ask before switching to machine-readable output, backgrounding themselves, or requiring explicit human consent.

```ts
import { detectAiSession, isAiSession } from "@visulima/find-ai-runner";

const session = detectAiSession();
// → { agent: "Claude Code", confidence: "definite", provider: "claude", variable: "CLAUDECODE" }

if (isAiSession()) {
    // emit JSON logs, skip interactive prompts, …
}
```

## Design

- **Sourced markers only.** Every table entry ships in a production implementation (Vercel CLI / Next.js `detect-agent.ts`, Prisma `ai-safety.ts`): Claude Code (`CLAUDECODE`/`CLAUDE_CODE`), Cursor Agent (`CURSOR_AGENT`), Codex (`CODEX_SANDBOX`/`CODEX_THREAD_ID`/`CODEX_CI`), Gemini CLI (`GEMINI_CLI`, shared by the Qwen Code fork), GitHub Copilot CLI (`COPILOT_MODEL`/`COPILOT_ALLOW_ALL`/`COPILOT_GITHUB_TOKEN`), opencode (`OPENCODE_CLIENT`), Amp (`AGENT=amp`), Cline (`CLINE_ACTIVE`), Aider (`OR_APP_NAME=Aider`), Antigravity, Augment, Replit Agent (`REPLIT_CLI`) — an unverified marker is a behavior bug waiting for a human to hit it.
- **`AI_AGENT` convention first.** The self-describing variable (Vercel convention) wins over the marker table.
- **Ambient vs definite confidence.** Markers that only prove the *platform* — a Cursor editor terminal (`CURSOR_TRACE_ID`), a Replit workspace (`REPL_ID`) — where a human may well be the one typing are classified `ambient` and only reported with `{ includeAmbient: true }`. Use ambient for telemetry, never for behavior switches.
- **Pure + injectable.** Both functions take an optional env object for tests; markers map back to invokable `AiProviderName`s where the agent is also a provider.

## Consumers

`@lunora/config` is wired to consume this (replacing its hand-rolled table) the moment this releases as `1.0.0-alpha.9` — verified against a packed tarball of this branch (1,081 downstream tests green).

## Testing

- New `__tests__/session.test.ts`: human env, definite markers + provider mapping, value-scoped markers (`AGENT=amp` vs other `AGENT` values), `AI_AGENT` priority + disable, empty/disabled values, ambient opt-in + definite-shadows-ambient. Package suite: 140 tests green; `tsc` + ESLint clean.
- README: new *Session Detection* section + API entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AhADYYkG7x9F77GHMw9Tw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session detection helpers to identify whether the current process is being driven by an AI agent.
  * Introduced a boolean convenience check and a detailed detection result for more flexible usage.
  * Added support for passing a custom environment for testing and controlled behavior.
  * Updated documentation with examples and public API details for the new session-detection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->