### PR TITLE
fix(is-ansi-color-supported): serve server build

### DIFF
--- a/packages/terminal/is-ansi-color-supported/__tests__/workerd/is-color-supported.workerd.test.ts
+++ b/packages/terminal/is-ansi-color-supported/__tests__/workerd/is-color-supported.workerd.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+    createIsColorSupported as browserCreateIsColorSupported,
+    isStdoutColorSupported as browserIsStdoutColorSupported,
+} from "../../src/is-color-supported.browser";
+import {
+    createIsColorSupported as edgeCreateIsColorSupported,
+    isStderrColorSupported as edgeIsStderrColorSupported,
+    isStdoutColorSupported as edgeIsStdoutColorSupported,
+} from "../../src/is-color-supported.edge-light";
+import {
+    createIsColorSupported as serverCreateIsColorSupported,
+    isStderrColorSupported as serverIsStderrColorSupported,
+    isStdoutColorSupported as serverIsStdoutColorSupported,
+} from "../../src/is-color-supported.server";
+
+/**
+ * Every entry point must load and answer inside `workerd`. The package advertises
+ * an `edge-light` export condition, so a runtime that has `process.env` but no
+ * `process.stdout.isTTY`, no `node:tty` and only a stubbed `node:os` must still get
+ * a level in `0..3` instead of a `ReferenceError` / `TypeError` at import time.
+ */
+const LEVELS = new Set([0, 1, 2, 3]);
+
+/** Live view of the workerd globals under test; `vi.stubGlobal` swaps them in place. */
+const globalScope = globalThis as unknown as {
+    navigator: { userAgent: string };
+    process: { env?: unknown; getBuiltinModule: (id: string) => unknown; stdout?: { isTTY?: unknown } };
+};
+
+describe("workerd runtime baseline", () => {
+    it("should expose the workerd globals the detectors branch on", () => {
+        expect.assertions(4);
+
+        // `nodejs_compat` gives a `process` with `env`/`argv`/`platform`, but no TTY streams.
+        expect(globalScope.process).toBeTypeOf("object");
+        expect(globalScope.process.env).toBeTypeOf("object");
+        expect(globalScope.process.stdout?.isTTY).toBeUndefined();
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- workerd always defines `navigator`; the browser detector branches on it
+        expect(globalScope.navigator.userAgent).toBe("Cloudflare-Workers");
+    });
+});
+
+describe("is-color-supported.server (workerd)", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+    });
+
+    it("should resolve and return a valid level without throwing", () => {
+        expect.assertions(2);
+
+        expect(LEVELS.has(serverIsStdoutColorSupported())).toBe(true);
+        expect(LEVELS.has(serverIsStderrColorSupported())).toBe(true);
+    });
+
+    it("should report no color for the bare workerd process (no TTY, no TERM)", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", {
+            argv: ["workerd"],
+            env: {},
+            platform: "linux",
+            stdout: {},
+        });
+
+        expect(serverIsStdoutColorSupported()).toBe(0);
+        expect(serverIsStderrColorSupported()).toBe(0);
+    });
+
+    it("should honour FORCE_COLOR from the workerd process.env", () => {
+        expect.assertions(1);
+
+        vi.stubEnv("FORCE_COLOR", "3");
+
+        expect(serverIsStdoutColorSupported()).toBe(3);
+    });
+
+    it("should honour NO_COLOR from the workerd process.env", () => {
+        expect.assertions(1);
+
+        vi.stubEnv("NO_COLOR", "1");
+
+        expect(serverIsStdoutColorSupported()).toBe(0);
+    });
+
+    it("should sniff CLI flags from the workerd process.argv", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", {
+            argv: ["workerd", "--color=256"],
+            env: {},
+            platform: "linux",
+        });
+
+        expect(serverCreateIsColorSupported("stdout")).toBe(2);
+    });
+
+    it("should ignore CLI flags when sniffFlags is disabled", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", {
+            argv: ["workerd", "--color=256"],
+            env: {},
+            platform: "linux",
+        });
+
+        expect(serverCreateIsColorSupported("stdout", { sniffFlags: false })).toBe(0);
+    });
+
+    it("should treat the missing process.stdout.isTTY as not-a-TTY", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", {
+            argv: ["workerd"],
+            env: { TERM: "xterm" },
+            platform: "linux",
+            stdout: {},
+        });
+
+        // `xterm` matches the color-capable TERM pattern but is gated behind isTTY,
+        // which workerd never sets.
+        expect(serverIsStdoutColorSupported()).toBe(0);
+        expect(serverCreateIsColorSupported("stdout", { isTTY: true })).toBe(1);
+    });
+
+    it("should not throw when process.argv is absent", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { env: {}, platform: "linux" });
+
+        expect(serverIsStdoutColorSupported()).toBe(0);
+    });
+
+    it("should not throw for a bare process shim with no env, argv or platform", () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("process", {});
+
+        expect(serverIsStdoutColorSupported()).toBe(0);
+        expect(serverCreateIsColorSupported("stderr")).toBe(0);
+    });
+
+    it("should not throw on the Windows branch when node:os is a workerd stub", () => {
+        expect.assertions(1);
+
+        const getBuiltinModule = globalScope.process.getBuiltinModule.bind(globalScope.process);
+
+        // workerd's `process.getBuiltinModule("node:os").release()` returns "", so the
+        // build-number heuristic must degrade to the 16-color floor rather than NaN-crash.
+        vi.stubGlobal("process", {
+            argv: [],
+            env: {},
+            getBuiltinModule,
+            platform: "win32",
+        });
+
+        expect(serverIsStdoutColorSupported()).toBe(1);
+    });
+
+    it("should not throw when process.getBuiltinModule is unavailable on the Windows branch", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { argv: [], env: {}, platform: "win32" });
+
+        expect(serverIsStdoutColorSupported()).toBe(1);
+    });
+
+    it("should not throw when there is no process global at all", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", undefined);
+
+        expect(serverIsStdoutColorSupported()).toBe(0);
+    });
+});
+
+describe("is-color-supported.browser (workerd)", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("should report no color for the workerd navigator", () => {
+        expect.assertions(2);
+
+        // workerd defines `navigator.userAgent === "Cloudflare-Workers"` and no
+        // `userAgentData`, so neither Chromium branch matches.
+        expect(browserIsStdoutColorSupported()).toBe(0);
+        expect(browserCreateIsColorSupported()).toBe(0);
+    });
+
+    it("should not read process at all", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", undefined);
+
+        expect(browserIsStdoutColorSupported()).toBe(0);
+    });
+});
+
+describe("is-color-supported.edge-light (workerd)", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+    });
+
+    it("should report no color on bare workerd", () => {
+        expect.assertions(3);
+
+        // Documented behaviour: workerd is not a terminal, so the edge-light build
+        // falls through to the browser detector and reports mono.
+        expect(edgeIsStdoutColorSupported()).toBe(0);
+        expect(edgeIsStderrColorSupported()).toBe(0);
+        expect(edgeCreateIsColorSupported("stderr")).toBe(0);
+    });
+
+    it("should report 16 colors when NEXT_RUNTIME marks an edge runtime", () => {
+        expect.assertions(1);
+
+        vi.stubEnv("NEXT_RUNTIME", "edge");
+
+        expect(edgeIsStdoutColorSupported()).toBe(1);
+    });
+
+    it("should not throw when process is removed", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", undefined);
+
+        expect(edgeIsStdoutColorSupported()).toBe(0);
+    });
+
+    it("should expose stdout and stderr detectors as the same implementation", () => {
+        expect.assertions(1);
+
+        expect(edgeIsStdoutColorSupported).toBe(edgeIsStderrColorSupported);
+    });
+});

--- a/packages/terminal/is-ansi-color-supported/eslint.config.js
+++ b/packages/terminal/is-ansi-color-supported/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/terminal/is-ansi-color-supported/package.json
+++ b/packages/terminal/is-ansi-color-supported/package.json
@@ -34,11 +34,6 @@
     ],
     "homepage": "https://visulima.com/packages/is-ansi-color-supported/",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -54,34 +49,19 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "type": "module",
-    "sideEffects": false,
-    "module": "dist/is-color-supported.server.js",
-    "browser": "dist/is-color-supported.browser.js",
-    "types": "dist/is-color-supported.server.d.ts",
-    "typesVersions": {
-        ">=5.0": {
-            ".": [
-                "./dist/is-color-supported.edge-light.d.ts",
-                "./dist/is-color-supported.browser.d.ts",
-                "./dist/is-color-supported.server.d.ts"
-            ],
-            "edge-light": [
-                "./dist/is-color-supported.edge-light.d.ts"
-            ],
-            "browser": [
-                "./dist/is-color-supported.browser.d.ts"
-            ]
-        }
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
     },
+    "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
+            "workerd": {
+                "types": "./dist/is-color-supported.server.d.ts",
+                "default": "./dist/is-color-supported.server.js"
+            },
             "edge-light": {
                 "types": "./dist/is-color-supported.edge-light.d.ts",
                 "default": "./dist/is-color-supported.edge-light.js"
@@ -105,10 +85,30 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
+    "module": "dist/is-color-supported.server.js",
+    "browser": "dist/is-color-supported.browser.js",
+    "types": "dist/is-color-supported.server.d.ts",
+    "typesVersions": {
+        ">=5.0": {
+            ".": [
+                "./dist/is-color-supported.edge-light.d.ts",
+                "./dist/is-color-supported.browser.d.ts",
+                "./dist/is-color-supported.server.d.ts"
+            ],
+            "edge-light": [
+                "./dist/is-color-supported.edge-light.d.ts"
+            ],
+            "browser": [
+                "./dist/is-color-supported.browser.d.ts"
+            ]
+        }
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -127,7 +127,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -135,6 +136,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:dev",
@@ -154,5 +156,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/is-ansi-color-supported/vitest.workerd.config.ts
+++ b/packages/terminal/is-ansi-color-supported/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8639,6 +8639,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: catalog:lint
         version: 13.0.2
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
Cloudflare sets `workerd` and `worker`, never `edge-light` — that condition is
Vercel's. Since export conditions match in package.json key order, `browser`
won and Workers received the browser build, and with it the DevTools
`navigator`-sniffing detector rather than the one that reads `process.env`.

Adds a `workerd` condition ahead of `browser`, pointing at the server build.
That build contains no `node:` imports, so it loads without `nodejs_compat`,
and it honours the `FORCE_COLOR`, `NO_COLOR` and CI variables Workers provides.
`edge-light` is left in place for Vercel.

No `worker` condition is added: browser bundlers set it for Web Workers, where
it would shadow the browser build.

Adds a workerd suite covering all three entry variants and the Windows branch
under a stubbed `node:os`, which degrades to the 16-colour floor rather than
producing `NaN`.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
