### PR TITLE
fix(redact): pass walked dot-path to censor

### DIFF
--- a/packages/data-manipulation/redact/README.md
+++ b/packages/data-manipulation/redact/README.md
@@ -178,6 +178,11 @@ redact({ card: "4111111111111111" }, [{ key: "card", replacement: (value) => `**
 // => { card: "****1111" }
 ```
 
+`path` is the full, lowercased dot-path the value was found at — not the rule key. A `card` rule
+matching `{ user: { card } }` receives `"user.card"`, and array elements are included by index
+(`"items.0.card"`). It is `undefined` for matches with no key path, such as string-anonymizer and
+URL query-string matches.
+
 The same works for `pattern`-based string rules (the matched substring is passed as `value`).
 
 ### Removing keys

--- a/packages/data-manipulation/redact/__tests__/unit/features.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/features.test.ts
@@ -85,6 +85,38 @@ describe("censor / partial masking", () => {
         expect(seen).toStrictEqual([{ path: "card", value: "4111111111111111" }]);
     });
 
+    // A plain (non-wildcard) rule that resolves on a nested node is applied through the
+    // direct-path branch of `recursivelyFilterAttributes`. That branch used to hand the censor
+    // the bare rule key, so `{ user: { card } }` + a "card" rule reported "card" instead of
+    // "user.card" — while wildcard rules already reported the full walked path. The censor's
+    // documented `path` argument is the dot-path of the matched key, so these pin the joined
+    // path for every branch that can reach a censor.
+    it.each([
+        ["a top-level key", { card: "x" }, "card", "card"],
+        ["a nested key", { user: { card: "x" } }, "card", "user.card"],
+        ["a deeply nested key", { a: { b: { c: { card: "x" } } } }, "card", "a.b.c.card"],
+        ["a key inside an array element", { items: [{ card: "x" }] }, "card", "items.0.card"],
+        ["a wildcard rule", { user: { cardNumber: "x" } }, "card*", "user.cardnumber"],
+        ["a dotted rule on a nested node", { a: { user: { card: "x" } } }, "user.card", "a.user.card"],
+    ])("passes the full walked dot-path to a censor for %s", (_name, input, key, expectedPath) => {
+        expect.assertions(1);
+
+        const seen: (string | undefined)[] = [];
+
+        redact(input, [
+            {
+                key,
+                replacement: (_value, path) => {
+                    seen.push(path);
+
+                    return "<MASKED>";
+                },
+            },
+        ]);
+
+        expect(seen).toStrictEqual([expectedPath]);
+    });
+
     it("applies a censor function via a pattern rule on a string", () => {
         expect.assertions(1);
 
@@ -99,6 +131,59 @@ describe("censor / partial masking", () => {
         ]);
 
         expect(result).toBe("contact me at ***@example.com");
+    });
+
+    it("supports a non-string replacement value", () => {
+        expect.assertions(2);
+
+        expect(redact({ secret: "x" }, [{ key: "secret", replacement: 0 }]).secret).toBe(0);
+        expect(redact({ secret: "x" }, [{ key: "secret", replacement: false }]).secret).toBe(false);
+    });
+
+    it("falls back to the default placeholder for a nullish replacement", () => {
+        expect.assertions(2);
+
+        // `replacement` is resolved with `??`, so an explicit null/undefined is
+        // treated as "not supplied" and the `<KEY>` default is used.
+        expect(redact({ secret: "x" }, [{ key: "secret", replacement: null }]).secret).toBe("<SECRET>");
+        expect(redact({ secret: "x" }, [{ key: "secret", replacement: undefined }]).secret).toBe("<SECRET>");
+    });
+});
+
+describe("accessor properties", () => {
+    it("materialises an own enumerable getter as its value", () => {
+        expect.assertions(2);
+
+        const input = {
+            get password(): string {
+                return "computed";
+            },
+            user: "alice",
+        };
+
+        const result = redact(input, ["password"]);
+
+        expect(result.password).toBe("<PASSWORD>");
+        expect(result.user).toBe("alice");
+    });
+
+    it("does not read prototype getters", () => {
+        expect.assertions(1);
+
+        // Only own properties are walked, so a prototype accessor is never invoked
+        // and never lands on the copy — invoking it could have side effects.
+        class WithAccessor {
+            public user = "alice";
+
+            // eslint-disable-next-line class-methods-use-this
+            public get password(): string {
+                return "computed";
+            }
+        }
+
+        const result = redact(new WithAccessor(), ["password"]) as Record<string, unknown>;
+
+        expect(Object.hasOwn(result, "password")).toBe(false);
     });
 });
 
@@ -233,7 +318,7 @@ describe("array index rules preserve later element paths", () => {
     });
 });
 
-describe("Map rule precedence", () => {
+describe("map rule precedence", () => {
     it("lets a later, more specific rule override an earlier one for Map entries", () => {
         expect.assertions(1);
 
@@ -296,5 +381,52 @@ describe("themed rule subsets", () => {
         const result = redact("met on monday", [...credentialRules]);
 
         expect(result).toBe("met on monday");
+    });
+
+    it("redacts a credential key and leaves the rest alone with credentialRules", () => {
+        expect.assertions(2);
+
+        const result = redact({ note: "public", password: "hunter2" }, credentialRules);
+
+        expect(result.password).toBe("<PASSWORD>");
+        expect(result.note).toBe("public");
+    });
+
+    it("masks a bearer token inside a nested string with credentialRules", () => {
+        expect.assertions(1);
+
+        const result = redact({ header: "Authorization: Bearer abc.def.ghi" }, credentialRules);
+
+        expect(result.header).not.toContain("abc.def.ghi");
+    });
+
+    it("runs the aggregate standard rule set without throwing", () => {
+        expect.assertions(2);
+
+        // eslint-disable-next-line sonarjs/no-hardcoded-ip
+        const result = redact({ card: "4111111111111111", ip: "192.168.0.1", password: "p" }, standardRules);
+
+        expect(result.password).toBe("<PASSWORD>");
+        expect(result.ip).toBeTypeOf("string");
+    });
+});
+
+describe("top-level string inputs", () => {
+    it("redacts a JSON string and returns JSON", () => {
+        expect.assertions(1);
+
+        const result = redact(String.raw`{"password":"p","user":"alice"}`, ["password"]);
+
+        expect(JSON.parse(result)).toStrictEqual({ password: "<PASSWORD>", user: "alice" });
+    });
+
+    it("returns primitives that are not strings unchanged", () => {
+        expect.assertions(4);
+
+        expect(redact(42, ["password"])).toBe(42);
+        expect(redact(true, ["password"])).toBe(true);
+        expect(redact(null, ["password"])).toBeNull();
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+        expect(redact(undefined, ["password"])).toBeUndefined();
     });
 });

--- a/packages/data-manipulation/redact/__tests__/workerd/index.test.ts
+++ b/packages/data-manipulation/redact/__tests__/workerd/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { createRedactor, credentialRules, piiRules, redact, standardRules, stringAnonymize } from "../../src/index";
+
+/**
+ * The behavioural assertions live in `__tests__/unit/**`, which
+ * `vitest.workerd.config.ts` also runs inside the isolate — so the redaction
+ * rules, the walker, the censor contract and the rule sets are all verified
+ * against workerd by their single definition.
+ *
+ * What is left here is what only workerd can answer: that the module graph
+ * (including the sizeable `compromise` NLP dependency) loads in an isolate with
+ * no `node:*` I/O, and that the walker copes with workerd's own host objects.
+ */
+describe("@visulima/redact on workerd", () => {
+    describe("module graph", () => {
+        it("should expose the whole public surface after loading in the isolate", () => {
+            expect.assertions(2);
+
+            expect([createRedactor, redact, stringAnonymize].every((exported) => typeof exported === "function")).toBe(true);
+            expect([credentialRules, piiRules, standardRules].every((rules) => Array.isArray(rules) && rules.length > 0)).toBe(true);
+        });
+
+        it("should load the compromise NLP dependency inside the isolate", () => {
+            expect.assertions(2);
+
+            // `compromise` is a real runtime dependency pulled in lazily for NLP rules.
+            // It is by far the largest thing in the graph, so a bundling or
+            // `node:*`-resolution failure would surface here first.
+            const output = stringAnonymize("write to alice@example.com today", [{ deep: true, key: "email" }]);
+
+            expect(output).not.toContain("alice@example.com");
+            expect(output).toContain("<EMAIL>");
+        });
+    });
+
+    describe("workerd host objects", () => {
+        it("should redact the entries lifted off a Headers instance", () => {
+            expect.assertions(2);
+
+            const headers = new Headers({ authorization: "Bearer abc.def.ghi", "x-request-id": "req-1" });
+            const output = redact(Object.fromEntries(headers), ["authorization"]);
+
+            expect(output.authorization).toBe("<AUTHORIZATION>");
+            expect(output["x-request-id"]).toBe("req-1");
+        });
+
+        it("should redact a query string produced by the URL implementation", () => {
+            expect.assertions(1);
+
+            const url = new URL("https://api.test/v1");
+
+            url.searchParams.set("access_token", "abc");
+            url.searchParams.set("page", "2");
+
+            // eslint-disable-next-line no-secrets/no-secrets -- the redacted placeholder this asserts on, not a real credential
+            expect(redact(url.toString(), ["access_token"])).toContain("access_token=<ACCESS_TOKEN>");
+        });
+    });
+});

--- a/packages/data-manipulation/redact/eslint.config.js
+++ b/packages/data-manipulation/redact/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "__bench__",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "package.json",

--- a/packages/data-manipulation/redact/package.json
+++ b/packages/data-manipulation/redact/package.json
@@ -26,11 +26,6 @@
     ],
     "homepage": "https://visulima.com/packages/redact/",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -46,14 +41,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "import": {
@@ -64,10 +58,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -86,7 +82,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "dependencies": {
         "compromise": "catalog:prod"
@@ -97,6 +94,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:dev",
@@ -117,5 +115,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/redact/src/index.ts
+++ b/packages/data-manipulation/redact/src/index.ts
@@ -115,7 +115,14 @@ const recursivelyFilterAttributes = (
         if (modifier.remove) {
             deleteProperty(copy, modifier.key);
         } else {
-            setProperty(copy, modifier.key, resolveReplacement(modifier, getProperty(copy, modifier.key), modifier.key));
+            // The censor receives the WALKED dot-path, not the bare rule key: a rule keyed
+            // "card" that resolves on the `user` node must report "user.card". `identifier`
+            // is the (already lowercased) path of this node and `modifier.key` is the
+            // lowercased key/dotted sub-path it resolved at, so joining them yields the same
+            // path shape the per-key and wildcard branches pass via `currentIdentifier`.
+            const modifierIdentifier = identifier ? `${identifier}.${modifier.key}` : modifier.key;
+
+            setProperty(copy, modifier.key, resolveReplacement(modifier, getProperty(copy, modifier.key), modifierIdentifier));
         }
     }
 };

--- a/packages/data-manipulation/redact/vitest.workerd.config.ts
+++ b/packages/data-manipulation/redact/vitest.workerd.config.ts
@@ -1,0 +1,9 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig({
+    test: {
+        include: ["__tests__/unit/**/*.test.ts", "__tests__/workerd/**/*.test.ts"],
+    },
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3343,6 +3343,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: catalog:lint
         version: 13.0.2
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
A custom censor received the bare rule key instead of the walked dot-path
whenever a plain rule resolved on a nested node: a rule keyed `card` applied
to `{ user: { card } }` reported `card` rather than `user.card`. Wildcard
rules already passed the full path, which is the inconsistency that gave it
away.

The direct-path branch fires on whichever node the key resolves at, so it has
to join the node's identifier with the rule key; `currentIdentifier` is scoped
to the per-key loop and is not in scope there.

This restores the documented contract rather than redefining it: the published
`Censor` type states `path` is "the dot-path of the matched key (e.g.
`user.card`)". Only `replacement` functions observe it — static replacements,
`<KEY>` placeholders and `remove: true` are byte-identical, and top-level rules
are unchanged, so the common single-level case sees nothing.

Runs the existing unit suite under workerd instead of duplicating assertions,
and adds a table test pinning the exact path for top-level, nested, deeply
nested, array-element and wildcard matches.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
