### PR TITLE
fix(boxen): drop static node builtin imports

### DIFF
--- a/packages/terminal/boxen/AGENTS.md
+++ b/packages/terminal/boxen/AGENTS.md
@@ -4,12 +4,13 @@ This file provides guidance to AI coding agents when working with code in this d
 
 ## Overview
 
-`@visulima/boxen` renders a string inside a styled, bordered box for terminal output — borders, padding, margins, alignment, header/footer, and float positioning. Single-file core in `src/index.ts`, with the bundled border catalog in `src/vendor/cli-boxes/` (a vendored copy of `cli-boxes`) and width measurement in `src/widest-line.ts`. Originally derived from Sindre Sorhus's `boxen`.
+`@visulima/boxen` renders a string inside a styled, bordered box for terminal output — borders, padding, margins, alignment, header/footer, and float positioning. Single-file core in `src/index.ts`, with the bundled border catalog in `src/vendor/cli-boxes/` (a vendored copy of `cli-boxes`), the terminal-width probe in `src/vendor/terminal-size/` (a port of `terminal-size`) and width measurement in `src/widest-line.ts`. Originally derived from Sindre Sorhus's `boxen`.
 
 ## Architecture
 
-- Hot-path dependencies are inlined via the bundler rather than declared as runtime deps: `@visulima/string` (for `alignText`, `getStringWidth`, `wordWrap`) and `terminal-size` live in `devDependencies` and are imported with `// eslint-disable-next-line import/no-extraneous-dependencies`. When changing imports inside `src/index.ts`, keep that pattern — boxen ships zero runtime deps in `package.json`.
+- Hot-path dependencies are inlined via the bundler rather than declared as runtime deps: `@visulima/string` (for `alignText`, `getStringWidth`, `wordWrap`) lives in `devDependencies` and is imported with `// eslint-disable-next-line import/no-extraneous-dependencies`. When changing imports inside `src/index.ts`, keep that pattern — boxen ships zero runtime deps in `package.json`.
 - Borders come from the vendored `cli-boxes` JSON in `src/vendor/`; do not depend on the npm `cli-boxes` package.
+- **The module graph must stay free of `node:*` imports.** `boxen()` is a pure string transform, so importing the package has to work on runtimes with no Node builtins (a Worker without `nodejs_compat`, Deno Deploy, the browser). The terminal-width probe is the only thing that wants builtins, and `src/vendor/terminal-size/` resolves them lazily via `process.getBuiltinModule()` — synchronously, because the public API is synchronous and a dynamic `import()` would not be. `__tests__/workerd/module-graph.test.ts` enforces this; do not add a static `node:*` (or `terminal-size`) import to `src/`.
 - Dual-published (ESM `.mjs` + CJS `.cjs`) — keep new top-level files framework-agnostic so both build outputs stay valid.
 
 ## Related

--- a/packages/terminal/boxen/LICENSE.md
+++ b/packages/terminal/boxen/LICENSE.md
@@ -66,14 +66,31 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+---
+
+File: src/vendor/terminal-size/index.ts
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 <!-- DEPENDENCIES -->
 
 # Licenses of bundled dependencies
+
 The published @visulima/boxen artifact additionally contains code with the following licenses:
 MIT
 
 # Bundled dependencies:
+
 ## @visulima/string
+
 License: MIT
 By: Daniel Bannert
 Repository: git+https://github.com/visulima/visulima.git
@@ -100,14 +117,15 @@ Repository: git+https://github.com/visulima/visulima.git
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 >
->
->
 > # Licenses of bundled dependencies
+>
 > The published @visulima/string artifact additionally contains code with the following licenses:
 > MIT
 >
 > # Bundled dependencies:
+>
 > ## codsen-utils
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -135,9 +153,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## emoji-regex-xs
+>
 > License: MIT
 > By: Steven Levithan
 > Repository: git+https://github.com/slevithan/emoji-regex-xs.git
@@ -164,9 +183,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > > SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## fastest-levenshtein
+>
 > License: MIT
 > By: Kasper U. Weihe
 > Repository: git+https://github.com/ka-weihe/fastest-levenshtein.git
@@ -193,9 +213,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > > SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## get-east-asian-width
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/get-east-asian-width
@@ -210,9 +231,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## html-entities
+>
 > License: MIT
 > By: Marat Dulin
 > Repository: https://github.com/mdevils/html-entities.git
@@ -237,9 +259,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > > THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## indent-string
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/indent-string
@@ -254,9 +277,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## lodash-es
+>
 > License: MIT
 > By: John-David Dalton, Mathias Bynens
 > Repository: lodash/lodash
@@ -309,9 +333,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > licenses; we recommend you read them, as their terms may differ from the
 > > terms above.
 >
-> ---------------------------------------
+> ---
 >
 > ## ranges-apply
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -339,9 +364,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## ranges-merge
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -369,9 +395,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## ranges-push
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -399,9 +426,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## ranges-sort
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -429,9 +457,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## redent
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/redent
@@ -446,32 +475,34 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## rfdc
+>
 > License: MIT
 > By: David Mark Clements
 > Repository: git+https://github.com/davidmarkclements/rfdc.git
 >
 > > Copyright 2019 "David Mark Clements <david.mark.clements@gmail.com>"
 > >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-> > documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-> > the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+> > documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+> > the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 > > to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 > >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+> > The above copyright notice and this permission notice shall be included in all copies or substantial portions
 > > of the Software.
 > >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-> > TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-> > THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-> > CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+> > TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+> > THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+> > CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 > > IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## string-collapse-leading-whitespace
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -499,9 +530,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## string-left-right
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -529,9 +561,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## string-strip-html
+>
 > License: MIT
 > By: Roy Revelt
 > Repository: git+https://github.com/codsen/codsen.git
@@ -559,9 +592,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## strip-indent
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/strip-indent
@@ -576,9 +610,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## tiny-invariant
+>
 > License: MIT
 > By: Alex Reardon
 > Repository: https://github.com/alexreardon/tiny-invariant.git
@@ -605,16 +640,15 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > > SOFTWARE.
 >
->
->
->
->
 > # Licenses of bundled types
+>
 > The published @visulima/string artifact additionally contains code with the following licenses:
 > MIT
 >
 > # Bundled types:
+>
 > ## fastest-levenshtein
+>
 > License: MIT
 > By: Kasper U. Weihe
 > Repository: git+https://github.com/ka-weihe/fastest-levenshtein.git
@@ -641,9 +675,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > > SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## get-east-asian-width
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/get-east-asian-width
@@ -658,9 +693,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## indent-string
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/indent-string
@@ -675,9 +711,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## redent
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/redent
@@ -692,9 +729,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
+> ---
 >
 > ## strip-indent
+>
 > License: MIT
 > By: Sindre Sorhus
 > Repository: sindresorhus/strip-indent
@@ -708,23 +746,6 @@ Repository: git+https://github.com/visulima/visulima.git
 > > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
-## terminal-size
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/terminal-size
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 <!-- /DEPENDENCIES -->
 

--- a/packages/terminal/boxen/__fixtures__/static-node-import-control.ts
+++ b/packages/terminal/boxen/__fixtures__/static-node-import-control.ts
@@ -1,0 +1,33 @@
+/**
+ * Control sample for `__tests__/workerd/module-graph.test.ts`.
+ *
+ * This module is never executed — it exists only so the module-graph guard has a
+ * source file that *does* contain the declarations it is meant to catch. Without
+ * it, the guard would report an empty list for every input and still pass.
+ *
+ * The dynamic `import()` below must NOT be reported: deferring a builtin behind a
+ * dynamic import is exactly the pattern the guard is supposed to permit.
+ *
+ * The `node:fs` import is deliberately wrapped across several lines — the shape
+ * Prettier produces once a named-import list runs past the print width. A
+ * line-based scan would never see it, so it belongs here as a sample the guard
+ * has to catch. This directory is both `.prettierignore`d and `eslint.config.js`
+ * ignored, so the wrapping stays exactly as written.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+    readFileSync,
+    writeFileSync,
+} from "node:fs";
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import terminalSize from "terminal-size";
+
+export const runProbe = async (): Promise<string> => {
+    const { fileURLToPath } = await import("node:url");
+
+    writeFileSync("/dev/null", readFileSync("/dev/null"));
+
+    return `${fileURLToPath("file:///")}${execFileSync("true").toString()}${terminalSize().columns}`;
+};

--- a/packages/terminal/boxen/__tests__/color.ts
+++ b/packages/terminal/boxen/__tests__/color.ts
@@ -1,0 +1,52 @@
+import { Colorize } from "@visulima/colorize";
+
+/**
+ * Color bindings for the test suite, pinned to a fixed color-support level.
+ *
+ * `@visulima/colorize` resolves its level once, at import time, by delegating to
+ * `@visulima/is-ansi-color-supported` — which reads `FORCE_COLOR`, `NO_COLOR`,
+ * the CI variables and `process.stdout.isTTY`. Its module-level `red`/`bgRed`/…
+ * exports therefore emit plain text whenever the suite runs without a TTY: under
+ * the husky + lint-staged pre-commit hook, with output piped to a file, or on a
+ * CI log collector. Tests that assert on escape sequences then fail for a reason
+ * that has nothing to do with boxen.
+ *
+ * Boxen never detects color itself — it only applies the color callbacks the
+ * caller hands it — so every escape sequence in these tests is produced by
+ * colorize, not by boxen. Binding the styles to an instance with an explicit
+ * level makes the assertions depend on boxen's behavior alone, which is what
+ * they are meant to cover, instead of on whichever terminal happens to be
+ * attached. Nothing is weakened: if boxen stopped applying a color callback the
+ * escape sequence would vanish from the output and the assertion would still
+ * catch it.
+ *
+ * Level 1 (basic 16 colors) rather than 3: every style used in the suite is a
+ * basic named color, and level 1 emits exactly the codes the committed snapshots
+ * record.
+ */
+const pinnedColorize = new Colorize({ level: 1 });
+
+const { bgRed, blue, green, red, yellow } = pinnedColorize;
+
+// `x` cannot occur inside an ANSI SGR sequence (ESC `[` digits `;` `m`), so
+// splitting a style's output on it always yields exactly the opening and
+// closing halves.
+const SENTINEL = "x";
+
+/**
+ * The opening escape sequence a pinned style emits, recovered from the style's
+ * own output.
+ *
+ * Assertions use this instead of a hand-written escape literal so they state the
+ * relationship — "the box contains what `bgRed` emits" — rather than a constant
+ * that has to be kept in sync with colorize by hand.
+ * @param style A pinned style function from this module.
+ * @returns The escape sequence `style` prepends to its input.
+ */
+const openSequence = (style: (value: string) => string): string => {
+    const [open = ""] = style(SENTINEL).split(SENTINEL);
+
+    return open;
+};
+
+export { bgRed, blue, green, openSequence, red, yellow };

--- a/packages/terminal/boxen/__tests__/unit/border-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/border-option.test.ts
@@ -1,7 +1,7 @@
-import { bgRed, blue, green, red, yellow } from "@visulima/colorize";
 import { describe, expect, it } from "vitest";
 
 import { boxen } from "../../src";
+import { bgRed, blue, green, red, yellow } from "../color";
 
 describe("border option", () => {
     it("should support border color (red)", () => {

--- a/packages/terminal/boxen/__tests__/unit/float-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/float-option.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: () => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/fullscreen-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/fullscreen-option.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: () => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/index.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/index.test.ts
@@ -23,7 +23,7 @@ Have a good day !
 const randomText
     = "lewb{+^PN_6-l 8eK2eqB:jn^YFgGl;wuT)mdA9TZlf 9}?X#P49`x\"@+nLx:BH5p{5_b`S'E8\0{A0l\"(62`TIf(z8n2arEY~]y|bk,6,FYf~rGY*Xfa00q{=fdm=4.zVf6#'|3S!`pJ3 6y02]nj2o4?-`1v$mudH?Wbw3fZ]a+aE''P4Q(6:NHBry)L_&/7v]0<!7<kw~gLc.)'ajS>\0~y8PZ*|-BRY&m%UaCe'3A,N?8&wbOP}*.O<47rnPzxO=4\"*|[%A):;E)Z6!V&x!1*OprW-*+q<F$6|864~1HmYX@J#Nl1j1`!$Y~j^`j;PB2qpe[_;.+vJGnE3) yo&5qRI~WHxK~r%+'P>Up&=P6M<kDdpSL#<Ur/[NN0qI3dFEEy|>_VGx0O/VOvPEez:7C58a^.N,\"Rxc|a6C[i$3QC_)~x!wd+ZMtYsGF&?";
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: () => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/index.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/index.test.ts
@@ -1,7 +1,7 @@
-import { blue, red, yellow } from "@visulima/colorize";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
+import { blue, red, yellow } from "../color";
 
 const longText
     = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas id erat arcu. Integer urna mauris, sodales vel egestas eu, consequat id turpis. Vivamus faucibus est mattis tincidunt lobortis. In aliquam placerat nunc eget viverra. Duis aliquet faucibus diam, blandit tincidunt magna congue eu. Sed vel ante vestibulum, maximus risus eget, iaculis velit. Quisque id dapibus purus, ut sodales lorem. Aenean laoreet iaculis tellus at malesuada. Donec imperdiet eu lacus vitae fringilla.";

--- a/packages/terminal/boxen/__tests__/unit/options.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/options.test.ts
@@ -1,15 +1,15 @@
 import { bgRed, red } from "@visulima/colorize";
 import { getStringWidth } from "@visulima/string";
-import terminalSize from "terminal-size";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { BorderStyleName } from "../../src";
 import { boxen, boxes, clearTerminalSizeCache } from "../../src";
+import terminalSize from "../../src/vendor/terminal-size";
 
 const TUPLE_ERROR = /must return a \[width, height\] tuple/;
 const NUMBER_ERROR = /both width and height must be numbers/;
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: vi.fn<() => { columns: number; rows: number }>(() => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/options.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/options.test.ts
@@ -1,10 +1,10 @@
-import { bgRed, red } from "@visulima/colorize";
 import { getStringWidth } from "@visulima/string";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { BorderStyleName } from "../../src";
 import { boxen, boxes, clearTerminalSizeCache } from "../../src";
 import terminalSize from "../../src/vendor/terminal-size";
+import { bgRed, openSequence, red } from "../color";
 
 const TUPLE_ERROR = /must return a \[width, height\] tuple/;
 const NUMBER_ERROR = /both width and height must be numbers/;
@@ -219,8 +219,9 @@ describe("backgroundColor", () => {
 
         const box = boxen("foo", { backgroundColor: (line) => bgRed(line) });
 
-        // bgRed opens with the background-red ANSI code.
-        expect(box).toContain("[41m");
+        // The whole interior line is handed to the callback, so its styled form
+        // appears verbatim in the box.
+        expect(box).toContain(bgRed("foo"));
         // Plain text is preserved alongside the styling.
         expect(box).toContain("foo");
     });
@@ -230,7 +231,7 @@ describe("backgroundColor", () => {
 
         const box = boxen("foo", { backgroundColor: (line) => bgRed(line) });
 
-        expect(box.split("\n")[0]).not.toContain("[41m");
+        expect(box.split("\n")[0]).not.toContain(openSequence(bgRed));
     });
 });
 
@@ -292,6 +293,8 @@ describe("regression: header/footer colors still apply", () => {
 
         const box = boxen("foo", { headerText: "hi", headerTextColor: (t) => red(t) });
 
-        expect(box).toContain("[31m");
+        // The header text is padded before it is colored, so assert on the
+        // opening sequence rather than on `red("hi")`.
+        expect(box).toContain(openSequence(red));
     });
 });

--- a/packages/terminal/boxen/__tests__/unit/terminal-size.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/terminal-size.test.ts
@@ -1,0 +1,62 @@
+import realTerminalSize from "terminal-size";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import terminalSize, { DEFAULT_COLUMNS, DEFAULT_ROWS } from "../../src/vendor/terminal-size";
+
+// The stubbed `process` must be torn down even if a test throws, so the rest of the
+// suite (and the parity check below) sees the real host runtime again.
+// eslint-disable-next-line vitest/require-top-level-describe
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("vendored terminalSize", () => {
+    it("prefers the stdout dimensions", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { stderr: { columns: 10, rows: 10 }, stdout: { columns: 120, rows: 40 } });
+
+        expect(terminalSize()).toStrictEqual({ columns: 120, rows: 40 });
+    });
+
+    it("falls back to stderr when stdout has no dimensions", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { stderr: { columns: 100, rows: 30 }, stdout: {} });
+
+        expect(terminalSize()).toStrictEqual({ columns: 100, rows: 30 });
+    });
+
+    it("falls back to the COLUMNS/LINES environment variables", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", { env: { COLUMNS: "133", LINES: "44" }, stderr: {}, stdout: {} });
+
+        expect(terminalSize()).toStrictEqual({ columns: 133, rows: 44 });
+    });
+
+    it("returns the documented fallback on a runtime with no Node builtins", () => {
+        expect.assertions(1);
+
+        // No `getBuiltinModule`: the shape a Worker/Deno-Deploy style runtime presents.
+        vi.stubGlobal("process", { env: {}, stderr: {}, stdout: {} });
+
+        expect(terminalSize()).toStrictEqual({ columns: DEFAULT_COLUMNS, rows: DEFAULT_ROWS });
+    });
+
+    it("returns the documented fallback when there is no process at all", () => {
+        expect.assertions(1);
+
+        vi.stubGlobal("process", undefined);
+
+        expect(terminalSize()).toStrictEqual({ columns: DEFAULT_COLUMNS, rows: DEFAULT_ROWS });
+    });
+
+    it("agrees with the upstream implementation on the host runtime", () => {
+        expect.assertions(1);
+
+        // Parity check against the real package (a devDependency, never shipped):
+        // the port must not change what boxen measures on Node.
+        expect(terminalSize()).toStrictEqual(realTerminalSize());
+    });
+});

--- a/packages/terminal/boxen/__tests__/unit/text-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/text-option.test.ts
@@ -1,7 +1,7 @@
-import { bgRed } from "@visulima/colorize";
 import { describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
+import { bgRed } from "../color";
 
 const longText
     = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas id erat arcu. Integer urna mauris, sodales vel egestas eu, consequat id turpis. Vivamus faucibus est mattis tincidunt lobortis. In aliquam placerat nunc eget viverra. Duis aliquet faucibus diam, blandit tincidunt magna congue eu. Sed vel ante vestibulum, maximus risus eget, iaculis velit. Quisque id dapibus purus, ut sodales lorem. Aenean laoreet iaculis tellus at malesuada. Donec imperdiet eu lacus vitae fringilla.";

--- a/packages/terminal/boxen/__tests__/unit/text-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/text-option.test.ts
@@ -6,7 +6,7 @@ import { boxen } from "../../src";
 const longText
     = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas id erat arcu. Integer urna mauris, sodales vel egestas eu, consequat id turpis. Vivamus faucibus est mattis tincidunt lobortis. In aliquam placerat nunc eget viverra. Duis aliquet faucibus diam, blandit tincidunt magna congue eu. Sed vel ante vestibulum, maximus risus eget, iaculis velit. Quisque id dapibus purus, ut sodales lorem. Aenean laoreet iaculis tellus at malesuada. Donec imperdiet eu lacus vitae fringilla.";
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: () => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/unicode-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/unicode-option.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
 
-vi.mock(import("terminal-size"), () => {
+vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
         default: () => {
             return {

--- a/packages/terminal/boxen/__tests__/unit/unicode-option.test.ts
+++ b/packages/terminal/boxen/__tests__/unit/unicode-option.test.ts
@@ -1,8 +1,8 @@
-import { green, red } from "@visulima/colorize";
 import { getStringWidth } from "@visulima/string";
 import { describe, expect, it, vi } from "vitest";
 
 import { boxen } from "../../src";
+import { green, red } from "../color";
 
 vi.mock(import("../../src/vendor/terminal-size"), () => {
     return {
@@ -54,8 +54,9 @@ describe("wide-character and ANSI content", () => {
 
         expectUniformWidth(box);
 
-        // The original styling codes survive untouched.
-        expect(box).toContain("[31m");
+        // The original styling codes survive untouched — opening sequence,
+        // payload and closing sequence, exactly as they went in.
+        expect(box).toContain(red("error"));
     });
 });
 

--- a/packages/terminal/boxen/__tests__/workerd/index.test.ts
+++ b/packages/terminal/boxen/__tests__/workerd/index.test.ts
@@ -1,0 +1,305 @@
+import { getStringWidth } from "@visulima/string";
+import { describe, expect, it } from "vitest";
+
+import { boxen, boxes, clearTerminalSizeCache } from "../../src";
+
+/** Width of every rendered line, so a box can be checked for a ragged right edge. */
+const lineWidths = (box: string): number[] => box.split("\n").map((line) => getStringWidth(line));
+
+describe("boxen in workerd", () => {
+    it("should run inside the workers runtime", () => {
+        expect.assertions(2);
+
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- `navigator` is a workerd global, not a Node builtin
+        expect((globalThis as { navigator?: { userAgent?: string } }).navigator?.userAgent).toBe("Cloudflare-Workers");
+        // There is no TTY behind `process.stdout` in a Worker, which is the exact condition the
+        // terminal-width probe has to survive.
+        expect(process.stdout.columns).toBeUndefined();
+    });
+
+    describe("terminal width detection without a TTY", () => {
+        it("should fall back to a finite default width instead of NaN", () => {
+            expect.assertions(4);
+
+            clearTerminalSizeCache();
+
+            const box = boxen("foo");
+            const widths = lineWidths(box);
+
+            expect(widths).toStrictEqual([5, 5, 5]);
+            expect(widths.every((width) => Number.isFinite(width))).toBe(true);
+            expect(box).not.toContain("NaN");
+            expect(box).toBe("┌───┐\n│foo│\n└───┘");
+        });
+
+        it("should cap an over-long line at the fallback terminal width", () => {
+            expect.assertions(3);
+
+            clearTerminalSizeCache();
+
+            const box = boxen("x".repeat(200));
+            const widths = lineWidths(box);
+
+            // 80 columns is the documented fallback when no TTY can be probed.
+            expect(Math.max(...widths)).toBe(80);
+            expect(new Set(widths).size).toBe(1);
+            expect(box.split("\n")).toHaveLength(5);
+        });
+
+        it("should not throw when the size cache is cleared repeatedly", () => {
+            expect.assertions(1);
+
+            clearTerminalSizeCache();
+            clearTerminalSizeCache();
+
+            expect(() => boxen("foo")).not.toThrow();
+        });
+
+        it("should honour explicit terminal dimensions over the probe", () => {
+            expect.assertions(1);
+
+            const box = boxen("x".repeat(40), { terminalColumns: 20 });
+
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([20]));
+        });
+    });
+
+    describe("borders", () => {
+        // `none` is special-cased into "no border rows at all" and is covered separately below.
+        it.each((Object.keys(boxes) as (keyof typeof boxes)[]).filter((style) => style !== "none"))("should render the %s border style", (style) => {
+            expect.assertions(3);
+
+            const chars = boxes[style];
+            const lines = boxen("foo", { borderStyle: style, terminalColumns: 80 }).split("\n");
+
+            expect(lines).toHaveLength(3);
+            expect(lines[0]).toStrictEqual(chars.topLeft + chars.top.repeat(3) + chars.topRight);
+            expect(lines[1]).toBe(`${chars.left}foo${chars.right}`);
+        });
+
+        it("should render a box with no border", () => {
+            expect.assertions(1);
+
+            expect(boxen("foo", { borderStyle: "none", terminalColumns: 80 })).toBe("foo");
+        });
+
+        it("should render a custom border style", () => {
+            expect.assertions(1);
+
+            expect(
+                boxen("foo", {
+                    borderStyle: { ...boxes.round, top: "=" },
+                    terminalColumns: 80,
+                }),
+            ).toBe("╭===╮\n│foo│\n╰───╯");
+        });
+
+        it("should reject an unknown border style", () => {
+            expect.assertions(1);
+
+            // @ts-expect-error - invalid border style
+            expect(() => boxen("foo", { borderStyle: "nope", terminalColumns: 80 })).toThrow("Invalid border style: nope");
+        });
+
+        it("should let a borderColor callback wrap the border characters", () => {
+            expect.assertions(1);
+
+            const box = boxen("foo", {
+                borderColor: (border) => `\u001B[31m${border}\u001B[39m`,
+                terminalColumns: 80,
+            });
+
+            expect(box).toContain("\u001B[31m┌\u001B[39m");
+        });
+    });
+
+    describe("padding and margin", () => {
+        it("should expand the box by a numeric padding", () => {
+            expect.assertions(1);
+
+            expect(boxen("foo", { padding: 1, terminalColumns: 80 })).toStrictEqual(
+                ["┌─────────┐", "│         │", "│   foo   │", "│         │", "└─────────┘"].join("\n"),
+            );
+        });
+
+        it("should accept per-side padding", () => {
+            expect.assertions(1);
+
+            expect(boxen("foo", { padding: { bottom: 0, left: 2, right: 1, top: 0 }, terminalColumns: 80 })).toBe("┌──────┐\n│  foo │\n└──────┘");
+        });
+
+        it("should indent by the left margin and pad with blank lines", () => {
+            expect.assertions(2);
+
+            const box = boxen("foo", { margin: 1, terminalColumns: 80 });
+            const lines = box.split("\n");
+
+            expect(lines[0]).toBe("");
+            expect(lines[1]).toBe("   ┌───┐");
+        });
+    });
+
+    describe("float", () => {
+        it.each([
+            ["left", 0],
+            ["center", 37],
+            ["right", 75],
+        ] as const)("should position a %s-floated box", (float, expectedIndent) => {
+            expect.assertions(1);
+
+            const box = boxen("foo", { float, terminalColumns: 80 });
+            const firstLine = box.split("\n")[0] as string;
+
+            expect(firstLine.length - firstLine.trimStart().length).toStrictEqual(expectedIndent);
+        });
+    });
+
+    describe("header and footer", () => {
+        it.each(["left", "center", "right"] as const)("should place a %s-aligned header", (headerAlignment) => {
+            expect.assertions(2);
+
+            const box = boxen("content here", { headerAlignment, headerText: "title", terminalColumns: 80 });
+            const widths = lineWidths(box);
+
+            expect(box).toContain("title");
+            expect(new Set(widths).size).toBe(1);
+        });
+
+        it.each(["left", "center", "right"] as const)("should place a %s-aligned footer", (footerAlignment) => {
+            expect.assertions(2);
+
+            const box = boxen("content here", { footerAlignment, footerText: "end", terminalColumns: 80 });
+            const widths = lineWidths(box);
+
+            expect(box).toContain("end");
+            expect(new Set(widths).size).toBe(1);
+        });
+
+        it("should truncate a header that is wider than a fixed width", () => {
+            expect.assertions(2);
+
+            const box = boxen("foo", { headerText: "a very long title indeed", terminalColumns: 80, width: 10 });
+
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([10]));
+            expect(box).toBe("┌ a very ┐\n│foo     │\n└────────┘");
+        });
+    });
+
+    describe("width and height", () => {
+        it("should render a fixed width box", () => {
+            expect.assertions(1);
+
+            expect(boxen("foo", { terminalColumns: 80, width: 20 })).toStrictEqual(
+                ["┌──────────────────┐", "│foo               │", "└──────────────────┘"].join("\n"),
+            );
+        });
+
+        it("should wrap content that exceeds a fixed width", () => {
+            expect.assertions(2);
+
+            const box = boxen("foo bar foo bar", { terminalColumns: 80, width: 10 });
+
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([10]));
+            expect(box.split("\n").length).toBeGreaterThan(3);
+        });
+
+        it.each(["top", "center", "bottom"] as const)("should %s-align content in a fixed height box", (verticalAlignment) => {
+            expect.assertions(2);
+
+            const box = boxen("foo", { height: 7, terminalColumns: 80, verticalAlignment });
+            const lines = box.split("\n");
+
+            expect(lines).toHaveLength(7);
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([5]));
+        });
+    });
+
+    describe("fullscreen", () => {
+        it("should size to the probed fallback dimensions", () => {
+            expect.assertions(2);
+
+            clearTerminalSizeCache();
+
+            const box = boxen("foo", { fullscreen: true });
+            const widths = lineWidths(box);
+
+            expect(box.split("\n")).toHaveLength(24);
+            expect(new Set(widths)).toStrictEqual(new Set([80]));
+        });
+
+        it("should accept a callback returning explicit dimensions", () => {
+            expect.assertions(2);
+
+            const box = boxen("foo", { fullscreen: () => [30, 4], terminalColumns: 80, terminalRows: 24 });
+
+            expect(box.split("\n")).toHaveLength(4);
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([30]));
+        });
+
+        it("should reject a callback returning a non-numeric size", () => {
+            expect.assertions(1);
+
+            expect(() => boxen("foo", { fullscreen: () => ["wide", 4] as unknown as [number, number], terminalColumns: 80, terminalRows: 24 })).toThrow(
+                "both width and height must be numbers",
+            );
+        });
+    });
+
+    describe("wide, emoji and ANSI content", () => {
+        it("should measure full-width CJK characters as two columns", () => {
+            expect.assertions(1);
+
+            expect(boxen("你好", { terminalColumns: 80 })).toBe("┌────┐\n│你好│\n└────┘");
+        });
+
+        it("should measure emoji as two columns", () => {
+            expect.assertions(1);
+
+            expect(boxen("🦄", { terminalColumns: 80 })).toBe("┌──┐\n│🦄│\n└──┘");
+        });
+
+        it("should ignore ANSI escapes when measuring content", () => {
+            expect.assertions(2);
+
+            const box = boxen("\u001B[31mfoo\u001B[39m", { terminalColumns: 80 });
+
+            expect(box).toContain("\u001B[31mfoo\u001B[39m");
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([5]));
+        });
+
+        it("should keep a mixed wide/ANSI line flush with the border", () => {
+            expect.assertions(1);
+
+            const box = boxen(`\u001B[32m你好\u001B[39m world\n短`, { terminalColumns: 80 });
+
+            expect(new Set(lineWidths(box)).size).toBe(1);
+        });
+    });
+
+    describe("text alignment", () => {
+        it.each(["left", "center", "right"] as const)("should %s-align text", (textAlignment) => {
+            expect.assertions(1);
+
+            const box = boxen("foo\nlonger line", { terminalColumns: 80, textAlignment });
+
+            expect(new Set(lineWidths(box))).toStrictEqual(new Set([13]));
+        });
+    });
+
+    describe("option validation", () => {
+        it("should reject non-function color options", () => {
+            expect.assertions(2);
+
+            // @ts-expect-error - invalid borderColor
+            expect(() => boxen("foo", { borderColor: "red", terminalColumns: 80 })).toThrow("\"borderColor\" must be a function, got string");
+            // @ts-expect-error - invalid fullscreen
+            expect(() => boxen("foo", { fullscreen: 1, terminalColumns: 80 })).toThrow("\"fullscreen\" must be a boolean or a function, got number");
+        });
+
+        it("should expand tabs to spaces", () => {
+            expect.assertions(1);
+
+            expect(boxen("a\tb", { terminalColumns: 80 })).toBe("┌──────┐\n│a    b│\n└──────┘");
+        });
+    });
+});

--- a/packages/terminal/boxen/__tests__/workerd/module-graph.test.ts
+++ b/packages/terminal/boxen/__tests__/workerd/module-graph.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error -- Vite `?raw` import. Control sample: this module does import Node builtins statically.
+import controlSource from "../../__fixtures__/static-node-import-control.ts?raw";
+// @ts-expect-error -- Vite `?raw` import: inlines the file contents as a string at transform time.
+import indexSource from "../../src/index.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import cliBoxesSource from "../../src/vendor/cli-boxes/boxes.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import terminalSizeSource from "../../src/vendor/terminal-size/index.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import widestLineSource from "../../src/widest-line.ts?raw";
+
+/**
+ * Every bare specifier that is known to pull Node builtins into the graph of
+ * whoever imports it. `node:` covers the builtins themselves; `terminal-size`
+ * is listed by name because its own entry statically imports four of them, so a
+ * static import of it is just as fatal on a runtime without Node builtins.
+ */
+const NODE_ONLY_SPECIFIERS = ["node:", "terminal-size"];
+
+/**
+ * Any *static* `import`/`export … from` declaration, plus bare side-effect imports.
+ *
+ * Matching is deliberately not line-based: Prettier wraps a named-import list that runs
+ * past the print width across several lines, and a per-line scan would never see the
+ * specifier. `[^;"']*` spans newlines but stops at the first `;` or quote, so a wrapped
+ * declaration is captured whole while the scan can neither run on into the statement that
+ * follows nor step over an intervening string literal.
+ *
+ * The `m` anchor is what keeps dynamic imports out: `await import("node:x")` never begins
+ * a line, and a line-initial `import("node:x")` has no whitespace after `import`, which
+ * the pattern requires.
+ *
+ * The clause before the specifier is optional so bare side-effect imports
+ * (`import "node:x";`) are covered by the same pattern rather than a second one.
+ */
+const STATIC_IMPORT_REGEX = /^(?:import|export)\s(?:[^;"']*\bfrom\s)?["']([^"']+)["'];?/gmu;
+
+/**
+ * Collects *static* `import`/`export ... from` declarations naming a specifier from
+ * {@link NODE_ONLY_SPECIFIERS} — the form that fails at module-load time.
+ * `await import("node:x")` is deliberately not reported: a dynamic import is only
+ * evaluated when the branch that needs it actually runs, and
+ * `process.getBuiltinModule("node:x")` is a plain runtime call no resolver ever sees.
+ * @param source The module source text.
+ * @returns Every offending declaration, verbatim — newlines included, for wrapped ones.
+ */
+const staticNodeImportsIn = (source: string): string[] => {
+    const offenders: string[] = [];
+
+    for (const match of source.matchAll(STATIC_IMPORT_REGEX)) {
+        const specifier = match[1];
+
+        if (specifier !== undefined && NODE_ONLY_SPECIFIERS.some((prefix) => specifier.startsWith(prefix))) {
+            offenders.push(match[0]);
+        }
+    }
+
+    return offenders;
+};
+
+/**
+ * `boxen()` is a pure string transform, so merely importing `@visulima/boxen` must not
+ * require a single Node builtin. A static `node:*` import anywhere in its module graph
+ * breaks that at *import* time — before a box is ever rendered — and cannot be caught by
+ * the runtime specs in this directory, because `nodejs_compat` makes those imports resolve
+ * under the workerd test harness even though a plain Worker would fail to load them.
+ */
+describe("boxen module graph", () => {
+    const modules: [string, string][] = [
+        ["index.ts", indexSource as string],
+        ["widest-line.ts", widestLineSource as string],
+        ["vendor/cli-boxes/boxes.ts", cliBoxesSource as string],
+        ["vendor/terminal-size/index.ts", terminalSizeSource as string],
+    ];
+
+    it.each(modules)("%s declares no static node-only import", (_name, source) => {
+        expect.assertions(2);
+
+        // Guards against `?raw` handing back an empty string, which would make the
+        // assertion below pass without inspecting anything.
+        expect(source.length).toBeGreaterThan(0);
+        expect(staticNodeImportsIn(source)).toStrictEqual([]);
+    });
+
+    it("detects static node-only imports when they are present", () => {
+        expect.assertions(1);
+
+        // Control sample — proves the checks above are not passing vacuously.
+        expect(staticNodeImportsIn(controlSource as string)).toStrictEqual([
+            "import { execFileSync } from \"node:child_process\";",
+            "import {\n    readFileSync,\n    writeFileSync,\n} from \"node:fs\";",
+            "import terminalSize from \"terminal-size\";",
+        ]);
+    });
+
+    it("reaches Node builtins only through process.getBuiltinModule", () => {
+        expect.assertions(2);
+
+        expect(terminalSizeSource as string).toContain("hostProcess.getBuiltinModule(id)");
+        expect(staticNodeImportsIn(terminalSizeSource as string)).toStrictEqual([]);
+    });
+
+    it("keeps the terminal-size probe synchronous", () => {
+        expect.assertions(2);
+
+        // A dynamic `import()` would also keep the graph clean, but it is asynchronous
+        // and the public `boxen()` API is not — so it must not appear here.
+        expect(terminalSizeSource as string).not.toContain("await import(");
+        expect(indexSource as string).not.toContain("await import(");
+    });
+});

--- a/packages/terminal/boxen/eslint.config.js
+++ b/packages/terminal/boxen/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/terminal/boxen/package.json
+++ b/packages/terminal/boxen/package.json
@@ -20,11 +20,6 @@
         "visulima"
     ],
     "homepage": "https://visulima.com/packages/boxen/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -40,19 +35,20 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./package.json": "./package.json"
+    },
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "typesVersions": {
@@ -62,17 +58,12 @@
             ]
         }
     },
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        },
-        "./package.json": "./package.json"
-    },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -91,7 +82,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -99,6 +91,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@types/node": "catalog:types",
         "@visulima/colorize": "2.0.0",
         "@visulima/packem": "catalog:dev",
@@ -120,5 +113,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/terminal/boxen/src/index.ts
+++ b/packages/terminal/boxen/src/index.ts
@@ -8,11 +8,10 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { alignText, getStringWidth, slice, wordWrap, WrapMode } from "@visulima/string";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import terminalSize from "terminal-size";
 
 import type { Alignment, BorderPosition, BorderStyle, BorderStyleName, DimensionOptions, Options, Spacer, VerticalAlignment } from "./types";
 import cliBoxes from "./vendor/cli-boxes/boxes";
+import terminalSize from "./vendor/terminal-size";
 import { widestLine } from "./widest-line";
 
 const NEWLINE = "\n";
@@ -23,6 +22,11 @@ const NONE = "none";
 // child process when stdout is not a TTY (CI, piped output), which is costly
 // to repeat on every `boxen()` call. The terminal dimensions effectively never
 // change within a single render pass, so cache the first lookup and reuse it.
+//
+// The probe itself lives in `./vendor/terminal-size` precisely so that importing
+// `@visulima/boxen` never pulls `node:child_process`/`node:fs`/`node:tty` into
+// the module graph; it resolves those builtins lazily, and only on the branch
+// that needs them.
 let probedTerminal: { columns: number; rows: number } | undefined;
 
 const probeTerminal = (): { columns: number; rows: number } => {

--- a/packages/terminal/boxen/src/vendor/terminal-size/index.ts
+++ b/packages/terminal/boxen/src/vendor/terminal-size/index.ts
@@ -1,0 +1,301 @@
+/**
+ * This file is a modified version of the original `terminal-size` package.
+ *
+ * MIT License
+ *
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ *
+ * The upstream module reaches for `node:process`, `node:child_process`, `node:fs`
+ * and `node:tty` through *static* imports. Importing it therefore drags those
+ * builtins into the module graph of everything that imports `@visulima/boxen` —
+ * which breaks at module-resolution time on runtimes that ship no Node builtins
+ * (Cloudflare Workers without `nodejs_compat`, Deno Deploy, browsers), long
+ * before any box is rendered.
+ *
+ * This port keeps the probing order and the documented 80x24 fallback, but
+ * resolves the builtins lazily via `process.getBuiltinModule()` and only on the
+ * path that actually needs them. That keeps `terminalSize()` synchronous — the
+ * public `boxen()` API is synchronous and must stay that way — while leaving the
+ * module graph free of `node:*` specifiers.
+ */
+
+/** Terminal dimensions in character cells. */
+export interface TerminalSize {
+    /** Number of columns (character cells across). */
+    columns: number;
+
+    /** Number of rows (character cells down). */
+    rows: number;
+}
+
+/** Documented fallback used when no probe can determine the real terminal size. */
+export const DEFAULT_COLUMNS = 80;
+
+/** Documented fallback used when no probe can determine the real terminal size. */
+export const DEFAULT_ROWS = 24;
+
+interface StandardStream {
+    columns?: number;
+    rows?: number;
+}
+
+interface HostProcess {
+    env?: Record<string, string | undefined>;
+    getBuiltinModule?: (id: string) => unknown;
+    platform?: string;
+    stderr?: StandardStream;
+    stdout?: StandardStream;
+}
+
+interface FsModule {
+    constants: { O_EVTONLY: number; O_NONBLOCK: number };
+    openSync: (path: string, flags: number) => number;
+    readFileSync: (path: string, encoding: string) => string;
+}
+
+interface TtyModule {
+    WriteStream: (fd: number) => StandardStream;
+}
+
+interface ChildProcessModule {
+    execFileSync: (
+        file: string,
+        arguments_: string[],
+        options: { encoding: string; env?: Record<string, string | undefined>; stdio: string[]; timeout: number },
+    ) => string;
+}
+
+/**
+ * The host `process` object, if the runtime exposes one.
+ *
+ * Read off `globalThis` rather than imported from `node:process` so the lookup
+ * degrades to `undefined` instead of failing module resolution.
+ * @returns The host `process`, or `undefined` on runtimes without one.
+ */
+const getHostProcess = (): HostProcess | undefined => (globalThis as { process?: HostProcess }).process;
+
+/**
+ * Synchronously resolve a Node builtin without a static import.
+ *
+ * `process.getBuiltinModule()` (Node >= 22.3) is the only synchronous escape
+ * hatch that is invisible to bundlers and module resolvers — a dynamic
+ * `import()` would work too, but it is asynchronous and `boxen()` is not.
+ * @param id The builtin specifier, e.g. `node:fs`.
+ * @returns The builtin module, or `undefined` when the runtime has no builtins.
+ */
+const getBuiltinModule = <T>(id: string): T | undefined => {
+    const hostProcess = getHostProcess();
+
+    if (typeof hostProcess?.getBuiltinModule !== "function") {
+        return undefined;
+    }
+
+    try {
+        return hostProcess.getBuiltinModule(id) as T;
+    } catch {
+        return undefined;
+    }
+};
+
+const create = (columns: number | string, rows: number | string): TerminalSize => ({
+    columns: Number.parseInt(String(columns), 10),
+    rows: Number.parseInt(String(rows), 10),
+});
+
+/**
+ * Reject probe output that is either unparseable or indistinguishable from the
+ * fallback, so a bogus reading never wins over a later, better probe.
+ * @param maybeColumns Raw column count reported by a probe.
+ * @param maybeRows Raw row count reported by a probe.
+ * @returns The parsed size, or `undefined` when it should not be trusted.
+ */
+const createIfNotDefault = (maybeColumns: string, maybeRows: string): TerminalSize | undefined => {
+    const { columns, rows } = create(maybeColumns, maybeRows);
+
+    if (Number.isNaN(columns) || Number.isNaN(rows)) {
+        return undefined;
+    }
+
+    if (columns === DEFAULT_COLUMNS && rows === DEFAULT_ROWS) {
+        return undefined;
+    }
+
+    return { columns, rows };
+};
+
+const exec = (command: string, arguments_: string[], environment?: Record<string, string | undefined>): string | undefined => {
+    const childProcess = getBuiltinModule<ChildProcessModule>("node:child_process");
+
+    if (childProcess?.execFileSync === undefined) {
+        return undefined;
+    }
+
+    return childProcess
+        .execFileSync(command, arguments_, {
+            encoding: "utf8",
+            env: environment,
+            stdio: ["ignore", "pipe", "ignore"],
+            timeout: 500,
+        })
+        .trim();
+};
+
+/**
+ * On Linux, a background process must not steal the foreground terminal's size.
+ * @returns `true` when this process owns the controlling terminal.
+ */
+const isForegroundProcess = (): boolean => {
+    const hostProcess = getHostProcess();
+
+    if (hostProcess?.platform !== "linux") {
+        return true;
+    }
+
+    try {
+        const fs = getBuiltinModule<FsModule>("node:fs");
+
+        if (fs === undefined) {
+            return false;
+        }
+
+        const statContents = fs.readFileSync("/proc/self/stat", "utf8");
+        const closingParenthesisIndex = statContents.lastIndexOf(") ");
+
+        if (closingParenthesisIndex === -1) {
+            return false;
+        }
+
+        const statFields = statContents
+            .slice(closingParenthesisIndex + 2)
+            .trim()
+            .split(/\s+/);
+        const processGroupId = Number.parseInt(statFields[2] as string, 10);
+        const foregroundProcessGroupId = Number.parseInt(statFields[5] as string, 10);
+
+        if (Number.isNaN(processGroupId) || Number.isNaN(foregroundProcessGroupId)) {
+            return false;
+        }
+
+        if (foregroundProcessGroupId <= 0) {
+            return false;
+        }
+
+        return processGroupId === foregroundProcessGroupId;
+    } catch {
+        return false;
+    }
+};
+
+/** Ask the controlling terminal directly; works even when stdout is redirected. */
+const devTty = (): TerminalSize | undefined => {
+    try {
+        const fs = getBuiltinModule<FsModule>("node:fs");
+        const tty = getBuiltinModule<TtyModule>("node:tty");
+
+        if (fs === undefined || tty === undefined) {
+            return undefined;
+        }
+
+        const hostProcess = getHostProcess();
+        // eslint-disable-next-line no-bitwise
+        const flags = hostProcess?.platform === "darwin" ? fs.constants.O_EVTONLY | fs.constants.O_NONBLOCK : fs.constants.O_NONBLOCK;
+        // eslint-disable-next-line new-cap
+        const { columns, rows } = tty.WriteStream(fs.openSync("/dev/tty", flags));
+
+        if (columns === undefined || rows === undefined) {
+            return undefined;
+        }
+
+        return { columns, rows };
+    } catch {
+        return undefined;
+    }
+};
+
+/** On macOS this only returns correct values when stdout is not redirected. */
+const tput = (): TerminalSize | undefined => {
+    try {
+        // `tput` requires the `TERM` environment variable to be set.
+        const environment = { TERM: "dumb", ...getHostProcess()?.env };
+        const columns = exec("tput", ["cols"], environment);
+        const rows = exec("tput", ["lines"], environment);
+
+        if (columns && rows) {
+            return createIfNotDefault(columns, rows);
+        }
+
+        return undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/** Only exists on Linux; works even when every file descriptor is redirected. */
+const resize = (): TerminalSize | undefined => {
+    try {
+        if (!isForegroundProcess()) {
+            return undefined;
+        }
+
+        const size = exec("resize", ["-u"])?.match(/\d+/g);
+
+        if (size?.length === 2) {
+            return createIfNotDefault(size[0] as string, size[1] as string);
+        }
+
+        return undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Reliably determine the terminal window size, synchronously.
+ *
+ * Probes, in order: `stdout`, `stderr`, the `COLUMNS`/`LINES` environment
+ * variables, then platform-specific probes (`/dev/tty`, `tput`, `resize`).
+ * Falls back to {@link DEFAULT_COLUMNS} x {@link DEFAULT_ROWS} when none of them
+ * answer — which is what happens on runtimes without Node builtins.
+ * @returns The detected terminal size, or the 80x24 fallback.
+ */
+const terminalSize = (): TerminalSize => {
+    const hostProcess = getHostProcess();
+    const { env, stderr, stdout } = hostProcess ?? {};
+
+    if (stdout?.columns && stdout?.rows) {
+        return create(stdout.columns, stdout.rows);
+    }
+
+    if (stderr?.columns && stderr?.rows) {
+        return create(stderr.columns, stderr.rows);
+    }
+
+    // These values are static, so not the first choice.
+    if (env?.COLUMNS && env?.LINES) {
+        return create(env.COLUMNS, env.LINES);
+    }
+
+    const fallback: TerminalSize = {
+        columns: DEFAULT_COLUMNS,
+        rows: DEFAULT_ROWS,
+    };
+
+    // Every remaining probe needs Node builtins. On a runtime without them the
+    // lazy lookups all return `undefined` and we land on the documented fallback.
+    if (typeof hostProcess?.getBuiltinModule !== "function") {
+        return fallback;
+    }
+
+    if (hostProcess.platform === "win32") {
+        // We include `tput` for Windows users using Git Bash.
+        return tput() ?? fallback;
+    }
+
+    if (hostProcess.platform === "darwin") {
+        return devTty() ?? tput() ?? fallback;
+    }
+
+    return devTty() ?? tput() ?? resize() ?? fallback;
+};
+
+export default terminalSize;

--- a/packages/terminal/boxen/vitest.workerd.config.ts
+++ b/packages/terminal/boxen/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7799,6 +7799,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: catalog:types
         version: 26.1.0
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
`src/index.ts` statically imported `terminal-size`, whose own entry statically
imports `node:process`, `node:child_process`, `node:fs` and `node:tty`. Because
this package declares no runtime dependencies, the bundler inlined it, so the
published `dist/index.js` opened with `import { createRequire } from
"node:module"` — a hard module-resolution failure on any runtime without Node
builtins, before a single box renders.

Vendors a port of the probe chain that resolves builtins lazily through
`process.getBuiltinModule()`, the one synchronous escape hatch bundlers and
resolvers do not follow. That matters because `boxen()` is synchronous and has
to stay that way. Probe order and the documented 80x24 fallback are preserved;
on a runtime without `getBuiltinModule` it short-circuits to the fallback.

Static `node:*` imports in the built bundle go from one to zero. A guard test
walks the module graph and asserts that, with a control fixture — including a
line-wrapped import — so it cannot pass vacuously.

The vendored file carries its upstream MIT notice, recorded in LICENSE.md.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
