### PR TITLE
fix(colorize): serve server build on workerd

### DIFF
--- a/packages/terminal/colorize/__tests__/workerd/colorize.workerd.test.ts
+++ b/packages/terminal/colorize/__tests__/workerd/colorize.workerd.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import Colorize, { stderrColorLevel, stdoutColorLevel } from "../../src/colorize.server";
+import { gradient } from "../../src/gradient";
+import browserColorize, { bold as browserBold, red as browserRed } from "../../src/index.browser";
+import colorize, { bold, green, hex, red, rgb, strip, underline } from "../../src/index.server.mts";
+import template, { makeTaggedTemplate } from "../../src/template";
+import type { ColorizeType } from "../../src/types";
+import { convertHexToRgb, rgbToAnsi256 } from "../../src/utils";
+
+const truecolor: ColorizeType = new Colorize({ level: 3 });
+const ansi256: ColorizeType = new Colorize({ level: 2 });
+const ansi16: ColorizeType = new Colorize({ level: 1 });
+const mono: ColorizeType = new Colorize({ level: 0 });
+
+describe("colorize import-time detection (workerd)", () => {
+    it("should detect a mono level for stdout and stderr on bare workerd", () => {
+        expect.assertions(2);
+
+        // workerd exposes `process.env` but no TTY streams and no TERM, so detection
+        // must land on level 0 rather than throwing while probing `process.stdout`.
+        expect(stdoutColorLevel).toBe(0);
+        expect(stderrColorLevel).toBe(0);
+    });
+
+    it("should emit plain text from the auto-detected singleton", () => {
+        expect.assertions(3);
+
+        expect(colorize.red("error")).toBe("error");
+        expect(red.bold("error")).toBe("error");
+        expect(bold`error ${green("here")}`).toBe("error here");
+    });
+});
+
+describe("colorize public API at every level (workerd)", () => {
+    it("should style a single color at truecolor", () => {
+        expect.assertions(2);
+
+        expect(truecolor.red("foo")).toBe("\u001B[31mfoo\u001B[39m");
+        expect(truecolor.bold("foo")).toBe("\u001B[1mfoo\u001B[22m");
+    });
+
+    it("should chain styles at truecolor", () => {
+        expect.assertions(1);
+
+        expect(truecolor.red.bold.underline("foo")).toBe("\u001B[31m\u001B[1m\u001B[4mfoo\u001B[24m\u001B[22m\u001B[39m");
+    });
+
+    it("should re-open the outer style after a nested close", () => {
+        expect.assertions(1);
+
+        expect(truecolor.red(`a ${truecolor.green("b")} c`)).toBe("\u001B[31ma \u001B[32mb\u001B[31m c\u001B[39m");
+    });
+
+    it("should render tagged templates at truecolor", () => {
+        expect.assertions(1);
+
+        expect(truecolor.green`foo ${truecolor.red`bar`}`).toBe("\u001B[32mfoo \u001B[31mbar\u001B[32m\u001B[39m");
+    });
+
+    it("should re-open styles across newlines at truecolor", () => {
+        expect.assertions(1);
+
+        expect(truecolor.red("a\nb")).toBe("\u001B[31ma\u001B[39m\n\u001B[31mb\u001B[39m");
+    });
+
+    it("should downgrade hex per level", () => {
+        expect.assertions(4);
+
+        expect(truecolor.hex("#FF0000")("foo")).toBe("\u001B[38;2;255;0;0mfoo\u001B[39m");
+        expect(ansi256.hex("#FF0000")("foo")).toBe("\u001B[38;5;196mfoo\u001B[39m");
+        expect(ansi16.hex("#FF0000")("foo")).toBe("\u001B[91mfoo\u001B[39m");
+        expect(mono.hex("#FF0000")("foo")).toBe("foo");
+    });
+
+    it("should downgrade ansi256 per level", () => {
+        expect.assertions(3);
+
+        expect(ansi256.ansi256(93)("foo")).toBe("\u001B[38;5;93mfoo\u001B[39m");
+        expect(ansi16.ansi256(93)("foo")).toBe("\u001B[94mfoo\u001B[39m");
+        expect(mono.ansi256(93)("foo")).toBe("foo");
+    });
+
+    it("should emit no escape codes at level 0", () => {
+        expect.assertions(3);
+
+        expect(mono.red.bold("foo")).toBe("foo");
+        expect(mono.rgb(1, 2, 3)("foo")).toBe("foo");
+        expect(mono.bgRed`foo`).toBe("foo");
+    });
+
+    it("should keep instances isolated from each other", () => {
+        expect.assertions(2);
+
+        expect(new Colorize({ level: 3 }).red("x")).toBe("\u001B[31mx\u001B[39m");
+        expect(new Colorize({ level: 0 }).red("x")).toBe("x");
+    });
+});
+
+describe("colorize string handling without Buffer (workerd)", () => {
+    it("should not touch the Buffer global while styling", () => {
+        expect.assertions(2);
+
+        const globalScope = globalThis as { Buffer?: unknown };
+        const original = globalScope.Buffer;
+
+        // Deleting `Buffer` proves the styling path is pure-string and never reaches
+        // for a Node polyfill — a worker can run without the `nodejs_compat` flag.
+        Reflect.deleteProperty(globalScope, "Buffer");
+
+        try {
+            expect(truecolor.red.bold("foo")).toBe("\u001B[31m\u001B[1mfoo\u001B[22m\u001B[39m");
+            expect(strip("\u001B[31mfoo\u001B[39m")).toBe("foo");
+        } finally {
+            globalScope.Buffer = original;
+        }
+    });
+
+    it("should preserve astral and combining characters", () => {
+        expect.assertions(2);
+
+        expect(truecolor.red("héllo 🎉 日本語")).toBe("\u001B[31mhéllo 🎉 日本語\u001B[39m");
+        expect(strip(truecolor.red("héllo 🎉 日本語"))).toBe("héllo 🎉 日本語");
+    });
+
+    it("should coerce non-string input without Node coercion helpers", () => {
+        expect.assertions(3);
+
+        expect(truecolor.red(0 as unknown as string)).toBe("\u001B[31m0\u001B[39m");
+        expect(truecolor.red(["a", "b"] as unknown as string)).toBe("\u001B[31ma,b\u001B[39m");
+        expect(truecolor.red("")).toBe("");
+    });
+});
+
+describe("colorize strip (workerd)", () => {
+    it("should strip nested and chained sequences", () => {
+        expect.assertions(2);
+
+        expect(strip(truecolor.red.bold.underline("foo"))).toBe("foo");
+        expect(colorize.strip("\u001B[38;2;255;0;0mfoo\u001B[39m")).toBe("foo");
+    });
+
+    it("should leave plain text untouched", () => {
+        expect.assertions(1);
+
+        expect(strip("plain")).toBe("plain");
+    });
+});
+
+describe("colorize named exports (workerd)", () => {
+    it("should expose the documented named exports", () => {
+        expect.assertions(4);
+
+        expect(red).toBeTypeOf("function");
+        expect(underline).toBeTypeOf("function");
+        expect(hex).toBeTypeOf("function");
+        expect(rgb).toBeTypeOf("function");
+    });
+});
+
+describe("colorize subpath entries (workerd)", () => {
+    it("should render the tagged template at a forced level", () => {
+        expect.assertions(2);
+
+        const tagged = makeTaggedTemplate(truecolor);
+
+        expect(tagged`{bold.red hello}`).toBe("\u001B[1m\u001B[31mhello\u001B[39m\u001B[22m");
+        // The default `./template` export is bound to the auto-detected level, which is 0 here.
+        expect(template`{bold.red hello}`).toBe("hello");
+    });
+
+    it("should build a gradient without a terminal", () => {
+        expect.assertions(2);
+
+        const rendered = gradient(["#FF0000", "#0000FF"])("abc");
+
+        expect(rendered).toBeTypeOf("string");
+        expect(strip(rendered)).toBe("abc");
+    });
+
+    it("should expose the color conversion utils", () => {
+        expect.assertions(2);
+
+        expect(convertHexToRgb("#FF0000")).toStrictEqual([255, 0, 0]);
+        expect(rgbToAnsi256(255, 0, 0)).toBe(196);
+    });
+});
+
+describe("colorize browser entry (workerd)", () => {
+    it("should resolve and emit console CSS directives", () => {
+        expect.assertions(3);
+
+        // The browser build always renders `%c` + CSS pairs for `console.log(...)`;
+        // it never emits ANSI, so it is level-independent and safe in workerd.
+        expect(browserColorize.red("foo")).toStrictEqual(["%cfoo", "color: red;"]);
+        expect(browserRed("foo")).toStrictEqual(["%cfoo", "color: red;"]);
+        expect(browserBold.red("foo")).toStrictEqual(["%cfoo", "color:red;font-weight:bold;"]);
+    });
+
+    it("should strip ANSI from forwarded server output", () => {
+        expect.assertions(1);
+
+        expect(browserColorize.strip("\u001B[31mfoo\u001B[39m")).toBe("foo");
+    });
+});

--- a/packages/terminal/colorize/__tests__/workerd/exports-resolution.workerd.test.ts
+++ b/packages/terminal/colorize/__tests__/workerd/exports-resolution.workerd.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * These specs deliberately import through the **bare package specifiers** rather than
+ * `../../src/...`, because the defect they guard is in `package.json` `exports` key
+ * order, not in the source.
+ *
+ * `@cloudflare/vitest-pool-workers` resolves with `["workerd", "worker", "module",
+ * "browser"]` and drops `"node"`. Export conditions are matched in the order the keys
+ * appear in `package.json`, so a `"browser"` key listed before the server entry wins on
+ * Cloudflare and ships the `%c`-CSS console build to a runtime whose logs are plain
+ * text. `"edge-light"` cannot save it — that is Vercel's condition and workerd never
+ * sets it.
+ */
+describe("colorize package exports under workerd", () => {
+    it("should resolve the server build, not the browser build", async () => {
+        expect.assertions(3);
+
+        const { default: colorize, red } = await import("@visulima/colorize");
+
+        // The browser build returns `["%cfoo", "color: red;"]`; the server build returns a string.
+        expect(colorize.red("foo")).toBeTypeOf("string");
+        expect(Array.isArray(red("foo"))).toBe(false);
+        expect(red("foo")).toBe("foo");
+    });
+
+    it("should style with ANSI when the level is forced", async () => {
+        expect.assertions(1);
+
+        const { Colorize } = await import("@visulima/colorize");
+
+        // `Colorize` is only exported by the server build; the browser entry has no
+        // level concept at all, so this both resolves and proves the ANSI code path.
+        expect(new Colorize({ level: 3 }).red("foo")).toBe("\u001B[31mfoo\u001B[39m");
+    });
+});
+
+describe("is-ansi-color-supported package exports under workerd", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it("should resolve the server detector, not the browser detector", async () => {
+        expect.assertions(1);
+
+        const { createIsColorSupported } = await import("@visulima/is-ansi-color-supported");
+
+        vi.stubEnv("FORCE_COLOR", "2");
+
+        // Only the server build reads `process.env`; the browser build sniffs
+        // `navigator` and the edge-light build only looks at `NEXT_RUNTIME`, so both
+        // would answer 0 here.
+        expect(createIsColorSupported("stdout")).toBe(2);
+    });
+
+    it("should honour the detector options that only the server build implements", async () => {
+        expect.assertions(2);
+
+        const { createIsColorSupported } = await import("@visulima/is-ansi-color-supported");
+
+        vi.stubEnv("TERM", "xterm");
+
+        expect(createIsColorSupported("stdout", { isTTY: true })).toBe(1);
+        expect(createIsColorSupported("stdout", { isTTY: false })).toBe(0);
+    });
+});

--- a/packages/terminal/colorize/eslint.config.js
+++ b/packages/terminal/colorize/eslint.config.js
@@ -12,6 +12,7 @@ export default createConfig(
             "examples",
             "__bench__",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/terminal/colorize/package.json
+++ b/packages/terminal/colorize/package.json
@@ -56,11 +56,6 @@
         "yellow"
     ],
     "homepage": "https://visulima.com/packages/colorize/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -76,43 +71,19 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
-    "sideEffects": false,
-    "module": "dist/index.server.js",
-    "types": "dist/index.server.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/index.browser.d.ts",
-                "./dist/index.server.d.ts"
-            ],
-            "browser": [
-                "./dist/index.browser.d.ts"
-            ],
-            "template": [
-                "./dist/template.d.ts"
-            ],
-            "gradient": [
-                "./dist/gradient.d.ts"
-            ],
-            "utils": [
-                "./dist/utils.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
+            "workerd": {
+                "types": "./dist/index.server.d.ts",
+                "default": "./dist/index.server.js"
+            },
             "browser": {
                 "types": "./dist/index.browser.d.ts",
                 "default": "./dist/index.browser.js"
@@ -144,10 +115,34 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "module": "dist/index.server.js",
+    "types": "dist/index.server.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/index.browser.d.ts",
+                "./dist/index.server.d.ts"
+            ],
+            "browser": [
+                "./dist/index.browser.d.ts"
+            ],
+            "template": [
+                "./dist/template.d.ts"
+            ],
+            "gradient": [
+                "./dist/gradient.d.ts"
+            ],
+            "utils": [
+                "./dist/utils.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -165,7 +160,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "dependencies": {
         "@visulima/is-ansi-color-supported": "3.0.1"
@@ -175,6 +171,7 @@
         "@anolilab/prettier-config": "catalog:lint",
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@rushstack/eslint-plugin-security": "catalog:lint",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@total-typescript/ts-reset": "catalog:dev",
@@ -199,5 +196,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/colorize/vitest.workerd.config.ts
+++ b/packages/terminal/colorize/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8116,6 +8116,9 @@ importers:
       '@anolilab/semantic-release-preset':
         specifier: catalog:dev
         version: 13.4.17(@anolilab/semantic-release-pnpm@8.1.16(@types/node@26.1.0)(yaml@2.9.0))(@semantic-release/npm@13.1.5(semantic-release@25.0.5(typescript@6.0.3)))(semantic-release@25.0.5(typescript@6.0.3))(yaml@2.9.0)
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@rushstack/eslint-plugin-security':
         specifier: catalog:lint
         version: 0.14.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
Cloudflare resolves with `workerd`, `worker`, `module` and `browser`, and
export conditions match in package.json key order — so `browser` won and
Workers received the browser build. That build emits `%c` CSS console pairs,
which Workers logs do not interpret, and it returns an **array** rather than a
string.

Adds a `workerd` condition ahead of `browser`, pointing at the same server
build `edge-light` already used. Node and browser-bundler resolution are
unchanged, verified against the full four-condition set.

It points at the server build rather than the edge-light one deliberately: the
edge-light detector special-cases only `NEXT_RUNTIME` and then falls through to
a browser detector that matches no Chromium branch, so it reports level 0 on
bare workerd. The server build honours `FORCE_COLOR`, `NO_COLOR` and the CI
variables Workers actually provides.

No `worker` condition is added: browser bundlers set it for Web Workers, where
it would shadow the browser build.

BREAKING CHANGE: on Cloudflare Workers, `@visulima/colorize` now resolves to
the server build, so styling helpers return a `string` instead of the browser
build's `["%ctext", "css"]` array. Worker code written as
`console.log(...red("x"))` must become `console.log(red("x"))`. Output changes
from uninterpreted `%c` markers to ANSI, which is what Workers logs render.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
