### PR TITLE
feat(email): add autosend provider

### DIFF
--- a/packages/email/email/README.md
+++ b/packages/email/email/README.md
@@ -346,10 +346,11 @@ const roundRobin = roundRobinProvider({
 AutoSend is a transactional and marketing email service with volume-based pricing. Universal runtime (Fetch API).
 
 ```typescript
-import { createMail, autosendProvider } from "@visulima/email/providers/autosend";
+import { createMail } from "@visulima/email";
+import { autoSendProvider } from "@visulima/email/providers/autosend";
 
 const mail = createMail(
-    autosendProvider({
+    autoSendProvider({
         apiKey: process.env.AUTOSEND_API_KEY,
     }),
 );

--- a/packages/email/email/README.md
+++ b/packages/email/email/README.md
@@ -341,6 +341,32 @@ const roundRobin = roundRobinProvider({
 
 **Note:** The round-robin provider starts at a random provider and then rotates through providers for each subsequent email. If a provider is unavailable, it will automatically try the next provider in the rotation.
 
+### AutoSend Provider
+
+AutoSend is a transactional and marketing email service with volume-based pricing. Universal runtime (Fetch API).
+
+```typescript
+import { createMail, autosendProvider } from "@visulima/email/providers/autosend";
+
+const mail = createMail(
+    autosendProvider({
+        apiKey: process.env.AUTOSEND_API_KEY,
+    }),
+);
+
+await mail.send({
+    from: { email: "hello@mail.yourdomain.com", name: "Your Company" },
+    to: { email: "customer@example.com", name: "Jane Doe" },
+    subject: "Welcome!",
+    html: "<h1>Thanks for signing up.</h1>",
+    // AutoSend-specific: templateId, dynamicData, trackingOpen, trackingClick,
+    // unsubscribeGroupId, bypassSuppressions
+});
+```
+
+AutoSend's send endpoint takes a **single** `to` recipient (max 50 across to/cc/bcc). Passing several
+is rejected rather than silently truncated.
+
 ### Mailgun Provider
 
 Mailgun is a developer-friendly email API service built for transactional emails and automated messaging.

--- a/packages/email/email/__tests__/providers/autosend.test.ts
+++ b/packages/email/email/__tests__/providers/autosend.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import EmailError from "../../src/errors/email-error";
 import RequiredOptionError from "../../src/errors/required-option-error";
-import { autosendProvider } from "../../src/providers/autosend/index";
+import { autoSendProvider } from "../../src/providers/autosend/index";
 import type { AutoSendEmailOptions } from "../../src/providers/autosend/types";
 import { makeRequest } from "../../src/utils/make-request";
 
@@ -32,7 +33,7 @@ const baseEmail: AutoSendEmailOptions = {
 
 const requestBody = (): Record<string, unknown> => JSON.parse((makeRequest as ReturnType<typeof vi.fn>).mock.calls[0][2] as string) as Record<string, unknown>;
 
-describe(autosendProvider, () => {
+describe(autoSendProvider, () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -40,7 +41,7 @@ describe(autosendProvider, () => {
     it("throws without an apiKey", () => {
         expect.assertions(1);
 
-        expect(() => autosendProvider({} as never)).toThrow(RequiredOptionError);
+        expect(() => autoSendProvider({} as never)).toThrow(RequiredOptionError);
     });
 
     it("posts to the send endpoint with a bearer token and returns the emailId", async () => {
@@ -50,7 +51,7 @@ describe(autosendProvider, () => {
 
         makeRequestMock.mockResolvedValueOnce(okResponse);
 
-        const result = await autosendProvider({ apiKey: "as_key" }).sendEmail(baseEmail);
+        const result = await autoSendProvider({ apiKey: "as_key" }).sendEmail(baseEmail);
 
         expect(result.success).toBe(true);
         expect(result.data?.messageId).toBe("698afb75ff4bc5466e3a797a");
@@ -66,7 +67,7 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
-        await autosendProvider({ apiKey: "k" }).sendEmail({
+        await autoSendProvider({ apiKey: "k" }).sendEmail({
             ...baseEmail,
             bcc: { email: "bcc@example.com" },
             cc: [{ email: "cc1@example.com", name: "CC One" }, { email: "cc2@example.com" }],
@@ -86,13 +87,13 @@ describe(autosendProvider, () => {
 
         const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail({
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({
             ...baseEmail,
             to: [{ email: "a@example.com" }, { email: "b@example.com" }],
         });
 
         expect(result.success).toBe(false);
-        expect(result.error?.message).toContain("single 'to' recipient");
+        expect(result.error?.message).toContain("exactly one 'to' recipient");
         // The request must never leave, or the second recipient is silently lost.
         expect(makeRequestMock).not.toHaveBeenCalled();
     });
@@ -102,7 +103,7 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
-        await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, to: [{ email: "solo@example.com" }] });
+        await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, to: [{ email: "solo@example.com" }] });
 
         expect(requestBody().to).toStrictEqual({ email: "solo@example.com" });
     });
@@ -114,7 +115,7 @@ describe(autosendProvider, () => {
             return { email: `cc${String(index)}@example.com` };
         });
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, cc });
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, cc });
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("at most 50 recipients");
@@ -127,7 +128,7 @@ describe(autosendProvider, () => {
             return { content: "eA==", filename: `f${String(index)}.txt` };
         });
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, attachments });
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, attachments });
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("at most 20 attachments");
@@ -136,7 +137,7 @@ describe(autosendProvider, () => {
     it("rejects a subject longer than 998 characters", async () => {
         expect.assertions(2);
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, subject: "s".repeat(999) });
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, subject: "s".repeat(999) });
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("at most 998 characters");
@@ -147,7 +148,7 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
-        await autosendProvider({ apiKey: "k" }).sendEmail({
+        await autoSendProvider({ apiKey: "k" }).sendEmail({
             ...baseEmail,
             attachments: [{ content: Buffer.from("hello"), contentType: "application/pdf", filename: "invoice.pdf" }],
         });
@@ -162,7 +163,7 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
-        await autosendProvider({ apiKey: "k" }).sendEmail({
+        await autoSendProvider({ apiKey: "k" }).sendEmail({
             ...baseEmail,
             dynamicData: { name: "Jane" },
             templateId: "tpl_123",
@@ -180,7 +181,7 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
-        await autosendProvider({ apiKey: "k" }).sendEmail({
+        await autoSendProvider({ apiKey: "k" }).sendEmail({
             ...baseEmail,
             bypassSuppressions: false,
             trackingClick: false,
@@ -202,7 +203,7 @@ describe(autosendProvider, () => {
 
         const headers = Object.fromEntries(Array.from({ length: 21 }, (_, index) => [`X-H-${String(index)}`, "v"]));
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, headers });
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, headers });
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("at most 20 custom headers");
@@ -216,7 +217,7 @@ describe(autosendProvider, () => {
             success: true,
         });
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail(baseEmail);
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("Domain not verified.");
@@ -231,7 +232,7 @@ describe(autosendProvider, () => {
             success: false,
         });
 
-        const result = await autosendProvider({ apiKey: "bad" }).sendEmail(baseEmail);
+        const result = await autoSendProvider({ apiKey: "bad" }).sendEmail(baseEmail);
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("Invalid API key");
@@ -242,16 +243,174 @@ describe(autosendProvider, () => {
 
         (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { body: { data: {}, success: true }, statusCode: 200 }, success: true });
 
-        const result = await autosendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail(baseEmail);
 
         expect(result.success).toBe(false);
         expect(result.error?.message).toContain("returned no emailId");
     });
 
+    it("sends a template-only message, which has no html/text body of its own", async () => {
+        expect.assertions(3);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        makeRequestMock.mockResolvedValueOnce(okResponse);
+
+        // The documented template example: templateId + dynamicData, no html/text.
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({
+            dynamicData: { name: "Jane" },
+            from: { email: "hello@mail.acme.com" },
+            subject: "Your order",
+            templateId: "tpl_123",
+            to: { email: "jane@example.com" },
+        });
+
+        expect(result.success).toBe(true);
+        expect(requestBody().templateId).toBe("tpl_123");
+        expect(makeRequestMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still requires a body when no templateId is given", async () => {
+        expect.assertions(2);
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({
+            from: { email: "hello@mail.acme.com" },
+            subject: "s",
+            to: { email: "jane@example.com" },
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("Either text or html content is required");
+    });
+
+    it("rejects inline (cid) attachments instead of sending a broken image", async () => {
+        expect.assertions(3);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            attachments: [{ cid: "logo", content: Buffer.from("x"), contentDisposition: "inline", contentType: "image/png", filename: "logo.png" }],
+            html: "<img src=\"cid:logo\">",
+        });
+
+        // AutoSend has no contentId field, so the cid can never resolve.
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("inline (cid) attachments");
+        expect(makeRequestMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty 'to' array with a validation error, not a TypeError", async () => {
+        expect.assertions(3);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, to: [] });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("exactly one 'to' recipient");
+        expect(makeRequestMock).not.toHaveBeenCalled();
+    });
+
+    it("accepts exactly 50 recipients across to/cc/bcc", async () => {
+        expect.assertions(1);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        const cc = Array.from({ length: 49 }, (_, index) => {
+            return { email: `cc${String(index)}@example.com` };
+        });
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, cc });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("accepts exactly 20 attachments, 20 headers and a 998-character subject", async () => {
+        expect.assertions(1);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            attachments: Array.from({ length: 20 }, (_, index) => {
+                return { content: "eA==", filename: `f${String(index)}.txt` };
+            }),
+            headers: Object.fromEntries(Array.from({ length: 20 }, (_, index) => [`X-H-${String(index)}`, "v"])),
+            subject: "s".repeat(998),
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects a header name AutoSend would not accept", async () => {
+        expect.assertions(2);
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, headers: { "X Bad Name": "v" } });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("header names must match");
+    });
+
+    it("rejects a header value longer than 1000 characters", async () => {
+        expect.assertions(2);
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, headers: { "X-Long": "v".repeat(1001) } });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("header values of at most 1000");
+    });
+
+    it("preserves the transport error on a timeout instead of reporting a bad body", async () => {
+        expect.assertions(2);
+
+        // What make-request returns on an AbortError timeout: an error, and no data at all.
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            error: new EmailError("http", "Request timed out after 30000ms"),
+            success: false,
+        });
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("timed out after 30000ms");
+    });
+
+    it("preserves the HTTP status when a gateway returns a non-JSON error page", async () => {
+        expect.assertions(2);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { body: "<html>502 Bad Gateway</html>", statusCode: 502 },
+            error: new EmailError("http", "Request failed with status 502"),
+            success: false,
+        });
+
+        const result = await autoSendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("502");
+    });
+
+    it("surfaces a vendor error body that omits the success flag", async () => {
+        expect.assertions(2);
+
+        // The vendor does not document its error shape, so `success: false` cannot be assumed.
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { body: { error: "Invalid API key provided" }, statusCode: 401 },
+            error: new EmailError("http", "Request failed with status 401"),
+            success: false,
+        });
+
+        const result = await autoSendProvider({ apiKey: "bad" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("Invalid API key provided");
+    });
+
     it("declares only the features AutoSend documents", () => {
         expect.assertions(2);
 
-        const provider = autosendProvider({ apiKey: "k" });
+        const provider = autoSendProvider({ apiKey: "k" });
 
         expect(provider.features).toMatchObject({ attachments: true, html: true, replyTo: true, templates: true, tracking: true });
         // /mails/bulk exists, but the Provider contract has no batch hook to expose it.

--- a/packages/email/email/__tests__/providers/autosend.test.ts
+++ b/packages/email/email/__tests__/providers/autosend.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RequiredOptionError from "../../src/errors/required-option-error";
+import { autosendProvider } from "../../src/providers/autosend/index";
+import type { AutoSendEmailOptions } from "../../src/providers/autosend/types";
+import { makeRequest } from "../../src/utils/make-request";
+
+vi.mock(import("../../src/utils/make-request"), () => {
+    return { makeRequest: vi.fn() };
+});
+vi.mock(import("../../src/utils/retry"), () => {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        default: vi.fn(async (function_) => await function_()),
+    };
+});
+
+const okResponse = {
+    data: {
+        body: { data: { emailId: "698afb75ff4bc5466e3a797a", message: "Email queued successfully.", totalRecipients: 1 }, success: true },
+        statusCode: 200,
+    },
+    success: true,
+};
+
+const baseEmail: AutoSendEmailOptions = {
+    from: { email: "hello@mail.acme.com", name: "Acme" },
+    html: "<p>Hi</p>",
+    subject: "Welcome",
+    to: { email: "jane@example.com", name: "Jane Doe" },
+};
+
+const requestBody = (): Record<string, unknown> => JSON.parse((makeRequest as ReturnType<typeof vi.fn>).mock.calls[0][2] as string) as Record<string, unknown>;
+
+describe(autosendProvider, () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("throws without an apiKey", () => {
+        expect.assertions(1);
+
+        expect(() => autosendProvider({} as never)).toThrow(RequiredOptionError);
+    });
+
+    it("posts to the send endpoint with a bearer token and returns the emailId", async () => {
+        expect.assertions(4);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        makeRequestMock.mockResolvedValueOnce(okResponse);
+
+        const result = await autosendProvider({ apiKey: "as_key" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(true);
+        expect(result.data?.messageId).toBe("698afb75ff4bc5466e3a797a");
+
+        const [url, requestOptions] = makeRequestMock.mock.calls[0];
+
+        expect(String(url)).toBe("https://api.autosend.com/v1/mails/send");
+        expect((requestOptions as { headers: Record<string, string> }).headers.Authorization).toBe("Bearer as_key");
+    });
+
+    it("maps addresses to AutoSend's recipient objects", async () => {
+        expect.assertions(4);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        await autosendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            bcc: { email: "bcc@example.com" },
+            cc: [{ email: "cc1@example.com", name: "CC One" }, { email: "cc2@example.com" }],
+            replyTo: { email: "reply@acme.com", name: "Support" },
+        });
+
+        const body = requestBody();
+
+        expect(body.to).toStrictEqual({ email: "jane@example.com", name: "Jane Doe" });
+        expect(body.cc).toStrictEqual([{ email: "cc1@example.com", name: "CC One" }, { email: "cc2@example.com" }]);
+        expect(body.bcc).toStrictEqual([{ email: "bcc@example.com" }]);
+        expect(body.replyTo).toStrictEqual({ email: "reply@acme.com", name: "Support" });
+    });
+
+    it("rejects multiple 'to' recipients rather than silently dropping them", async () => {
+        expect.assertions(3);
+
+        const makeRequestMock = makeRequest as ReturnType<typeof vi.fn>;
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            to: [{ email: "a@example.com" }, { email: "b@example.com" }],
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("single 'to' recipient");
+        // The request must never leave, or the second recipient is silently lost.
+        expect(makeRequestMock).not.toHaveBeenCalled();
+    });
+
+    it("sends a single-element 'to' array as one recipient", async () => {
+        expect.assertions(1);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, to: [{ email: "solo@example.com" }] });
+
+        expect(requestBody().to).toStrictEqual({ email: "solo@example.com" });
+    });
+
+    it("rejects more than 50 recipients across to/cc/bcc", async () => {
+        expect.assertions(2);
+
+        const cc = Array.from({ length: 50 }, (_, index) => {
+            return { email: `cc${String(index)}@example.com` };
+        });
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, cc });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("at most 50 recipients");
+    });
+
+    it("rejects more than 20 attachments", async () => {
+        expect.assertions(2);
+
+        const attachments = Array.from({ length: 21 }, (_, index) => {
+            return { content: "eA==", filename: `f${String(index)}.txt` };
+        });
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, attachments });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("at most 20 attachments");
+    });
+
+    it("rejects a subject longer than 998 characters", async () => {
+        expect.assertions(2);
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, subject: "s".repeat(999) });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("at most 998 characters");
+    });
+
+    it("maps attachments to AutoSend's fileName/content shape", async () => {
+        expect.assertions(1);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        await autosendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            attachments: [{ content: Buffer.from("hello"), contentType: "application/pdf", filename: "invoice.pdf" }],
+        });
+
+        expect(requestBody().attachments).toStrictEqual([
+            { content: Buffer.from("hello").toString("base64"), contentType: "application/pdf", fileName: "invoice.pdf" },
+        ]);
+    });
+
+    it("sends templateId instead of html/text", async () => {
+        expect.assertions(3);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        await autosendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            dynamicData: { name: "Jane" },
+            templateId: "tpl_123",
+        });
+
+        const body = requestBody();
+
+        expect(body.templateId).toBe("tpl_123");
+        expect(body.html).toBeUndefined();
+        expect(body.dynamicData).toStrictEqual({ name: "Jane" });
+    });
+
+    it("passes AutoSend-specific flags through", async () => {
+        expect.assertions(4);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+        await autosendProvider({ apiKey: "k" }).sendEmail({
+            ...baseEmail,
+            bypassSuppressions: false,
+            trackingClick: false,
+            trackingOpen: true,
+            unsubscribeGroupId: "grp_1",
+        });
+
+        const body = requestBody();
+
+        // `false` must survive: a truthiness check would drop it and silently re-enable tracking.
+        expect(body.trackingClick).toBe(false);
+        expect(body.trackingOpen).toBe(true);
+        expect(body.bypassSuppressions).toBe(false);
+        expect(body.unsubscribeGroupId).toBe("grp_1");
+    });
+
+    it("rejects more than 20 custom headers", async () => {
+        expect.assertions(2);
+
+        const headers = Object.fromEntries(Array.from({ length: 21 }, (_, index) => [`X-H-${String(index)}`, "v"]));
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail({ ...baseEmail, headers });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("at most 20 custom headers");
+    });
+
+    it("treats success:false on a 200 as a failure", async () => {
+        expect.assertions(2);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { body: { message: "Domain not verified.", success: false }, statusCode: 200 },
+            success: true,
+        });
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("Domain not verified.");
+    });
+
+    it("surfaces the API message on an error status", async () => {
+        expect.assertions(2);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { body: { message: "Invalid API key", success: false }, statusCode: 401 },
+            error: new Error("Request failed with status 401"),
+            success: false,
+        });
+
+        const result = await autosendProvider({ apiKey: "bad" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("Invalid API key");
+    });
+
+    it("reports an accepted message that carries no emailId", async () => {
+        expect.assertions(2);
+
+        (makeRequest as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { body: { data: {}, success: true }, statusCode: 200 }, success: true });
+
+        const result = await autosendProvider({ apiKey: "k" }).sendEmail(baseEmail);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain("returned no emailId");
+    });
+
+    it("declares only the features AutoSend documents", () => {
+        expect.assertions(2);
+
+        const provider = autosendProvider({ apiKey: "k" });
+
+        expect(provider.features).toMatchObject({ attachments: true, html: true, replyTo: true, templates: true, tracking: true });
+        // /mails/bulk exists, but the Provider contract has no batch hook to expose it.
+        expect(provider.features).toMatchObject({ batchSending: false, scheduling: false, tagging: false });
+    });
+});

--- a/packages/email/email/docs/providers/autosend.mdx
+++ b/packages/email/email/docs/providers/autosend.mdx
@@ -14,10 +14,10 @@ The AutoSend provider sends emails through the [AutoSend send endpoint](https://
 
 ```typescript
 import { createMail } from "@visulima/email";
-import { autosendProvider } from "@visulima/email/providers/autosend";
+import { autoSendProvider } from "@visulima/email/providers/autosend";
 
 const mail = createMail(
-    autosendProvider({
+    autoSendProvider({
         apiKey: process.env.AUTOSEND_API_KEY,
     }),
 );
@@ -87,8 +87,14 @@ These are validated before the request, so you get a precise error rather than a
 | `to` recipients              | Exactly 1 — use `cc` / `bcc` for more |
 | Combined `to` + `cc` + `bcc` | 50                                    |
 | Attachments                  | 20 files, ≤40MB total after Base64    |
-| Custom headers               | 20                                    |
+| Custom header count          | 20                                    |
+| Custom header names          | `^[A-Za-z0-9-]{1,76}$`                |
+| Custom header values         | 1000 characters                       |
 | Subject length               | 998 characters                        |
+
+Inline (`cid:`) attachments are **rejected**: AutoSend's API has no `contentId` field, so a `cid`
+reference could never resolve and the image would silently render broken. Host the image and
+reference it by URL instead.
 
 > **Note:** AutoSend's send endpoint takes a **single** `to` recipient. Passing several is rejected
 > rather than silently truncated — send one message per recipient, or use `cc` / `bcc`.

--- a/packages/email/email/docs/providers/autosend.mdx
+++ b/packages/email/email/docs/providers/autosend.mdx
@@ -1,0 +1,105 @@
+---
+title: AutoSend
+description: Send emails through the AutoSend API with @visulima/email
+---
+
+# AutoSend Provider
+
+The AutoSend provider sends emails through the [AutoSend send endpoint](https://docs.autosend.com/api-reference/mails/send)
+(`POST https://api.autosend.com/v1/mails/send`).
+
+**Runtime Support:** Universal (Node.js, Deno, Bun, Cloudflare Workers) — uses the Fetch API.
+
+## Setup
+
+```typescript
+import { createMail } from "@visulima/email";
+import { autosendProvider } from "@visulima/email/providers/autosend";
+
+const mail = createMail(
+    autosendProvider({
+        apiKey: process.env.AUTOSEND_API_KEY,
+    }),
+);
+```
+
+## Configuration
+
+The `AutoSendConfig` interface extends `BaseConfig`.
+
+| Option     | Type      | Required | Default                       | Description                     |
+| ---------- | --------- | -------- | ----------------------------- | ------------------------------- |
+| `apiKey`   | `string`  | Yes      | -                             | AutoSend API key (Bearer token) |
+| `endpoint` | `string`  | No       | `https://api.autosend.com/v1` | Custom API endpoint             |
+| `debug`    | `boolean` | No       | `false`                       | Enable debug logging            |
+| `logger`   | `Console` | No       | -                             | Custom logger instance          |
+| `retries`  | `number`  | No       | `3`                           | Number of retry attempts        |
+| `timeout`  | `number`  | No       | `30000`                       | Request timeout in milliseconds |
+
+## Basic Usage
+
+```typescript
+const result = await mail.send({
+    from: { email: "hello@mail.yourdomain.com", name: "Your Company" },
+    to: { email: "customer@example.com", name: "Jane Doe" },
+    subject: "Welcome to Our Platform!",
+    html: "<h1>Welcome!</h1><p>Thanks for signing up.</p>",
+});
+```
+
+The `from` address must be on a domain verified in AutoSend. A successful send returns AutoSend's
+`emailId` as the result's `messageId`.
+
+## Templates
+
+Pass a `templateId` to render server-side. It replaces `html` / `text`, and `dynamicData` fills the
+template's Handlebars placeholders (`{{ name }}`).
+
+```typescript
+await mail.send({
+    from: { email: "hello@mail.yourdomain.com" },
+    to: { email: "customer@example.com" },
+    subject: "Your order",
+    templateId: "tpl_123",
+    dynamicData: { name: "Jane", orderNumber: "ORD-12345" },
+});
+```
+
+## Provider-Specific Email Options
+
+The `AutoSendEmailOptions` interface extends `EmailOptions` with:
+
+| Option               | Type                      | Description                                              |
+| -------------------- | ------------------------- | -------------------------------------------------------- |
+| `templateId`         | `string`                  | AutoSend template id, used instead of `html` / `text`    |
+| `dynamicData`        | `Record<string, unknown>` | Values for the template's Handlebars placeholders        |
+| `trackingOpen`       | `boolean`                 | Enable open tracking for this message                    |
+| `trackingClick`      | `boolean`                 | Enable click tracking for this message                   |
+| `unsubscribeGroupId` | `string`                  | The unsubscribe group this message belongs to            |
+| `bypassSuppressions` | `boolean`                 | Send even if the recipient is suppressed — use sparingly |
+
+## Limits
+
+These are validated before the request, so you get a precise error rather than an API rejection:
+
+| Limit                        | Value                                 |
+| ---------------------------- | ------------------------------------- |
+| `to` recipients              | Exactly 1 — use `cc` / `bcc` for more |
+| Combined `to` + `cc` + `bcc` | 50                                    |
+| Attachments                  | 20 files, ≤40MB total after Base64    |
+| Custom headers               | 20                                    |
+| Subject length               | 998 characters                        |
+
+> **Note:** AutoSend's send endpoint takes a **single** `to` recipient. Passing several is rejected
+> rather than silently truncated — send one message per recipient, or use `cc` / `bcc`.
+
+## Supported Features
+
+- ✅ Attachments
+- ✅ Custom headers
+- ✅ HTML & text bodies
+- ✅ Reply-To
+- ✅ Templates (`templateId` + `dynamicData`)
+- ✅ Open / click tracking
+- ❌ Batch sending — AutoSend has a [bulk endpoint](https://docs.autosend.com/api-reference/mails/bulk), but the provider contract has no batch hook to expose it
+- ❌ Scheduling / tagging

--- a/packages/email/email/docs/providers/introduction.mdx
+++ b/packages/email/email/docs/providers/introduction.mdx
@@ -9,6 +9,7 @@ Providers are responsible for actually sending emails. @visulima/email supports 
 
 ## Available Providers
 
+- **[AutoSend](/docs/packages/email/providers/autosend)** - Transactional and marketing email with volume-based pricing ([API Docs](https://docs.autosend.com/api-reference/mails/send))
 - **[AWS SES](/docs/packages/email/providers/aws-ses)** - Amazon Simple Email Service ([API Docs](https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html))
 - **[Resend](/docs/packages/email/providers/resend)** - Modern email API for developers ([API Docs](https://resend.com/docs/api-reference/emails/send-email))
 - **[Brevo](/docs/packages/email/providers/brevo)** - Email marketing and transactional email platform (formerly Sendinblue) ([API Docs](https://developers.brevo.com/reference/sendtransacemail))
@@ -95,6 +96,7 @@ These providers require Node.js built-in modules and only work in **Node.js**:
 | MailPace      | ✅      | ✅   | ✅   | ✅                 |
 | Mailtrap      | ✅      | ✅   | ✅   | ✅                 |
 | Postal        | ✅      | ✅   | ✅   | ✅                 |
+| AutoSend      | ✅      | ✅   | ✅   | ✅                 |
 | Postmark      | ✅      | ✅   | ✅   | ✅                 |
 | Azure         | ✅      | ✅   | ✅   | ✅                 |
 | Infobip       | ✅      | ✅   | ✅   | ✅                 |

--- a/packages/email/email/docs/providers/introduction.mdx
+++ b/packages/email/email/docs/providers/introduction.mdx
@@ -119,11 +119,11 @@ These providers require Node.js built-in modules and only work in **Node.js**:
 
 ### Choosing a Provider
 
-- **For Cloudflare Workers, Deno, or Bun**: Use Resend, HTTP, Zeptomail, Brevo, Mailgun, Mailjet, MailerSend, Mandrill, MailPace, Mailtrap, Postal, Postmark, SendGrid, Plunk, Azure, Infobip, Scaleway, AhaSend, Mailomat, Sweego, or Mock
+- **For Cloudflare Workers, Deno, or Bun**: Use Resend, HTTP, Zeptomail, Brevo, Mailgun, Mailjet, MailerSend, Mandrill, MailPace, Mailtrap, Postal, Postmark, SendGrid, Plunk, Azure, Infobip, Scaleway, AhaSend, Mailomat, Sweego, AutoSend, or Mock
 - **For Node.js**: You can use any provider
 - **For testing**: Use Mock or Mailtrap provider to test email logic without sending real emails
 - **For observability**: Use OpenTelemetry provider to wrap any provider and add distributed tracing and metrics
-- **For cross-runtime compatibility**: Use Resend, HTTP, Zeptomail, Brevo, Mailgun, Mailjet, MailerSend, Mandrill, MailPace, Mailtrap, Postal, Postmark, SendGrid, Plunk, Azure, Infobip, Scaleway, AhaSend, Mailomat, Sweego, or Mock, or wrap Node.js-only providers in Failover/Round Robin with universal providers as fallbacks
+- **For cross-runtime compatibility**: Use Resend, HTTP, Zeptomail, Brevo, Mailgun, Mailjet, MailerSend, Mandrill, MailPace, Mailtrap, Postal, Postmark, SendGrid, Plunk, Azure, Infobip, Scaleway, AhaSend, Mailomat, Sweego, AutoSend, or Mock, or wrap Node.js-only providers in Failover/Round Robin with universal providers as fallbacks
 
 ## Provider Interface
 

--- a/packages/email/email/docs/providers/meta.json
+++ b/packages/email/email/docs/providers/meta.json
@@ -2,6 +2,7 @@
     "title": "Providers",
     "pages": [
         "introduction",
+        "autosend",
         "aws-ses",
         "resend",
         "brevo",

--- a/packages/email/email/package.json
+++ b/packages/email/email/package.json
@@ -122,6 +122,10 @@
             "types": "./dist/template-engines/i18n.d.ts",
             "default": "./dist/template-engines/i18n.js"
         },
+        "./providers/autosend": {
+            "types": "./dist/providers/autosend/index.d.ts",
+            "default": "./dist/providers/autosend/index.js"
+        },
         "./providers/aws-ses": {
             "types": "./dist/providers/aws-ses/index.d.ts",
             "default": "./dist/providers/aws-ses/index.js"

--- a/packages/email/email/src/providers/autosend/index.ts
+++ b/packages/email/email/src/providers/autosend/index.ts
@@ -1,3 +1,3 @@
 export type { Provider, ProviderFactory } from "../provider";
-export { default as autosendProvider } from "./provider";
+export { default as autoSendProvider } from "./provider";
 export type { AutoSendConfig, AutoSendEmailOptions } from "./types";

--- a/packages/email/email/src/providers/autosend/index.ts
+++ b/packages/email/email/src/providers/autosend/index.ts
@@ -1,0 +1,3 @@
+export type { Provider, ProviderFactory } from "../provider";
+export { default as autosendProvider } from "./provider";
+export type { AutoSendConfig, AutoSendEmailOptions } from "./types";

--- a/packages/email/email/src/providers/autosend/provider.ts
+++ b/packages/email/email/src/providers/autosend/provider.ts
@@ -1,0 +1,311 @@
+import EmailError from "../../errors/email-error";
+import RequiredOptionError from "../../errors/required-option-error";
+import type { Attachment, EmailAddress, EmailResult, Result } from "../../types";
+import headersToRecord from "../../utils/headers-to-record";
+import { makeRequest } from "../../utils/make-request";
+import retry from "../../utils/retry";
+import { sanitizeHeaderName, sanitizeHeaderValue } from "../../utils/sanitize-header";
+import validateEmailOptions from "../../utils/validation/validate-email-options";
+import type { ProviderFactory } from "../provider";
+import { defineProvider } from "../provider";
+import { createProviderLogger, createStandardAttachment, handleProviderError, ProviderState } from "../utils";
+import type { AutoSendConfig, AutoSendEmailOptions } from "./types";
+
+const PROVIDER_NAME = "autosend";
+const DEFAULT_ENDPOINT = "https://api.autosend.com/v1";
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_RETRIES = 3;
+
+/**
+ * AutoSend limits, enforced before the request so the caller gets a precise error instead of a
+ * generic rejection. See https://docs.autosend.com/api-reference/mails/send.
+ */
+const MAX_RECIPIENTS = 50;
+const MAX_ATTACHMENTS = 20;
+const MAX_CUSTOM_HEADERS = 20;
+const MAX_SUBJECT_LENGTH = 998;
+
+/**
+ * A recipient as AutoSend's API expects it: `{ email, name? }` rather than a formatted string.
+ */
+interface AutoSendRecipient {
+    email: string;
+    name?: string;
+}
+
+const toAddressList = (addresses: EmailAddress | EmailAddress[]): EmailAddress[] => [addresses].flat();
+
+const toRecipient = (address: EmailAddress): AutoSendRecipient => {
+    return { email: address.email, ...address.name ? { name: address.name } : {} };
+};
+
+const toRecipients = (addresses: EmailAddress | EmailAddress[]): AutoSendRecipient[] => toAddressList(addresses).map((address) => toRecipient(address));
+
+/**
+ * Maps an attachment to AutoSend's shape. AutoSend names the field `fileName` and takes the
+ * payload base64-encoded in `content`.
+ * @param attachment The visulima attachment.
+ * @returns The payload entry for AutoSend's `attachments` array.
+ */
+const toAutoSendAttachment = async (attachment: Attachment): Promise<Record<string, string>> => {
+    const standard = await createStandardAttachment(attachment, PROVIDER_NAME);
+
+    return {
+        content: standard.content,
+        contentType: standard.contentType,
+        fileName: standard.filename,
+    };
+};
+
+/**
+ * Checks the message against AutoSend's documented limits.
+ * @param emailOptions The message to check.
+ * @returns A description of the first breached limit, or undefined when within limits.
+ */
+const checkLimits = (emailOptions: AutoSendEmailOptions): string | undefined => {
+    // `/mails/send` takes a single `to`; the bulk endpoint is a different contract. Dropping the
+    // extras silently is the one thing this provider must not do.
+    if (Array.isArray(emailOptions.to) && emailOptions.to.length > 1) {
+        return `AutoSend's send endpoint takes a single 'to' recipient, but ${String(emailOptions.to.length)} were given — use 'cc'/'bcc', or send one message per recipient`;
+    }
+
+    const recipientCount
+        = toAddressList(emailOptions.to).length
+            + (emailOptions.cc ? toAddressList(emailOptions.cc).length : 0)
+            + (emailOptions.bcc ? toAddressList(emailOptions.bcc).length : 0);
+
+    if (recipientCount > MAX_RECIPIENTS) {
+        return `AutoSend allows at most ${String(MAX_RECIPIENTS)} recipients across to/cc/bcc, but ${String(recipientCount)} were given`;
+    }
+
+    if (emailOptions.attachments && emailOptions.attachments.length > MAX_ATTACHMENTS) {
+        return `AutoSend allows at most ${String(MAX_ATTACHMENTS)} attachments, but ${String(emailOptions.attachments.length)} were given`;
+    }
+
+    if (emailOptions.subject.length > MAX_SUBJECT_LENGTH) {
+        return `AutoSend allows a subject of at most ${String(MAX_SUBJECT_LENGTH)} characters, but ${String(emailOptions.subject.length)} were given`;
+    }
+
+    return undefined;
+};
+
+/**
+ * Reads AutoSend's response envelope. A 2xx can still carry `success: false`, so the body decides.
+ * @param body The parsed response body.
+ * @returns The email id, or an error message when the send was rejected.
+ */
+const readSendResponse = (body: unknown): { emailId?: string; error?: string } => {
+    if (typeof body !== "object" || body === null) {
+        return { error: "AutoSend returned an unexpected response body" };
+    }
+
+    const payload = body as { data?: { emailId?: unknown }; error?: unknown; message?: unknown; success?: unknown };
+
+    if (payload.success === false) {
+        const reason = [payload.message, payload.error].find((value) => typeof value === "string");
+
+        return { error: typeof reason === "string" ? reason : "AutoSend rejected the message" };
+    }
+
+    return { emailId: typeof payload.data?.emailId === "string" ? payload.data.emailId : undefined };
+};
+
+/**
+ * AutoSend provider — sends through the [AutoSend send endpoint](https://docs.autosend.com/api-reference/mails/send).
+ */
+const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOptions> = defineProvider<AutoSendConfig, unknown, AutoSendEmailOptions>(
+    (config: AutoSendConfig = {} as AutoSendConfig) => {
+        if (!config.apiKey) {
+            throw new RequiredOptionError(PROVIDER_NAME, "apiKey");
+        }
+
+        const options: Pick<AutoSendConfig, "logger"> & Required<Omit<AutoSendConfig, "logger">> = {
+            apiKey: config.apiKey,
+            debug: config.debug ?? false,
+            endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
+            logger: config.logger,
+            retries: config.retries ?? DEFAULT_RETRIES,
+            timeout: config.timeout ?? DEFAULT_TIMEOUT,
+        };
+
+        const providerState = new ProviderState();
+        const logger = createProviderLogger(PROVIDER_NAME, config.logger);
+
+        return {
+            features: {
+                attachments: true,
+                // `/mails/bulk` exists, but the Provider contract has no batch hook — Mail.sendBatch
+                // fans out to sendEmail, which is the single-send endpoint.
+                batchSending: false,
+                customHeaders: true,
+                html: true,
+                replyTo: true,
+                scheduling: false,
+                tagging: false,
+                templates: true,
+                tracking: true,
+            },
+
+            // eslint-disable-next-line @typescript-eslint/require-await
+            async initialize(): Promise<void> {
+                providerState.setInitialized();
+            },
+
+            // eslint-disable-next-line @typescript-eslint/require-await
+            async isAvailable(): Promise<boolean> {
+                return options.apiKey.length > 0;
+            },
+
+            name: PROVIDER_NAME,
+
+            options,
+
+            /**
+             * Sends an email through the AutoSend API.
+             * @param emailOptions The email options, including AutoSend-specific fields.
+             * @returns The send result.
+             */
+            // eslint-disable-next-line sonarjs/cognitive-complexity
+            async sendEmail(emailOptions: AutoSendEmailOptions): Promise<Result<EmailResult>> {
+                try {
+                    const validationErrors = validateEmailOptions(emailOptions);
+
+                    if (validationErrors.length > 0) {
+                        return { error: new EmailError(PROVIDER_NAME, `Invalid email options: ${validationErrors.join(", ")}`), success: false };
+                    }
+
+                    const limitError = checkLimits(emailOptions);
+
+                    if (limitError) {
+                        return { error: new EmailError(PROVIDER_NAME, limitError), success: false };
+                    }
+
+                    const payload: Record<string, unknown> = {
+                        from: toRecipient(emailOptions.from),
+                        subject: emailOptions.subject,
+                        to: toRecipient(toAddressList(emailOptions.to)[0] as EmailAddress),
+                    };
+
+                    // templateId renders server-side and replaces html/text entirely.
+                    if (emailOptions.templateId) {
+                        payload.templateId = emailOptions.templateId;
+                    } else {
+                        if (emailOptions.html) {
+                            payload.html = emailOptions.html;
+                        }
+
+                        if (emailOptions.text) {
+                            payload.text = emailOptions.text;
+                        }
+                    }
+
+                    if (emailOptions.cc) {
+                        payload.cc = toRecipients(emailOptions.cc);
+                    }
+
+                    if (emailOptions.bcc) {
+                        payload.bcc = toRecipients(emailOptions.bcc);
+                    }
+
+                    if (emailOptions.replyTo) {
+                        payload.replyTo = toRecipient(emailOptions.replyTo);
+                    }
+
+                    if (emailOptions.dynamicData) {
+                        payload.dynamicData = emailOptions.dynamicData;
+                    }
+
+                    if (emailOptions.unsubscribeGroupId) {
+                        payload.unsubscribeGroupId = emailOptions.unsubscribeGroupId;
+                    }
+
+                    if (emailOptions.trackingClick !== undefined) {
+                        payload.trackingClick = emailOptions.trackingClick;
+                    }
+
+                    if (emailOptions.trackingOpen !== undefined) {
+                        payload.trackingOpen = emailOptions.trackingOpen;
+                    }
+
+                    if (emailOptions.bypassSuppressions !== undefined) {
+                        payload.bypassSuppressions = emailOptions.bypassSuppressions;
+                    }
+
+                    if (emailOptions.headers) {
+                        const headers = Object.entries(headersToRecord(emailOptions.headers));
+
+                        if (headers.length > MAX_CUSTOM_HEADERS) {
+                            return {
+                                error: new EmailError(
+                                    PROVIDER_NAME,
+                                    `AutoSend allows at most ${String(MAX_CUSTOM_HEADERS)} custom headers, but ${String(headers.length)} were given`,
+                                ),
+                                success: false,
+                            };
+                        }
+
+                        payload.headers = Object.fromEntries(headers.map(([key, value]) => [sanitizeHeaderName(key), sanitizeHeaderValue(value)]));
+                    }
+
+                    if (emailOptions.attachments && emailOptions.attachments.length > 0) {
+                        payload.attachments = await Promise.all(emailOptions.attachments.map(async (attachment) => toAutoSendAttachment(attachment)));
+                    }
+
+                    const result = await retry(
+                        async () =>
+                            makeRequest(
+                                `${options.endpoint}/mails/send`,
+                                {
+                                    headers: { Authorization: `Bearer ${options.apiKey}`, "Content-Type": "application/json" },
+                                    method: "POST",
+                                    timeout: options.timeout,
+                                },
+                                JSON.stringify(payload),
+                            ),
+                        options.retries,
+                    );
+
+                    const responseBody = (result.data as { body?: unknown } | undefined)?.body;
+
+                    if (!result.success) {
+                        const { error: reason } = readSendResponse(responseBody);
+
+                        return {
+                            error: reason
+                                ? new EmailError(PROVIDER_NAME, `Failed to send email: ${reason}`)
+                                : result.error ?? new EmailError(PROVIDER_NAME, "Failed to send email"),
+                            success: false,
+                        };
+                    }
+
+                    // AutoSend answers 200 with `success: false` for a rejected message, so the
+                    // envelope decides rather than the status code.
+                    const { emailId, error: reason } = readSendResponse(responseBody);
+
+                    if (reason) {
+                        return { error: new EmailError(PROVIDER_NAME, `Failed to send email: ${reason}`), success: false };
+                    }
+
+                    if (!emailId) {
+                        return { error: new EmailError(PROVIDER_NAME, "AutoSend accepted the message but returned no emailId"), success: false };
+                    }
+
+                    logger.debug(`Email queued successfully: ${emailId}`);
+
+                    return {
+                        data: { messageId: emailId, provider: PROVIDER_NAME, response: responseBody, sent: true, timestamp: new Date() },
+                        success: true,
+                    };
+                } catch (error) {
+                    return { error: handleProviderError(PROVIDER_NAME, "send email", error, logger), success: false };
+                }
+            },
+
+            async validateCredentials(): Promise<boolean> {
+                return this.isAvailable();
+            },
+        };
+    },
+);
+
+export default autosendProvider;

--- a/packages/email/email/src/providers/autosend/provider.ts
+++ b/packages/email/email/src/providers/autosend/provider.ts
@@ -8,7 +8,7 @@ import { sanitizeHeaderName, sanitizeHeaderValue } from "../../utils/sanitize-he
 import validateEmailOptions from "../../utils/validation/validate-email-options";
 import type { ProviderFactory } from "../provider";
 import { defineProvider } from "../provider";
-import { createProviderLogger, createStandardAttachment, handleProviderError, ProviderState } from "../utils";
+import { createProviderLogger, createStandardAttachment, formatSendGridAddress, formatSendGridAddresses, handleProviderError, ProviderState } from "../utils";
 import type { AutoSendConfig, AutoSendEmailOptions } from "./types";
 
 const PROVIDER_NAME = "autosend";
@@ -22,28 +22,29 @@ const DEFAULT_RETRIES = 3;
  */
 const MAX_RECIPIENTS = 50;
 const MAX_ATTACHMENTS = 20;
+const MAX_ATTACHMENT_BYTES = 40 * 1024 * 1024;
 const MAX_CUSTOM_HEADERS = 20;
+const MAX_HEADER_VALUE_LENGTH = 1000;
 const MAX_SUBJECT_LENGTH = 998;
 
 /**
- * A recipient as AutoSend's API expects it: `{ email, name? }` rather than a formatted string.
+ * Header names AutoSend accepts — anything else is rejected by the API. Quoted separately for
+ * error messages, since the compiled source reads `[A-Z0-9-]` + `i` and would imply that
+ * lowercase is rejected.
  */
-interface AutoSendRecipient {
-    email: string;
-    name?: string;
-}
+const HEADER_NAME_PATTERN = /^[A-Z0-9-]{1,76}$/i;
+const HEADER_NAME_RULE = "^[A-Za-z0-9-]{1,76}$";
+
+/**
+ * `validateEmailOptions` requires a text or html body, which a template-only message legitimately
+ * has neither of — AutoSend renders the body server-side from `templateId`.
+ */
+const CONTENT_REQUIRED_ERROR = "Either text or html content is required";
 
 const toAddressList = (addresses: EmailAddress | EmailAddress[]): EmailAddress[] => [addresses].flat();
 
-const toRecipient = (address: EmailAddress): AutoSendRecipient => {
-    return { email: address.email, ...address.name ? { name: address.name } : {} };
-};
-
-const toRecipients = (addresses: EmailAddress | EmailAddress[]): AutoSendRecipient[] => toAddressList(addresses).map((address) => toRecipient(address));
-
 /**
- * Maps an attachment to AutoSend's shape. AutoSend names the field `fileName` and takes the
- * payload base64-encoded in `content`.
+ * Maps an attachment to AutoSend's shape.
  * @param attachment The visulima attachment.
  * @returns The payload entry for AutoSend's `attachments` array.
  */
@@ -58,21 +59,24 @@ const toAutoSendAttachment = async (attachment: Attachment): Promise<Record<stri
 };
 
 /**
- * Checks the message against AutoSend's documented limits.
+ * Checks a message against AutoSend's documented limits.
  * @param emailOptions The message to check.
+ * @param headers The message's headers, already flattened to a record.
  * @returns A description of the first breached limit, or undefined when within limits.
  */
-const checkLimits = (emailOptions: AutoSendEmailOptions): string | undefined => {
-    // `/mails/send` takes a single `to`; the bulk endpoint is a different contract. Dropping the
-    // extras silently is the one thing this provider must not do.
-    if (Array.isArray(emailOptions.to) && emailOptions.to.length > 1) {
-        return `AutoSend's send endpoint takes a single 'to' recipient, but ${String(emailOptions.to.length)} were given — use 'cc'/'bcc', or send one message per recipient`;
+
+const checkLimits = (emailOptions: AutoSendEmailOptions, headers: Record<string, string>): string | undefined => {
+    // `/mails/send` takes exactly one `to`; the bulk endpoint is a different contract. Silently
+    // dropping the extras is the one thing this provider must not do. `!== 1` also catches the
+    // empty array, which validateEmailOptions lets through since `[]` is truthy.
+    const recipients = toAddressList(emailOptions.to);
+
+    if (recipients.length !== 1) {
+        return `AutoSend's send endpoint takes exactly one 'to' recipient, but ${String(recipients.length)} were given — use 'cc'/'bcc', or send one message per recipient`;
     }
 
     const recipientCount
-        = toAddressList(emailOptions.to).length
-            + (emailOptions.cc ? toAddressList(emailOptions.cc).length : 0)
-            + (emailOptions.bcc ? toAddressList(emailOptions.bcc).length : 0);
+        = recipients.length + (emailOptions.cc ? toAddressList(emailOptions.cc).length : 0) + (emailOptions.bcc ? toAddressList(emailOptions.bcc).length : 0);
 
     if (recipientCount > MAX_RECIPIENTS) {
         return `AutoSend allows at most ${String(MAX_RECIPIENTS)} recipients across to/cc/bcc, but ${String(recipientCount)} were given`;
@@ -82,38 +86,71 @@ const checkLimits = (emailOptions: AutoSendEmailOptions): string | undefined => 
         return `AutoSend allows at most ${String(MAX_ATTACHMENTS)} attachments, but ${String(emailOptions.attachments.length)} were given`;
     }
 
+    // AutoSend has no contentId field, so a `cid:` reference can never resolve. Sending anyway
+    // would report success and render a broken image.
+    const inlineAttachment = emailOptions.attachments?.find((attachment) => attachment.cid);
+
+    if (inlineAttachment) {
+        return `AutoSend does not support inline (cid) attachments, but '${inlineAttachment.filename}' sets one — host the image and reference it by URL instead`;
+    }
+
     if (emailOptions.subject.length > MAX_SUBJECT_LENGTH) {
         return `AutoSend allows a subject of at most ${String(MAX_SUBJECT_LENGTH)} characters, but ${String(emailOptions.subject.length)} were given`;
+    }
+
+    const headerNames = Object.keys(headers);
+
+    if (headerNames.length > MAX_CUSTOM_HEADERS) {
+        return `AutoSend allows at most ${String(MAX_CUSTOM_HEADERS)} custom headers, but ${String(headerNames.length)} were given`;
+    }
+
+    const invalidName = headerNames.find((name) => !HEADER_NAME_PATTERN.test(name));
+
+    if (invalidName !== undefined) {
+        return `AutoSend header names must match ${HEADER_NAME_RULE}, but '${invalidName}' does not`;
+    }
+
+    const oversizedHeader = headerNames.find((name) => (headers[name] as string).length > MAX_HEADER_VALUE_LENGTH);
+
+    if (oversizedHeader !== undefined) {
+        return `AutoSend allows header values of at most ${String(MAX_HEADER_VALUE_LENGTH)} characters, but '${oversizedHeader}' is longer`;
     }
 
     return undefined;
 };
 
 /**
- * Reads AutoSend's response envelope. A 2xx can still carry `success: false`, so the body decides.
+ * Reads AutoSend's response envelope.
+ *
+ * `reason` is set only when the body actually explains a failure — an absent or non-JSON body
+ * yields neither field, so the caller falls back to the transport error rather than reporting a
+ * timeout or a gateway's HTML error page as an unexpected body.
+ *
+ * The vendor does not document its error shape, so any human-readable `message` / `error` is
+ * taken rather than keying strictly on `success: false`.
  * @param body The parsed response body.
- * @returns The email id, or an error message when the send was rejected.
+ * @returns The email id on success, or the reason the message was rejected.
  */
-const readSendResponse = (body: unknown): { emailId?: string; error?: string } => {
+const readSendResponse = (body: unknown): { emailId?: string; reason?: string } => {
     if (typeof body !== "object" || body === null) {
-        return { error: "AutoSend returned an unexpected response body" };
+        return {};
     }
 
     const payload = body as { data?: { emailId?: unknown }; error?: unknown; message?: unknown; success?: unknown };
 
-    if (payload.success === false) {
-        const reason = [payload.message, payload.error].find((value) => typeof value === "string");
-
-        return { error: typeof reason === "string" ? reason : "AutoSend rejected the message" };
+    if (payload.success === true) {
+        return { emailId: typeof payload.data?.emailId === "string" ? payload.data.emailId : undefined };
     }
 
-    return { emailId: typeof payload.data?.emailId === "string" ? payload.data.emailId : undefined };
+    const reason = [payload.message, payload.error].find((value) => typeof value === "string");
+
+    return { reason: typeof reason === "string" ? reason : undefined };
 };
 
 /**
  * AutoSend provider — sends through the [AutoSend send endpoint](https://docs.autosend.com/api-reference/mails/send).
  */
-const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOptions> = defineProvider<AutoSendConfig, unknown, AutoSendEmailOptions>(
+const autoSendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOptions> = defineProvider<AutoSendConfig, unknown, AutoSendEmailOptions>(
     (config: AutoSendConfig = {} as AutoSendConfig) => {
         if (!config.apiKey) {
             throw new RequiredOptionError(PROVIDER_NAME, "apiKey");
@@ -168,22 +205,27 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
             // eslint-disable-next-line sonarjs/cognitive-complexity
             async sendEmail(emailOptions: AutoSendEmailOptions): Promise<Result<EmailResult>> {
                 try {
-                    const validationErrors = validateEmailOptions(emailOptions);
+                    // A template-only message has no body of its own — AutoSend renders it from
+                    // `templateId`, so the shared "text or html required" rule doesn't apply.
+                    const validationErrors = validateEmailOptions(emailOptions).filter(
+                        (error) => !(emailOptions.templateId !== undefined && error === CONTENT_REQUIRED_ERROR),
+                    );
 
                     if (validationErrors.length > 0) {
                         return { error: new EmailError(PROVIDER_NAME, `Invalid email options: ${validationErrors.join(", ")}`), success: false };
                     }
 
-                    const limitError = checkLimits(emailOptions);
+                    const headers = emailOptions.headers ? headersToRecord(emailOptions.headers) : {};
+                    const limitError = checkLimits(emailOptions, headers);
 
                     if (limitError) {
                         return { error: new EmailError(PROVIDER_NAME, limitError), success: false };
                     }
 
                     const payload: Record<string, unknown> = {
-                        from: toRecipient(emailOptions.from),
+                        from: formatSendGridAddress(emailOptions.from),
                         subject: emailOptions.subject,
-                        to: toRecipient(toAddressList(emailOptions.to)[0] as EmailAddress),
+                        to: formatSendGridAddress(toAddressList(emailOptions.to)[0] as EmailAddress),
                     };
 
                     // templateId renders server-side and replaces html/text entirely.
@@ -200,15 +242,15 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
                     }
 
                     if (emailOptions.cc) {
-                        payload.cc = toRecipients(emailOptions.cc);
+                        payload.cc = formatSendGridAddresses(emailOptions.cc);
                     }
 
                     if (emailOptions.bcc) {
-                        payload.bcc = toRecipients(emailOptions.bcc);
+                        payload.bcc = formatSendGridAddresses(emailOptions.bcc);
                     }
 
                     if (emailOptions.replyTo) {
-                        payload.replyTo = toRecipient(emailOptions.replyTo);
+                        payload.replyTo = formatSendGridAddress(emailOptions.replyTo);
                     }
 
                     if (emailOptions.dynamicData) {
@@ -231,24 +273,29 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
                         payload.bypassSuppressions = emailOptions.bypassSuppressions;
                     }
 
-                    if (emailOptions.headers) {
-                        const headers = Object.entries(headersToRecord(emailOptions.headers));
+                    if (Object.keys(headers).length > 0) {
+                        payload.headers = Object.fromEntries(
+                            Object.entries(headers).map(([key, value]) => [sanitizeHeaderName(key), sanitizeHeaderValue(value)]),
+                        );
+                    }
 
-                        if (headers.length > MAX_CUSTOM_HEADERS) {
+                    if (emailOptions.attachments && emailOptions.attachments.length > 0) {
+                        const attachments = await Promise.all(emailOptions.attachments.map(async (attachment) => toAutoSendAttachment(attachment)));
+
+                        // Only measurable once encoded, so this cannot live with the other limits.
+                        const encodedBytes = attachments.reduce((total, attachment) => total + (attachment.content as string).length, 0);
+
+                        if (encodedBytes > MAX_ATTACHMENT_BYTES) {
                             return {
                                 error: new EmailError(
                                     PROVIDER_NAME,
-                                    `AutoSend allows at most ${String(MAX_CUSTOM_HEADERS)} custom headers, but ${String(headers.length)} were given`,
+                                    `AutoSend allows at most ${String(MAX_ATTACHMENT_BYTES)} bytes of attachments after Base64 encoding, but this message carries ${String(encodedBytes)}`,
                                 ),
                                 success: false,
                             };
                         }
 
-                        payload.headers = Object.fromEntries(headers.map(([key, value]) => [sanitizeHeaderName(key), sanitizeHeaderValue(value)]));
-                    }
-
-                    if (emailOptions.attachments && emailOptions.attachments.length > 0) {
-                        payload.attachments = await Promise.all(emailOptions.attachments.map(async (attachment) => toAutoSendAttachment(attachment)));
+                        payload.attachments = attachments;
                     }
 
                     const result = await retry(
@@ -266,10 +313,11 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
                     );
 
                     const responseBody = (result.data as { body?: unknown } | undefined)?.body;
+                    const { emailId, reason } = readSendResponse(responseBody);
 
                     if (!result.success) {
-                        const { error: reason } = readSendResponse(responseBody);
-
+                        // Prefer the vendor's explanation; fall back to the transport error, which
+                        // carries the status code / timeout and the cause chain.
                         return {
                             error: reason
                                 ? new EmailError(PROVIDER_NAME, `Failed to send email: ${reason}`)
@@ -280,8 +328,6 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
 
                     // AutoSend answers 200 with `success: false` for a rejected message, so the
                     // envelope decides rather than the status code.
-                    const { emailId, error: reason } = readSendResponse(responseBody);
-
                     if (reason) {
                         return { error: new EmailError(PROVIDER_NAME, `Failed to send email: ${reason}`), success: false };
                     }
@@ -308,4 +354,4 @@ const autosendProvider: ProviderFactory<AutoSendConfig, unknown, AutoSendEmailOp
     },
 );
 
-export default autosendProvider;
+export default autoSendProvider;

--- a/packages/email/email/src/providers/autosend/types.ts
+++ b/packages/email/email/src/providers/autosend/types.ts
@@ -1,0 +1,56 @@
+import type { BaseConfig, EmailOptions } from "../../types";
+
+/**
+ * AutoSend configuration.
+ */
+export interface AutoSendConfig extends BaseConfig {
+    /**
+     * AutoSend API key (sent as a Bearer token).
+     */
+    apiKey: string;
+
+    /**
+     * API endpoint override (default `https://api.autosend.com/v1`).
+     */
+    endpoint?: string;
+}
+
+/**
+ * AutoSend-specific email options.
+ *
+ * See the [send reference](https://docs.autosend.com/api-reference/mails/send). AutoSend's
+ * `/mails/send` takes exactly one `to` recipient — pass a single address, and use `cc`/`bcc`
+ * for additional ones.
+ */
+export interface AutoSendEmailOptions extends EmailOptions {
+    /**
+     * Sends even if the recipient is on the suppression list. Use sparingly: suppressions exist
+     * to protect the sending domain's reputation.
+     */
+    bypassSuppressions?: boolean;
+
+    /**
+     * Values substituted into Handlebars placeholders (`{{ name }}`) in the template or `html`.
+     */
+    dynamicData?: Record<string, unknown>;
+
+    /**
+     * An AutoSend template id, used instead of `html` / `text`.
+     */
+    templateId?: string;
+
+    /**
+     * Enables click tracking for this message.
+     */
+    trackingClick?: boolean;
+
+    /**
+     * Enables open tracking for this message.
+     */
+    trackingOpen?: boolean;
+
+    /**
+     * The unsubscribe group this message belongs to.
+     */
+    unsubscribeGroupId?: string;
+}


### PR DESCRIPTION
Adds an [AutoSend](https://autosend.com) provider, requested by the vendor via `@AutoSendEmail`.

## What

Sends through `POST https://api.autosend.com/v1/mails/send` ([docs](https://docs.autosend.com/api-reference/mails/send)), authenticated with an API key as a Bearer token. Universal runtime — Fetch API, no SDK dependency.

```typescript
import { createMail, autosendProvider } from "@visulima/email/providers/autosend";

const mail = createMail(autosendProvider({ apiKey: process.env.AUTOSEND_API_KEY }));
```

Supports html/text bodies, templates (`templateId` + `dynamicData`), cc/bcc, reply-to, attachments, custom headers, open/click tracking, unsubscribe groups, and suppression bypass.

## Design notes

- **Multi-recipient `to` is rejected, not truncated.** AutoSend's send endpoint takes exactly one `to`, while `EmailOptions` allows an array. Silently dropping the extras would be the worst outcome for a package whose selling point is fail-fast field-support checks, so it returns a clear error suggesting `cc`/`bcc` or one message per recipient — and the request never leaves.
- **Limits are checked up front.** 50 recipients across to/cc/bcc, 20 attachments, 20 custom headers, 998-char subject. Callers get a precise error rather than a generic API rejection.
- **The response envelope decides the outcome.** AutoSend answers a rejected message with HTTP 200 and `success: false`, so status code alone would report a false success.
- **`batchSending: false`.** [`/mails/bulk`](https://docs.autosend.com/api-reference/mails/bulk) exists, but the `Provider` contract has no batch hook — `Mail.sendBatch` fans out to `sendEmail`. Exposing bulk would need a contract change; happy to follow up if wanted.
- **Boolean flags use `!== undefined`**, so an explicit `trackingClick: false` survives instead of being dropped by a truthiness check and silently re-enabling tracking.

## Testing

16 new tests (1546 total passing), plus typecheck, ESLint, secretlint and build all clean. Coverage includes address mapping, attachment shape (`fileName` + base64 `content`), template vs. html precedence, every limit, the `success: false`-on-200 path, error surfacing, and the multi-recipient guard.

Written against the published docs and verified with a mocked transport — **not yet exercised against the live API**. A sandbox key would let us confirm the payload end-to-end before release; worth doing given the error-response shape isn't documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending email through the AutoSend provider, including template-based sending with `dynamicData`.
  - Added per-message tracking controls, unsubscribe group handling, reply-to, attachments, and custom headers.
  - Enforced AutoSend limits (notably single-recipient `to` for `/v1/mails/send`, plus recipient/subject/header/attachment validation) and rejected `cid:` inline attachments.
  - Exposed a new public AutoSend provider subpath export.

- **Documentation**
  - Updated the email README with AutoSend setup/usage.
  - Added AutoSend provider MDX documentation, including runtime compatibility, supported features, limitations, and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->