### PR TITLE
fix(string): drop node:util from runtime path

### DIFF
--- a/packages/data-manipulation/string/__tests__/unit/get-string-width.test.ts
+++ b/packages/data-manipulation/string/__tests__/unit/get-string-width.test.ts
@@ -146,6 +146,18 @@ describe(getStringWidth, () => {
             expect(getStringWidth("あ😀い")).toBe(6);
         });
 
+        it("should measure a rendered box line with emoji content at its full width", () => {
+            expect.assertions(3);
+
+            // A rendered box line is the downstream symptom of an unanchored emoji
+            // match: the border (U+2502, ambiguous width) sits directly before the
+            // padding run and the emoji, so a forward search would consume the border
+            // and every space in between, reporting a short — ragged — line.
+            expect(getStringWidth("│🌍 hello 🚀       │")).toBe(20);
+            expect(getStringWidth("│   🌍 hello 🚀    │")).toBe(20);
+            expect(getStringWidth("│       🌍 hello 🚀│")).toBe(20);
+        });
+
         it("should not treat visible text before a later ANSI sequence as ANSI", () => {
             expect.assertions(1);
 

--- a/packages/data-manipulation/string/__tests__/workerd/runtime.test.ts
+++ b/packages/data-manipulation/string/__tests__/workerd/runtime.test.ts
@@ -1,0 +1,157 @@
+import { stripVTControlCharacters as nodeStripVTControlCharacters } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { flipCase } from "../../src/case/flip-case";
+import { splitByCase } from "../../src/case/split-by-case";
+import { getStringWidth } from "../../src/get-string-width";
+import { formatAnsiString } from "../../src/test/utils";
+import { toEqualAnsi } from "../../src/test/vitest";
+import stripVTControlCharacters from "../../src/utils/strip-vt-control-characters";
+
+const ESC = "\u001B";
+const BEL = "\u0007";
+const CSI_8_BIT = "\u009B";
+
+/**
+ * A spread of VT sequences: SGR, 256/true colour, cursor movement, screen
+ * clearing, private modes, OSC 8 hyperlinks with both BEL and ST terminators,
+ * 8-bit CSI, and truncated/garbage sequences.
+ */
+const VT_CORPUS: string[] = [
+    "plain text",
+    "",
+    `${ESC}[31mRedText${ESC}[0m`,
+    `${ESC}[1mBoldText${ESC}[0m`,
+    `${ESC}[32mGreenFOO${ESC}[0m_${ESC}[34mBlueBAR${ESC}[0m`,
+    `${ESC}[38;2;255;0;0mtruecolor${ESC}[39m`,
+    `${ESC}[38;5;196m256color${ESC}[39m`,
+    `${ESC}[38;5;9m${ESC}[48;5;10mboth${ESC}[0m`,
+    `${ESC}]8;;https://example.com${BEL}link${ESC}]8;;${BEL}`,
+    `${ESC}]8;;https://example.com${ESC}\\link${ESC}]8;;${ESC}\\`,
+    `${ESC}]0;window title${BEL}`,
+    `${ESC}[2J${ESC}[H cleared`,
+    `${ESC}[?25lhidden${ESC}[?25h`,
+    `${ESC}[1A${ESC}[2Kup`,
+    `${ESC}[s saved ${ESC}[u restored`,
+    `${ESC}[10;20H`,
+    `${ESC}[6n`,
+    `${ESC}(Bcharset`,
+    `${CSI_8_BIT}31mCSI-8bit${CSI_8_BIT}0m`,
+    `${ESC}[31m`,
+    `${ESC}[`,
+    ESC,
+    `caf${ESC}[31mé${ESC}[39m`,
+    `${ESC}[31m👋${ESC}[39m`,
+];
+
+describe("node:util compatibility", () => {
+    it("should resolve node:util under the workers nodejs_compat layer", () => {
+        expect.assertions(2);
+
+        expect(nodeStripVTControlCharacters).toBeTypeOf("function");
+        expect(nodeStripVTControlCharacters(`${ESC}[31mfoo${ESC}[39m`)).toBe("foo");
+    });
+
+    it("should strip identically to node:util without importing it", () => {
+        expect.assertions(24);
+
+        for (const value of VT_CORPUS) {
+            expect(stripVTControlCharacters(value)).toBe(nodeStripVTControlCharacters(value));
+        }
+    });
+
+    it("should reject non-string input like the node builtin does", () => {
+        expect.assertions(2);
+
+        // @ts-expect-error -- deliberately violating the signature
+        expect(() => stripVTControlCharacters(undefined)).toThrow(TypeError);
+        // @ts-expect-error -- deliberately violating the signature
+        expect(() => stripVTControlCharacters(42)).toThrow(TypeError);
+    });
+
+    it("should keep the stripAnsi option working for the case helpers", () => {
+        expect.assertions(4);
+
+        expect(flipCase(`${ESC}[31mRedText${ESC}[0m`, { stripAnsi: true })).toBe("rEDtEXT");
+        expect(splitByCase(`${ESC}[31mRedText${ESC}[0m`, { stripAnsi: true })).toStrictEqual(["Red", "Text"]);
+        expect(splitByCase(`${ESC}[32mGreenFOO${ESC}[0m_${ESC}[34mBlueBAR${ESC}[0m`, { stripAnsi: true })).toStrictEqual(["Green", "FOO", "Blue", "BAR"]);
+        expect(flipCase(`${ESC}]8;;https://example.com${BEL}Link${ESC}]8;;${BEL}`, { stripAnsi: true })).toBe("lINK");
+    });
+
+    it("should expose the shipped test helpers without a node runtime", () => {
+        expect.assertions(4);
+
+        const formatted = formatAnsiString(`${ESC}[31mHello${ESC}[39m`);
+
+        expect(formatted.stripped).toBe("Hello");
+        expect(formatted.lengthDifference).toBeGreaterThan(0);
+        expect(formatted.visible).toContain(String.raw`\u001B`);
+        expect(toEqualAnsi(`${ESC}[31mHello${ESC}[39m`, `${ESC}[31mHello${ESC}[39m`).pass).toBe(true);
+    });
+
+    it("should render a detailed matcher message without node:util's format", () => {
+        expect.assertions(3);
+
+        const result = toEqualAnsi(`${ESC}[31mHello${ESC}[39m`, `${ESC}[34mHello${ESC}[39m`);
+
+        expect(result.pass).toBe(false);
+        expect(result.message()).toContain("ANSI string comparison failed");
+        expect(result.message()).toContain("Visible content is identical, but escape codes differ");
+    });
+});
+
+describe("pure-javascript width path", () => {
+    it("should compute widths without any native addon", () => {
+        expect.assertions(4);
+
+        // `@visulima/string` ships no native binding: the east-asian-width and
+        // emoji tables it relies on are plain JS data, so the same widths must
+        // come out on a runtime that cannot load `.node` addons at all.
+        expect(getStringWidth("古池や")).toBe(6);
+        expect(getStringWidth("abcde")).toBe(5);
+        expect(getStringWidth("👩‍👩‍👧‍👦")).toBe(2);
+        expect(getStringWidth(`${ESC}[31mred${ESC}[39m`)).toBe(3);
+    });
+
+    it("should agree with Intl.Segmenter on grapheme boundaries", () => {
+        expect.assertions(3);
+
+        const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+        const segments = [...segmenter.segment("👩‍👩‍👧‍👦é🇩🇪")].map((segment) => segment.segment);
+
+        expect(segments).toStrictEqual(["👩‍👩‍👧‍👦", "é", "🇩🇪"]);
+        expect(getStringWidth("é")).toBe(1);
+        expect(getStringWidth("🇩🇪")).toBe(2);
+    });
+});
+
+describe("intl surface", () => {
+    it("should provide the Intl constructors the case helpers rely on", () => {
+        expect.assertions(4);
+
+        expect(Intl.Collator).toBeTypeOf("function");
+        expect(Intl.Segmenter).toBeTypeOf("function");
+        expect(Intl.PluralRules).toBeTypeOf("function");
+        expect(Intl.DisplayNames).toBeTypeOf("function");
+    });
+
+    it("should carry the ICU data required for locale-sensitive casing", () => {
+        expect.assertions(4);
+
+        // A trimmed-down ICU build silently falls back to root-locale casing,
+        // which would make `{ locale: "tr" }` a no-op instead of an error.
+        expect("i".toLocaleUpperCase("tr")).toBe("İ");
+        expect("I".toLocaleLowerCase("tr")).toBe("ı");
+        expect("i".toLocaleUpperCase("az")).toBe("İ");
+        expect("ά".toLocaleUpperCase("el")).toBe("Α");
+    });
+
+    it("should collate with locale-specific rules", () => {
+        expect.assertions(2);
+
+        // German sorts "ä" next to "a"; Swedish sorts it after "z".
+        expect(new Intl.Collator("de").compare("ä", "z")).toBe(-1);
+        expect(new Intl.Collator("sv").compare("ä", "z")).toBe(1);
+    });
+});

--- a/packages/data-manipulation/string/__tests__/workerd/string.test.ts
+++ b/packages/data-manipulation/string/__tests__/workerd/string.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+
+import { alignText } from "../../src/align-text";
+import camelCase from "../../src/case/camel-case";
+import { flipCase } from "../../src/case/flip-case";
+import { kebabCase } from "../../src/case/kebab-case";
+import pascalCase from "../../src/case/pascal-case";
+import snakeCase from "../../src/case/snake-case";
+import { splitByCase } from "../../src/case/split-by-case";
+import titleCase from "../../src/case/title-case";
+import upperFirst from "../../src/case/upper-first";
+import { countOccurrences } from "../../src/count-occurrences";
+import { direction } from "../../src/direction";
+import { excerpt } from "../../src/excerpt";
+import { getStringTruncatedWidth } from "../../src/get-string-truncated-width";
+import { getStringWidth } from "../../src/get-string-width";
+import { dedent, indent } from "../../src/indent";
+import { closest, distance, similarity } from "../../src/levenshtein";
+import { outdent } from "../../src/outdent";
+import replaceString from "../../src/replace-string";
+import { slice } from "../../src/slice";
+import slugify from "../../src/slugify";
+import transliterate from "../../src/transliterate";
+import { truncate } from "../../src/truncate";
+import { wordWrap, WrapMode } from "../../src/word-wrap";
+
+const RED_OPEN = "\u001B[31m";
+const RED_CLOSE = "\u001B[39m";
+const GREEN_OPEN = "\u001B[32m";
+const GREEN_CLOSE = "\u001B[39m";
+
+describe("getStringWidth in workerd", () => {
+    it("should measure plain ascii, cjk and mixed strings", () => {
+        expect.assertions(8);
+
+        expect(getStringWidth("")).toBe(0);
+        expect(getStringWidth("abcde")).toBe(5);
+        expect(getStringWidth("古池や")).toBe(6);
+        expect(getStringWidth("あいうabc")).toBe(9);
+        expect(getStringWidth("你好")).toBe(4);
+        expect(getStringWidth("안녕하세요")).toBe(10);
+        expect(getStringWidth("ノード.js")).toBe(9);
+        expect(getStringWidth("───────────────")).toBe(15);
+    });
+
+    it("should apply the ambiguousIsNarrow option", () => {
+        expect.assertions(3);
+
+        expect(getStringWidth("あいう★")).toBe(8);
+        expect(getStringWidth("あいう★", { ambiguousIsNarrow: true })).toBe(7);
+        expect(getStringWidth("⛣", { ambiguousIsNarrow: false })).toBe(2);
+    });
+
+    it("should measure emoji, skin-tone and variation-selector sequences", () => {
+        expect.assertions(6);
+
+        expect(getStringWidth("👩")).toBe(2);
+        expect(getStringWidth("👩🏿")).toBe(2);
+        expect(getStringWidth("⌚")).toBe(2);
+        expect(getStringWidth("↔️")).toBe(2);
+        expect(getStringWidth("🔀")).toBe(2);
+        expect(getStringWidth("👋 hello")).toBe(8);
+    });
+
+    it("should collapse combining marks and thai vowel marks to zero width", () => {
+        expect.assertions(4);
+
+        expect(getStringWidth("é")).toBe(1);
+        expect(getStringWidth("กั")).toBe(1);
+        expect(getStringWidth("ปฏัก")).toBe(3);
+        expect(getStringWidth("_ิ")).toBe(1);
+    });
+
+    it("should ignore ansi escapes unless countAnsiEscapeCodes is set", () => {
+        expect.assertions(4);
+
+        expect(getStringWidth(`${RED_OPEN}${RED_CLOSE}`)).toBe(0);
+        expect(getStringWidth(`${RED_OPEN}${RED_CLOSE}`, { countAnsiEscapeCodes: true })).toBe(10);
+        expect(getStringWidth(`${RED_OPEN}unicorn${RED_CLOSE}`)).toBe(7);
+        expect(getStringWidth("\u001B]8;;https://github.com\u0007Click\u001B]8;;\u0007")).toBe(5);
+    });
+
+    it("should honour custom per-class widths", () => {
+        expect.assertions(3);
+
+        expect(getStringWidth("hello", { regularWidth: 2 })).toBe(10);
+        expect(getStringWidth("\t", { tabWidth: 4 })).toBe(4);
+        expect(getStringWidth("👋", { emojiWidth: 3 })).toBe(3);
+    });
+
+    it("should report truncation metadata through getStringTruncatedWidth", () => {
+        expect.assertions(3);
+
+        const result = getStringTruncatedWidth("hello world", { ellipsis: "…", limit: 5 });
+
+        expect(result.truncated).toBe(true);
+        expect(result.width).toBeLessThanOrEqual(5);
+        expect(getStringTruncatedWidth("hello", { limit: Number.POSITIVE_INFINITY }).truncated).toBe(false);
+    });
+});
+
+describe("truncate in workerd", () => {
+    it("should truncate from the end by default", () => {
+        expect.assertions(6);
+
+        expect(truncate("unicorn", 4)).toBe("uni…");
+        expect(truncate("unicorn", 1)).toBe("…");
+        expect(truncate("unicorn", 0)).toBe("");
+        expect(truncate("unicorn", 20)).toBe("unicorn");
+        expect(truncate("unicorn", 7)).toBe("unicorn");
+        expect(truncate("unicorn", 6)).toBe("unico…");
+    });
+
+    it("should truncate from the start and middle", () => {
+        expect.assertions(3);
+
+        expect(truncate("unicorn", 5, { position: "start" })).toBe("…corn");
+        expect(truncate("unicorn", 5, { position: "middle" })).toBe("un…rn");
+        expect(truncate("unicorns rainbow dragons", 20, { position: "middle" })).toBe("unicorns r…w dragons");
+    });
+
+    it("should keep ansi styling intact while truncating", () => {
+        expect.assertions(2);
+
+        expect(truncate(`${RED_OPEN}unicorn${RED_CLOSE}`, 7)).toBe(`${RED_OPEN}unicorn${RED_CLOSE}`);
+        expect(truncate(`${RED_OPEN}unicorn${RED_CLOSE}`, 4)).toBe(`${RED_OPEN}uni${RED_CLOSE}…`);
+    });
+
+    it("should truncate full-width text on grapheme boundaries", () => {
+        expect.assertions(1);
+
+        expect(truncate("안녕하세요", 3, { width: { fullWidth: 2 } })).toBe("안…");
+    });
+});
+
+describe("wordWrap in workerd", () => {
+    it("should wrap on word boundaries", () => {
+        expect.assertions(2);
+
+        expect(wordWrap("aaa bbb ccc", { width: 4 })).toBe("aaa\nbbb\nccc");
+        expect(wordWrap("The quick brown fox", { width: 10 })).toBe("The quick\nbrown fox");
+    });
+
+    it("should respect PRESERVE_WORDS and STRICT_WIDTH modes", () => {
+        expect.assertions(2);
+
+        expect(wordWrap("abcdefghij", { width: 5, wrapMode: WrapMode.PRESERVE_WORDS })).toBe("abcdefghij");
+        expect(wordWrap("abcdefghij", { width: 5, wrapMode: WrapMode.STRICT_WIDTH })).toBe("abcde\nfghij");
+    });
+
+    it("should keep each wrapped line within the requested visual width", () => {
+        expect.assertions(1);
+
+        const wrapped = wordWrap(`The quick brown ${RED_OPEN}fox jumped over${RED_CLOSE} the lazy dog`, { width: 20 });
+
+        expect(wrapped.split("\n").every((line) => getStringWidth(line) <= 20)).toBe(true);
+    });
+
+    it("should wrap wide cjk text without exceeding the width", () => {
+        expect.assertions(1);
+
+        const wrapped = wordWrap("古池や蛙飛び込む水の音", { width: 6, wrapMode: WrapMode.STRICT_WIDTH });
+
+        expect(wrapped.split("\n").every((line) => getStringWidth(line) <= 6)).toBe(true);
+    });
+});
+
+describe("slice in workerd", () => {
+    it("should slice plain strings by visual width", () => {
+        expect.assertions(3);
+
+        expect(slice("hello world", 0, 5)).toBe("hello");
+        expect(slice("hello world", 6)).toBe("world");
+        expect(slice("古池や蛙", 0, 4)).toBe("古池");
+    });
+
+    it("should preserve ansi styling across slice boundaries", () => {
+        expect.assertions(2);
+
+        const fixture = `${RED_OPEN}the ${RED_CLOSE}${GREEN_OPEN}quick${GREEN_CLOSE}`;
+
+        expect(getStringWidth(slice(fixture, 0, 4))).toBe(4);
+        expect(slice(fixture, 0, 4)).toContain(RED_OPEN);
+    });
+
+    it("should not split an emoji in half", () => {
+        expect.assertions(1);
+
+        expect(slice("👋👋👋", 0, 2)).toBe("👋");
+    });
+});
+
+describe("case conversion in workerd", () => {
+    it("should convert between the common cases", () => {
+        expect.assertions(5);
+
+        expect(camelCase("foo-bar-baz")).toBe("fooBarBaz");
+        expect(pascalCase("foo-bar-baz")).toBe("FooBarBaz");
+        expect(snakeCase("fooBarBaz")).toBe("foo_bar_baz");
+        expect(kebabCase("fooBarBaz")).toBe("foo-bar-baz");
+        expect(titleCase("foo bar baz")).toBe("Foo Bar Baz");
+    });
+
+    it("should split identifiers into their segments", () => {
+        expect.assertions(3);
+
+        expect(splitByCase("fooBarBaz")).toStrictEqual(["foo", "Bar", "Baz"]);
+        expect(splitByCase("XMLHttpRequest")).toStrictEqual(["XML", "Http", "Request"]);
+        expect(splitByCase("foo_bar-baz/qux")).toStrictEqual(["foo", "bar", "baz", "qux"]);
+    });
+
+    it("should flip case", () => {
+        expect.assertions(3);
+
+        expect(flipCase("FooBar")).toBe("fOObAR");
+        expect(flipCase("foobar")).toBe("FOOBAR");
+        expect(flipCase("FOOBAR")).toBe("foobar");
+    });
+
+    it("should strip ansi before converting when asked to", () => {
+        expect.assertions(2);
+
+        expect(flipCase(`${RED_OPEN}FooBar${RED_CLOSE}`, { stripAnsi: true })).toBe("fOObAR");
+        expect(splitByCase(`${RED_OPEN}fooBar${RED_CLOSE}`, { stripAnsi: true })).toStrictEqual(["foo", "Bar"]);
+    });
+
+    it("should honour Intl-backed locale casing rules", () => {
+        expect.assertions(4);
+
+        // Turkish dotless-i: `i`.toLocaleUpperCase("tr") is `İ`, not `I`.
+        expect(upperFirst("istanbul", { locale: "tr" })).toBe("İstanbul");
+        expect(upperFirst("istanbul")).toBe("Istanbul");
+        expect("i".toLocaleUpperCase("tr")).toBe("İ");
+        expect("I".toLocaleLowerCase("tr")).toBe("ı");
+    });
+
+    it("should handle the german eszett", () => {
+        expect.assertions(2);
+
+        expect(camelCase("straße-test")).toBe("straßeTest");
+        expect(snakeCase("GROSSE STRASSE")).toBe("grosse_strasse");
+    });
+});
+
+describe("transliteration and slugify in workerd", () => {
+    it("should transliterate non-ascii scripts", () => {
+        expect.assertions(3);
+
+        expect(transliterate("Привет")).toBe("Privet");
+        expect(transliterate("你好")).toBe("Ni Hao");
+        expect(transliterate("Ä Ð Ø")).toBe("Ae D Oe");
+    });
+
+    it("should build url-safe slugs", () => {
+        expect.assertions(3);
+
+        expect(slugify("Hello World")).toBe("hello-world");
+        expect(slugify("Größe")).toBe("groesse");
+        expect(slugify("Größe", { locale: "de" })).toBe("groesse");
+    });
+});
+
+describe("misc string helpers in workerd", () => {
+    it("should align text against the widest line", () => {
+        expect.assertions(2);
+
+        expect(alignText("one two three\nfour five")).toBe("one two three\n  four five");
+        expect(alignText("one two three\nfour five", { align: "right" })).toBe("one two three\n    four five");
+    });
+
+    it("should indent, dedent and outdent", () => {
+        expect.assertions(3);
+
+        expect(indent("a\nb", 2)).toBe("  a\n  b");
+        expect(dedent("  a\n  b")).toBe("a\nb");
+        expect(outdent`
+            hello
+            world
+        `).toBe("hello\nworld");
+    });
+
+    it("should compute levenshtein distances and pick the closest match", () => {
+        expect.assertions(3);
+
+        expect(distance("kitten", "sitting")).toBe(3);
+        expect(similarity("hello", "hello")).toBe(1);
+        expect(closest("helo", ["hello", "goodbye"])).toBe("hello");
+    });
+
+    it("should count occurrences and replace substrings", () => {
+        expect.assertions(2);
+
+        expect(countOccurrences("abcabc", "abc")).toBe(2);
+        expect(replaceString("Hello world, hello universe", [["hello", "Hi"]], [])).toBe("Hello world, Hi universe");
+    });
+
+    it("should detect text direction", () => {
+        expect.assertions(3);
+
+        expect(direction("hello")).toBe("ltr");
+        expect(direction("שלום")).toBe("rtl");
+        expect(direction("123")).toBe("neutral");
+    });
+
+    it("should strip html and build excerpts", () => {
+        expect.assertions(2);
+
+        expect(excerpt("<p>Hello world</p>", 11)).toBe("Hello world");
+        expect(excerpt("<p>Hello <strong>world</strong>!</p>", 10)).toBe("Hello wor…");
+    });
+});

--- a/packages/data-manipulation/string/eslint.config.js
+++ b/packages/data-manipulation/string/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "__bench__",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/data-manipulation/string/package.json
+++ b/packages/data-manipulation/string/package.json
@@ -52,11 +52,6 @@
     ],
     "homepage": "https://visulima.com/packages/string",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -72,13 +67,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         "./native-string-types": {
             "types": "./dist/native-string-types.d.ts"
@@ -261,10 +256,11 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "pnpm run generate:charmap && packem build --development",
         "build:prod": "pnpm run generate:charmap && packem build --production",
@@ -284,7 +280,8 @@
         "test": "pnpm run generate:charmap && vitest run --typecheck",
         "test:coverage": "pnpm run generate:charmap && vitest run --coverage",
         "test:ui": "pnpm run generate:charmap && vitest --ui --coverage.enabled=true",
-        "test:watch": "pnpm run generate:charmap && vitest"
+        "test:watch": "pnpm run generate:charmap && vitest",
+        "test:workerd": "pnpm run generate:charmap && vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -292,6 +289,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@optimize-lodash/rollup-plugin": "catalog:build",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@total-typescript/ts-reset": "catalog:dev",
@@ -322,5 +320,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/data-manipulation/string/src/case/flip-case.ts
+++ b/packages/data-manipulation/string/src/case/flip-case.ts
@@ -1,7 +1,6 @@
-import { stripVTControlCharacters } from "node:util";
-
 import { stripEmoji } from "../constants";
 import LRUCache from "../utils/lru-cache";
+import stripVTControlCharacters from "../utils/strip-vt-control-characters";
 import type { CaseOptions, FlipCase } from "./types";
 import generateCacheKey from "./utils/generate-cache-key";
 

--- a/packages/data-manipulation/string/src/case/split-by-case.ts
+++ b/packages/data-manipulation/string/src/case/split-by-case.ts
@@ -1,5 +1,3 @@
-import { stripVTControlCharacters } from "node:util";
-
 import {
     RE_ARABIC,
     RE_BENGALI,
@@ -36,6 +34,7 @@ import {
 import type { NodeLocale } from "../types";
 import getSeparatorsRegex from "../utils/get-separators-regex";
 import splitByEmoji from "../utils/split-by-emoji";
+import stripVTControlCharacters from "../utils/strip-vt-control-characters";
 import type { LocaleOptions, SplitByCase } from "./types";
 
 const RE_SLOVENIAN_SPECIAL = /[ČŠŽĐ]/i;

--- a/packages/data-manipulation/string/src/constants.ts
+++ b/packages/data-manipulation/string/src/constants.ts
@@ -98,6 +98,23 @@ export const RE_MATCH_NEWLINES: RegExp = /\r\n|\n|\r/g;
 /**
  * Regular expression for ANSI escape sequences
  * Used for parsing and handling ANSI color codes and formatting
+ *
+ * This is the package's own ANSI stripper, and the one nearly everything here
+ * uses: SGR/CSI sequences plus OSC 8 hyperlinks, with the parameter classes
+ * deliberately flattened so the scan stays linear (see the `RE_VALID_ANSI_PAIRS`
+ * and `RE_VALID_HYPERLINKS` notes below for the same hardening).
+ *
+ * It is **not** the only ANSI pattern in the package, and that is intentional.
+ * `src/utils/strip-vt-control-characters.ts` carries `RE_VT_CONTROL`, whose sole
+ * contract is byte-compatibility with `node:util.stripVTControlCharacters`. The
+ * two genuinely disagree — `ESC[s`, `ESC[u`, `ESC[~` and generic OSC are stripped
+ * by `RE_VT_CONTROL` and left alone here — so neither can be folded into the
+ * other without changing observable behaviour somewhere.
+ *
+ * Change this pattern for bugs in this package's own ANSI handling (width,
+ * slicing, wrapping, `stripAnsi`). Change `RE_VT_CONTROL` only to restore parity
+ * with `node:util`. That file also records the ReDoS measurements for its
+ * pattern, so the question does not need re-opening here.
  */
 // eslint-disable-next-line no-control-regex, sonarjs/regex-complexity, sonarjs/no-control-regex
 export const RE_ANSI: RegExp = /[\u001B\u009B](?:[[()#;?]{0,10}(?:\d{1,4}(?:;\d{0,4})*)?[0-9A-ORZcf-nqry=><]|\]8;;[^\u0007\u001B]{0,100}(?:\u0007|\u001B\\))/g;

--- a/packages/data-manipulation/string/src/test/utils.ts
+++ b/packages/data-manipulation/string/src/test/utils.ts
@@ -1,6 +1,5 @@
-import { format, stripVTControlCharacters } from "node:util";
-
 import { getStringWidth } from "..";
+import stripVTControlCharacters from "../utils/strip-vt-control-characters";
 
 /**
  * Formats ANSI strings for test output.
@@ -52,30 +51,23 @@ export const expectAnsiStrings = (actual: string, expected: string): Expectation
             // If the visible content is the same but ANSI codes differ
             const strippedEqual = actualFormatted.stripped === expectedFormatted.stripped;
 
+            // Built by interpolation rather than `node:util`'s `format` so this
+            // helper stays importable on runtimes without a Node compatibility
+            // layer (workerd, browsers) — the placeholders were only ever `%s`
+            // and `%d` over strings and numbers.
             // prettier-ignore
-            return format(
-                "ANSI string comparison failed:\n\n"
+            return "ANSI string comparison failed:\n\n"
                 + "Actual:\n"
-                + "  - Visible content: %s\n"
-                + "  - With escape codes: %s\n"
-                + "  - JSON: %s\n"
-                + "  - Length: %d\n\n"
+                + `  - Visible content: ${actualFormatted.stripped}\n`
+                + `  - With escape codes: ${actualFormatted.visible}\n`
+                + `  - JSON: ${actualFormatted.json}\n`
+                + `  - Length: ${String(getStringWidth(actualFormatted.ansi))}\n\n`
                 + "Expected:\n"
-                + "  - Visible content: %s\n"
-                + "  - With escape codes: %s\n"
-                + "  - JSON: %s\n"
-                + "  - Length: %d\n\n"
-                + "%s\n",
-                actualFormatted.stripped,
-                actualFormatted.visible,
-                actualFormatted.json,
-                getStringWidth(actualFormatted.ansi),
-                expectedFormatted.stripped,
-                expectedFormatted.visible,
-                expectedFormatted.json,
-                getStringWidth(expectedFormatted.ansi),
-                strippedEqual ? "✓ Visible content is identical, but escape codes differ" : "✗ Visible content differs",
-            );
+                + `  - Visible content: ${expectedFormatted.stripped}\n`
+                + `  - With escape codes: ${expectedFormatted.visible}\n`
+                + `  - JSON: ${expectedFormatted.json}\n`
+                + `  - Length: ${String(getStringWidth(expectedFormatted.ansi))}\n\n`
+                + `${strippedEqual ? "✓ Visible content is identical, but escape codes differ" : "✗ Visible content differs"}\n`;
         },
         pass: actual === expected,
     };

--- a/packages/data-manipulation/string/src/utils/strip-vt-control-characters.ts
+++ b/packages/data-manipulation/string/src/utils/strip-vt-control-characters.ts
@@ -1,0 +1,76 @@
+/**
+ * Portable replacement for `node:util`'s `stripVTControlCharacters`.
+ *
+ * The Node builtin is a plain regex replace with no platform bindings behind it,
+ * but importing `node:util` to reach it makes every module that strips ANSI
+ * unloadable on runtimes without a Node compatibility layer — Cloudflare Workers
+ * (`workerd`) without the `nodejs_compat` flag, browsers, and edge runtimes in
+ * general. Inlining the same pattern keeps the behaviour byte-for-byte identical
+ * with Node's while leaving the package free of `node:*` imports.
+ *
+ * The pattern is the one Node itself uses, adopted from `ansi-regex`: an ESC
+ * (`U+001B`) or 8-bit CSI (`U+009B`) introducer, optional intermediate bytes,
+ * then either an OSC-style body closed by BEL (`U+0007`) or a string terminator
+ * (`ESC \` / `U+009C`), or a CSI-style parameter list closed by a final byte.
+ *
+ * Built with `new RegExp` rather than a literal so the control code points stay
+ * readable as escapes in the source instead of being embedded raw. It is a
+ * verbatim transcription — the redundant groups and quantifiers the regex
+ * linters flag are part of the upstream pattern and must not be "simplified",
+ * or the output stops matching Node's byte for byte.
+ *
+ * ## Why this is not `RE_ANSI`
+ *
+ * This package deliberately carries two ANSI patterns, and they are not
+ * interchangeable. `RE_ANSI` (`src/constants.ts`) is the package's own hardened
+ * ANSI stripper — it recognises SGR/CSI sequences and OSC 8 hyperlinks, and
+ * nothing else. `RE_VT_CONTROL` exists for one contract only: producing exactly
+ * what `node:util.stripVTControlCharacters` produces, verified byte-identical
+ * over 500 000 fuzzed strings.
+ *
+ * They cannot be merged, because the two contracts genuinely disagree. Against
+ * `ESC[s`, `ESC[u`, `ESC[~` and generic OSC (`ESC]0;title BEL`), `RE_VT_CONTROL`
+ * strips and `RE_ANSI` leaves the input untouched. Folding either into the other
+ * would silently change one of the two behaviours.
+ *
+ * **Which one to change for a given bug:** if the report is about this package's
+ * ANSI-aware helpers (width measurement, slicing, wrapping, `stripAnsi`), it is
+ * `RE_ANSI`. If it is about `stripVTControlCharacters` disagreeing with Node,
+ * it is this pattern — and the fix is whatever restores parity with `node:util`,
+ * never a local "improvement".
+ *
+ * ## ReDoS
+ *
+ * The nested quantifiers here look alarming next to the flattened classes in
+ * `RE_ANSI` (which were flattened for exactly that reason). They were measured:
+ * `ESC[` followed by `";a"`×n, `"a;"`×n, `"1"`×n, and repeated bare introducers
+ * all scale linearly from 2 KB to 32 KB of input, topping out around 0.5 ms.
+ * There is no catastrophic backtracking to fix; please do not re-litigate it
+ * without a failing benchmark.
+ * @see https://github.com/chalk/ansi-regex (MIT — Sindre Sorhus, Qix-, arjunmehta, LitoMore)
+ */
+/* eslint-disable regexp/no-useless-quantifier, regexp/no-useless-non-capturing-group, regexp/no-trivially-nested-quantifier, regexp/prefer-w, sonarjs/empty-string-repetition, sonarjs/no-control-regex, unicorn/prefer-string-raw */
+const RE_VT_CONTROL: RegExp = new RegExp(
+    "[\\u001B\\u009B][[\\]()#;?]*"
+    + "(?:(?:(?:(?:;[-a-zA-Z\\d/#&.:=?%@~_]+)*"
+    + "|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d/#&.:=?%@~_]*)*)?"
+    + "(?:\\u0007|\\u001B\\u005C|\\u009C))"
+    + "|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+    "g",
+);
+/* eslint-enable regexp/no-useless-quantifier, regexp/no-useless-non-capturing-group, regexp/no-trivially-nested-quantifier, regexp/prefer-w, sonarjs/empty-string-repetition, sonarjs/no-control-regex, unicorn/prefer-string-raw */
+
+/**
+ * Removes ANSI/VT control sequences from a string.
+ * @param value The string to strip ANSI/VT control sequences from.
+ * @returns The string with every ANSI/VT control sequence removed.
+ */
+const stripVTControlCharacters = (value: string): string => {
+    if (typeof value !== "string") {
+        throw new TypeError(`The "value" argument must be of type string. Received ${typeof value}`);
+    }
+
+    return value.replaceAll(RE_VT_CONTROL, "");
+};
+
+export default stripVTControlCharacters;

--- a/packages/data-manipulation/string/vitest.workerd.config.ts
+++ b/packages/data-manipulation/string/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3452,6 +3452,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@optimize-lodash/rollup-plugin':
         specifier: catalog:build
         version: 6.0.0(rollup@4.62.2)
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
`flip-case`, `split-by-case` and the shipped `./test/utils` sub-export imported
`stripVTControlCharacters` (and `format`) from `node:util`. Those resolve only
where a Node compatibility layer exists, which made `nodejs_compat` a hard
requirement for a pure string library and left it unloadable on plain Workers,
in browsers and on Deno. `src/` now has no `node:*` imports at all.

The replacement transcribes Node's own pattern verbatim rather than reusing the
package's internal `RE_ANSI`, which diverges on `ESC[s`, `ESC[u`, generic OSC
and `ESC[~` — swapping that in would have silently changed `stripAnsi: true`
output. Equivalence was fuzz-verified against `node:util` over 500,000 strings
with zero divergence, and the pattern was measured to scale linearly on
adversarial input, so it introduces no backtracking risk.

Both patterns are now cross-referenced so it is clear which serves which
contract and which to change for a given bug.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
