### PR TITLE
fix(deps): force adm-zip >=0.6.0 to clear GHSA-xcpc-8h2w-3j85

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1568,6 +1568,7 @@ catalogs:
 overrides:
   picomatch: 4.0.5
   tinyglobby: 0.2.17
+  adm-zip@<0.6.0: '>=0.6.0'
   '@tanstack/start-server-core@<1.167.30': '>=1.167.30'
   fastify@<5.7.2: '>=5.7.2'
   fastify@<=5.7.2: '>=5.7.3'
@@ -20341,9 +20342,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   adverb-where@0.2.6:
     resolution: {integrity: sha512-uVazUDEPYpBSVRjEDTzO6hVXh9X/eQb+gobzDpqdzMiM1MkfGxfPtgN8YerBjAeDkoABZprsOwhSZnY4X3knnw==}
@@ -45498,7 +45499,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   adverb-where@0.2.6: {}
 
@@ -48203,12 +48204,12 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -54909,7 +54910,7 @@ snapshots:
 
   mysql-memory-server@1.14.1:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       semver: 7.8.5
       signal-exit: 4.1.0
 
@@ -59211,8 +59212,8 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
+      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)
       eslint-plugin-promise: 6.6.0(eslint@8.57.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -838,6 +838,12 @@ overrides:
   # picomatch. Bumping either one is now a deliberate edit here plus a re-cut patch.
   picomatch: 4.0.5
   tinyglobby: 0.2.17
+  # adm-zip <0.6.0 (GHSA-xcpc-8h2w-3j85, high): a crafted ZIP triggers a ~4GB memory
+  # allocation. Only reached via mysql-memory-server (a dev-only MySQL test helper in
+  # @visulima/workflow) which pins ^0.5.16; force the patched 0.6.0. adm-zip 0.6.0 needs
+  # node >=14, well within mysql-memory-server's >=16.6 engine, and its extract API is
+  # unchanged.
+  adm-zip@<0.6.0: '>=0.6.0'
   '@tanstack/start-server-core@<1.167.30': '>=1.167.30'
   fastify@<5.7.2: '>=5.7.2'
   fastify@<=5.7.2: '>=5.7.3'


### PR DESCRIPTION
## What

Forces `adm-zip` to the patched `>=0.6.0` via a pnpm override, clearing the one non-ignored advisory that fails `pnpm audit` (and therefore the `Lint (eslint/types/attw)` and `Lint (fallow)` CI jobs, which run the audit in setup).

## The advisory

- **GHSA-xcpc-8h2w-3j85** (high) — `adm-zip <0.6.0`: a crafted ZIP triggers a ~4GB memory allocation.
- Reached only through `mysql-memory-server` (a dev-only MySQL test helper in `@visulima/workflow`), which pins `adm-zip: ^0.5.16` → resolved `0.5.17`.

## Why an override is safe here

- `0.6.0` is the advisory's own patched range.
- adm-zip `0.6.0` requires `node >=14`, well within `mysql-memory-server`'s `>=16.6` engine.
- adm-zip's extract API is unchanged between 0.5.x and 0.6.0, so the test helper keeps working.

## Verification

- `pnpm install --lockfile-only` re-resolves `adm-zip` to `0.6.0` (no `0.5.x` left in the lockfile).
- `pnpm audit` now exits `0` — remaining entries are the two already in `auditConfig.ignoreGhsas`/`ignoreCves`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
