### PR TITLE
feat(email): add microsoft graph oauth to outlook365

### DIFF
--- a/packages/email/email/README.md
+++ b/packages/email/email/README.md
@@ -960,7 +960,8 @@ the built-in app-only (client credentials) or delegated (refresh token) flow, or
 (`Mail.Send` scope) via `accessToken` / `getAccessToken`.
 
 ```typescript
-import { createMail, outlook365Provider } from "@visulima/email/providers/outlook365";
+import { createMail } from "@visulima/email";
+import { outlook365Provider } from "@visulima/email/providers/outlook365";
 
 // App-only (client credentials) — userId is required, app-only tokens have no "me" mailbox.
 const mail = createMail(

--- a/packages/email/email/README.md
+++ b/packages/email/email/README.md
@@ -955,16 +955,31 @@ await mail.send({
 
 ### Outlook365 Provider
 
-Sends through Microsoft Graph `sendMail`. Universal runtime (Fetch API). Bring your own OAuth2 token (`Mail.Send` scope)
-via `accessToken` or `getAccessToken` — no auth SDK is bundled.
+Sends through Microsoft Graph `sendMail`. Universal runtime (Fetch API). No auth SDK is bundled — authenticate with
+the built-in app-only (client credentials) or delegated (refresh token) flow, or bring your own OAuth2 token
+(`Mail.Send` scope) via `accessToken` / `getAccessToken`.
 
 ```typescript
 import { createMail, outlook365Provider } from "@visulima/email/providers/outlook365";
 
+// App-only (client credentials) — userId is required, app-only tokens have no "me" mailbox.
 const mail = createMail(
     outlook365Provider({
-        getAccessToken: async () => getGraphAccessToken(),
-        userId: "sender@contoso.com", // or "me" (default)
+        tenantId: process.env.AZURE_TENANT_ID,
+        clientId: process.env.AZURE_CLIENT_ID,
+        clientSecret: process.env.AZURE_CLIENT_SECRET,
+        userId: "sender@contoso.com",
+    }),
+);
+
+// Delegated (refresh token) — sends as the consenting user.
+const delegated = createMail(
+    outlook365Provider({
+        tenantId: process.env.AZURE_TENANT_ID,
+        clientId: process.env.AZURE_CLIENT_ID,
+        refreshToken: await loadRefreshToken(),
+        // Azure AD may rotate the refresh token; this is awaited before the token is used.
+        onRefreshToken: async (token) => saveRefreshToken(token),
     }),
 );
 

--- a/packages/email/email/__tests__/providers/outlook365-auth.test.ts
+++ b/packages/email/email/__tests__/providers/outlook365-auth.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { outlook365Provider } from "../../src/providers/outlook365/index";
+import { makeRequest } from "../../src/utils/make-request";
+
+// Deliberately does NOT stub `retry` — these tests cover the token request's retry behaviour,
+// which the stub in outlook365.test.ts short-circuits.
+vi.mock(import("../../src/utils/make-request"), () => {
+    return { makeRequest: vi.fn() };
+});
+
+const email = { from: { email: "from@x.com" }, subject: "s", text: "t", to: { email: "to@x.com" } };
+const sendResponse = { data: { body: "", statusCode: 202 }, success: true };
+const tokenResponse = { data: { body: { access_token: "graph-token", expires_in: 3600 }, statusCode: 200 }, success: true };
+
+const config = { clientId: "client-id", clientSecret: "client-secret", tenantId: "tenant-id", userId: "sender@contoso.com" };
+
+const tokenCalls = (): unknown[][] => (makeRequest as ReturnType<typeof vi.fn>).mock.calls.filter(([url]) => String(url).includes("/oauth2/v2.0/token"));
+
+describe("outlook365 token retries", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("retries a throttled token request and succeeds", async () => {
+        expect.assertions(2);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        makeRequestMock
+            .mockResolvedValueOnce({ data: { body: { error: "temporarily_unavailable" }, statusCode: 429 }, success: false })
+            .mockResolvedValueOnce(tokenResponse)
+            .mockResolvedValueOnce(sendResponse);
+
+        const result = await outlook365Provider({ ...config, retries: 1 }).sendEmail(email);
+
+        expect(result.success).toBe(true);
+        expect(tokenCalls()).toHaveLength(2);
+    });
+
+    it("retries a 5xx from the token endpoint", async () => {
+        expect.assertions(2);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        makeRequestMock
+            .mockResolvedValueOnce({ data: { body: "gateway", statusCode: 503 }, success: false })
+            .mockResolvedValueOnce(tokenResponse)
+            .mockResolvedValueOnce(sendResponse);
+
+        const result = await outlook365Provider({ ...config, retries: 1 }).sendEmail(email);
+
+        expect(result.success).toBe(true);
+        expect(tokenCalls()).toHaveLength(2);
+    });
+
+    it("does not retry a credential rejection, which can never succeed", async () => {
+        expect.assertions(3);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        makeRequestMock.mockResolvedValue({
+            data: { body: { error: "invalid_client", error_description: "AADSTS7000215: Invalid client secret provided." }, statusCode: 401 },
+            success: false,
+        });
+
+        const result = await outlook365Provider({ ...config, retries: 3 }).sendEmail(email);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("AADSTS7000215");
+        expect(tokenCalls()).toHaveLength(1);
+    });
+});

--- a/packages/email/email/__tests__/providers/outlook365.test.ts
+++ b/packages/email/email/__tests__/providers/outlook365.test.ts
@@ -5,6 +5,9 @@ import { outlook365Provider } from "../../src/providers/outlook365/index";
 import type { Outlook365EmailOptions } from "../../src/providers/outlook365/types";
 import { makeRequest } from "../../src/utils/make-request";
 
+const MISSING_TENANT_AND_CLIENT = /'tenantId', 'clientId'/;
+const MISSING_REFRESH_TOKEN = /'refreshToken'/;
+
 vi.mock(import("../../src/utils/make-request"), () => {
     return { makeRequest: vi.fn() };
 });
@@ -20,7 +23,7 @@ describe(outlook365Provider, () => {
         vi.clearAllMocks();
     });
 
-    it("throws when neither accessToken nor getAccessToken is provided", () => {
+    it("throws when no auth mode is configured", () => {
         expect.assertions(1);
 
         expect(() => outlook365Provider({} as any)).toThrow(RequiredOptionError);
@@ -59,5 +62,387 @@ describe(outlook365Provider, () => {
         await provider.sendEmail({ from: { email: "from@x.com" }, subject: "s", text: "t", to: { email: "t@x.com" } });
 
         expect(String(makeRequestMock.mock.calls[0][0])).toContain("/users/sender@contoso.com/sendMail");
+    });
+
+    describe("oAuth2 flows", () => {
+        const TOKEN_URL = "/oauth2/v2.0/token";
+        const tokenResponse = (body: Record<string, unknown> = {}) => {
+            return { data: { body: { access_token: "graph-token", expires_in: 3600, ...body }, statusCode: 200 }, success: true };
+        };
+        const sendResponse = { data: { body: "", statusCode: 202 }, success: true };
+        const email: Outlook365EmailOptions = { from: { email: "from@x.com" }, subject: "s", text: "t", to: { email: "to@x.com" } };
+
+        const appOnlyConfig = {
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            tenantId: "tenant-id",
+            userId: "sender@contoso.com",
+        };
+
+        // Select calls by URL rather than by index: token and send requests interleave in one
+        // global mock log, so positional assertions break whenever a request is added.
+        const callsTo = (fragment: string): unknown[][] => (makeRequest as ReturnType<typeof vi.fn>).mock.calls.filter(([url]) => String(url).includes(fragment));
+        const tokenCalls = (): unknown[][] => callsTo(TOKEN_URL);
+        const sendCalls = (): unknown[][] => callsTo("/sendMail");
+        const formBody = (call: unknown[]): Record<string, string> => Object.fromEntries(new URLSearchParams(call[2] as string));
+        const authHeader = (call: unknown[]): string => (call[1] as { headers: Record<string, string> }).headers.Authorization;
+
+        it("exchanges client credentials for a token and sends with it", async () => {
+            expect.assertions(5);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            const result = await outlook365Provider(appOnlyConfig).sendEmail(email);
+
+            expect(result.success).toBe(true);
+            expect(String(tokenCalls()[0][0])).toBe("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token");
+            expect((tokenCalls()[0][1] as { method: string }).method).toBe("POST");
+            expect(formBody(tokenCalls()[0])).toStrictEqual({
+                client_id: "client-id",
+                client_secret: "client-secret",
+                grant_type: "client_credentials",
+                scope: "https://graph.microsoft.com/.default",
+            });
+            expect(authHeader(sendCalls()[0])).toBe("Bearer graph-token");
+        });
+
+        it("requires an explicit userId for the app-only flow, since Graph has no app-only 'me'", () => {
+            expect.assertions(2);
+
+            expect(() => outlook365Provider({ ...appOnlyConfig, userId: undefined })).toThrow("requires an explicit 'userId'");
+            expect(() => outlook365Provider({ ...appOnlyConfig, userId: "me" })).toThrow("requires an explicit 'userId'");
+        });
+
+        it("exchanges a refresh token for a token in the delegated flow", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            // No userId — the delegated flow may target the token owner's own mailbox.
+            const result = await outlook365Provider({ clientId: "client-id", refreshToken: "refresh-token", tenantId: "tenant-id" }).sendEmail(email);
+
+            expect(result.success).toBe(true);
+            expect(formBody(tokenCalls()[0])).toStrictEqual({
+                client_id: "client-id",
+                grant_type: "refresh_token",
+                refresh_token: "refresh-token",
+                scope: "https://graph.microsoft.com/Mail.Send offline_access",
+            });
+        });
+
+        it("requires tenantId and clientId for the built-in flows, naming every missing option", () => {
+            expect.assertions(2);
+
+            expect(() => outlook365Provider({ clientSecret: "s", userId: "u@x.com" })).toThrow(RequiredOptionError);
+            expect(() => outlook365Provider({ clientSecret: "s", userId: "u@x.com" })).toThrow(MISSING_TENANT_AND_CLIENT);
+        });
+
+        it("reports the missing credential for an explicitly pinned mode", () => {
+            expect.assertions(1);
+
+            expect(() => outlook365Provider({ authMode: "refreshToken", clientId: "c", tenantId: "t" })).toThrow(MISSING_REFRESH_TOKEN);
+        });
+
+        it("pins the flow via authMode when a config matches both built-in flows", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            // Without authMode this config infers the delegated flow, since refreshToken wins.
+            const result = await outlook365Provider({ ...appOnlyConfig, authMode: "clientCredentials", refreshToken: "stale-leftover" }).sendEmail(email);
+
+            expect(result.success).toBe(true);
+            expect(formBody(tokenCalls()[0]).grant_type).toBe("client_credentials");
+        });
+
+        it("warns when the chosen flow ignores configured credentials", () => {
+            expect.assertions(1);
+
+            const warn = vi.fn();
+
+            outlook365Provider({ ...appOnlyConfig, authMode: "clientCredentials", logger: { ...console, warn } as unknown as Console, refreshToken: "stale" });
+
+            expect(warn.mock.calls[0][0]).toContain("ignores these configured options: refreshToken");
+        });
+
+        it("caches the token across sends and refreshes it once expired", async () => {
+            expect.assertions(4);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            let clock = 0;
+
+            makeRequestMock
+                .mockResolvedValueOnce(tokenResponse({ access_token: "first" }))
+                .mockResolvedValueOnce(sendResponse)
+                .mockResolvedValueOnce(sendResponse)
+                .mockResolvedValueOnce(tokenResponse({ access_token: "second" }))
+                .mockResolvedValueOnce(sendResponse);
+
+            const provider = outlook365Provider({ ...appOnlyConfig, now: () => clock });
+
+            await provider.sendEmail(email);
+            await provider.sendEmail(email);
+
+            expect(tokenCalls()).toHaveLength(1);
+            expect(sendCalls()).toHaveLength(2);
+
+            // Past expiry minus the refresh skew.
+            clock = 3_600_000;
+
+            await provider.sendEmail(email);
+
+            expect(tokenCalls()).toHaveLength(2);
+            expect(authHeader(sendCalls()[2])).toBe("Bearer second");
+        });
+
+        it("honours tokenRefreshSkewMs", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            let clock = 0;
+
+            makeRequestMock.mockResolvedValue(sendResponse);
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            // Expiry is 3_600_000; a 10-minute skew must force a refresh 10 minutes early.
+            const provider = outlook365Provider({ ...appOnlyConfig, now: () => clock, tokenRefreshSkewMs: 600_000 });
+
+            await provider.sendEmail(email);
+
+            clock = 2_999_999;
+            await provider.sendEmail(email);
+
+            expect(tokenCalls()).toHaveLength(1);
+
+            clock = 3_000_000;
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+            await provider.sendEmail(email);
+
+            expect(tokenCalls()).toHaveLength(2);
+        });
+
+        it("applies a scopes override", async () => {
+            expect.assertions(1);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            await outlook365Provider({ ...appOnlyConfig, scopes: ["https://graph.microsoft.us/.default"] }).sendEmail(email);
+
+            expect(formBody(tokenCalls()[0]).scope).toBe("https://graph.microsoft.us/.default");
+        });
+
+        it("normalises a sovereign-cloud authority with a trailing slash", async () => {
+            expect.assertions(1);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(sendResponse);
+
+            await outlook365Provider({ ...appOnlyConfig, authority: "https://login.microsoftonline.us///" }).sendEmail(email);
+
+            expect(String(tokenCalls()[0][0])).toBe("https://login.microsoftonline.us/tenant-id/oauth2/v2.0/token");
+        });
+
+        it("collapses concurrent sends into a single token request", async () => {
+            expect.assertions(1);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse()).mockResolvedValue(sendResponse);
+
+            const provider = outlook365Provider(appOnlyConfig);
+
+            await Promise.all([provider.sendEmail(email), provider.sendEmail(email), provider.sendEmail(email)]);
+
+            expect(tokenCalls()).toHaveLength(1);
+        });
+
+        it("adopts and reports a rotated refresh token", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            let clock = 0;
+
+            makeRequestMock
+                .mockResolvedValueOnce(tokenResponse({ refresh_token: "rotated-token" }))
+                .mockResolvedValueOnce(sendResponse)
+                .mockResolvedValueOnce(tokenResponse())
+                .mockResolvedValueOnce(sendResponse);
+
+            const onRefreshToken = vi.fn();
+            const provider = outlook365Provider({
+                clientId: "client-id",
+                now: () => clock,
+                onRefreshToken,
+                refreshToken: "original-token",
+                tenantId: "tenant-id",
+            });
+
+            await provider.sendEmail(email);
+
+            expect(onRefreshToken).toHaveBeenCalledWith("rotated-token");
+
+            clock = 3_600_000;
+
+            await provider.sendEmail(email);
+
+            // The second refresh must use the rotated token — replaying the original fails once
+            // Azure AD has rotation enabled.
+            expect(formBody(tokenCalls()[1]).refresh_token).toBe("rotated-token");
+        });
+
+        it("awaits an async onRefreshToken before handing out the token", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse({ refresh_token: "rotated-token" })).mockResolvedValueOnce(sendResponse);
+
+            const order: string[] = [];
+            const provider = outlook365Provider({
+                clientId: "client-id",
+                onRefreshToken: async () => {
+                    await Promise.resolve();
+                    order.push("persisted");
+                },
+                refreshToken: "original-token",
+                tenantId: "tenant-id",
+            });
+
+            const result = await provider.sendEmail(email);
+
+            order.push("sent");
+
+            expect(result.success).toBe(true);
+            expect(order).toStrictEqual(["persisted", "sent"]);
+        });
+
+        it("logs, but does not fail the send, when persisting a rotated token rejects", async () => {
+            expect.assertions(3);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse({ refresh_token: "rotated-token" })).mockResolvedValueOnce(sendResponse);
+
+            const rejections: unknown[] = [];
+            const onUnhandled = (reason: unknown): void => {
+                rejections.push(reason);
+            };
+
+            process.on("unhandledRejection", onUnhandled);
+
+            const error = vi.fn();
+            const provider = outlook365Provider({
+                clientId: "client-id",
+                logger: { ...console, error } as unknown as Console,
+                onRefreshToken: () => Promise.reject(new Error("disk write failed")),
+                refreshToken: "original-token",
+                tenantId: "tenant-id",
+            });
+
+            const result = await provider.sendEmail(email);
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+
+            process.off("unhandledRejection", onUnhandled);
+
+            // The access token is valid, so the send must still succeed...
+            expect(result.success).toBe(true);
+            // ...the failure must be reported...
+            expect(error.mock.calls[0][0]).toContain("disk write failed");
+            // ...and must never escape as an unhandled rejection.
+            expect(rejections).toStrictEqual([]);
+        });
+
+        it("surfaces the OAuth2 error description when the token request fails", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce({
+                data: { body: { error: "invalid_client", error_description: "AADSTS7000215: Invalid client secret provided." }, statusCode: 401 },
+                success: false,
+            });
+
+            const result = await outlook365Provider(appOnlyConfig).sendEmail(email);
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("AADSTS7000215");
+        });
+
+        it("reports a non-JSON token response", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce({ data: { body: "<html>gateway</html>", statusCode: 200 }, success: true });
+
+            const result = await outlook365Provider(appOnlyConfig).sendEmail(email);
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("non-JSON response");
+        });
+
+        it("reports a token response with no access_token", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce({ data: { body: { token_type: "Bearer" }, statusCode: 200 }, success: true });
+
+            const result = await outlook365Provider(appOnlyConfig).sendEmail(email);
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("did not contain an access_token");
+        });
+
+        it("reports a transport failure that carries no parseable body", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce({ error: new Error("socket hang up"), success: false });
+
+            const result = await outlook365Provider(appOnlyConfig).sendEmail(email);
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("socket hang up");
+        });
+
+        it("validates credentials by acquiring a token", async () => {
+            expect.assertions(2);
+
+            const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+            makeRequestMock.mockResolvedValueOnce(tokenResponse());
+
+            await expect(outlook365Provider(appOnlyConfig).validateCredentials()).resolves.toBe(true);
+
+            makeRequestMock.mockResolvedValueOnce({ data: { body: { error: "invalid_client" }, statusCode: 401 }, success: false });
+
+            await expect(outlook365Provider(appOnlyConfig).validateCredentials()).resolves.toBe(false);
+        });
+
+        it("keeps credentials out of the publicly readable options", () => {
+            expect.assertions(2);
+
+            const provider = outlook365Provider({ ...appOnlyConfig, refreshToken: "rt" });
+
+            expect(provider.options).not.toHaveProperty("clientSecret");
+            expect(provider.options).toMatchObject({ authMode: "refreshToken", clientId: "client-id", tenantId: "tenant-id" });
+        });
     });
 });

--- a/packages/email/email/__tests__/utils/create-token-cache.test.ts
+++ b/packages/email/email/__tests__/utils/create-token-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import createTokenCache from "../../src/utils/create-token-cache";
+
+describe(createTokenCache, () => {
+    it("caches the token until the skew window", async () => {
+        expect.assertions(2);
+
+        let clock = 0;
+        const fetchToken = vi.fn(() => Promise.resolve({ accessToken: "a", expiresAt: 10_000 }));
+        const getToken = createTokenCache(fetchToken, { now: () => clock, skewMs: 1000 });
+
+        await getToken();
+        clock = 8999;
+        await getToken();
+
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+
+        // Expiry (10000) minus skew (1000) has now been reached.
+        clock = 9000;
+        await getToken();
+
+        expect(fetchToken).toHaveBeenCalledTimes(2);
+    });
+
+    it("treats a token without an expiry as never expiring", async () => {
+        expect.assertions(1);
+
+        const fetchToken = vi.fn(() => Promise.resolve({ accessToken: "a" }));
+        const getToken = createTokenCache(fetchToken, { now: () => 1e12 });
+
+        await getToken();
+        await getToken();
+
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses concurrent callers into a single fetch", async () => {
+        expect.assertions(2);
+
+        const fetchToken = vi.fn(() => Promise.resolve({ accessToken: "a", expiresAt: 1e12 }));
+        const getToken = createTokenCache(fetchToken, { now: () => 0 });
+
+        const results = await Promise.all([getToken(), getToken(), getToken()]);
+
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+        expect(results.map((r) => r.accessToken)).toStrictEqual(["a", "a", "a"]);
+    });
+
+    it("rejects every concurrent waiter and recovers on the next call", async () => {
+        expect.assertions(3);
+
+        const fetchToken = vi
+            .fn<() => Promise<{ accessToken: string; expiresAt: number }>>()
+            .mockRejectedValueOnce(new Error("boom"))
+            .mockResolvedValue({ accessToken: "good", expiresAt: 1e12 });
+        const getToken = createTokenCache(fetchToken, { now: () => 0 });
+
+        const settled = await Promise.allSettled([getToken(), getToken()]);
+
+        expect(settled.map((s) => s.status)).toStrictEqual(["rejected", "rejected"]);
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+
+        // A failed fetch must not be cached, and must not leave the in-flight promise stuck.
+        await expect(getToken()).resolves.toStrictEqual({ accessToken: "good", expiresAt: 1e12 });
+    });
+
+    it("clamps a negative skew so tokens are never served past expiry", async () => {
+        expect.assertions(1);
+
+        let clock = 0;
+        const fetchToken = vi.fn(() => Promise.resolve({ accessToken: "a", expiresAt: 1000 }));
+        const getToken = createTokenCache(fetchToken, { now: () => clock, skewMs: -5000 });
+
+        await getToken();
+        clock = 1000;
+        await getToken();
+
+        expect(fetchToken).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/email/email/docs/middleware/introduction.mdx
+++ b/packages/email/email/docs/middleware/introduction.mdx
@@ -170,7 +170,9 @@ mail.use(loggingMiddleware({ logger: myLogger, redact: false }));
 
 ## oauth2Middleware
 
-Injects an OAuth2 bearer credential into each outgoing message, caching it until just before expiry and refreshing on demand. Use it for Gmail / Microsoft 365, where access tokens are short-lived. The token can be injected as a request header (default) or handed to the `onToken` callback for SMTP XOAUTH2 clients.
+Injects an OAuth2 bearer credential into each outgoing message, caching it until just before expiry and refreshing on demand. Use it for Gmail / Microsoft 365, where access tokens are short-lived. The token can be injected as a request header (default) or handed to the `onToken` callback for SMTP XOAUTH2 clients. Concurrent sends during a refresh share one in-flight request rather than stampeding the token endpoint.
+
+> **Note:** the [Outlook365 provider](/docs/providers/outlook365) authenticates to Microsoft Graph itself — app-only (client credentials) and delegated (refresh token) flows are built in, so it needs no middleware. Reach for `oauth2Middleware` when a provider takes its credential from a request header, or for SMTP XOAUTH2.
 
 ```typescript
 type OAuth2Token = {

--- a/packages/email/email/docs/providers/outlook365.mdx
+++ b/packages/email/email/docs/providers/outlook365.mdx
@@ -5,14 +5,31 @@ description: Send emails through Microsoft Graph (Outlook365) with @visulima/ema
 
 # Outlook365 Provider
 
-The Outlook365 provider sends emails through the [Microsoft Graph `sendMail` endpoint](https://learn.microsoft.com/en-us/graph/api/user-sendmail).
+The Outlook365 provider sends emails through the [Microsoft Graph `sendMail` endpoint](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+(`POST https://graph.microsoft.com/v1.0/users/{senderUpn}/sendMail`).
 
 **Runtime Support:** Universal (Node.js, Deno, Bun, Cloudflare Workers) — uses the Fetch API.
 
-Authentication is delegated: you supply a static `accessToken` or an async `getAccessToken` (e.g. backed by
-`@azure/msal-node`). The provider never bundles an auth SDK, so it stays dependency-light and runtime-agnostic.
+**Reference:** [app-only auth](https://learn.microsoft.com/en-us/graph/auth-v2-service) ·
+[delegated auth](https://learn.microsoft.com/en-us/graph/auth-v2-user)
 
-## Setup
+No auth SDK is bundled, so the provider stays dependency-light and runtime-agnostic. It supports four
+authentication modes, evaluated in this precedence order:
+
+| Mode                       | When to use                                                   |
+| -------------------------- | ------------------------------------------------------------- |
+| `getAccessToken`           | You already mint tokens (e.g. via `@azure/msal-node`)         |
+| `accessToken`              | A static token — scripts, tests, short-lived jobs             |
+| `refreshToken` (delegated) | Send **as a signed-in user** without them being present       |
+| `clientSecret` (app-only)  | Send as **any mailbox in the tenant** from a daemon / backend |
+
+For the two built-in flows the provider calls the Azure AD token endpoint itself, caches the access token
+until shortly before it expires, and collapses concurrent sends into a single token request.
+
+## App-only (client credentials)
+
+Best for backends sending from a fixed mailbox. In the Azure app registration grant the **application**
+permission `Mail.Send` and click _Grant admin consent_.
 
 ```typescript
 import { createMail } from "@visulima/email";
@@ -20,7 +37,48 @@ import { outlook365Provider } from "@visulima/email/providers/outlook365";
 
 const mail = createMail(
     outlook365Provider({
-        // Bring your own OAuth2 token with the `Mail.Send` scope.
+        tenantId: process.env.AZURE_TENANT_ID,
+        clientId: process.env.AZURE_CLIENT_ID,
+        clientSecret: process.env.AZURE_CLIENT_SECRET,
+        // Required: app-only tokens belong to the app, not a user, so there is no "me" mailbox.
+        userId: "sender@contoso.com",
+    }),
+);
+```
+
+> **Note:** Application permissions grant access to **every** mailbox in the tenant. Scope them down with an
+> [application access policy](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access).
+
+## Delegated (refresh token)
+
+Sends as the user who consented. Grant the **delegated** permission `Mail.Send`, and obtain a refresh token
+through the authorization-code flow with the `offline_access` scope.
+
+```typescript
+const mail = createMail(
+    outlook365Provider({
+        tenantId: process.env.AZURE_TENANT_ID, // or "common"
+        clientId: process.env.AZURE_CLIENT_ID,
+        clientSecret: process.env.AZURE_CLIENT_SECRET, // omit for public clients
+        refreshToken: await loadRefreshToken(),
+        // Azure AD may rotate the refresh token — persist the new one to survive a restart.
+        // Awaited before the token is used; if it rejects, the send still succeeds and the
+        // failure is logged, but the stored token is stale until the next rotation.
+        onRefreshToken: async (token) => saveRefreshToken(token),
+        // userId defaults to "me" — the consenting user's own mailbox.
+    }),
+);
+```
+
+> **Note:** a confidential-client delegated config and an app-only config with a leftover
+> `refreshToken` look identical — both carry `tenantId`, `clientId`, `clientSecret` and
+> `refreshToken`. `refreshToken` wins by default; set `authMode` to pin the flow explicitly.
+
+## Bring your own token
+
+```typescript
+const mail = createMail(
+    outlook365Provider({
         getAccessToken: async () => getGraphAccessToken(),
         userId: "sender@contoso.com", // or "me" (default) to use the token's own mailbox
     }),
@@ -29,19 +87,30 @@ const mail = createMail(
 
 ## Configuration
 
-The `Outlook365Config` interface extends `BaseConfig`. One of `accessToken` / `getAccessToken` is required.
+The `Outlook365Config` interface extends `BaseConfig`. At least one of `accessToken`, `getAccessToken`,
+`refreshToken` or `clientSecret` is required.
 
-| Option            | Type                         | Required | Default                            | Description                                                  |
-| ----------------- | ---------------------------- | -------- | ---------------------------------- | ------------------------------------------------------------ |
-| `accessToken`     | `string`                     | Cond.    | -                                  | Static OAuth2 token with the `Mail.Send` scope               |
-| `getAccessToken`  | `() => MaybePromise<string>` | Cond.    | -                                  | Returns a fresh OAuth2 token (preferred for expiring tokens) |
-| `userId`          | `string`                     | No       | `me`                               | Mailbox to send as (user id / UPN)                           |
-| `saveToSentItems` | `boolean`                    | No       | `true`                             | Keep a copy in the Sent Items folder                         |
-| `endpoint`        | `string`                     | No       | `https://graph.microsoft.com/v1.0` | Custom Graph endpoint                                        |
-| `debug`           | `boolean`                    | No       | `false`                            | Enable debug logging                                         |
-| `logger`          | `Console`                    | No       | -                                  | Custom logger instance                                       |
-| `retries`         | `number`                     | No       | `3`                                | Number of retry attempts                                     |
-| `timeout`         | `number`                     | No       | `30000`                            | Request timeout in milliseconds                              |
+| Option               | Type                                    | Required | Default                             | Description                                                              |
+| -------------------- | --------------------------------------- | -------- | ----------------------------------- | ------------------------------------------------------------------------ |
+| `accessToken`        | `string`                                | Cond.    | -                                   | Static OAuth2 token with the `Mail.Send` scope                           |
+| `getAccessToken`     | `() => MaybePromise<string>`            | Cond.    | -                                   | Returns a fresh OAuth2 token (preferred for expiring tokens)             |
+| `tenantId`           | `string`                                | Cond.    | -                                   | Azure AD tenant id — required by the built-in flows                      |
+| `clientId`           | `string`                                | Cond.    | -                                   | App registration client id — required by the built-in flows              |
+| `clientSecret`       | `string`                                | Cond.    | -                                   | Client secret; alone it selects the app-only flow                        |
+| `refreshToken`       | `string`                                | Cond.    | -                                   | Refresh token; selects the delegated flow                                |
+| `authMode`           | `Outlook365AuthMode`                    | No       | Inferred                            | Pins the flow when a config matches more than one                        |
+| `onRefreshToken`     | `(token: string) => MaybePromise<void>` | No       | -                                   | Awaited when Azure AD rotates the refresh token, so it can be stored     |
+| `scopes`             | `string[]`                              | No       | Flow-dependent                      | Scope override for the built-in flows                                    |
+| `authority`          | `string`                                | No       | `https://login.microsoftonline.com` | Login authority — override for sovereign clouds                          |
+| `tokenRefreshSkewMs` | `number`                                | No       | `60000`                             | Renew the access token this long before it expires; negative clamps to 0 |
+| `now`                | `() => number`                          | No       | `Date.now`                          | Time source in milliseconds — injectable for tests                       |
+| `userId`             | `string`                                | No       | `me`                                | Mailbox to send as (user id / UPN); required for the app-only flow       |
+| `saveToSentItems`    | `boolean`                               | No       | `true`                              | Keep a copy in the Sent Items folder                                     |
+| `endpoint`           | `string`                                | No       | `https://graph.microsoft.com/v1.0`  | Custom Graph endpoint                                                    |
+| `debug`              | `boolean`                               | No       | `false`                             | Enable debug logging                                                     |
+| `logger`             | `Console`                               | No       | -                                   | Custom logger instance                                                   |
+| `retries`            | `number`                                | No       | `3`                                 | Number of retry attempts                                                 |
+| `timeout`            | `number`                                | No       | `30000`                             | Request timeout in milliseconds                                          |
 
 ## Basic Usage
 

--- a/packages/email/email/src/middleware/oauth2.ts
+++ b/packages/email/email/src/middleware/oauth2.ts
@@ -1,20 +1,12 @@
+import type { CacheableToken } from "../utils/create-token-cache";
+import createTokenCache from "../utils/create-token-cache";
 import headersToRecord from "../utils/headers-to-record";
 import type { Middleware } from "./types";
 
 /**
  * An OAuth2 access token plus its expiry.
  */
-export interface OAuth2Token {
-    /**
-     * The bearer access token.
-     */
-    accessToken: string;
-
-    /**
-     * Absolute expiry time in milliseconds since the epoch. Omit for non-expiring tokens.
-     */
-    expiresAt?: number;
-}
+export type OAuth2Token = CacheableToken;
 
 /**
  * Options for the {@link oauth2Middleware}.
@@ -70,20 +62,13 @@ export interface OAuth2MiddlewareOptions {
 export const oauth2Middleware = (options: OAuth2MiddlewareOptions): Middleware => {
     const { fetchToken, headerName = "Authorization", now = Date.now, onToken, scheme = "Bearer", skewMs = 60_000 } = options;
 
-    let cached: OAuth2Token | undefined;
+    const getToken = createTokenCache(async () => {
+        const token = await fetchToken();
 
-    const getToken = async (): Promise<OAuth2Token> => {
-        const valid = cached && (cached.expiresAt === undefined || cached.expiresAt - skewMs > now());
+        onToken?.(token);
 
-        if (valid && cached) {
-            return cached;
-        }
-
-        cached = await fetchToken();
-        onToken?.(cached);
-
-        return cached;
-    };
+        return token;
+    }, { now, skewMs });
 
     return async (emailOptions, next) => {
         const token = await getToken();

--- a/packages/email/email/src/providers/outlook365/auth.ts
+++ b/packages/email/email/src/providers/outlook365/auth.ts
@@ -336,4 +336,4 @@ const createTokenResolver = (auth: ResolvedAuth, config: Outlook365Config, provi
     };
 };
 
-export { createTokenResolver, resolveAuth };
+export { createTokenResolver, DEFAULT_AUTHORITY, resolveAuth };

--- a/packages/email/email/src/providers/outlook365/auth.ts
+++ b/packages/email/email/src/providers/outlook365/auth.ts
@@ -1,0 +1,339 @@
+import EmailError from "../../errors/email-error";
+import RequiredOptionError from "../../errors/required-option-error";
+import type { Result } from "../../types";
+import type { Logger } from "../../utils/create-logger";
+import createTokenCache from "../../utils/create-token-cache";
+import { makeRequest } from "../../utils/make-request";
+import retry from "../../utils/retry";
+import type { Outlook365AuthMode, Outlook365Config } from "./types";
+
+const DEFAULT_AUTHORITY = "https://login.microsoftonline.com";
+const DEFAULT_SKEW_MS = 60_000;
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_RETRIES = 3;
+
+/**
+ * Lifetime assumed when Azure AD omits `expires_in`. Deliberately short: caching a token whose
+ * real lifetime is unknown risks serving a dead one, and a needless refresh is cheap.
+ */
+const FALLBACK_EXPIRES_IN_SECONDS = 300;
+
+/**
+ * Scope used by the app-only (client credentials) flow — permissions come from the app
+ * registration's admin-consented roles, so `.default` is the only valid request.
+ */
+const APP_ONLY_SCOPE = "https://graph.microsoft.com/.default";
+
+/**
+ * Scopes used by the delegated (refresh token) flow. `offline_access` keeps a refresh
+ * token in the response so the resolver can keep renewing without user interaction.
+ */
+const DELEGATED_SCOPES = ["https://graph.microsoft.com/Mail.Send", "offline_access"];
+
+/**
+ * Returns a bearer token valid for the Graph `sendMail` call.
+ */
+type TokenResolver = () => Promise<string>;
+
+/**
+ * A config resolved to exactly one flow, with that flow's credentials proven present. Resolving
+ * once up front means the fetch path never re-narrows the loose config.
+ */
+type ResolvedAuth
+    = | { clientId: string; clientSecret: string; mode: "clientCredentials"; tenantId: string }
+        | { clientId: string; clientSecret?: string; mode: "refreshToken"; refreshToken: string; tenantId: string }
+        | { getToken: TokenResolver; mode: "accessToken" }
+        | { getToken: TokenResolver; mode: "getAccessToken" };
+
+/**
+ * Config fields that only mean something for a given flow. Used to warn when a flow was chosen
+ * that silently ignores credentials the caller supplied.
+ */
+const IGNORED_FIELDS_BY_MODE: Record<Outlook365AuthMode, (keyof Outlook365Config)[]> = {
+    accessToken: ["clientId", "clientSecret", "refreshToken", "tenantId"],
+    clientCredentials: ["refreshToken"],
+    getAccessToken: ["accessToken", "clientId", "clientSecret", "refreshToken", "tenantId"],
+    refreshToken: [],
+};
+
+/**
+ * A token response parsed into the fields this provider needs.
+ */
+interface ParsedTokenResponse {
+    accessToken: string;
+    expiresIn: number;
+    refreshToken?: string;
+}
+
+/**
+ * Strips trailing slashes without a regex — `/\/+$/` trips `sonarjs/slow-regex` even at module
+ * scope, since it backtracks super-linearly.
+ * @param value The string to trim.
+ * @returns The value without trailing slashes.
+ */
+const stripTrailingSlashes = (value: string): string => {
+    let endIndex = value.length;
+
+    while (endIndex > 0 && value[endIndex - 1] === "/") {
+        endIndex -= 1;
+    }
+
+    return value.slice(0, endIndex);
+};
+
+/**
+ * Picks the flow implied by the supplied credentials. A caller-supplied token always wins, so an
+ * explicit `accessToken` / `getAccessToken` overrides an otherwise complete built-in config.
+ * @param config The provider config.
+ * @param providerName Provider name used in thrown errors.
+ * @returns The inferred auth mode.
+ */
+const inferAuthMode = (config: Outlook365Config, providerName: string): Outlook365AuthMode => {
+    if (config.getAccessToken) {
+        return "getAccessToken";
+    }
+
+    if (config.accessToken) {
+        return "accessToken";
+    }
+
+    if (config.refreshToken) {
+        return "refreshToken";
+    }
+
+    if (config.clientSecret) {
+        return "clientCredentials";
+    }
+
+    throw new RequiredOptionError(providerName, ["accessToken", "getAccessToken", "clientSecret", "refreshToken"]);
+};
+
+/**
+ * Resolves the config to exactly one flow and proves that flow's required options are present.
+ * @param config The provider config.
+ * @param providerName Provider name used in thrown errors.
+ * @param logger Receives warnings about credentials the chosen flow ignores.
+ * @returns The resolved auth.
+ */
+// eslint-disable-next-line sonarjs/cognitive-complexity
+const resolveAuth = (config: Outlook365Config, providerName: string, logger: Logger): ResolvedAuth => {
+    const mode = config.authMode ?? inferAuthMode(config, providerName);
+
+    const ignored = IGNORED_FIELDS_BY_MODE[mode].filter((field) => config[field] !== undefined);
+
+    if (ignored.length > 0) {
+        logger.warn(`The '${mode}' auth mode ignores these configured options: ${ignored.join(", ")}. Set 'authMode' to pin the intended flow.`);
+    }
+
+    if (mode === "getAccessToken") {
+        const { getAccessToken } = config;
+
+        if (!getAccessToken) {
+            throw new RequiredOptionError(providerName, "getAccessToken");
+        }
+
+        return { getToken: async () => getAccessToken(), mode };
+    }
+
+    if (mode === "accessToken") {
+        const { accessToken } = config;
+
+        if (!accessToken) {
+            throw new RequiredOptionError(providerName, "accessToken");
+        }
+
+        return { getToken: () => Promise.resolve(accessToken), mode };
+    }
+
+    const { clientId, clientSecret, refreshToken, tenantId } = config;
+
+    const missing: string[] = [];
+
+    if (!tenantId) {
+        missing.push("tenantId");
+    }
+
+    if (!clientId) {
+        missing.push("clientId");
+    }
+
+    if (mode === "clientCredentials" && !clientSecret) {
+        missing.push("clientSecret");
+    }
+
+    if (mode === "refreshToken" && !refreshToken) {
+        missing.push("refreshToken");
+    }
+
+    // Each throw below reports the full `missing` list, so one error names every absent option.
+    if (!tenantId || !clientId) {
+        throw new RequiredOptionError(providerName, missing);
+    }
+
+    if (mode === "clientCredentials") {
+        if (!clientSecret) {
+            throw new RequiredOptionError(providerName, missing);
+        }
+
+        return { clientId, clientSecret, mode, tenantId };
+    }
+
+    if (!refreshToken) {
+        throw new RequiredOptionError(providerName, missing);
+    }
+
+    return { clientId, clientSecret, mode, refreshToken, tenantId };
+};
+
+/**
+ * Reads the token endpoint payload, converting an OAuth2 error response into an {@link EmailError}.
+ * @param body The parsed response body.
+ * @param providerName Provider name used in thrown errors.
+ * @param statusCode The HTTP status code of the token response.
+ * @returns The access token, its lifetime in seconds, and a rotated refresh token when present.
+ */
+const readTokenResponse = (body: unknown, providerName: string, statusCode: number): ParsedTokenResponse => {
+    if (typeof body !== "object" || body === null) {
+        throw new EmailError(providerName, `Token endpoint returned a non-JSON response (status ${String(statusCode)})`);
+    }
+
+    const payload = body as Record<string, unknown>;
+
+    if (typeof payload.error === "string") {
+        const description = typeof payload.error_description === "string" ? payload.error_description : "no description provided";
+
+        throw new EmailError(providerName, `Token request failed: ${payload.error} — ${description}`, {
+            code: payload.error,
+            hint: "Check the tenantId, clientId and client secret / refresh token in the Azure app registration.",
+        });
+    }
+
+    if (typeof payload.access_token !== "string") {
+        throw new EmailError(providerName, `Token endpoint response did not contain an access_token (status ${String(statusCode)})`);
+    }
+
+    return {
+        accessToken: payload.access_token,
+        expiresIn: typeof payload.expires_in === "number" ? payload.expires_in : FALLBACK_EXPIRES_IN_SECONDS,
+        refreshToken: typeof payload.refresh_token === "string" ? payload.refresh_token : undefined,
+    };
+};
+
+/**
+ * Azure AD throttles the token endpoint (429) and can return 5xx; a status of 0 means the
+ * request never landed. Credential errors (400/401) will never succeed on a retry.
+ * @param statusCode The HTTP status code.
+ * @returns Whether the request is worth retrying.
+ */
+const isRetryableStatus = (statusCode: number): boolean => statusCode === 0 || statusCode === 408 || statusCode === 429 || statusCode >= 500;
+
+/**
+ * Builds a token resolver for the resolved auth, caching the token until shortly before it
+ * expires and collapsing concurrent refreshes into a single request.
+ * @param auth The resolved auth.
+ * @param config The provider config, for transport and cache tuning.
+ * @param providerName Provider name used in thrown errors.
+ * @param logger Receives refresh-token persistence failures.
+ * @returns A function returning a valid bearer token.
+ */
+const createTokenResolver = (auth: ResolvedAuth, config: Outlook365Config, providerName: string, logger: Logger): TokenResolver => {
+    if (auth.mode === "accessToken" || auth.mode === "getAccessToken") {
+        return auth.getToken;
+    }
+
+    const authority = stripTrailingSlashes(config.authority ?? DEFAULT_AUTHORITY);
+    const tokenUrl = `${authority}/${auth.tenantId}/oauth2/v2.0/token`;
+    const timeout = config.timeout ?? DEFAULT_TIMEOUT;
+    const retries = config.retries ?? DEFAULT_RETRIES;
+    const now = config.now ?? Date.now;
+
+    // Azure AD may rotate the refresh token on every use, so track the latest one rather than
+    // replaying the original — a stale token gets rejected once rotation is enabled.
+    let refreshToken = auth.mode === "refreshToken" ? auth.refreshToken : undefined;
+
+    const buildBody = (): string => {
+        const body = new URLSearchParams({
+            client_id: auth.clientId,
+            scope: (config.scopes ?? (auth.mode === "clientCredentials" ? [APP_ONLY_SCOPE] : DELEGATED_SCOPES)).join(" "),
+        });
+
+        if (auth.clientSecret) {
+            body.set("client_secret", auth.clientSecret);
+        }
+
+        if (auth.mode === "clientCredentials") {
+            body.set("grant_type", "client_credentials");
+        } else {
+            body.set("grant_type", "refresh_token");
+            body.set("refresh_token", refreshToken as string);
+        }
+
+        return body.toString();
+    };
+
+    const readStatus = (result: Result): number => (result.data as { statusCode?: number } | undefined)?.statusCode ?? 0;
+
+    /**
+     * `retry` retries whenever the result is unsuccessful, so only transient failures are
+     * reported as such — a bad secret is returned as "successful transport" for the caller to
+     * parse, rather than being retried three times with backoff.
+     */
+    const requestToken = async (): Promise<Result> => {
+        const result = await makeRequest(tokenUrl, { headers: { "Content-Type": "application/x-www-form-urlencoded" }, method: "POST", timeout }, buildBody());
+
+        if (!result.success && isRetryableStatus(readStatus(result))) {
+            return result;
+        }
+
+        return { data: result.data, success: true };
+    };
+
+    const persistRotatedToken = async (rotated: string): Promise<void> => {
+        // Adopt before persisting: Azure AD has already invalidated the previous token, so the
+        // rotated one is the only usable value whether or not the caller can store it.
+        refreshToken = rotated;
+
+        if (!config.onRefreshToken) {
+            return;
+        }
+
+        try {
+            await config.onRefreshToken(rotated);
+        } catch (error) {
+            // The access token in hand is still valid, so failing the send here would be
+            // spurious — but the stored token is now stale and will break on restart.
+            logger.error(
+                `Failed to persist the rotated refresh token — the stored token is stale and sending will fail after a restart: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    };
+
+    const fetchToken = async (): Promise<{ accessToken: string; expiresAt: number }> => {
+        const result = await retry(requestToken, retries);
+        const responseBody = (result.data as { body?: unknown } | undefined)?.body;
+
+        // A non-2xx token response still carries an OAuth2 error payload, which is far more useful
+        // than the generic transport error, so parse the body before falling back to result.error.
+        if (!result.success && (typeof responseBody !== "object" || responseBody === null)) {
+            throw result.error instanceof Error ? result.error : new EmailError(providerName, "Token request failed");
+        }
+
+        const parsed = readTokenResponse(responseBody, providerName, readStatus(result));
+
+        if (parsed.refreshToken && parsed.refreshToken !== refreshToken) {
+            await persistRotatedToken(parsed.refreshToken);
+        }
+
+        return { accessToken: parsed.accessToken, expiresAt: now() + parsed.expiresIn * 1000 };
+    };
+
+    const getToken = createTokenCache(fetchToken, { now, skewMs: config.tokenRefreshSkewMs ?? DEFAULT_SKEW_MS });
+
+    return async (): Promise<string> => {
+        const token = await getToken();
+
+        return token.accessToken;
+    };
+};
+
+export { createTokenResolver, resolveAuth };

--- a/packages/email/email/src/providers/outlook365/index.ts
+++ b/packages/email/email/src/providers/outlook365/index.ts
@@ -1,3 +1,3 @@
 export type { Provider, ProviderFactory } from "../provider";
 export { default as outlook365Provider } from "./provider";
-export type { Outlook365Config, Outlook365EmailOptions } from "./types";
+export type { Outlook365AuthMode, Outlook365Config, Outlook365EmailOptions } from "./types";

--- a/packages/email/email/src/providers/outlook365/provider.ts
+++ b/packages/email/email/src/providers/outlook365/provider.ts
@@ -7,7 +7,7 @@ import validateEmailOptions from "../../utils/validation/validate-email-options"
 import type { ProviderFactory } from "../provider";
 import { defineProvider } from "../provider";
 import { createProviderLogger, createStandardAttachment, handleProviderError, ProviderState } from "../utils";
-import { createTokenResolver, resolveAuth } from "./auth";
+import { createTokenResolver, DEFAULT_AUTHORITY, resolveAuth } from "./auth";
 import type { Outlook365Config, Outlook365EmailOptions } from "./types";
 
 const PROVIDER_NAME = "outlook365";
@@ -77,7 +77,7 @@ const outlook365Provider: ProviderFactory<Outlook365Config, unknown, Outlook365E
     // resolver closes over `config` instead, which also keeps it immune to mutations here.
     const options: ResolvedOptions = {
         authMode: auth.mode,
-        authority: config.authority,
+        authority: config.authority ?? DEFAULT_AUTHORITY,
         clientId: config.clientId,
         debug: config.debug ?? false,
         endpoint: config.endpoint ?? DEFAULT_ENDPOINT,

--- a/packages/email/email/src/providers/outlook365/provider.ts
+++ b/packages/email/email/src/providers/outlook365/provider.ts
@@ -1,5 +1,4 @@
 import EmailError from "../../errors/email-error";
-import RequiredOptionError from "../../errors/required-option-error";
 import type { EmailAddress, EmailResult, Result } from "../../types";
 import generateMessageId from "../../utils/generate-message-id";
 import { makeRequest } from "../../utils/make-request";
@@ -8,6 +7,7 @@ import validateEmailOptions from "../../utils/validation/validate-email-options"
 import type { ProviderFactory } from "../provider";
 import { defineProvider } from "../provider";
 import { createProviderLogger, createStandardAttachment, handleProviderError, ProviderState } from "../utils";
+import { createTokenResolver, resolveAuth } from "./auth";
 import type { Outlook365Config, Outlook365EmailOptions } from "./types";
 
 const PROVIDER_NAME = "outlook365";
@@ -23,36 +23,77 @@ const toGraphRecipients = (addresses: EmailAddress[]): { emailAddress: { address
     });
 
 /**
- * Outlook365 provider — sends email through the Microsoft Graph `sendMail` endpoint.
+ * Converts a token-acquisition failure into an {@link EmailError}.
+ *
+ * The built-in flows already throw a descriptive EmailError (e.g. the AADSTS code from Azure AD)
+ * — re-wrapping it would bury the diagnostic. Anything else (a transport error, a throwing
+ * `getAccessToken`) keeps its message.
+ * @param error The thrown value.
+ * @returns The error to report.
  */
-const outlook365Provider: ProviderFactory<Outlook365Config> = defineProvider((config: Outlook365Config = {}) => {
-    if (!config.accessToken && !config.getAccessToken) {
-        throw new RequiredOptionError(PROVIDER_NAME, ["accessToken", "getAccessToken"]);
+const toTokenError = (error: unknown): EmailError => {
+    if (error instanceof EmailError) {
+        return error;
     }
 
-    const options: Pick<Outlook365Config, "accessToken" | "getAccessToken" | "logger">
-        & Required<Omit<Outlook365Config, "accessToken" | "getAccessToken" | "logger">> = {
-            accessToken: config.accessToken,
-            debug: config.debug ?? false,
-            endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
-            getAccessToken: config.getAccessToken,
-            logger: config.logger,
-            retries: config.retries ?? DEFAULT_RETRIES,
-            saveToSentItems: config.saveToSentItems ?? true,
-            timeout: config.timeout ?? DEFAULT_TIMEOUT,
-            userId: config.userId ?? "me",
-        };
+    const reason = error instanceof Error ? error.message : String(error);
 
-    const providerState = new ProviderState();
+    return new EmailError(PROVIDER_NAME, `Failed to obtain access token: ${reason}`, { cause: error });
+};
+
+/**
+ * The publicly readable `provider.options` — every option the provider defaults is guaranteed
+ * present, and every credential is omitted.
+ */
+type ResolvedOptions = Omit<Outlook365Config, "accessToken" | "clientSecret" | "getAccessToken" | "onRefreshToken" | "refreshToken">
+    & Required<Pick<Outlook365Config, "debug" | "endpoint" | "retries" | "saveToSentItems" | "timeout" | "userId">>;
+
+/**
+ * Outlook365 provider — sends email through the Microsoft Graph `sendMail` endpoint.
+ *
+ * Authenticates with a caller-supplied token (`accessToken` / `getAccessToken`), the delegated
+ * refresh-token flow, or the app-only client-credentials flow. See {@link Outlook365Config}.
+ */
+const outlook365Provider: ProviderFactory<Outlook365Config, unknown, Outlook365EmailOptions> = defineProvider<
+    Outlook365Config,
+    unknown,
+    Outlook365EmailOptions
+>((config: Outlook365Config = {}) => {
     const logger = createProviderLogger(PROVIDER_NAME, config.logger);
 
-    const resolveToken = async (): Promise<string> => {
-        if (options.getAccessToken) {
-            return options.getAccessToken();
-        }
+    // Throws unless exactly one flow's credentials are present.
+    const auth = resolveAuth(config, PROVIDER_NAME, logger);
 
-        return options.accessToken as string;
+    // App-only tokens belong to the application, not a user, so Graph rejects `/me` with
+    // "/me request is only valid with delegated authentication flow".
+    if (auth.mode === "clientCredentials" && (config.userId === undefined || config.userId === "me")) {
+        throw new EmailError(PROVIDER_NAME, "The app-only (client credentials) flow requires an explicit 'userId'", {
+            hint: "Set 'userId' to the sender's mailbox id or UPN — app-only tokens have no 'me' mailbox.",
+        });
+    }
+
+    // Credentials are deliberately kept out of `options`: it is a public field, so a crash
+    // reporter or a `console.log(provider.options)` would otherwise dump a client secret. The
+    // resolver closes over `config` instead, which also keeps it immune to mutations here.
+    const options: ResolvedOptions = {
+        authMode: auth.mode,
+        authority: config.authority,
+        clientId: config.clientId,
+        debug: config.debug ?? false,
+        endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
+        logger: config.logger,
+        now: config.now,
+        retries: config.retries ?? DEFAULT_RETRIES,
+        saveToSentItems: config.saveToSentItems ?? true,
+        scopes: config.scopes,
+        tenantId: config.tenantId,
+        timeout: config.timeout ?? DEFAULT_TIMEOUT,
+        tokenRefreshSkewMs: config.tokenRefreshSkewMs,
+        userId: config.userId ?? "me",
     };
+
+    const providerState = new ProviderState();
+    const resolveToken = createTokenResolver(auth, config, PROVIDER_NAME, logger);
 
     return {
         features: {
@@ -74,7 +115,9 @@ const outlook365Provider: ProviderFactory<Outlook365Config> = defineProvider((co
 
         // eslint-disable-next-line @typescript-eslint/require-await
         async isAvailable(): Promise<boolean> {
-            return Boolean(options.accessToken ?? options.getAccessToken);
+            // Always true: the factory throws unless a flow's credentials are present. Reaching
+            // the token endpoint is `validateCredentials`'s job.
+            return true;
         },
 
         name: PROVIDER_NAME,
@@ -94,7 +137,7 @@ const outlook365Provider: ProviderFactory<Outlook365Config> = defineProvider((co
                 try {
                     accessToken = await resolveToken();
                 } catch (error) {
-                    return { error: new EmailError(PROVIDER_NAME, "Failed to obtain access token", { cause: error }), success: false };
+                    return { error: toTokenError(error), success: false };
                 }
 
                 const message: Record<string, unknown> = {
@@ -165,7 +208,19 @@ const outlook365Provider: ProviderFactory<Outlook365Config> = defineProvider((co
         },
 
         async validateCredentials(): Promise<boolean> {
-            return this.isAvailable();
+            // For the built-in flows this round-trips the Azure AD token endpoint; for a
+            // caller-supplied token it only confirms the source resolves.
+            try {
+                await resolveToken();
+
+                return true;
+            } catch (error) {
+                // Warn, not debug: the boolean throws away the AADSTS reason, so this log is the
+                // only place it survives.
+                logger.warn(`Credential validation failed: ${error instanceof Error ? error.message : String(error)}`);
+
+                return false;
+            }
         },
     };
 });

--- a/packages/email/email/src/providers/outlook365/types.ts
+++ b/packages/email/email/src/providers/outlook365/types.ts
@@ -1,11 +1,26 @@
 import type { BaseConfig, EmailOptions, MaybePromise } from "../../types";
 
 /**
+ * Which OAuth2 flow a config resolves to.
+ */
+export type Outlook365AuthMode = "accessToken" | "clientCredentials" | "getAccessToken" | "refreshToken";
+
+/**
  * Outlook365 / Microsoft Graph configuration.
  *
- * Authentication is delegated: supply a static `accessToken` or an async
- * `getAccessToken` (e.g. backed by `@azure/msal-node`). The provider never bundles an
- * auth SDK, so it stays dependency-light and runtime-agnostic.
+ * Four authentication modes are supported, in precedence order:
+ *
+ * 1. `getAccessToken` — bring your own async token source (e.g. `@azure/msal-node`).
+ * 2. `accessToken` — a static token, for scripts and tests.
+ * 3. `refreshToken` — delegated flow; the provider exchanges the refresh token for access tokens and caches them. Requires `tenantId` + `clientId`.
+ * 4. `clientSecret` — app-only flow (client credentials). Requires `tenantId` + `clientId`, and `userId` must name a real mailbox, since app-only tokens have no `me`.
+ *
+ * A confidential-client delegated config and an app-only config with a leftover `refreshToken`
+ * are indistinguishable — both carry `tenantId`, `clientId`, `clientSecret` and `refreshToken`.
+ * Set {@link Outlook365Config.authMode} to pin the flow when both are present.
+ *
+ * The built-in flows talk to the Azure AD token endpoint over `fetch` — no auth SDK is
+ * bundled, so the provider stays dependency-light and runtime-agnostic.
  */
 export interface Outlook365Config extends BaseConfig {
     /**
@@ -13,6 +28,32 @@ export interface Outlook365Config extends BaseConfig {
      * {@link Outlook365Config.getAccessToken} for tokens that expire.
      */
     accessToken?: string;
+
+    /**
+     * Pins the authentication flow instead of inferring it from which credentials are present.
+     * Use it when a config could match more than one flow — most notably `clientCredentials`
+     * vs `refreshToken` when both a client secret and a refresh token are supplied.
+     */
+    authMode?: Outlook365AuthMode;
+
+    /**
+     * Azure AD login authority (default `https://login.microsoftonline.com`). Override for
+     * sovereign clouds, e.g. `https://login.microsoftonline.us`.
+     */
+    authority?: string;
+
+    /**
+     * Application (client) id of the Azure AD app registration. Required by the
+     * `refreshToken` and `clientSecret` flows.
+     */
+    clientId?: string;
+
+    /**
+     * Client secret of the Azure AD app registration. Supplying this without a
+     * {@link Outlook365Config.refreshToken} selects the app-only (client credentials) flow.
+     * It is also sent with the delegated flow when the app is a confidential client.
+     */
+    clientSecret?: string;
 
     /**
      * API endpoint override (default `https://graph.microsoft.com/v1.0`).
@@ -25,12 +66,57 @@ export interface Outlook365Config extends BaseConfig {
     getAccessToken?: () => MaybePromise<string>;
 
     /**
+     * Time source in milliseconds — injectable for tests. Defaults to `Date.now`.
+     */
+    now?: () => number;
+
+    /**
+     * Called whenever Azure AD rotates the refresh token, so it can be persisted. Awaited
+     * before the access token is handed out, so a rejected promise is reported rather than
+     * surfacing as an unhandled rejection.
+     *
+     * The rotated token is adopted in-process regardless of whether persisting succeeds — the
+     * previous token is already dead at Azure AD, so the new one is the only usable value. A
+     * persist failure is logged rather than failing the send, but the stored token is then
+     * stale and sending will break on restart.
+     * @param refreshToken The new refresh token.
+     */
+    onRefreshToken?: (refreshToken: string) => MaybePromise<void>;
+
+    /**
+     * A long-lived OAuth2 refresh token, selecting the delegated flow. Obtain it via the
+     * authorization-code flow with the `offline_access` scope.
+     */
+    refreshToken?: string;
+
+    /**
      * Whether to keep a copy in the Sent Items folder (default true).
      */
     saveToSentItems?: boolean;
 
     /**
+     * Scope override for the built-in flows. Defaults to
+     * `["https://graph.microsoft.com/.default"]` for the app-only flow and
+     * `["https://graph.microsoft.com/Mail.Send", "offline_access"]` for the delegated flow.
+     */
+    scopes?: string[];
+
+    /**
+     * Azure AD tenant id (or `common` / `organizations` for the delegated flow). Required by
+     * the `refreshToken` and `clientSecret` flows.
+     */
+    tenantId?: string;
+
+    /**
+     * Renew the access token this many milliseconds before it expires (default 60000).
+     * Negative values are clamped to 0. A value larger than the token lifetime disables
+     * caching, costing one token request per send.
+     */
+    tokenRefreshSkewMs?: number;
+
+    /**
      * The mailbox to send as: a user id/UPN. Defaults to `me` (the token's own mailbox).
+     * The app-only flow has no `me`, so it requires an explicit value.
      */
     userId?: string;
 }

--- a/packages/email/email/src/providers/outlook365/types.ts
+++ b/packages/email/email/src/providers/outlook365/types.ts
@@ -13,7 +13,7 @@ export type Outlook365AuthMode = "accessToken" | "clientCredentials" | "getAcces
  * 1. `getAccessToken` — bring your own async token source (e.g. `@azure/msal-node`).
  * 2. `accessToken` — a static token, for scripts and tests.
  * 3. `refreshToken` — delegated flow; the provider exchanges the refresh token for access tokens and caches them. Requires `tenantId` + `clientId`.
- * 4. `clientSecret` — app-only flow (client credentials). Requires `tenantId` + `clientId`, and `userId` must name a real mailbox, since app-only tokens have no `me`.
+ * 4. `clientCredentials` (selected by supplying `clientSecret`) — app-only flow. Requires `tenantId` + `clientId`, and `userId` must name a real mailbox, since app-only tokens have no `me`.
  *
  * A confidential-client delegated config and an app-only config with a leftover `refreshToken`
  * are indistinguishable — both carry `tenantId`, `clientId`, `clientSecret` and `refreshToken`.

--- a/packages/email/email/src/utils/create-token-cache.ts
+++ b/packages/email/email/src/utils/create-token-cache.ts
@@ -1,0 +1,82 @@
+/**
+ * A token that may carry an absolute expiry.
+ */
+interface CacheableToken {
+    /**
+     * The bearer access token.
+     */
+    accessToken: string;
+
+    /**
+     * Absolute expiry time in milliseconds since the epoch. Omit for non-expiring tokens.
+     */
+    expiresAt?: number;
+}
+
+/**
+ * Options for {@link createTokenCache}.
+ */
+interface TokenCacheOptions {
+    /**
+     * Time source in milliseconds — injectable for tests.
+     * @default Date.now
+     */
+    now?: () => number;
+
+    /**
+     * Refresh this many milliseconds before the token actually expires.
+     * @default 60000
+     */
+    skewMs?: number;
+}
+
+const DEFAULT_SKEW_MS = 60_000;
+
+/**
+ * Wraps a token fetcher with caching: the token is reused until `skewMs` before it expires, and
+ * concurrent callers during a refresh share one in-flight request rather than stampeding the
+ * token endpoint.
+ *
+ * A failed fetch is never cached, and rejects every waiter of that attempt — the next call
+ * retries from scratch.
+ * @param fetchToken Acquires (or renews) the token.
+ * @param options Cache configuration. See {@link TokenCacheOptions}.
+ * @returns A function returning a valid token.
+ */
+const createTokenCache = <T extends CacheableToken>(fetchToken: () => Promise<T>, options: TokenCacheOptions = {}): () => Promise<T> => {
+    const { now = Date.now, skewMs = DEFAULT_SKEW_MS } = options;
+
+    // A negative skew would hand out tokens past their expiry.
+    const effectiveSkewMs = Math.max(0, skewMs);
+
+    let cached: T | undefined;
+    let pending: Promise<T> | undefined;
+
+    const isFresh = (token: T): boolean => token.expiresAt === undefined || token.expiresAt - effectiveSkewMs > now();
+
+    return async (): Promise<T> => {
+        if (cached && isFresh(cached)) {
+            return cached;
+        }
+
+        // Collapse a burst of concurrent callers into one fetch. `cached` is only assigned on
+        // success, so a failed refresh cannot poison the cache; `finally` clears `pending` on
+        // both paths, so the next call retries.
+        pending ??= fetchToken()
+            .then((token) => {
+                cached = token;
+
+                return token;
+            })
+            .finally(() => {
+                pending = undefined;
+            });
+
+        const token = await pending;
+
+        return token;
+    };
+};
+
+export type { CacheableToken, TokenCacheOptions };
+export default createTokenCache;


### PR DESCRIPTION
## What

The `outlook365` provider already sent through the Microsoft Graph [`sendMail` endpoint](https://learn.microsoft.com/en-us/graph/api/user-sendmail), but required a caller-supplied access token. This adds the two OAuth2 flows from the Graph auth docs, talking to the Azure AD token endpoint over `fetch` — no auth SDK is bundled, so the provider stays dependency-light and runtime-agnostic.

- **App-only / client credentials** ([docs](https://learn.microsoft.com/en-us/graph/auth-v2-service)) — `tenantId` + `clientId` + `clientSecret`, scope `https://graph.microsoft.com/.default`
- **Delegated / refresh token** ([docs](https://learn.microsoft.com/en-us/graph/auth-v2-user)) — `tenantId` + `clientId` + `refreshToken`, scopes `Mail.Send` + `offline_access`

Existing `accessToken` / `getAccessToken` configs keep working and take precedence — **backward compatible**.

## Notable behaviour

- **App-only requires an explicit `userId`.** Graph rejects `/me` for app-only tokens (`/me request is only valid with delegated authentication flow`), so the combination now throws at construction instead of failing on every send.
- **`onRefreshToken` is awaited**, typed `MaybePromise<void>`. Azure AD rotates refresh tokens; a dropped promise surfaced as an unhandled rejection (a process crash on Node 15+) and left the stored token dead after a restart. The rotated token is adopted regardless of whether persisting succeeds — the previous one is already invalid at Azure — and a persist failure is logged rather than failing the send.
- **The token request is retried** on transient failures (408/429/5xx) but not on credential rejections, which can never succeed. Previously the auth leg had no retry at all, so a single Azure throttle killed the send.
- **`authMode` pins the flow.** A confidential-client delegated config and an app-only config with a stale `refreshToken` are indistinguishable — both carry all four fields. `refreshToken` wins by default; `authMode` disambiguates. A warning fires when the chosen flow ignores supplied credentials.
- **Credentials are kept out of `provider.options`**, which is a public field.

## Refactor

Extracts `createTokenCache` (`src/utils/create-token-cache.ts`), now shared with `oauth2Middleware` — it rebuilt the same expiry-skew cache and stampeded the token endpoint on concurrent sends. It inherits single-flight collapsing from this change.

## Testing

- `1559` tests passing (20 new), typecheck, ESLint, secretlint and build all clean.
- New coverage includes both flows, token caching/expiry/skew, single-flight collapsing, refresh-token rotation, retry vs. non-retry paths, the unhandled-rejection fix, error surfacing (`AADSTS…` codes), and credential redaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded Outlook365 Microsoft Graph auth modes, including app-only and delegated refresh-token support, plus explicit auth-mode selection.
  * Introduced refresh-token rotation persistence via an `onRefreshToken` callback.
  * Added shared token caching with automatic reuse near expiry and safer concurrent refresh.
  * Exported `Outlook365AuthMode`.

* **Documentation**
  * Updated Outlook365 provider and authentication guidance with clearer configuration precedence and `sendMail` details.
  * Clarified when `oauth2Middleware` is (and isn’t) required.

* **Bug Fixes**
  * Improved token acquisition error handling, credential validation behavior, and transient retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->