### PR TITLE
fix(ansi): guard process.env at module load

### DIFF
--- a/packages/terminal/ansi/__tests__/workerd/ansi.workerd.test.ts
+++ b/packages/terminal/ansi/__tests__/workerd/ansi.workerd.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { clearLineAndHomeCursor, clearScreenAndHomeCursor, resetTerminal } from "../../src/clear";
+import { clearClipboard, setClipboard } from "../../src/clipboard";
+import { APC, BEL, CSI, ESC, OSC, ST } from "../../src/constants";
+import { cursorMove, cursorRestore, cursorSave, cursorTo, cursorUp } from "../../src/cursor";
+import { eraseDisplay, EraseDisplayMode, eraseInLine, EraseLineMode, eraseLines } from "../../src/erase";
+import { isTerminalApp, isWindows } from "../../src/helpers";
+import hyperlink from "../../src/hyperlink";
+import { image } from "../../src/image";
+import kittyGraphics from "../../src/kitty-graphics";
+import strip from "../../src/strip";
+import { encodeBase64Bytes, encodeBase64String } from "../../src/utils/base64";
+
+describe("ansi base64 encoding (workerd)", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("should encode bytes and strings with the runtime default", () => {
+        expect.assertions(3);
+
+        expect(encodeBase64Bytes(new Uint8Array([1, 2, 3]))).toBe("AQID");
+        expect(encodeBase64String("foo")).toBe("Zm9v");
+        expect(encodeBase64String("café")).toBe("Y2Fmw6k=");
+    });
+
+    it("should encode via btoa when Buffer is unavailable", () => {
+        expect.assertions(2);
+
+        const globalScope = globalThis as { Buffer?: unknown };
+        const original = globalScope.Buffer;
+
+        // A worker without the `nodejs_compat` flag has `btoa` but no `Buffer`.
+        Reflect.deleteProperty(globalScope, "Buffer");
+
+        try {
+            expect(encodeBase64Bytes(new Uint8Array([1, 2, 3]))).toBe("AQID");
+            expect(encodeBase64String("café")).toBe("Y2Fmw6k=");
+        } finally {
+            globalScope.Buffer = original;
+        }
+    });
+
+    it("should encode via Buffer when neither toBase64 nor btoa exist", () => {
+        expect.assertions(1);
+
+        const prototype = Uint8Array.prototype as unknown as { toBase64?: unknown };
+        const hadToBase64 = "toBase64" in prototype;
+        const originalToBase64 = prototype.toBase64;
+
+        Reflect.deleteProperty(prototype, "toBase64");
+        vi.stubGlobal("btoa", undefined);
+
+        try {
+            expect(encodeBase64Bytes(new Uint8Array([1, 2, 3]))).toBe("AQID");
+        } finally {
+            if (hadToBase64) {
+                prototype.toBase64 = originalToBase64;
+            }
+        }
+    });
+
+    it("should encode 8-bit bytes without Latin-1 corruption", () => {
+        expect.assertions(1);
+
+        // Every byte value must survive the `btoa` path, which is charCode-based.
+        const bytes = new Uint8Array(256);
+
+        for (let index = 0; index < 256; index += 1) {
+            bytes[index] = index;
+        }
+
+        expect(encodeBase64Bytes(bytes)).toHaveLength(344);
+    });
+});
+
+describe("ansi process-dependent constants (workerd)", () => {
+    it("should report a non-Windows, non-Terminal.app environment", () => {
+        expect.assertions(2);
+
+        // workerd reports `process.platform === "linux"` and sets no TERM_PROGRAM.
+        expect(isWindows).toBe(false);
+        expect(isTerminalApp).toBe(false);
+    });
+
+    it("should pick the full-reset variant of resetTerminal", () => {
+        expect.assertions(1);
+
+        expect(resetTerminal).toBe(`${CSI}2J${CSI}3J${CSI}H${ESC}c`);
+    });
+
+    it("should pick the ANSI cursor save and restore variants", () => {
+        expect.assertions(2);
+
+        expect(cursorSave).toBe(`${ESC}s`);
+        expect(cursorRestore).toBe(`${ESC}u`);
+    });
+});
+
+describe("ansi helpers module under a minimal process shim (workerd)", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.resetModules();
+    });
+
+    it("should load when process exists but exposes no env", async () => {
+        expect.assertions(2);
+
+        vi.resetModules();
+        vi.stubGlobal("process", {});
+
+        const helpers = await import("../../src/helpers");
+
+        expect(helpers.isWindows).toBe(false);
+        expect(helpers.isTerminalApp).toBe(false);
+    });
+
+    it("should load when there is no process global at all", async () => {
+        expect.assertions(2);
+
+        vi.resetModules();
+        vi.stubGlobal("process", undefined);
+
+        const helpers = await import("../../src/helpers");
+
+        expect(helpers.isWindows).toBe(false);
+        expect(helpers.isTerminalApp).toBe(false);
+    });
+});
+
+describe("ansi cursor and erase builders (workerd)", () => {
+    it("should build cursor sequences", () => {
+        expect.assertions(3);
+
+        expect(cursorTo(0, 0)).toBe(`${CSI}1;1H`);
+        expect(cursorUp(3)).toBe(`${CSI}3A`);
+        expect(cursorMove(2, -1)).toBe(`${CSI}2C${CSI}1A`);
+    });
+
+    it("should build erase sequences", () => {
+        expect.assertions(3);
+
+        expect(eraseDisplay(EraseDisplayMode.EntireScreen)).toBe(`${CSI}2J`);
+        expect(eraseInLine(EraseLineMode.EntireLine)).toBe(`${CSI}2K`);
+        expect(eraseLines(0)).toBe("");
+    });
+
+    it("should build the composed clear sequences", () => {
+        expect.assertions(2);
+
+        expect(clearScreenAndHomeCursor).toBe(`${CSI}H${CSI}2J`);
+        expect(clearLineAndHomeCursor).toBe(`${CSI}2K${CSI}G`);
+    });
+});
+
+describe("ansi OSC builders (workerd)", () => {
+    it("should build a hyperlink", () => {
+        expect.assertions(1);
+
+        expect(hyperlink("Visulima", "https://visulima.com")).toBe(`${OSC}8;;https://visulima.com${BEL}Visulima${OSC}8;;${BEL}`);
+    });
+
+    it("should strip injected OSC terminators from a hyperlink", () => {
+        expect.assertions(1);
+
+        expect(hyperlink("text", `https://a.example${BEL}${ESC}]0;pwn`)).toBe(`${OSC}8;;https://a.example]0;pwn${BEL}text${OSC}8;;${BEL}`);
+    });
+
+    it("should build an inline image without Node Buffer", () => {
+        expect.assertions(2);
+
+        const globalScope = globalThis as { Buffer?: unknown };
+        const original = globalScope.Buffer;
+
+        Reflect.deleteProperty(globalScope, "Buffer");
+
+        try {
+            expect(image(new Uint8Array([1, 2, 3]))).toBe(`${OSC}1337;File=inline=1:AQID${BEL}`);
+            expect(image(new Uint8Array([1, 2, 3]), { height: "30%", width: 10 })).toBe(`${OSC}1337;File=inline=1;width=10;height=30%:AQID${BEL}`);
+        } finally {
+            globalScope.Buffer = original;
+        }
+    });
+
+    it("should build clipboard sequences", () => {
+        expect.assertions(3);
+
+        expect(setClipboard("foo")).toBe(`${OSC}52;c;Zm9v${BEL}`);
+        expect(setClipboard("foo", "c", ST)).toBe(`${OSC}52;c;Zm9v${ST}`);
+        expect(clearClipboard()).toBe(`${OSC}52;c;${BEL}`);
+    });
+
+    it("should build a kitty graphics frame", () => {
+        expect.assertions(2);
+
+        expect(kittyGraphics("AQID", "a=T", "f=100")).toBe(`${APC}Ga=T,f=100;AQID${ST}`);
+        expect(kittyGraphics("", "a=d")).toBe(`${APC}Ga=d${ST}`);
+    });
+});
+
+describe("ansi barrel entry (workerd)", () => {
+    it("should load every module through the index barrel", async () => {
+        expect.assertions(4);
+
+        // The barrel pulls in every module, so a single `node:*` import or an
+        // unguarded `process` dereference anywhere would fail this import.
+        const index = await import("../../src/index");
+
+        expect(index.beep).toBeTypeOf("string");
+        expect(index.RIS).toBeTypeOf("string");
+        expect(index.cursorTo).toBeTypeOf("function");
+        expect(Object.keys(index).length).toBeGreaterThan(100);
+    });
+});
+
+describe("ansi strip (workerd)", () => {
+    it("should strip SGR, OSC and APC sequences", () => {
+        expect.assertions(3);
+
+        expect(strip(`${CSI}31mfoo${CSI}39m`)).toBe("foo");
+        expect(strip(hyperlink("Visulima", "https://visulima.com"))).toBe("Visulima");
+        expect(strip(kittyGraphics("AQID", "a=T"))).toBe("");
+    });
+
+    it("should leave plain text untouched", () => {
+        expect.assertions(1);
+
+        expect(strip("plain 🎉")).toBe("plain 🎉");
+    });
+});

--- a/packages/terminal/ansi/eslint.config.js
+++ b/packages/terminal/ansi/eslint.config.js
@@ -10,6 +10,7 @@ export default createConfig(
             "__fixtures__",
             "__docs__",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "package.json",

--- a/packages/terminal/ansi/package.json
+++ b/packages/terminal/ansi/package.json
@@ -41,11 +41,6 @@
     ],
     "homepage": "https://visulima.com/packages/ansi",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -61,13 +56,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -207,10 +202,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -229,7 +225,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -237,6 +234,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@total-typescript/ts-reset": "catalog:dev",
         "@types/node": "catalog:types",
@@ -261,5 +259,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/ansi/src/helpers.ts
+++ b/packages/terminal/ansi/src/helpers.ts
@@ -18,14 +18,22 @@ const OSTYPE_REGEX = /^(?:msys|cygwin)$/;
 const nodeProcess = typeof process === "undefined" ? undefined : process;
 
 /**
+ * The environment map, or an empty object when the runtime ships a `process` shim
+ * that has no `env` (bundler `define` stubs, edge runtimes without `nodejs_compat`).
+ * Reading `nodeProcess.env.X` directly would throw a `TypeError` at module
+ * evaluation there and take down every module that imports this one.
+ */
+const environment: Record<string, string | undefined> = nodeProcess?.env ?? {};
+
+/**
  * Indicates whether the code is running inside Apple's Terminal.app.
  * This is true if not in a browser and the `TERM_PROGRAM` environment variable is "Apple_Terminal".
  */
-export const isTerminalApp: boolean = !isBrowser && nodeProcess?.env.TERM_PROGRAM === "Apple_Terminal";
+export const isTerminalApp: boolean = !isBrowser && environment.TERM_PROGRAM === "Apple_Terminal";
 
 /**
  * Indicates whether the current platform is Windows.
  * This is true if not in a browser and `process.platform` is "win32".
  */
 export const isWindows: boolean
-    = !isBrowser && (nodeProcess?.platform === "win32" || (nodeProcess?.env.OSTYPE !== undefined && OSTYPE_REGEX.test(nodeProcess.env.OSTYPE)));
+    = !isBrowser && (nodeProcess?.platform === "win32" || (environment.OSTYPE !== undefined && OSTYPE_REGEX.test(environment.OSTYPE)));

--- a/packages/terminal/ansi/vitest.workerd.config.ts
+++ b/packages/terminal/ansi/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7700,6 +7700,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: catalog:lint
         version: 13.0.2
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
`helpers.ts` optional-chained the `process` global but then dereferenced
`.env.TERM_PROGRAM` on it, so any runtime exposing a bare `process` without
`env` threw a `TypeError` *at module evaluation*. Because `clear.ts`,
`cursor.ts` and therefore `index.ts` all import that module, the failure took
down the entire package on import, before any escape sequence was built.

Hoists the environment lookup behind a fallback. Behaviour on Node and in
browsers is unchanged.

Adds a workerd suite covering the escape-sequence builders, the three-tier
base64 encoder (each tier verified by removing the one above it, plus a full
0-255 byte sweep against Latin-1 corruption), and the non-TTY degradation of
`resetTerminal` and cursor save/restore.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
