### PR TITLE
fix(path): guard process access in resolve

### DIFF
--- a/packages/filesystem/path/__tests__/workerd/path.test.ts
+++ b/packages/filesystem/path/__tests__/workerd/path.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Runtime-portability suite executed inside `workerd` (the Cloudflare Workers
+ * runtime) via `@cloudflare/vitest-pool-workers`.
+ *
+ * `@visulima/path` advertises itself as a runtime-agnostic, always-POSIX
+ * drop-in for `node:path`. These specs pin that promise down on a runtime that
+ * has no real working directory, reports `process.platform` as `"linux"`
+ * regardless of the host OS, and only exposes `node:*` builtins behind the
+ * `nodejs_compat` compatibility flag.
+ */
+import { describe, expect, it } from "vitest";
+
+import defaultExport, { posix, win32 } from "../../src/index";
+import {
+    basename,
+    delimiter,
+    dirname,
+    extname,
+    format,
+    isAbsolute,
+    join,
+    matchesGlob,
+    normalize,
+    parse,
+    relative,
+    resolve,
+    sep as separator,
+    toNamespacedPath,
+} from "../../src/path";
+
+describe("workerd runtime", () => {
+    it("runs inside workerd and not on the host platform", () => {
+        expect.assertions(2);
+
+        const workerNavigator = Reflect.get(globalThis, "navigator") as { userAgent?: string } | undefined;
+
+        expect(workerNavigator?.userAgent).toBe("Cloudflare-Workers");
+        // workerd always reports "linux" no matter what the host OS is.
+        expect(process.platform).toBe("linux");
+    });
+
+    it("resolves the `node:url` import site that `src/utils.ts` depends on", async () => {
+        expect.assertions(2);
+
+        const nodeUrl = await import("node:url");
+
+        expect(nodeUrl.fileURLToPath).toBeTypeOf("function");
+        expect(nodeUrl.fileURLToPath(new URL("file:///srv/a.txt"))).toBe("/srv/a.txt");
+    });
+
+    it("resolves the `node:path` import site that `src/index.ts` types against", async () => {
+        expect.assertions(1);
+
+        const nodePath = await import("node:path");
+
+        expect(nodePath.join).toBeTypeOf("function");
+    });
+});
+
+describe("workerd path constants", () => {
+    it("forces the POSIX separator and delimiter", () => {
+        expect.assertions(2);
+
+        expect(separator).toBe("/");
+        expect(delimiter).toBe(":");
+    });
+});
+
+describe("workerd join", () => {
+    it("joins and normalises POSIX segments", () => {
+        expect.assertions(4);
+
+        expect(join("a", "b")).toBe("a/b");
+        expect(join("/foo", "bar", "baz/asdf", "quux", "..")).toBe("/foo/bar/baz/asdf");
+        expect(join("foo", "", "bar")).toBe("foo/bar");
+        expect(join("/a/", "/b/", "/c")).toBe("/a/b/c");
+    });
+
+    it("folds backslash input into POSIX form", () => {
+        expect.assertions(2);
+
+        expect(join(String.raw`C:\foo`, "bar")).toBe("C:/foo/bar");
+        expect(join(String.raw`foo\bar`, "baz")).toBe("foo/bar/baz");
+    });
+
+    it("returns the current directory for an empty join", () => {
+        expect.assertions(1);
+
+        expect(join()).toBe(".");
+    });
+});
+
+describe("workerd normalize", () => {
+    it("collapses redundant segments", () => {
+        expect.assertions(4);
+
+        expect(normalize("/foo/bar//baz/asdf/quux/..")).toBe("/foo/bar/baz/asdf");
+        expect(normalize("")).toBe(".");
+        expect(normalize("./")).toBe("./");
+        expect(normalize("foo/../../bar")).toBe("../bar");
+    });
+
+    it("keeps UNC and drive roots intact", () => {
+        expect.assertions(2);
+
+        expect(normalize("//server/share")).toBe("//server/share");
+        expect(normalize("C:\\work\\\\foo\\bar\\..\\")).toBe("C:/work/foo/");
+    });
+});
+
+describe("workerd resolve", () => {
+    it("resolves absolute inputs without consulting the working directory", () => {
+        expect.assertions(3);
+
+        expect(resolve("/foo/bar", "./baz")).toBe("/foo/bar/baz");
+        expect(resolve("/foo/bar", "/srv/file/")).toBe("/srv/file");
+        expect(resolve("C:/foo", "bar")).toBe("C:/foo/bar");
+    });
+
+    /**
+     * `resolve()` with only relative segments is the one call that needs a real
+     * `process.cwd()`. workerd has no working directory of its own, so the
+     * documented contract is: never throw, never interpolate `undefined`, and
+     * always hand back an absolute POSIX path — falling back to the `"/"` root
+     * when the runtime cannot supply a cwd.
+     */
+    it("returns an absolute path for relative-only segments", () => {
+        expect.assertions(4);
+
+        const resolved = resolve("a", "b");
+
+        expect(resolved).toBeTypeOf("string");
+        expect(isAbsolute(resolved)).toBe(true);
+        expect(resolved).not.toContain("undefined");
+        expect(resolved.endsWith("/a/b")).toBe(true);
+    });
+
+    it("returns an absolute path when called with no arguments at all", () => {
+        expect.assertions(3);
+
+        const resolved = resolve();
+
+        expect(resolved).toBeTypeOf("string");
+        expect(isAbsolute(resolved)).toBe(true);
+        expect(resolved).not.toContain("undefined");
+    });
+
+    it("collapses a bare drive to its drive root", () => {
+        expect.assertions(1);
+
+        expect(resolve("C:/temp/..")).toBe("C:/");
+    });
+});
+
+describe("workerd relative", () => {
+    it("computes relative paths between absolute paths", () => {
+        expect.assertions(3);
+
+        expect(relative("/data/orandea/test/aaa", "/data/orandea/impl/bbb")).toBe("../../impl/bbb");
+        expect(relative("/a/b/c", "/a/b/c")).toBe("");
+        expect(relative("/a/b", "/a/b/c/d")).toBe("c/d");
+    });
+
+    it("returns the target verbatim across differing drive letters", () => {
+        expect.assertions(1);
+
+        expect(relative("C:/a/b", "D:/c/d")).toBe("D:/c/d");
+    });
+});
+
+describe("workerd dirname", () => {
+    it("returns the parent directory", () => {
+        expect.assertions(4);
+
+        expect(dirname("/foo/bar/baz/asdf/quux")).toBe("/foo/bar/baz/asdf");
+        expect(dirname("/foo")).toBe("/");
+        expect(dirname("foo")).toBe(".");
+        expect(dirname("C:/temp/file.txt")).toBe("C:/temp");
+    });
+});
+
+describe("workerd basename", () => {
+    it("returns the trailing segment", () => {
+        expect.assertions(3);
+
+        expect(basename("/foo/bar/baz/asdf/quux.html")).toBe("quux.html");
+        expect(basename("/foo/bar/baz/asdf/quux.html", ".html")).toBe("quux");
+        expect(basename(String.raw`C:\foo\bar.txt`)).toBe("bar.txt");
+    });
+});
+
+describe("workerd extname", () => {
+    it("returns the trailing extension", () => {
+        expect.assertions(4);
+
+        expect(extname("index.html")).toBe(".html");
+        expect(extname("index.coffee.md")).toBe(".md");
+        expect(extname("/path/to/file.tar.gz")).toBe(".gz");
+        expect(extname("index")).toBe("");
+    });
+});
+
+describe("workerd isAbsolute", () => {
+    it("classifies POSIX, UNC and drive-letter paths", () => {
+        expect.assertions(5);
+
+        expect(isAbsolute("/foo/bar")).toBe(true);
+        expect(isAbsolute("//server")).toBe(true);
+        expect(isAbsolute("C:/foo")).toBe(true);
+        expect(isAbsolute("bar/baz")).toBe(false);
+        expect(isAbsolute(".")).toBe(false);
+    });
+});
+
+describe("workerd parse and format", () => {
+    it("parses a path into its components", () => {
+        expect.assertions(1);
+
+        expect(parse("/home/user/dir/file.txt")).toStrictEqual({
+            base: "file.txt",
+            dir: "/home/user/dir",
+            ext: ".txt",
+            name: "file",
+            root: "/",
+        });
+    });
+
+    it("round-trips parse into format", () => {
+        expect.assertions(1);
+
+        const parsed = parse("/home/user/dir/file.txt");
+
+        expect(format({ base: parsed.base, dir: parsed.dir })).toBe("/home/user/dir/file.txt");
+    });
+
+    it("formats from root, name and ext", () => {
+        expect.assertions(2);
+
+        expect(format({ base: "file.txt", root: "/" })).toBe("/file.txt");
+        expect(format({ ext: ".txt", name: "file" })).toBe("file.txt");
+    });
+});
+
+describe("workerd toNamespacedPath", () => {
+    it("folds a namespaced Windows path into POSIX form", () => {
+        expect.assertions(2);
+
+        expect(toNamespacedPath(String.raw`C:\foo\bar`)).toBe("C:/foo/bar");
+        expect(toNamespacedPath("/foo/bar")).toBe("/foo/bar");
+    });
+});
+
+describe("workerd matchesGlob", () => {
+    it("matches globs through the bundled matcher", () => {
+        expect.assertions(2);
+
+        expect(matchesGlob("/foo/bar.js", "**/*.js")).toBe(true);
+        expect(matchesGlob("/foo/bar.ts", "**/*.js")).toBe(false);
+    });
+});
+
+describe("workerd posix and win32 namespaces", () => {
+    it("aliases both namespaces onto the same POSIX implementation", () => {
+        expect.assertions(3);
+
+        expect(posix).toBe(win32);
+        expect(posix.sep).toBe("/");
+        expect(win32.sep).toBe("/");
+    });
+
+    it("produces identical output from both namespaces", () => {
+        expect.assertions(3);
+
+        expect(win32.join("a", "b")).toBe("a/b");
+        expect(posix.join("a", "b")).toBe("a/b");
+        expect(win32.normalize(String.raw`a\b\..\c`)).toBe("a/c");
+    });
+
+    it("exposes the same implementation through the default export", () => {
+        expect.assertions(2);
+
+        expect(defaultExport.sep).toBe("/");
+        expect(defaultExport.join("a", "b")).toBe("a/b");
+    });
+});

--- a/packages/filesystem/path/__tests__/workerd/utils.test.ts
+++ b/packages/filesystem/path/__tests__/workerd/utils.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Platform-detection and URL-helper portability specs for `workerd`.
+ *
+ * The interesting cases here are the ones where `process` is only partially
+ * present: workerd exposes a `process` shim behind `nodejs_compat`, bundlers
+ * frequently inject a stub such as `{ platform: "browser" }`, and sandboxed
+ * runtimes can expose `process.cwd` while making the call itself throw. None of
+ * those shapes may crash a path library.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isAbsolute, resolve, sep as separator } from "../../src/path";
+import { filename, isBinaryPath, isRelative, isWindows, normalizeAliases, resolveAlias, reverseResolveAlias, toPath } from "../../src/utils";
+
+describe("workerd isWindows", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("reports false on the stock workerd runtime", () => {
+        expect.assertions(1);
+
+        // workerd reports `process.platform === "linux"` even when the host is
+        // Windows or macOS, so path behaviour must never key off the host OS.
+        expect(isWindows()).toBe(false);
+    });
+
+    it("reports false when there is no process global at all", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", undefined);
+
+        expect(isWindows()).toBe(false);
+    });
+
+    it("does not throw when process exists without an env object", () => {
+        expect.assertions(1);
+
+        // A bare `{}` is what minimal bundler/runtime shims provide.
+        vi.stubGlobal("process", {});
+
+        expect(isWindows()).toBe(false);
+    });
+
+    it("does not throw when process reports a platform but has no env object", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { platform: "linux" });
+
+        expect(isWindows()).toBe(false);
+    });
+
+    it("honours a stubbed win32 platform", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", { env: {}, platform: "win32" });
+
+        expect(isWindows()).toBe(true);
+
+        vi.stubGlobal("process", { env: {}, platform: "cygwin" });
+
+        expect(isWindows()).toBe(true);
+    });
+
+    it("honours the OSTYPE escape hatch", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", { env: { OSTYPE: "msys" }, platform: "linux" });
+
+        expect(isWindows()).toBe(true);
+
+        vi.stubGlobal("process", { env: { OSTYPE: "darwin" }, platform: "linux" });
+
+        expect(isWindows()).toBe(false);
+    });
+});
+
+describe("workerd platform independence", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("keeps POSIX behaviour even when the platform claims win32", () => {
+        expect.assertions(3);
+
+        vi.stubGlobal("process", { cwd: () => String.raw`C:\Windows\path\only`, env: {}, platform: "win32" });
+
+        // `sep` is a module constant and is POSIX by contract on every platform.
+        expect(separator).toBe("/");
+        expect(resolve("/foo", "bar")).toBe("/foo/bar");
+        expect(resolve("a")).toBe("C:/Windows/path/only/a");
+    });
+
+    it("falls back to the root when the runtime has no cwd function", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", { env: {}, platform: "linux" });
+
+        expect(resolve("a", "b")).toBe("/a/b");
+        expect(isAbsolute(resolve("a", "b"))).toBe(true);
+    });
+
+    /**
+     * Sandboxed runtimes (workerd behind some flag combinations, Deno without
+     * `--allow-sys`) expose `process.cwd` but throw when it is called. `resolve()`
+     * already documents that it "handles relative paths to be safe (might happen
+     * when process.cwd() fails)" — so the failure must be absorbed, not rethrown.
+     */
+    it("falls back to the root when cwd() throws", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", {
+            cwd: () => {
+                throw new Error("Not implemented");
+            },
+            env: {},
+            platform: "linux",
+        });
+
+        expect(() => resolve("a", "b")).not.toThrow();
+        expect(resolve("a", "b")).toBe("/a/b");
+    });
+
+    it("falls back to the root when cwd() returns a non-string", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { cwd: () => undefined, env: {}, platform: "linux" });
+
+        expect(resolve("a", "b")).toBe("/a/b");
+    });
+});
+
+describe("workerd toPath", () => {
+    it("converts a file URL to a POSIX path", () => {
+        expect.assertions(2);
+
+        expect(toPath(new URL("file:///srv/foo/bar.txt"))).toBe("/srv/foo/bar.txt");
+        expect(toPath("/srv/foo/bar.txt")).toBe("/srv/foo/bar.txt");
+    });
+
+    it("percent-decodes file URLs", () => {
+        expect.assertions(1);
+
+        expect(toPath(new URL("file:///srv/a%20b/c.txt"))).toBe("/srv/a b/c.txt");
+    });
+
+    it("folds backslashes in plain string input", () => {
+        expect.assertions(1);
+
+        expect(toPath(String.raw`C:\foo\bar.txt`)).toBe("C:/foo/bar.txt");
+    });
+});
+
+describe("workerd utils helpers", () => {
+    it("extracts filenames", () => {
+        expect.assertions(3);
+
+        expect(filename("/foo/bar/baz.txt")).toBe("baz");
+        expect(filename(String.raw`C:\foo\bar.tar.gz`)).toBe("bar.tar");
+        expect(filename("")).toBeUndefined();
+    });
+
+    it("detects binary extensions", () => {
+        expect.assertions(2);
+
+        expect(isBinaryPath("/foo/bar.png")).toBe(true);
+        expect(isBinaryPath("/foo/bar.ts")).toBe(false);
+    });
+
+    it("detects relative paths", () => {
+        expect.assertions(3);
+
+        expect(isRelative("./foo")).toBe(true);
+        expect(isRelative("..")).toBe(true);
+        expect(isRelative("/foo")).toBe(false);
+    });
+
+    it("normalises and resolves aliases", () => {
+        expect.assertions(3);
+
+        const aliases = normalizeAliases({ "@": "/root", "~": "/root/index.js" });
+
+        expect(aliases).toStrictEqual({ "@": "/root", "~": "/root/index.js" });
+        expect(resolveAlias("@/foo/bar", aliases)).toBe("/root/foo/bar");
+        expect(reverseResolveAlias("/root/foo/bar", aliases)).toBe("@/foo/bar");
+    });
+});

--- a/packages/filesystem/path/eslint.config.js
+++ b/packages/filesystem/path/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "package.json",

--- a/packages/filesystem/path/package.json
+++ b/packages/filesystem/path/package.json
@@ -19,11 +19,6 @@
     ],
     "homepage": "https://visulima.com/packages/path",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -39,19 +34,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -63,10 +52,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -85,7 +76,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -93,6 +85,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:dev",
@@ -114,5 +107,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/filesystem/path/src/path.ts
+++ b/packages/filesystem/path/src/path.ts
@@ -32,9 +32,30 @@ const EXTNAME_RE = /[^/](\.[^./]+)$/;
 const PATH_ROOT_RE = /^[/\\]|^[a-z]:[/\\]/i;
 const TRAILING_SLASH_RE = /\/$/;
 
-const cwd = () => {
+/**
+ * The working directory used to anchor relative {@link resolve} calls.
+ *
+ * Runtimes without a filesystem (workerd/Cloudflare Workers, browsers) either
+ * omit `process` entirely, expose a `process` shim with no `cwd`, or expose a
+ * `cwd` that throws or hands back a non-string. In every one of those cases the
+ * documented fallback is the POSIX root `"/"`, so `resolve()` still yields an
+ * absolute path instead of throwing or leaking `undefined` into the result.
+ *
+ * A `cwd()` that returns an empty string is deliberately *not* treated as a
+ * failure: it is an explicit "no anchor" answer and keeps `resolve(".", "./")`
+ * collapsing to `"."` rather than being rooted at `"/"`.
+ */
+const cwd = (): string => {
     if (typeof process !== "undefined" && typeof process.cwd === "function") {
-        return normalizeWindowsPath(process.cwd());
+        try {
+            const current = process.cwd();
+
+            if (typeof current === "string") {
+                return normalizeWindowsPath(current);
+            }
+        } catch {
+            // Sandboxed runtimes can expose `cwd` and still deny the call.
+        }
     }
 
     return "/";

--- a/packages/filesystem/path/src/utils.ts
+++ b/packages/filesystem/path/src/utils.ts
@@ -146,6 +146,28 @@ const IS_RELATIVE_RE = /^(?:\.?\.[/\\]|\.\.\B)/;
 
 const MSYS_CYGWIN_RE = /^(?:msys|cygwin)$/;
 
+/** The part of the `process` global this module reads, with every member optional. */
+interface HostProcess {
+    env?: Record<string, string | undefined>;
+}
+
+/**
+ * The environment map of a `process` global, or an empty object when the runtime
+ * ships a `process` that has no `env` — workerd without `nodejs_compat`, and bundler
+ * shims that inject only `{ platform }`. Reading `process.env.X` straight off the
+ * global would throw a `TypeError` there.
+ *
+ * `@visulima/ansi` solves the same problem with a module-level constant, but that
+ * shape does not fit here: `isWindows()` is a function so that callers — and its
+ * tests, via `vi.stubGlobal("process", …)` — can swap the global and see the answer
+ * change, which a value captured at module evaluation could not do. Widening the
+ * parameter to {@link HostProcess} is what makes `?? {}` type-necessary, so no lint
+ * suppression is needed to express it.
+ * @param host The `process` global to read.
+ * @returns The environment map, never `undefined`.
+ */
+const environmentOf = (host: HostProcess): Record<string, string | undefined> => host.env ?? {};
+
 export const isRelative = (path: string): boolean => IS_RELATIVE_RE.test(path) || path === "..";
 
 /**
@@ -173,7 +195,7 @@ export const isWindows = (): boolean => {
         return true;
     }
 
-    const osType = globalThis.process.env.OSTYPE;
+    const osType = environmentOf(globalThis.process).OSTYPE;
 
     if (typeof osType !== "string") {
         return false;

--- a/packages/filesystem/path/vitest.workerd.config.ts
+++ b/packages/filesystem/path/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6325,6 +6325,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: catalog:lint
         version: 13.0.2
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
Two defects, both reachable outside Node:

`isWindows()` checked `globalThis.process` and then dereferenced
`process.env.OSTYPE` unconditionally, throwing a `TypeError` on any runtime
that exposes a `process` without `env` — workerd without `nodejs_compat`, and
the common bundler shim that injects only `{ platform }`.

`resolve()` checked that `process.cwd` was a function but not that calling it
worked. A sandboxed `cwd` that throws escaped out of `resolve()`, and one
returning a non-string produced a relative path where an absolute one is
contracted. Both now fall back to the POSIX root the code already documents.

An empty-string `cwd()` is deliberately still treated as valid, which keeps
the existing `resolve(".", "./") === "."` contract.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
