### PR TITLE
test(pagination): add workerd runtime suite

### DIFF
--- a/packages/api/pagination/__tests__/workerd/cursor-paginator.test.ts
+++ b/packages/api/pagination/__tests__/workerd/cursor-paginator.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Cursor paginator specs executed inside `workerd`. Keyset pagination is the
+ * shape most edge handlers reach for, so the cursor derivation, boundary
+ * handling and URL building all need to hold on the Workers runtime.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CursorPaginator } from "../../src";
+
+describe("workerd cursor paginator basics", () => {
+    it("derives the next cursor from the last row", () => {
+        expect.assertions(3);
+
+        const paginator = CursorPaginator.fromArray(3, [{ id: 1 }, { id: 2 }, { id: 3 }], { hasMore: true });
+
+        expect(paginator.getNextCursor()).toBe("3");
+        expect(paginator.hasMorePages).toBe(true);
+        expect(paginator.getPreviousCursor()).toBeNull();
+    });
+
+    it("derives the previous cursor from the first row when a cursor was supplied", () => {
+        expect.assertions(2);
+
+        const paginator = CursorPaginator.fromArray(2, [{ id: 5 }, { id: 6 }], { currentCursor: "4" });
+
+        expect(paginator.getPreviousCursor()).toBe("5");
+        expect(paginator.getNextCursor()).toBeNull();
+    });
+
+    it("falls back to String(row) when the row has no id", () => {
+        expect.assertions(2);
+
+        expect(CursorPaginator.fromArray(2, ["a", "b"], { hasMore: true }).getNextCursor()).toBe("b");
+        expect(CursorPaginator.fromArray(2, [1, 2], { hasMore: true }).getNextCursor()).toBe("2");
+    });
+
+    it("supports a custom cursor resolver", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(2, [{ slug: "a" }, { slug: "b" }], {
+            getCursor: (row) => row.slug,
+            hasMore: true,
+        });
+
+        expect(paginator.getNextCursor()).toBe("b");
+    });
+
+    it("keeps Array behaviour with a plain-Array species", () => {
+        expect.assertions(3);
+
+        const paginator = CursorPaginator.fromArray(3, [1, 2, 3]);
+
+        expect(paginator).toHaveLength(3);
+        expect(paginator.all()).toStrictEqual([1, 2, 3]);
+        expect(Array.isArray(paginator.map((value) => value))).toBe(true);
+    });
+});
+
+describe("workerd cursor paginator boundary conditions", () => {
+    it("clamps perPage of 0, negative and non-finite values up to 1", () => {
+        expect.assertions(4);
+
+        expect(CursorPaginator.fromArray(0, []).perPage).toBe(1);
+        expect(CursorPaginator.fromArray(-3, []).perPage).toBe(1);
+        expect(CursorPaginator.fromArray(Number.NaN, []).perPage).toBe(1);
+        expect(CursorPaginator.fromArray(Number.POSITIVE_INFINITY, []).perPage).toBe(1);
+    });
+
+    it("truncates a fractional perPage", () => {
+        expect.assertions(1);
+
+        expect(CursorPaginator.fromArray(2.9, []).perPage).toBe(2);
+    });
+
+    it("returns null cursors for an empty page even when hasMore is set", () => {
+        expect.assertions(3);
+
+        const paginator = CursorPaginator.fromArray(10, [], { currentCursor: "abc", hasMore: true });
+
+        expect(paginator.isEmpty).toBe(true);
+        expect(paginator.getNextCursor()).toBeNull();
+        expect(paginator.getPreviousCursor()).toBeNull();
+    });
+
+    it("returns a null next cursor when there are no more pages", () => {
+        expect.assertions(2);
+
+        const paginator = CursorPaginator.fromArray(3, [{ id: 1 }], { hasMore: false });
+
+        expect(paginator.getNextCursor()).toBeNull();
+        expect(paginator.hasMorePages).toBe(false);
+    });
+
+    it("returns a null url for a null cursor", () => {
+        expect.assertions(2);
+
+        const paginator = CursorPaginator.fromArray(3, [{ id: 1 }]);
+
+        expect(paginator.getUrl(null)).toBeNull();
+        expect(paginator.getUrl("abc")).toBe("/?cursor=abc");
+    });
+});
+
+describe("workerd cursor paginator links", () => {
+    it("builds cursor urls on top of the base url and query string", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(2, [{ id: 5 }, { id: 6 }], { currentCursor: "4", hasMore: true })
+            .baseUrl("/api/items")
+            .queryString({ sort: "asc" });
+
+        expect(paginator.getMeta()).toStrictEqual({
+            nextCursor: "6",
+            nextPageUrl: "/api/items?sort=asc&cursor=6",
+            perPage: 2,
+            previousCursor: "5",
+            previousPageUrl: "/api/items?sort=asc&cursor=5",
+        });
+    });
+
+    it("percent-encodes opaque cursors", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(1, [{ id: "a b/c" }], { hasMore: true }).baseUrl("/api/items");
+
+        expect(paginator.getMeta().nextPageUrl).toBe("/api/items?cursor=a%20b%2Fc");
+    });
+
+    it("appends array query values as repeated keys", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(2, [{ id: 5 }, { id: 6 }], { hasMore: true })
+            .baseUrl("/api/items")
+            .queryString({ tag: ["a", "b"] });
+
+        expect(paginator.getMeta().nextPageUrl).toBe("/api/items?tag=a&tag=b&cursor=6");
+    });
+});
+
+describe("workerd cursor paginator serialisation", () => {
+    it("serialises data and meta through toJSON", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(1, [{ id: 9 }], { hasMore: false });
+
+        expect(paginator.toJSON()).toStrictEqual({
+            data: [{ id: 9 }],
+            meta: {
+                nextCursor: null,
+                nextPageUrl: null,
+                perPage: 1,
+                previousCursor: null,
+                previousPageUrl: null,
+            },
+        });
+    });
+
+    it("survives a JSON.stringify round-trip in an edge response body", () => {
+        expect.assertions(1);
+
+        const paginator = CursorPaginator.fromArray(2, [{ id: 1 }, { id: 2 }], { hasMore: true }).baseUrl("/api/items");
+        const body = JSON.stringify(paginator.toJSON());
+
+        expect(JSON.parse(body)).toStrictEqual(paginator.toJSON());
+    });
+});

--- a/packages/api/pagination/__tests__/workerd/paginator.test.ts
+++ b/packages/api/pagination/__tests__/workerd/paginator.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Offset paginator specs executed inside `workerd` (the Cloudflare Workers
+ * runtime) via `@cloudflare/vitest-pool-workers`.
+ *
+ * Pagination is exactly the kind of logic that runs in an edge API handler, so
+ * this suite locks in that the package stays free of Node-only surface: it
+ * leans on `URLSearchParams` (Web standard) and on `Array` subclassing with a
+ * `Symbol.species` override, both of which have to behave identically on the
+ * workerd isolate.
+ */
+import { describe, expect, it } from "vitest";
+
+import { paginate, Paginator, snakeCaseNamingStrategy } from "../../src";
+
+describe("workerd runtime", () => {
+    it("runs inside workerd and not on the host platform", () => {
+        expect.assertions(1);
+
+        const workerNavigator = Reflect.get(globalThis, "navigator") as { userAgent?: string } | undefined;
+
+        expect(workerNavigator?.userAgent).toBe("Cloudflare-Workers");
+    });
+
+    it("has the Web-standard URLSearchParams the query builder relies on", () => {
+        expect.assertions(1);
+
+        expect(URLSearchParams).toBeTypeOf("function");
+    });
+});
+
+describe("workerd paginator basics", () => {
+    it("exposes the computed page state", () => {
+        expect.assertions(8);
+
+        const paginator = new Paginator(
+            100,
+            10,
+            1,
+            Array.from({ length: 10 }, (_, index) => index),
+        );
+
+        expect(paginator.total).toBe(100);
+        expect(paginator.perPage).toBe(10);
+        expect(paginator.currentPage).toBe(1);
+        expect(paginator.lastPage).toBe(10);
+        expect(paginator.firstPage).toBe(1);
+        expect(paginator.isEmpty).toBe(false);
+        expect(paginator.hasPages).toBe(true);
+        expect(paginator.hasTotal).toBe(true);
+    });
+
+    it("keeps Array behaviour with a plain-Array species", () => {
+        expect.assertions(4);
+
+        const paginator = paginate(1, 10, 3, [1, 2, 3]);
+
+        expect(paginator).toHaveLength(3);
+        expect(paginator.all()).toStrictEqual([1, 2, 3]);
+        expect(paginator.map((value) => value * 2)).toStrictEqual([2, 4, 6]);
+        expect(Array.isArray(paginator.filter((value) => value > 1))).toBe(true);
+    });
+
+    it("returns a defensive copy from all()", () => {
+        expect.assertions(2);
+
+        const paginator = paginate(1, 10, 3, [1, 2, 3]);
+        const rows = paginator.all();
+
+        rows.push(4);
+
+        expect(paginator).toHaveLength(3);
+        expect(rows).toStrictEqual([1, 2, 3, 4]);
+    });
+});
+
+describe("workerd paginator boundary conditions", () => {
+    it("clamps page 0 and negative pages up to the first page", () => {
+        expect.assertions(2);
+
+        expect(new Paginator(100, 10, 0, []).currentPage).toBe(1);
+        expect(new Paginator(100, 10, -7, []).currentPage).toBe(1);
+    });
+
+    it("clamps a perPage of 0 or negative up to 1", () => {
+        expect.assertions(4);
+
+        expect(new Paginator(10, 0, 1, []).perPage).toBe(1);
+        expect(new Paginator(10, -5, 1, []).perPage).toBe(1);
+        expect(new Paginator(10, 0, 1, []).lastPage).toBe(10);
+        expect(new Paginator(10, 2.9, 1, []).perPage).toBe(2);
+    });
+
+    it("clamps a negative or non-finite total to 0", () => {
+        expect.assertions(4);
+
+        expect(new Paginator(-5, 10, 1, []).total).toBe(0);
+        expect(new Paginator(Number.NaN, 10, 1, []).total).toBe(0);
+        expect(new Paginator(Number.POSITIVE_INFINITY, 10, 1, []).total).toBe(0);
+        expect(new Paginator(Number.NaN, Number.NaN, Number.NaN, []).perPage).toBe(1);
+    });
+
+    it("reports a single last page for a total of 0", () => {
+        expect.assertions(6);
+
+        const paginator = new Paginator(0, 10, 1, []);
+
+        expect(paginator.total).toBe(0);
+        expect(paginator.lastPage).toBe(1);
+        expect(paginator.hasPages).toBe(false);
+        expect(paginator.hasTotal).toBe(false);
+        expect(paginator.isEmpty).toBe(true);
+        expect(paginator.hasMorePages).toBe(false);
+    });
+
+    it("keeps a page beyond the last page addressable without a next link", () => {
+        expect.assertions(4);
+
+        const paginator = new Paginator(30, 10, 99, []);
+
+        expect(paginator.currentPage).toBe(99);
+        expect(paginator.lastPage).toBe(3);
+        expect(paginator.hasMorePages).toBe(false);
+        expect(paginator.getNextPageUrl()).toBeNull();
+    });
+
+    it("clamps getUrl() to at least page 1", () => {
+        expect.assertions(3);
+
+        const paginator = new Paginator(100, 10, 1, []);
+
+        expect(paginator.getUrl(0)).toBe("/?page=1");
+        expect(paginator.getUrl(-4)).toBe("/?page=1");
+        expect(paginator.getUrl(3)).toBe("/?page=3");
+    });
+});
+
+describe("workerd paginator links", () => {
+    it("builds first/last/next/previous urls", () => {
+        expect.assertions(4);
+
+        const paginator = new Paginator(100, 10, 5, []).baseUrl("/api/users");
+
+        expect(paginator.getUrl(1)).toBe("/api/users?page=1");
+        expect(paginator.getNextPageUrl()).toBe("/api/users?page=6");
+        expect(paginator.getPreviousPageUrl()).toBe("/api/users?page=4");
+        expect(paginator.getUrl(paginator.lastPage)).toBe("/api/users?page=10");
+    });
+
+    it("returns null neighbours at the boundaries", () => {
+        expect.assertions(2);
+
+        expect(new Paginator(100, 10, 1, []).getPreviousPageUrl()).toBeNull();
+        expect(new Paginator(100, 10, 10, []).getNextPageUrl()).toBeNull();
+    });
+
+    it("appends a serialized query string before the page parameter", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 2, []).baseUrl("/api/users").queryString({ sort: "asc" });
+
+        expect(paginator.getUrl(2)).toBe("/api/users?sort=asc&page=2");
+    });
+
+    it("serializes array values as repeated keys and skips null/undefined", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 1, [])
+            .baseUrl("/api/users")
+            .queryString({ empty: null, missing: undefined, tag: ["a", "b"] });
+
+        expect(paginator.getUrl(1)).toBe("/api/users?tag=a&tag=b&page=1");
+    });
+
+    it("url-encodes query values through URLSearchParams", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 1, []).baseUrl("/api/users").queryString({ q: "a b&c" });
+
+        expect(paginator.getUrl(1)).toBe("/api/users?q=a+b%26c&page=1");
+    });
+
+    it("builds an inclusive range of urls", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 2, []).baseUrl("/api/users");
+
+        expect(paginator.getUrlsForRange(1, 3)).toStrictEqual([
+            { isActive: false, page: 1, url: "/api/users?page=1" },
+            { isActive: true, page: 2, url: "/api/users?page=2" },
+            { isActive: false, page: 3, url: "/api/users?page=3" },
+        ]);
+    });
+});
+
+describe("workerd paginator windowed links", () => {
+    it("returns every page when the range is small enough", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(50, 10, 2, []).baseUrl("/p");
+
+        expect(paginator.getUrlsForWindow()).toStrictEqual([
+            { isActive: false, page: 1, url: "/p?page=1" },
+            { isActive: true, page: 2, url: "/p?page=2" },
+            { isActive: false, page: 3, url: "/p?page=3" },
+            { isActive: false, page: 4, url: "/p?page=4" },
+            { isActive: false, page: 5, url: "/p?page=5" },
+        ]);
+    });
+
+    it("emits a trailing ellipsis marker near the start of a long range", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 1, []).baseUrl("/p");
+
+        expect(paginator.getUrlsForWindow()).toStrictEqual([
+            { isActive: true, page: 1, url: "/p?page=1" },
+            { isActive: false, page: 2, url: "/p?page=2" },
+            { isActive: false, page: 3, url: "/p?page=3" },
+            { isActive: false, page: null, url: null },
+            { isActive: false, page: 10, url: "/p?page=10" },
+        ]);
+    });
+
+    it("emits ellipsis markers on both sides of a centred window", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(200, 10, 10, []).baseUrl("/p");
+
+        expect(paginator.getUrlsForWindow({ eachSide: 1 })).toStrictEqual([
+            { isActive: false, page: 1, url: "/p?page=1" },
+            { isActive: false, page: null, url: null },
+            { isActive: false, page: 9, url: "/p?page=9" },
+            { isActive: true, page: 10, url: "/p?page=10" },
+            { isActive: false, page: 11, url: "/p?page=11" },
+            { isActive: false, page: null, url: null },
+            { isActive: false, page: 20, url: "/p?page=20" },
+        ]);
+    });
+
+    it("clamps an out-of-range current page onto the last page window", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(200, 10, 99, []).baseUrl("/p");
+
+        expect(paginator.getUrlsForWindow()).toStrictEqual([
+            { isActive: false, page: 1, url: "/p?page=1" },
+            { isActive: false, page: null, url: null },
+            { isActive: false, page: 18, url: "/p?page=18" },
+            { isActive: false, page: 19, url: "/p?page=19" },
+            { isActive: false, page: 20, url: "/p?page=20" },
+        ]);
+    });
+
+    it("falls back to the default window for a negative eachSide", () => {
+        expect.assertions(2);
+
+        const paginator = new Paginator(100, 10, 1, []).baseUrl("/p");
+
+        expect(paginator.getUrlsForWindow({ eachSide: -1 })).toStrictEqual(paginator.getUrlsForWindow());
+        expect(paginator.getUrlsForWindow({ eachSide: Number.NaN })).toStrictEqual(paginator.getUrlsForWindow());
+    });
+});
+
+describe("workerd paginator serialisation", () => {
+    it("emits camelCase meta by default", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 2, []).baseUrl("/api/users");
+
+        expect(paginator.getMeta()).toStrictEqual({
+            firstPage: 1,
+            firstPageUrl: "/api/users?page=1",
+            lastPage: 10,
+            lastPageUrl: "/api/users?page=10",
+            nextPageUrl: "/api/users?page=3",
+            page: 2,
+            perPage: 10,
+            previousPageUrl: "/api/users?page=1",
+            total: 100,
+        });
+    });
+
+    it("emits snake_case meta with the built-in naming strategy", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(100, 10, 1, []).baseUrl("/api/users");
+
+        expect(paginator.getMeta(snakeCaseNamingStrategy)).toStrictEqual({
+            first_page: 1,
+            first_page_url: "/api/users?page=1",
+            last_page: 10,
+            last_page_url: "/api/users?page=10",
+            next_page_url: "/api/users?page=2",
+            page: 1,
+            per_page: 10,
+            previous_page_url: null,
+            total: 100,
+        });
+    });
+
+    it("supports a custom naming strategy", () => {
+        expect.assertions(1);
+
+        const paginator = new Paginator(10, 10, 1, []).baseUrl("/p");
+
+        expect(Object.keys(paginator.getMeta((key) => key.toUpperCase()))).toStrictEqual([
+            "FIRSTPAGE",
+            "FIRSTPAGEURL",
+            "LASTPAGE",
+            "LASTPAGEURL",
+            "NEXTPAGEURL",
+            "PAGE",
+            "PERPAGE",
+            "PREVIOUSPAGEURL",
+            "TOTAL",
+        ]);
+    });
+
+    it("serialises data and meta through toJSON", () => {
+        expect.assertions(1);
+
+        const paginator = paginate(1, 2, 3, [{ id: 1 }, { id: 2 }]).baseUrl("/api/items");
+
+        expect(paginator.toJSON()).toStrictEqual({
+            data: [{ id: 1 }, { id: 2 }],
+            meta: {
+                firstPage: 1,
+                firstPageUrl: "/api/items?page=1",
+                lastPage: 2,
+                lastPageUrl: "/api/items?page=2",
+                nextPageUrl: "/api/items?page=2",
+                page: 1,
+                perPage: 2,
+                previousPageUrl: null,
+                total: 3,
+            },
+        });
+    });
+
+    it("survives a JSON.stringify round-trip in an edge response body", () => {
+        expect.assertions(1);
+
+        const paginator = paginate(1, 2, 3, [{ id: 1 }, { id: 2 }]).baseUrl("/api/items");
+        const body = JSON.stringify(paginator.toJSON());
+
+        expect(JSON.parse(body)).toStrictEqual(paginator.toJSON());
+    });
+});

--- a/packages/api/pagination/__tests__/workerd/swagger.test.ts
+++ b/packages/api/pagination/__tests__/workerd/swagger.test.ts
@@ -1,0 +1,100 @@
+/**
+ * OpenAPI schema-builder specs executed inside `workerd`. These are pure object
+ * builders, so the point of running them on the Workers runtime is to prove the
+ * module graph reached from `src/index.ts` pulls in nothing Node-only.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createPaginationMetaSchemaObject, createPaginationSchemaObject } from "../../src";
+
+describe("workerd pagination meta schema", () => {
+    it("emits OpenAPI 3.0 nullable url fields by default", () => {
+        expect.assertions(4);
+
+        const schema = createPaginationMetaSchemaObject();
+
+        expect(Object.keys(schema)).toStrictEqual(["PaginationData"]);
+        expect(schema.PaginationData?.properties?.nextPageUrl).toStrictEqual({
+            description: "The URL for the next page, or null when on the last page",
+            nullable: true,
+            type: "string",
+        });
+        expect(schema.PaginationData?.properties?.firstPageUrl).toStrictEqual({
+            description: "The URL for the first page",
+            type: "string",
+        });
+        expect(schema.PaginationData?.required).toStrictEqual([
+            "firstPage",
+            "firstPageUrl",
+            "lastPage",
+            "lastPageUrl",
+            "nextPageUrl",
+            "page",
+            "perPage",
+            "previousPageUrl",
+            "total",
+        ]);
+    });
+
+    it("emits JSON-Schema style nullability for OpenAPI 3.1", () => {
+        expect.assertions(2);
+
+        const schema = createPaginationMetaSchemaObject("Meta", { openApiVersion: "3.1" });
+
+        expect(schema.Meta?.properties?.nextPageUrl).toStrictEqual({
+            description: "The URL for the next page, or null when on the last page",
+            type: ["string", "null"],
+        });
+        expect(schema.Meta?.properties?.previousPageUrl).toStrictEqual({
+            description: "The URL for the previous page, or null when on the first page",
+            type: ["string", "null"],
+        });
+    });
+
+    it("honours a custom component name in the xml block", () => {
+        expect.assertions(2);
+
+        const schema = createPaginationMetaSchemaObject("CustomMeta");
+
+        expect(Object.keys(schema)).toStrictEqual(["CustomMeta"]);
+        expect(schema.CustomMeta?.xml).toStrictEqual({ name: "CustomMeta" });
+    });
+});
+
+describe("workerd pagination response schema", () => {
+    it("wraps an item schema in a paginated envelope", () => {
+        expect.assertions(1);
+
+        expect(createPaginationSchemaObject("Users", { $ref: "#/components/schemas/User" })).toStrictEqual({
+            Users: {
+                properties: {
+                    data: {
+                        items: { $ref: "#/components/schemas/User" },
+                        type: "array",
+                        xml: { name: "data", wrapped: true },
+                    },
+                    meta: { $ref: "#/components/schemas/PaginationData" },
+                },
+                required: ["data", "meta"],
+                type: "object",
+                xml: { name: "Users" },
+            },
+        });
+    });
+
+    it("accepts the meta reference as a bare string", () => {
+        expect.assertions(1);
+
+        const schema = createPaginationSchemaObject("Users", { type: "string" }, "#/components/schemas/Meta");
+
+        expect(schema.Users?.properties?.meta).toStrictEqual({ $ref: "#/components/schemas/Meta" });
+    });
+
+    it("accepts the meta reference through the options object", () => {
+        expect.assertions(1);
+
+        const schema = createPaginationSchemaObject("Users", { type: "string" }, { metaReference: "#/components/schemas/Meta" });
+
+        expect(schema.Users?.properties?.meta).toStrictEqual({ $ref: "#/components/schemas/Meta" });
+    });
+});

--- a/packages/api/pagination/eslint.config.js
+++ b/packages/api/pagination/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "package.json",

--- a/packages/api/pagination/package.json
+++ b/packages/api/pagination/package.json
@@ -14,11 +14,6 @@
     ],
     "homepage": "https://visulima.com/packages/pagination/",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -34,19 +29,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -54,10 +43,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -76,7 +67,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -84,6 +76,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:dev",
         "@vitest/coverage-v8": "catalog:test",
@@ -102,5 +95,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/api/pagination/vitest.workerd.config.ts
+++ b/packages/api/pagination/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2575,6 +2575,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: catalog:types
         version: 26.1.0
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
Exercises the public API inside a workerd isolate: page/offset/cursor
calculations, boundary conditions, link and metadata generation, the
naming strategies, and both OpenAPI schema builders.

No source change was needed. The package's only platform surface is
`URLSearchParams` and an `Array` subclass with a `Symbol.species`
override, both of which behave correctly on the isolate.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
