### PR TITLE
fix(tui): preserve last static line after a full clear

### DIFF
--- a/packages/terminal/tui/__tests__/ink/full-clear-static.test.tsx
+++ b/packages/terminal/tui/__tests__/ink/full-clear-static.test.tsx
@@ -1,0 +1,62 @@
+import { clearScreenAndHomeCursor } from "@visulima/ansi";
+import { describe, expect, it } from "vitest";
+
+import { Box, Text } from "../../src/components/index";
+import { render } from "../../src/ink/index";
+import createStdout from "../helpers/ink-create-stdout";
+import waitFor from "../helpers/wait-for";
+
+/**
+ * Regression coverage for vadimdemedes/ink#974.
+ *
+ * On a full-clear frame the renderer wrote the live region as `output` (no
+ * trailing newline) but told `log.sync()` it had written `outputToRender`
+ * (which appends one in non-fullscreen mode). `sync` derives `previousLineCount`
+ * from that string, so the log believed the live region was one line taller than
+ * it was, and the next frame's `log.clear()` erased one row too many — eating the
+ * bottom line of the `&lt;Static>` block sitting above it.
+ *
+ * Only non-fullscreen full-clear frames are affected: when the frame fills the
+ * viewport `outputToRender === output`, so there is no discrepancy.
+ */
+const ROWS = 6;
+
+const Frame = ({ height, label }: { readonly height: number; readonly label: string }) => (
+    <Box flexDirection="column" height={height}>
+        <Text>{label}</Text>
+    </Box>
+);
+
+describe("full clear + static accounting (ink#974)", () => {
+    it("writes the same live region it reports to the log on a full-clear frame", async () => {
+        expect.assertions(2);
+
+        const stdout = createStdout(20, true, ROWS);
+
+        // Start fullscreen so that shrinking below the viewport triggers the
+        // `isLeavingFullscreen` full-clear path.
+        const { rerender, unmount } = render(<Frame height={ROWS} label="first" />, { interactive: true, stdout });
+
+        await waitFor(() => stdout.getWrites().join("").includes("first"));
+
+        const before = stdout.getWrites().length;
+
+        rerender(<Frame height={1} label="second" />);
+
+        await waitFor(() => stdout.getWrites().join("").includes("second"));
+
+        const clearWrite = stdout
+            .getWrites()
+            .slice(before)
+            .find((write) => write.includes(clearScreenAndHomeCursor));
+
+        expect(clearWrite).toBeDefined();
+
+        // The payload must end with the trailing newline that log.sync() counts.
+        // Without it the log over-counts the live region by one line and the next
+        // clear() eats the row above.
+        expect(clearWrite?.endsWith("\n")).toBe(true);
+
+        unmount();
+    });
+});

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -1536,7 +1536,12 @@ export default class Ink {
             // backbufferOutput sits above the live output for this frame only;
             // it is deliberately excluded from this.fullStaticOutput so it is
             // not replayed (and duplicated) on subsequent clear/redraw cycles.
-            this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + backbufferOutput + output);
+            // Write `outputToRender`, not `output`: log.sync() below derives its
+            // line count from `outputToRender`, so emitting the un-terminated
+            // `output` here would leave the log believing the live region is one
+            // row taller than it is, and the next clear() would erase the bottom
+            // line of the static block above it. See vadimdemedes/ink#974.
+            this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + backbufferOutput + outputToRender);
             this.lastOutput = output;
             this.lastOutputToRender = outputToRender;
             this.lastOutputHeight = outputHeight;


### PR DESCRIPTION
Ports [vadimdemedes/ink#974](https://github.com/vadimdemedes/ink/pull/974) (shipped in ink v7.1.1). We had the same defect.

## The bug

`renderInteractiveFrame` computes:

```ts
const outputToRender = isFullscreen ? output : `${output}\n`;
```

On the full-clear path it then wrote `output` but told the log it had written `outputToRender`:

```ts
this.options.stdout.write(clearScreenAndHomeCursor + this.fullStaticOutput + backbufferOutput + output);
this.log.sync(outputToRender);
```

`log.sync()` sets `previousLineCount = string_.split("\n").length`. In non-fullscreen mode `outputToRender` carries a trailing newline, so the log counted one row more than was actually emitted. The next frame’s `log.clear()` erases `previousLineCount` rows — one too many — eating the bottom line of the `<Static>` block sitting above the live region.

Fullscreen frames were unaffected, since there `outputToRender === output`. So this only bit frames that leave fullscreen or overflow the viewport (`isLeavingFullscreen` / `wasOverflowing`).

## The fix

Write `outputToRender`, matching what is synced — same one-word change as upstream.

## Test

`__tests__/ink/full-clear-static.test.tsx` renders fullscreen, then shrinks below the viewport to trigger the full-clear path, and asserts the emitted payload ends with the newline the log accounts for. Verified failing before the fix (`expected false to be true`) and passing after.

Full tui suite: 1395 passing. The single failing file, `native-binding.test.ts`, is pre-existing and environmental — the Rust addon is not compiled in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal redraw behavior after clearing the screen.
  * Prevented the bottom line of previously displayed static content from being erased during subsequent clears.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->