### PR TITLE
test(object): add workerd runtime coverage

### DIFF
--- a/packages/data-manipulation/object/__tests__/omit.test.ts
+++ b/packages/data-manipulation/object/__tests__/omit.test.ts
@@ -228,12 +228,67 @@ describe(omit, () => {
     });
 
     it("should not pollute Object.prototype when omitting near a __proto__ key", () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const input = JSON.parse(`{ "__proto__": { "polluted": true }, "safe": 1 }`) as Record<string, unknown>;
         const result = omit(input, ["safe"]);
 
         expect(({} as Record<string, unknown>).polluted).toBeUndefined();
         expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+        // The own "__proto__" data property is carried over as an ordinary key.
+        expect(Object.hasOwn(result, "__proto__")).toBe(true);
+    });
+
+    it("should treat constructor as an ordinary own key", () => {
+        expect.assertions(1);
+
+        const input = { constructor: "c", prototype: "p", safe: 1 };
+
+        expect(omit(input, ["constructor"])).toStrictEqual({ prototype: "p", safe: 1 });
+    });
+
+    it("should drop a primitive array element addressed by index", () => {
+        expect.assertions(1);
+
+        const input = { list: [1, 2, 3] };
+
+        expect(omit(input, ["list.1" as never])).toStrictEqual({ list: [1, 3] });
+    });
+
+    it("should not mutate the input when omitting a nested key", () => {
+        expect.assertions(2);
+
+        const input = { nested: { secret: "x", visible: 1 } };
+        const result = omit(input, ["nested.secret"]);
+
+        expect(input.nested.secret).toBe("x");
+        expect(result).toStrictEqual({ nested: { visible: 1 } });
+    });
+
+    it("should keep a non-plain value by reference instead of descending into it", () => {
+        expect.assertions(2);
+
+        const map = new Map([["secret", "x"]]);
+        const input = { map, other: 1 };
+        const result = omit(input, ["map.secret" as never]) as { map: Map<string, string> };
+
+        expect(result.map).toBe(map);
+        expect(result.map.get("secret")).toBe("x");
+    });
+
+    it("should omit from a null-prototype object", () => {
+        expect.assertions(1);
+
+        const input = Object.assign(Object.create(null) as Record<string, unknown>, { a: 1, b: 2 });
+
+        expect(omit(input as never, ["b" as never])).toStrictEqual({ a: 1 });
+    });
+
+    it("should traverse a nested null-prototype object", () => {
+        expect.assertions(1);
+
+        const nested = Object.assign(Object.create(null) as Record<string, unknown>, { keep: 1, secret: 2 });
+
+        expect(omit({ nested } as never, ["nested.secret" as never])).toStrictEqual({ nested: { keep: 1 } });
     });
 });

--- a/packages/data-manipulation/object/__tests__/pick.test.ts
+++ b/packages/data-manipulation/object/__tests__/pick.test.ts
@@ -281,4 +281,35 @@ describe(pick, () => {
 
         expect(result.when).toBe(date);
     });
+
+    it("should not re-parent the result when picking a __proto__ key", () => {
+        expect.assertions(3);
+
+        // `JSON.parse` is the only way to get a real own "__proto__" data property.
+        // Picking it must copy it as an ordinary key, never as a prototype swap.
+        const input = JSON.parse(String.raw`{"__proto__": {"polluted": true}, "safe": 1}`) as Record<string, unknown>;
+        const result = pick(input as never, ["__proto__" as never]) as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+        expect(Object.hasOwn(result, "__proto__")).toBe(true);
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it("should treat constructor and prototype as ordinary own keys", () => {
+        expect.assertions(2);
+
+        const input = { constructor: "c", prototype: "p", safe: 1 };
+        const result = pick(input, ["constructor", "prototype"]) as Record<string, unknown>;
+
+        expect(result.constructor).toBe("c");
+        expect(result.prototype).toBe("p");
+    });
+
+    it("should pick from a null-prototype object", () => {
+        expect.assertions(1);
+
+        const input = Object.assign(Object.create(null) as Record<string, unknown>, { a: 1, b: 2 });
+
+        expect(pick(input as never, ["a" as never])).toStrictEqual({ a: 1 });
+    });
 });

--- a/packages/data-manipulation/object/__tests__/re-exports.test.ts
+++ b/packages/data-manipulation/object/__tests__/re-exports.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { deepKeys, deepKeysFromList, deleteProperty, escapePath, getProperty, hasProperty, setProperty } from "../src";
+
+/**
+ * `@visulima/object` is a façade: `dot-prop` and `deeks` are bundled in rather
+ * than declared as runtime dependencies, so these pin the re-exported surface.
+ * A bundler or dependency bump that drops one of them fails here instead of in
+ * a consumer.
+ */
+describe("re-exported dot-prop helpers", () => {
+    it("should get, set, check and delete nested properties", () => {
+        expect.assertions(5);
+
+        const target: Record<string, unknown> = { a: { b: [{ c: 1 }] } };
+
+        const initial: unknown = getProperty(target, "a.b.0.c");
+
+        expect(initial).toBe(1);
+        expect(hasProperty(target, "a.b.0.c")).toBe(true);
+
+        setProperty(target, "a.b.0.d", 2);
+
+        const added: unknown = getProperty(target, "a.b.0.d");
+
+        expect(added).toBe(2);
+
+        deleteProperty(target, "a.b.0.c");
+
+        const fallback: unknown = getProperty(target, "missing.path", "fallback");
+
+        expect(hasProperty(target, "a.b.0.c")).toBe(false);
+        expect(fallback).toBe("fallback");
+    });
+
+    it("should escape a literal dot in a key", () => {
+        expect.assertions(2);
+
+        const escaped = escapePath("a.b");
+
+        const value: unknown = getProperty({ "a.b": 1 }, escaped);
+
+        expect(escaped).toBe(String.raw`a\.b`);
+        expect(value).toBe(1);
+    });
+
+    it("should refuse to pollute Object.prototype via setProperty", () => {
+        expect.assertions(2);
+
+        const target: Record<string, unknown> = {};
+
+        setProperty(target, "__proto__.polluted", true);
+
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+        expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+    });
+
+    it("should refuse to pollute via a constructor.prototype path", () => {
+        expect.assertions(1);
+
+        const target: Record<string, unknown> = {};
+
+        setProperty(target, "constructor.prototype.polluted", true);
+
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+});
+
+describe("re-exported deeks helpers", () => {
+    it("should list the deep keys of an object", () => {
+        expect.assertions(1);
+
+        expect(deepKeys({ a: { b: 1, c: { d: 2 } }, e: 3 })).toStrictEqual(["a.b", "a.c.d", "e"]);
+    });
+
+    it("should list the deep keys of a list of objects", () => {
+        expect.assertions(1);
+
+        expect(deepKeysFromList([{ a: 1 }, { b: { c: 2 } }])).toStrictEqual([["a"], ["b.c"]]);
+    });
+});

--- a/packages/data-manipulation/object/__tests__/utils/is-plain-object.test.ts
+++ b/packages/data-manipulation/object/__tests__/utils/is-plain-object.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import isPlainObject from "../../src/utils/is-plain-object";
+
+describe("is-plain-object", () => {
+    it("should accept object literals", () => {
+        expect.assertions(2);
+
+        expect(isPlainObject({})).toBe(true);
+        expect(isPlainObject({ a: 1 })).toBe(true);
+    });
+
+    it("should classify a null-prototype object as plain", () => {
+        expect.assertions(1);
+
+        expect(isPlainObject(Object.create(null))).toBe(true);
+    });
+
+    it("should reject arrays, dates, maps, sets and class instances", () => {
+        expect.assertions(5);
+
+        class Custom {
+            public value = 1;
+        }
+
+        expect(isPlainObject([])).toBe(false);
+        expect(isPlainObject(new Date())).toBe(false);
+        expect(isPlainObject(new Map())).toBe(false);
+        expect(isPlainObject(new Set())).toBe(false);
+        expect(isPlainObject(new Custom())).toBe(false);
+    });
+
+    it("should reject primitives and null", () => {
+        expect.assertions(4);
+
+        expect(isPlainObject(null)).toBe(false);
+        expect(isPlainObject(undefined)).toBe(false);
+        expect(isPlainObject("x")).toBe(false);
+        expect(isPlainObject(1)).toBe(false);
+    });
+
+    it("should reject host objects that carry a toStringTag or an iterator", () => {
+        expect.assertions(2);
+
+        // Platform objects are what `pick`/`omit` must copy by reference rather
+        // than walk into, and they are told apart by these two well-known symbols.
+        expect(isPlainObject(new URLSearchParams())).toBe(false);
+        expect(isPlainObject(new WeakMap())).toBe(false);
+    });
+});

--- a/packages/data-manipulation/object/__tests__/workerd/index.test.ts
+++ b/packages/data-manipulation/object/__tests__/workerd/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { deepKeys, deepKeysFromList, deleteProperty, escapePath, getProperty, hasProperty, isPlainObject, omit, pick, setProperty } from "../../src/index";
+
+/**
+ * The package's behavioural assertions live in `__tests__/*.test.ts` and
+ * `__tests__/utils/**`, which `vitest.workerd.config.ts` also runs inside the
+ * isolate — so `pick`, `omit` and the re-exported helpers are already verified
+ * against workerd by their single definition.
+ *
+ * What is left here is what only workerd can answer: that the module graph
+ * resolves at all in the isolate, and that `isPlainObject` classifies workerd's
+ * own host objects the way it classifies Node's.
+ */
+describe("@visulima/object on workerd", () => {
+    describe("module graph", () => {
+        it("should expose the whole public surface after loading in the isolate", () => {
+            expect.assertions(1);
+
+            const surface = { deepKeys, deepKeysFromList, deleteProperty, escapePath, getProperty, hasProperty, isPlainObject, omit, pick, setProperty };
+
+            expect(Object.values(surface).every((exported) => typeof exported === "function")).toBe(true);
+        });
+    });
+
+    describe("workerd host objects", () => {
+        it("should reject workerd-native objects that carry a toStringTag", () => {
+            expect.assertions(3);
+
+            // These are host objects implemented by the runtime, not by V8, so their
+            // prototype chain and well-known symbols are a runtime detail. `pick`/`omit`
+            // must treat them as opaque here exactly as they do in Node.
+            expect(isPlainObject(new Headers())).toBe(false);
+            expect(isPlainObject(new URLSearchParams())).toBe(false);
+            expect(isPlainObject(new Request("https://example.test"))).toBe(false);
+        });
+
+        it("should keep a workerd host object by reference instead of copying it", () => {
+            expect.assertions(2);
+
+            const headers = new Headers({ authorization: "Bearer x" });
+            const result = pick({ headers, other: 1 }, ["headers"]);
+
+            expect(result.headers).toBe(headers);
+            expect(result.headers.get("authorization")).toBe("Bearer x");
+        });
+    });
+});

--- a/packages/data-manipulation/object/eslint.config.js
+++ b/packages/data-manipulation/object/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/data-manipulation/object/package.json
+++ b/packages/data-manipulation/object/package.json
@@ -23,11 +23,6 @@
     ],
     "homepage": "https://visulima.com/packages/object",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -43,13 +38,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -57,10 +52,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -79,7 +75,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "dependencies": {
         "type-fest": "catalog:prod"
@@ -90,6 +87,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@total-typescript/ts-reset": "catalog:dev",
         "@types/node": "catalog:types",
@@ -112,5 +110,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/object/vitest.workerd.config.ts
+++ b/packages/data-manipulation/object/vitest.workerd.config.ts
@@ -1,0 +1,9 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig({
+    test: {
+        include: ["__tests__/*.test.ts", "__tests__/utils/**/*.test.ts", "__tests__/workerd/**/*.test.ts"],
+    },
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3252,6 +3252,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: catalog:lint
         version: 13.0.2
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
Runs the existing unit suite inside a workerd isolate rather than keeping a
second hand-written copy of the same assertions, so there is one definition
of each and no drift between runtimes. `__tests__/workerd/` keeps only what
workerd alone can answer: the export surface, `isPlainObject` against
`Headers`/`URLSearchParams`/`Request`, and a host object surviving `pick`.

Doing that surfaced real gaps the duplicate had been masking: there was no
`isPlainObject` test at all, no coverage of the re-exported `dot-prop` and
`deeks` helpers, and no null-prototype cases. Those now exist as unit tests
and run in both pools.

No source change was needed.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
