### PR TITLE
fix(error): degrade render on unreadable sources

### DIFF
--- a/packages/error-debugging/error/__tests__/integration/dist-node-interop.test.ts
+++ b/packages/error-debugging/error/__tests__/integration/dist-node-interop.test.ts
@@ -1,0 +1,116 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distributionRoot = join(here, "..", "..", "dist");
+
+/** Any `import`/`export … from` declaration, plus bare side-effect imports. */
+const STATIC_SPECIFIER_REGEX = /^(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)["']|^import\s*["']([^"']+)["']/gmu;
+
+/** A `__cjs_getBuiltinModule("node:…")` call site, with whatever immediately precedes it. */
+const BUILTIN_LOOKUP_REGEX = /(.{0,18})__cjs_getBuiltinModule\(/gu;
+
+const distributionFiles = (): string[] => {
+    const found: string[] = [];
+    const queue = [distributionRoot];
+
+    while (queue.length > 0) {
+        for (const entry of readdirSync(queue.pop() as string, { withFileTypes: true })) {
+            const path = join(entry.parentPath, entry.name);
+
+            if (entry.isDirectory()) {
+                queue.push(path);
+            } else if (entry.name.endsWith(".js")) {
+                found.push(path);
+            }
+        }
+    }
+
+    return found.toSorted((a, b) => a.localeCompare(b));
+};
+
+const staticSpecifiersIn = (source: string): string[] => {
+    const specifiers: string[] = [];
+
+    for (const match of source.matchAll(STATIC_SPECIFIER_REGEX)) {
+        const specifier = match[1] ?? match[2];
+
+        if (specifier !== undefined) {
+            specifiers.push(specifier);
+        }
+    }
+
+    return specifiers;
+};
+
+/**
+ * This package declares `"sideEffects": false`, and consumers bundle it on that promise. The
+ * bundler's `requireCJS` pass would otherwise break it: it rewrites `import … from "node:*"` into a
+ * module-scope `__cjs_getBuiltinModule("node:*")` call backed by a static
+ * `import { createRequire } from "node:module"`, so a chunk stays alive for its top-level statements
+ * alone and drags `node:module` into consumer bundles that never touch the exports it provides.
+ *
+ * On a runtime with no Node core (Cloudflare Workers without `nodejs_compat`, Vercel Edge) a static
+ * `node:module` import fails at import time, so this is a correctness property and not just a size
+ * one. `packem.config.ts` strips the dead `createRequire` fallback and annotates the remaining
+ * lookups as pure; these assertions are what keeps it honest.
+ */
+describe("built `@visulima/error` distribution", () => {
+    it("exists so the assertions below are not vacuous", () => {
+        expect.assertions(2);
+
+        expect(existsSync(distributionRoot), `${distributionRoot} is missing — run \`pnpm run build\` first`).toBe(true);
+        expect(distributionFiles().length).toBeGreaterThan(0);
+    });
+
+    it("declares no static `node:` import", () => {
+        expect.assertions(1);
+
+        const offenders = distributionFiles().flatMap((file) =>
+            staticSpecifiersIn(readFileSync(file, "utf8"))
+                .filter((specifier) => specifier.startsWith("node:"))
+                .map((specifier) => [relative(distributionRoot, file), specifier]),
+        );
+
+        expect(offenders).toStrictEqual([]);
+    });
+
+    it("ships no `createRequire` fallback", () => {
+        expect.assertions(1);
+
+        expect(
+            distributionFiles()
+                .filter((file) => readFileSync(file, "utf8").includes("createRequire"))
+                .map((file) => relative(distributionRoot, file)),
+        ).toStrictEqual([]);
+    });
+
+    it("annotates every Node-builtin lookup as pure so consumers can drop it", () => {
+        expect.assertions(2);
+
+        const lookups: string[] = [];
+        const unannotated: string[] = [];
+
+        for (const file of distributionFiles()) {
+            for (const match of readFileSync(file, "utf8").matchAll(BUILTIN_LOOKUP_REGEX)) {
+                // The helper's own declaration is not a call site.
+                if (match[1]?.endsWith("const ")) {
+                    continue;
+                }
+
+                lookups.push(`${relative(distributionRoot, file)}: ${match[0]}`);
+
+                if (!match[1]?.endsWith("/* @__PURE__ */ ")) {
+                    unannotated.push(`${relative(distributionRoot, file)}: ${match[0]}`);
+                }
+            }
+        }
+
+        // Guards against the whole check going vacuous if `requireCJS` is ever turned off.
+        expect(lookups.length).toBeGreaterThan(0);
+        expect(unannotated).toStrictEqual([]);
+    });
+});

--- a/packages/error-debugging/error/__tests__/workerd/import-safety.test.ts
+++ b/packages/error-debugging/error/__tests__/workerd/import-safety.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * The single most important property on the edge: importing the package must not throw.
+ *
+ * Every public entry point is pulled in dynamically inside the assertion so a module-evaluation
+ * failure surfaces as a failing expectation rather than a collection-time crash that hides which
+ * entry point broke.
+ */
+describe("`@visulima/error` import safety on workerd", () => {
+    it("should run inside workerd", () => {
+        expect.assertions(1);
+
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- workerd always provides `navigator`
+        expect(navigator.userAgent).toBe("Cloudflare-Workers");
+    });
+
+    it("should import the root entry point without throwing", async () => {
+        expect.assertions(1);
+
+        await expect(import("../../src/index")).resolves.toBeDefined();
+    });
+
+    it("should import every sub-path entry point without throwing", async () => {
+        expect.assertions(4);
+
+        await expect(import("../../src/code-frame/index")).resolves.toBeDefined();
+        await expect(import("../../src/error/index")).resolves.toBeDefined();
+        await expect(import("../../src/stacktrace/index")).resolves.toBeDefined();
+        await expect(import("../../src/solution/index")).resolves.toBeDefined();
+    });
+
+    it("should expose the full public API from the root entry point", async () => {
+        expect.assertions(1);
+
+        const module = await import("../../src/index");
+
+        expect(Object.keys(module).toSorted((a, b) => a.localeCompare(b))).toStrictEqual([
+            "addKnownErrorConstructor",
+            "aiPrompt",
+            "aiSolutionResponse",
+            "captureRawStackTrace",
+            "CODE_FRAME_POINTER",
+            "codeFrame",
+            "composeFilters",
+            "deserializeError",
+            "errorHintFinder",
+            "formatStackFrameLine",
+            "formatStacktrace",
+            "getErrorCauses",
+            "indexToLineColumn",
+            "isErrorLike",
+            "isVisulimaError",
+            "NonError",
+            "parseStacktrace",
+            "renderError",
+            "ruleBasedFinder",
+            "serializeError",
+            "stackFilters",
+            "VisulimaError",
+        ]);
+    });
+
+    it("should not pull `node:fs`-backed AI caching onto the root import path", async () => {
+        expect.assertions(1);
+
+        // `./solution/ai` is an opt-in sub-path: it caches AI answers to disk (`node:fs`, `node:os`)
+        // and requires the `ai` peer. The root entry must expose only the prompt/response helpers so
+        // an edge bundle never drags the filesystem-backed finder in.
+        const module = await import("../../src/index");
+
+        expect("aiFinder" in module).toBe(false);
+    });
+});

--- a/packages/error-debugging/error/__tests__/workerd/render.test.ts
+++ b/packages/error-debugging/error/__tests__/workerd/render.test.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { CODE_FRAME_POINTER, codeFrame } from "../../src/code-frame";
+import { renderError } from "../../src/error/render/error";
+
+const SOURCE = ["const a = 1;", "const b = 2;", "throw new Error(\"boom\");", "const c = 3;"].join("\n");
+
+const withStack = (...frames: string[]): Error => {
+    const error = new Error("boom");
+
+    error.stack = ["Error: boom", ...frames].join("\n");
+
+    return error;
+};
+
+describe("code frames on workerd", () => {
+    it("should render a code frame from in-memory source", () => {
+        expect.assertions(2);
+
+        const frame = codeFrame(SOURCE, { start: { column: 7, line: 3 } });
+
+        expect(frame).toContain("throw new Error(\"boom\");");
+        expect(frame).toContain(CODE_FRAME_POINTER);
+    });
+
+    it("should pick a code-frame pointer without a POSIX/Windows `process` mismatch", () => {
+        expect.assertions(1);
+
+        // The pointer is chosen from `process.platform`; workerd reports "linux" under nodejs_compat
+        // and the shim yields `undefined` without it. Either way the non-Windows pointer is used.
+        expect(CODE_FRAME_POINTER).toBe("❯");
+    });
+
+    it("should use the source supplied by a source-map resolver instead of touching the filesystem", () => {
+        expect.assertions(2);
+
+        // The only way to get a code frame on the edge: hand the renderer the original source
+        // (e.g. from an inlined `sourcesContent`) so it never needs to read from disk.
+        const output = renderError(withStack("    at handler (index.js:3:7)"), {
+            sourceMap: () => {
+                return { column: 7, file: "src/index.ts", line: 3, source: SOURCE };
+            },
+        });
+
+        expect(output).toContain("throw new Error(\"boom\");");
+        expect(output).toContain("src/index.ts");
+    });
+
+    it("should keep rendering when the source-map resolver throws", () => {
+        expect.assertions(2);
+
+        const output = renderError(withStack("    at handler (index.js:3:7)"), {
+            sourceMap: () => {
+                throw new Error("resolver exploded");
+            },
+        });
+
+        expect(output).toContain("Error: boom");
+        expect(output).not.toContain("resolver exploded");
+    });
+});
+
+describe("filesystem-backed enrichment on workerd", () => {
+    it("should have no readable project files, so this suite exercises the degraded path", () => {
+        expect.assertions(1);
+
+        // Documents the premise of the tests below: workerd's filesystem is virtual and holds none
+        // of the project's sources, so reading a stack frame's file can never succeed here.
+        expect(existsSync(`${process.cwd()}/src/index.ts`)).toBe(false);
+    });
+
+    it("should render the frame but omit the code frame when the file cannot be read", () => {
+        expect.assertions(3);
+
+        const output = renderError(withStack("    at handler (/app/src/index.ts:3:7)"), { cwd: "/app" });
+
+        expect(output).toContain("Error: boom");
+        expect(output).toContain("/app/src/index.ts");
+        // No source available => no gutter/pointer, but no crash either.
+        expect(output).not.toContain(CODE_FRAME_POINTER);
+    });
+
+    it("should not throw when a stack frame points at a directory that does exist", () => {
+        expect.assertions(2);
+
+        // `/bundle` is a real directory in workerd's virtual filesystem: `existsSync` says yes and
+        // the read then fails with "illegal operation on a directory". Existence alone is not a
+        // sufficient guard, and the failure must not escape `renderError`.
+        expect(existsSync("/bundle")).toBe(true);
+
+        const output = renderError(withStack("    at handler (/bundle:1:1)"), { allowAllFilePaths: true, cwd: "/" });
+
+        expect(output).toContain("Error: boom");
+    });
+
+    it("should not throw on a `file:` URL naming a remote host", () => {
+        expect.assertions(1);
+
+        // A stack is just a string and may arrive from a deserialized/untrusted error. `file:` URLs
+        // with a host are rejected by `fileURLToPath`; that must degrade, not abort rendering.
+        const output = renderError(withStack("    at handler (file://evil.example.com/a.js:1:1)"), { displayShortPath: true });
+
+        expect(output).toContain("Error: boom");
+    });
+
+    it("should render a full cause chain with no filesystem access", () => {
+        expect.assertions(3);
+
+        const root = withStack("    at root (index.js:1:1)");
+        const middle = new Error("middle", { cause: root });
+
+        middle.stack = "Error: middle\n    at middle (index.js:2:1)";
+
+        const top = new Error("top", { cause: middle });
+
+        top.stack = "Error: top\n    at top (index.js:3:1)";
+
+        const output = renderError(top);
+
+        expect(output).toContain("Error: top");
+        expect(output).toContain("Error: middle");
+        expect(output).toContain("Error: boom");
+    });
+
+    it("should render an AggregateError with no filesystem access", () => {
+        expect.assertions(2);
+
+        const aggregate = new AggregateError([withStack("    at a (index.js:1:1)"), withStack("    at b (index.js:2:1)")], "many failures");
+
+        aggregate.stack = "AggregateError: many failures\n    at handler (index.js:3:1)";
+
+        const output = renderError(aggregate);
+
+        expect(output).toContain("many failures");
+        expect(output).toContain("Errors:");
+    });
+
+    it("should render a non-Error cause", () => {
+        expect.assertions(1);
+
+        const error = withStack("    at handler (index.js:1:1)");
+
+        (error as Error & { cause?: unknown }).cause = { code: "E_EDGE" };
+
+        expect(renderError(error)).toContain("E_EDGE");
+    });
+});

--- a/packages/error-debugging/error/__tests__/workerd/runtime-capabilities.test.ts
+++ b/packages/error-debugging/error/__tests__/workerd/runtime-capabilities.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { codeFrame } from "../../src/code-frame";
+import captureRawStackTrace from "../../src/error/capture-raw-stack-trace";
+import { VisulimaError } from "../../src/error/visulima-error";
+import parseStacktrace from "../../src/stacktrace/parse-stacktrace";
+import process from "../../src/util/process";
+
+describe("runtime capabilities on workerd", () => {
+    it("should read `process` through the shim without throwing", () => {
+        expect.assertions(3);
+
+        // The package never touches the bare `process` global; it goes through a Proxy shim that
+        // yields `undefined` for missing keys instead of a ReferenceError. Under `nodejs_compat`
+        // the real values come through; either way, reading must be safe.
+        expect(() => process.platform).not.toThrow();
+        expect(() => process.env?.DEBUG).not.toThrow();
+        expect(process.versions).toBeDefined();
+    });
+
+    it("should return undefined for a key that exists on neither `process` nor the shim", () => {
+        expect.assertions(1);
+
+        expect((process as unknown as Record<string, unknown>).thisKeyDoesNotExist).toBeUndefined();
+    });
+
+    it("should expose `process.cwd()` under nodejs_compat", () => {
+        expect.assertions(1);
+
+        expect(process.cwd?.()).toBeTypeOf("string");
+    });
+
+    it("should not require `DEBUG` to be set for the parser to run", () => {
+        expect.assertions(1);
+
+        // `parseStacktrace` reads `process.env?.DEBUG` on every call; on a runtime where `env` is
+        // absent this must be a no-op rather than a TypeError.
+        expect(parseStacktrace({ stack: "Error: x\n    at handler (index.js:1:1)" } as Error)).toHaveLength(1);
+    });
+
+    it("should capture a raw stack trace via V8's `captureStackTrace`", () => {
+        expect.assertions(2);
+
+        // workerd is V8, so the API exists; the helper still guards for runtimes where it does not.
+        expect("captureStackTrace" in Error).toBe(true);
+        expect(captureRawStackTrace()).toContain("at ");
+    });
+
+    it("should build a VisulimaError with a hint and a location", () => {
+        expect.assertions(3);
+
+        const error = new VisulimaError({ hint: "try again", message: "edge failure", name: "EdgeError" });
+
+        expect(error.name).toBe("EdgeError");
+        expect(error.hint).toBe("try again");
+        expect(error.stack).toBeDefined();
+    });
+
+    it("should not need `Buffer` for any code-frame work", () => {
+        expect.assertions(1);
+
+        // Code framing is pure string work — no `Buffer`, no `TextDecoder`, no filesystem.
+        expect(codeFrame("a\r\nb\r\nc", { start: { line: 2 } })).toContain("b");
+    });
+
+    it("should offer Web Crypto rather than needing `node:crypto`", async () => {
+        expect.assertions(2);
+
+        // Nothing on the root import path hashes anything; the only `node:crypto` use is the
+        // opt-in AI solution cache. Web Crypto is what an edge consumer should reach for instead.
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Web Crypto is always present on workerd
+        expect(crypto.randomUUID()).toBeTypeOf("string");
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Web Crypto is always present on workerd
+        await expect(crypto.subtle.digest("SHA-256", new TextEncoder().encode("x"))).resolves.toBeInstanceOf(ArrayBuffer);
+    });
+});

--- a/packages/error-debugging/error/__tests__/workerd/serialize.test.ts
+++ b/packages/error-debugging/error/__tests__/workerd/serialize.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { deserializeError, getErrorCauses, isErrorLike, serializeError } from "../../src/error";
+
+describe("error serialisation on workerd", () => {
+    it("should serialise a plain error to a JSON-safe payload", () => {
+        expect.assertions(3);
+
+        const serialized = serializeError(new Error("boom"));
+
+        expect(serialized.name).toBe("Error");
+        expect(serialized.message).toBe("boom");
+        expect(JSON.stringify(serialized)).toBeTypeOf("string");
+    });
+
+    it("should serialise a cause chain", () => {
+        expect.assertions(2);
+
+        const serialized = serializeError(new Error("outer", { cause: new TypeError("inner") }));
+
+        expect((serialized.cause as { name: string }).name).toBe("TypeError");
+        expect((serialized.cause as { message: string }).message).toBe("inner");
+    });
+
+    it("should break a circular cause chain instead of recursing forever", () => {
+        expect.assertions(1);
+
+        const error: Error & { cause?: unknown } = new Error("circular");
+
+        error.cause = error;
+
+        expect(serializeError(error).cause).toBe("[Circular]");
+    });
+
+    it("should serialise an AggregateError with its `errors` array", () => {
+        expect.assertions(2);
+
+        const serialized = serializeError(new AggregateError([new Error("a"), new RangeError("b")], "many"));
+
+        expect((serialized.errors as { name: string }[]).map((entry) => entry.name)).toStrictEqual(["Error", "RangeError"]);
+        expect(serialized.message).toBe("many");
+    });
+
+    it("should honour a custom `toJSON` when `useToJSON` is enabled", () => {
+        expect.assertions(1);
+
+        class ApiError extends Error {
+            public constructor() {
+                super("api");
+                this.name = "ApiError";
+            }
+
+            // eslint-disable-next-line class-methods-use-this
+            public toJSON(): { marker: string } {
+                return { marker: "from-toJSON" };
+            }
+        }
+
+        expect(serializeError(new ApiError() as unknown as Error, { useToJSON: true })).toStrictEqual({ marker: "from-toJSON" });
+    });
+
+    it("should round-trip an error through serialise/deserialise", () => {
+        expect.assertions(3);
+
+        const restored = deserializeError(serializeError(new TypeError("round-trip", { cause: new Error("root") })));
+
+        expect(restored).toBeInstanceOf(Error);
+        expect(restored.message).toBe("round-trip");
+        expect((restored.cause as Error).message).toBe("root");
+    });
+
+    it("should serialise a Web-standard value that only exists on the edge", () => {
+        expect.assertions(1);
+
+        // `Buffer` is absent from a bare Worker, but `URL` and typed arrays are always present. The
+        // serializer must map them to their string form instead of an empty object.
+        const error: Error & { url?: URL } = new Error("with url");
+
+        error.url = new URL("https://example.com/a?b=1");
+
+        expect(serializeError(error).url).toBe("https://example.com/a?b=1");
+    });
+
+    it("should walk a cause chain with `getErrorCauses`", () => {
+        expect.assertions(2);
+
+        const causes = getErrorCauses(new Error("a", { cause: new Error("b", { cause: new Error("c") }) }));
+
+        expect(causes).toHaveLength(3);
+        expect(causes.map((cause) => cause.message)).toStrictEqual(["a", "b", "c"]);
+    });
+
+    it("should stop `getErrorCauses` on a self-referencing cause", () => {
+        expect.assertions(1);
+
+        const error: Error & { cause?: unknown } = new Error("loop");
+
+        error.cause = error;
+
+        expect(getErrorCauses(error)).toHaveLength(1);
+    });
+
+    it("should recognise a structured-clone-style error payload as error-like", () => {
+        expect.assertions(2);
+
+        // Errors crossing a Worker boundary (queues, RPC, `structuredClone`) arrive as plain objects.
+        expect(isErrorLike({ message: "boom", name: "Error", stack: "Error: boom\n    at handler (index.js:1:1)" })).toBe(true);
+        expect(isErrorLike({ message: "boom" })).toBe(false);
+    });
+});

--- a/packages/error-debugging/error/__tests__/workerd/stacktrace.test.ts
+++ b/packages/error-debugging/error/__tests__/workerd/stacktrace.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { composeFilters, formatStacktrace, parseStacktrace, stackFilters } from "../../src/stacktrace";
+
+const withStack = (...frames: string[]): Error => {
+    const error = new Error("boom");
+
+    error.stack = ["Error: boom", ...frames].join("\n");
+
+    return error;
+};
+
+describe("stack-trace parsing on workerd", () => {
+    it("should parse a stack thrown by workerd itself", () => {
+        expect.assertions(4);
+
+        let caught: Error | undefined;
+
+        const inner = (): never => {
+            throw new Error("thrown on the edge");
+        };
+
+        const outer = (): void => inner();
+
+        try {
+            outer();
+        } catch (error) {
+            caught = error as Error;
+        }
+
+        const frames = parseStacktrace(caught as Error);
+
+        expect(frames.length).toBeGreaterThan(1);
+        expect(frames[0]?.methodName).toBe("inner");
+        expect(frames[1]?.methodName).toBe("outer");
+        expect(frames[0]?.line).toBeTypeOf("number");
+    });
+
+    it("should parse workerd module specifiers that are not file URLs", () => {
+        expect.assertions(2);
+
+        // Deployed Workers report bundle-relative specifiers, not absolute paths or `file:` URLs.
+        const frames = parseStacktrace(withStack("    at handler (index.js:5:11)", "    at fetch (worker.js:1:1)"));
+
+        expect(frames[0]).toStrictEqual({
+            column: 11,
+            evalOrigin: undefined,
+            file: "index.js",
+            line: 5,
+            methodName: "handler",
+            raw: "at handler (index.js:5:11)",
+            type: undefined,
+        });
+        expect(frames[1]?.file).toBe("worker.js");
+    });
+
+    it("should keep the `async` marker out of the resolved file name", () => {
+        expect.assertions(2);
+
+        const frames = parseStacktrace(withStack("    at async fetchHandler (index.js:9:3)"));
+
+        expect(frames[0]?.file).toBe("index.js");
+        expect(frames[0]?.line).toBe(9);
+    });
+
+    it("should not tag any workerd frame as a Node internal", () => {
+        expect.assertions(1);
+
+        // workerd emits no `node:internal/*` frames, so the `internal` classification must stay off
+        // for an all-workerd stack — otherwise consumers filtering internals would drop real frames.
+        const frames = parseStacktrace(withStack("    at handler (index.js:5:11)", "    at fetch (worker.js:1:1)", "    at <anonymous> (index.js:1:1)"));
+
+        expect(frames.filter((frame) => frame.type === "internal")).toStrictEqual([]);
+    });
+
+    it("should keep workerd frames when the internals filter is applied", () => {
+        expect.assertions(2);
+
+        // A Node-originated error rendered inside a Worker still carries `node:internal/*` frames;
+        // the preset must drop those and keep the workerd ones.
+        const frames = parseStacktrace(withStack("    at handler (index.js:5:11)", "    at Module._compile (node:internal/modules/cjs/loader:1105:14)"), {
+            filter: stackFilters.internals,
+        });
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]?.file).toBe("index.js");
+    });
+
+    it("should compose filters without touching workerd frames", () => {
+        expect.assertions(1);
+
+        const frames = parseStacktrace(
+            withStack("    at handler (index.js:5:11)", "    at run (/bundle/node_modules/dep/index.js:2:2)", "    at boot (node:internal/main:1:1)"),
+            { filter: composeFilters(stackFilters.internals, stackFilters.nodeModules) },
+        );
+
+        expect(frames.map((frame) => frame.file)).toStrictEqual(["index.js"]);
+    });
+
+    it("should stringify parsed workerd frames back to stack lines", () => {
+        expect.assertions(1);
+
+        const frames = parseStacktrace(withStack("    at handler (index.js:5:11)"));
+
+        expect(formatStacktrace(frames)).toContain("index.js:5:11");
+    });
+
+    it("should honour the frame limit on deep workerd stacks", () => {
+        expect.assertions(1);
+
+        const frames = parseStacktrace(
+            withStack(...Array.from({ length: 40 }, (_, index) => `    at frame${String(index)} (index.js:${String(index + 1)}:1)`)),
+            { frameLimit: 3 },
+        );
+
+        expect(frames).toHaveLength(3);
+    });
+
+    it("should return no frames for an error with no stack", () => {
+        expect.assertions(1);
+
+        const error = new Error("stackless");
+
+        error.stack = undefined;
+
+        expect(parseStacktrace(error)).toStrictEqual([]);
+    });
+});

--- a/packages/error-debugging/error/eslint.config.js
+++ b/packages/error-debugging/error/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/error-debugging/error/package.json
+++ b/packages/error-debugging/error/package.json
@@ -38,11 +38,6 @@
     ],
     "homepage": "https://visulima.com/packages/error/",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -58,19 +53,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -102,10 +91,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -124,7 +115,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -132,6 +124,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@total-typescript/ts-reset": "catalog:dev",
         "@types/command-line-args": "catalog:types",
         "@types/node": "catalog:types",
@@ -146,6 +139,7 @@
         "prettier": "catalog:lint",
         "publint": "catalog:dev",
         "rimraf": "catalog:node",
+        "rollup": "catalog:build",
         "semantic-release": "catalog:cli",
         "typescript": "catalog:tsc",
         "vitest": "catalog:test"
@@ -160,5 +154,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/error/packem.config.ts
+++ b/packages/error-debugging/error/packem.config.ts
@@ -1,6 +1,189 @@
+import { createRequire } from "node:module";
+
 import type { BuildConfig } from "@visulima/packem/config";
 import { defineConfig } from "@visulima/packem/config";
 import transformer from "@visulima/packem/transformer/esbuild";
+import type { Plugin } from "rollup";
+
+/**
+ * `requireCJS.builtinNodeModules` rewrites every `import … from "node:*"` into a module-scope
+ * `__cjs_getBuiltinModule("node:*")` call, and prepends an interop preamble that resolves the
+ * builtin through `process.getBuiltinModule` with a `createRequire` fallback for Node < 20.16 /
+ * < 22.3. That preamble is what makes the emitted chunks contradict this package's
+ * `"sideEffects": false`:
+ *
+ * - the destructuring is a module-scope *call*, so a bundler that assumes side effects keeps the
+ *   whole chunk alive even when none of its exports are used;
+ * - the `createRequire` fallback needs a static `import { createRequire } from "node:module"`,
+ *   which then rides along into every consumer bundle — including ones targeting runtimes that
+ *   have no Node core at all, where a static `node:module` import fails at *import* time.
+ *
+ * A consumer importing only `serializeError` from `./error` therefore inherits `node:module`
+ * purely because `renderError` and `getErrorCauses` sit in the same barrel.
+ *
+ * Both halves of that are avoidable here:
+ *
+ * 1. This package's `engines.node` is `^22.14.0 || >=24.10.0`, so `process.getBuiltinModule` is
+ *    always present and the `createRequire` fallback is dead code. Dropping it removes the only
+ *    static `node:module` import from the output.
+ * 2. Resolving a Node core module has no observable side effect, so the lookup can carry a
+ *    `@__PURE__` annotation. With it, a consumer's bundler drops the destructuring — and then the
+ *    rest of the preamble — as soon as the imported binding is unused.
+ *
+ * This has to be fixed here rather than in a consumer's build. Rollup honours our
+ * `"sideEffects": false` and drops the unused chunks outright — but only while the consumer
+ * registers no build plugin of its own: with one present, packem falls back to
+ * `treeshake.moduleSideEffects: true` for the whole graph and the chunks come back. Whether a
+ * consumer's bundle stays free of `node:module` must not depend on that.
+ *
+ * ## What this narrows
+ *
+ * `engines.node` only constrains Node. Point 1 also drops the fallback for *non-Node* runtimes
+ * that report a `process.versions.node` while implementing no `process.getBuiltinModule` — older
+ * Deno and Bun releases both do, and they used to land on `createRequire`. Restoring the fallback
+ * is not an option: its static `import { createRequire } from "node:module"` is the very thing
+ * that has to go. Those runtimes are therefore no longer supported, and the replacement helper
+ * below says so explicitly instead of letting them fail with an opaque
+ * `TypeError: __cjs_getProcess.getBuiltinModule is not a function`.
+ *
+ * ## What keeps this honest
+ *
+ * Every rewrite below asserts the packem fragment it expects and throws when it is missing, so a
+ * preamble reshuffle surfaces as a build failure rather than silently reinstating `node:module`.
+ * Two paths cannot throw — a chunk with no interop at all is the normal case, and a chunk whose
+ * `__cjs_require` call count is unexpected may legitimately have a second CJS dependency — so
+ * those warn instead, and the plugin's `generateBundle` hook warns once per build if *no* chunk
+ * matched at all (which is what a helper rename upstream would look like).
+ *
+ * `__tests__/integration/dist-node-interop.test.ts` guards the output shape directly and fails
+ * hard on any of those warnings' underlying causes;
+ * `packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts` guards the
+ * end-to-end effect, on a built edge entry that pulls `serializeError` out of this package.
+ */
+
+/** Named in every diagnostic below: the preamble shape is version-specific, so say which version. */
+const PACKEM_VERSION: string = (createRequire(import.meta.url)("@visulima/packem/package.json") as { version: string }).version;
+
+/** Static import that only exists to back the `createRequire` fallback. */
+const CREATE_REQUIRE_IMPORT_REGEX = /^import \{ createRequire as __cjs_createRequire \} from "node:module";\n+/mu;
+
+/** The memoised `createRequire` wrapper the fallback calls. */
+const CJS_REQUIRE_HELPER_REGEX = /^let __cjs_cachedRequire;\nconst __cjs_require = \(id\) => \{\n(?:.*\n)*?\};\n+/mu;
+
+/** The builtin resolver, whose Node-version branch and fallback are both dead under our engines. */
+const GET_BUILTIN_MODULE_HELPER_REGEX = /^const __cjs_getBuiltinModule = \(module\) => \{\n(?:.*\n)*?\};\n/mu;
+
+/**
+ * Replacement for the helper above. The shape matters: when a consumer inlines one of our chunks
+ * and its own `requireCJS` pass prepends a second preamble, packem de-duplicates the two by
+ * matching `const __cjs_getBuiltinModule = (…) => { … };` textually. An expression-bodied arrow
+ * would slip past that and leave the identifier declared twice in the consumer's chunk, so keep the
+ * block body — and keep it free of any `};` before the closing one, which is where that match ends.
+ *
+ * The capability check is what replaces packem's `versions.node` branch: without the
+ * `createRequire` fallback there is nothing to degrade to, so a runtime that cannot satisfy the
+ * lookup should say which capability it is missing rather than throw `… is not a function` from
+ * somewhere inside a bundled chunk.
+ */
+const GET_BUILTIN_MODULE_HELPER = `const __cjs_getBuiltinModule = (module) => {
+    if (typeof __cjs_getProcess?.getBuiltinModule !== "function") {
+        throw new Error("[@visulima/error] Cannot load " + module + ": this runtime implements no process.getBuiltinModule(). Requires Node >= 20.16 / >= 22.3, or another runtime providing process.getBuiltinModule().");
+    }
+    return __cjs_getProcess.getBuiltinModule(module);
+};
+`;
+
+/** Call sites of the resolver that are not already annotated. */
+const BUILTIN_LOOKUP_REGEX = /(?<!\/\* @__PURE__ \*\/ )__cjs_getBuiltinModule\(/gu;
+
+/** Emitted when a rewrite is skipped, so the packem upgrade that caused it is identifiable. */
+const shapeChanged = (detail: string): string =>
+    `${detail} Verified against @visulima/packem@${PACKEM_VERSION}; the CJS-interop preamble shape appears to have changed — update packem.config.ts.`;
+
+const dropDeadNodeInterop = (code: string, chunkName: string, warn: (message: string) => void): string => {
+    let next = code;
+
+    // `__cjs_require` is also the generic CJS-require helper. This package has no runtime
+    // dependencies, so its only caller is the builtin fallback below; if that ever stops being
+    // true, leave the fallback in place and settle for the annotation.
+    const requireCallSites = (code.match(/__cjs_require\(/gu) ?? []).length;
+
+    if (requireCallSites === 1) {
+        for (const [what, pattern] of [
+            ["the `node:module` import", CREATE_REQUIRE_IMPORT_REGEX],
+            ["the `__cjs_require` helper", CJS_REQUIRE_HELPER_REGEX],
+        ] as const) {
+            if (!pattern.test(next)) {
+                throw new Error(shapeChanged(`Could not find ${what} in the CJS-interop preamble of "${chunkName}".`));
+            }
+
+            next = next.replace(pattern, "");
+        }
+
+        if (!GET_BUILTIN_MODULE_HELPER_REGEX.test(next)) {
+            throw new Error(shapeChanged(`Could not find the \`__cjs_getBuiltinModule\` helper in "${chunkName}".`));
+        }
+
+        next = next.replace(GET_BUILTIN_MODULE_HELPER_REGEX, GET_BUILTIN_MODULE_HELPER);
+    } else {
+        // Zero means the fallback stopped calling `__cjs_require`; two or more means a real CJS
+        // dependency shares the helper. Either way the removal above is unsafe, so only the
+        // annotation applies — and `node:module` stays in the chunk. Not fatal (a stray CJS dep
+        // must not break the build outright), but never silent: `dist-node-interop.test.ts` turns
+        // it into a hard CI failure.
+        warn(
+            shapeChanged(
+                `Expected exactly one \`__cjs_require(\` call site — the dead builtin fallback — in "${chunkName}", found ${String(requireCallSites)}. Left the \`createRequire\` fallback and its \`node:module\` import in place.`,
+            ),
+        );
+    }
+
+    return next.replaceAll(BUILTIN_LOOKUP_REGEX, "/* @__PURE__ */ __cjs_getBuiltinModule(");
+};
+
+/**
+ * A chunk without `__cjs_getBuiltinModule(` is the overwhelmingly common case, so that check
+ * cannot throw. But if it short-circuits *every* chunk of a build, the helper was renamed upstream
+ * and this whole plugin quietly became a no-op — which is exactly the failure it exists to prevent.
+ */
+const createPruneNodeBuiltinInterop = (): Plugin => {
+    let chunksRewritten = 0;
+
+    return {
+        generateBundle: {
+            handler() {
+                if (chunksRewritten === 0) {
+                    this.warn(
+                        shapeChanged(
+                            "No chunk contained a `__cjs_getBuiltinModule(` call, so the CJS-interop preamble was never rewritten and the build may ship a `createRequire` fallback.",
+                        ),
+                    );
+                }
+            },
+            order: "post",
+        },
+        name: "error:prune-node-builtin-interop",
+        renderChunk: {
+            handler(code, chunk) {
+                if (!code.includes("__cjs_getBuiltinModule(")) {
+                    return null;
+                }
+
+                chunksRewritten += 1;
+
+                return {
+                    code: dropDeadNodeInterop(code, chunk.fileName, (message) => {
+                        this.warn(message);
+                    }),
+                    map: null,
+                };
+            },
+            // `packem:plugin-require-cjs` emits the preamble from its own `renderChunk` hook, which
+            // runs in the default ("pre") slot.
+            order: "post",
+        },
+    };
+};
 
 // eslint-disable-next-line import/no-unused-modules
 export default defineConfig({
@@ -12,6 +195,12 @@ export default defineConfig({
         license: {
             path: "./LICENSE.md",
         },
+        plugins: [
+            {
+                plugin: createPruneNodeBuiltinInterop(),
+                type: "build",
+            },
+        ],
         requireCJS: {
             builtinNodeModules: true,
         },

--- a/packages/error-debugging/error/src/error/render/error.ts
+++ b/packages/error-debugging/error/src/error/render/error.ts
@@ -35,6 +35,26 @@ const getPrefix = (prefix: string, indentation: number | "\t", deep: number): st
  */
 const normalizePathSeparators = (filePath: string): string => filePath.replaceAll("\\", "/");
 
+/**
+ * Convert a `file:` URL from a stack frame to a path, falling back to the URL itself when it is not
+ * a convertible file URL.
+ *
+ * `fileURLToPath` rejects `file:` URLs that name a remote host (`file://example.com/a.js`) and other
+ * malformed forms. A stack is just a string and can carry anything — including frames from a
+ * deserialized or otherwise untrusted error — so a rejected URL must not abort rendering.
+ */
+const toDisplayPath = (path: string): string => {
+    if (!path.startsWith("file:")) {
+        return path;
+    }
+
+    try {
+        return fileURLToPath(path);
+    } catch {
+        return path;
+    }
+};
+
 const getRelativePath = (filePath: string, cwdPath: string) => {
     /**
      * Node.js error stack is all messed up. Some lines have file info
@@ -42,7 +62,7 @@ const getRelativePath = (filePath: string, cwdPath: string) => {
      */
     const path = filePath.replace("async file:", "file:");
 
-    return normalizePathSeparators(relative(cwdPath, path.startsWith("file:") ? fileURLToPath(path) : path));
+    return normalizePathSeparators(relative(cwdPath, toDisplayPath(path)));
 };
 
 /**
@@ -156,6 +176,28 @@ const isReadableSourcePath = (filePath: string, options: Options): boolean => {
     return resolved === root || resolved.startsWith(root + sep);
 };
 
+/**
+ * Read a stack-frame's source file, or return `undefined` when it cannot be read.
+ *
+ * Reading is best-effort enrichment: a code frame is nice to have, never required. `existsSync` is
+ * not a sufficient guard — the path may exist but not be readable as a file (a directory, a device
+ * node, a permissions failure), and on runtimes with a virtual or absent filesystem (Cloudflare
+ * Workers / workerd, and other edge runtimes) reads fail by design. Any such failure must degrade to
+ * "no code frame" rather than propagate out of `renderError` and replace the error the caller was
+ * trying to render in the first place.
+ */
+const readSourceFile = (filePath: string): string | undefined => {
+    try {
+        if (!existsSync(filePath)) {
+            return undefined;
+        }
+
+        return readFileSync(filePath, "utf8");
+    } catch {
+        return undefined;
+    }
+};
+
 const getCode = (resolved: ResolvedFrame, options: Options, deep: number): string | undefined => {
     const { color, indentation, linesAbove, linesBelow, prefix, showGutter, showLineNumbers, tabWidth } = options;
     const { source: resolvedSource, trace: frame } = resolved;
@@ -175,11 +217,13 @@ const getCode = (resolved: ResolvedFrame, options: Options, deep: number): strin
             return undefined;
         }
 
-        if (!existsSync(filePath)) {
+        const source = readSourceFile(filePath);
+
+        if (source === undefined) {
             return undefined;
         }
 
-        fileContent = readFileSync(filePath, "utf8");
+        fileContent = source;
     } else {
         // The resolver supplied the original source directly (e.g. inlined sourcesContent).
         fileContent = resolvedSource;

--- a/packages/error-debugging/error/src/error/serialize/error-constructors.ts
+++ b/packages/error-debugging/error/src/error/serialize/error-constructors.ts
@@ -1,6 +1,18 @@
-// Default error constructors that are commonly used
+// Type for error constructors (flexible to handle different signatures)
 
-const defaultErrorConstructors = new Map<string, new (...arguments_: any[]) => Error>([
+type ErrorConstructor = new (...arguments_: any[]) => Error;
+
+// Default error constructors that are commonly used.
+//
+// `AggregateError` has a different constructor signature and is not guaranteed to exist, so it is
+// registered conditionally — but from inside the initialiser rather than a follow-up `.set()` call.
+// A top-level `.set()` is a module side effect, which contradicts this package's
+// `"sideEffects": false` and keeps the whole registry alive in consumer bundles that only pull, say,
+// `serializeError` out of the `./error` barrel. A single `new Map(...)` initialiser is pure, so it
+// is dropped when nothing uses it. The annotation is spelled out because the spread stops the
+// bundler from inferring it.
+// eslint-disable-next-line jsdoc/no-bad-blocks -- `/* @__PURE__ */` is a bundler annotation, not JSDoc
+const defaultErrorConstructors = /* @__PURE__ */ new Map<string, ErrorConstructor>([
     ["Error", Error],
     ["EvalError", EvalError],
     ["RangeError", RangeError],
@@ -8,16 +20,8 @@ const defaultErrorConstructors = new Map<string, new (...arguments_: any[]) => E
     ["SyntaxError", SyntaxError],
     ["TypeError", TypeError],
     ["URIError", URIError],
+    ...typeof AggregateError === "undefined" ? [] : [["AggregateError", AggregateError as ErrorConstructor] as [string, ErrorConstructor]],
 ]);
-
-// Handle AggregateError separately since it has a different constructor signature
-if (typeof AggregateError !== "undefined") {
-    defaultErrorConstructors.set("AggregateError", AggregateError as new (...arguments_: any[]) => Error);
-}
-
-// Type for error constructors (flexible to handle different signatures)
-
-type ErrorConstructor = new (...arguments_: any[]) => Error;
 
 /**
  * Add a known error constructor to the registry.

--- a/packages/error-debugging/error/vitest.workerd.config.ts
+++ b/packages/error-debugging/error/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4677,6 +4677,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@total-typescript/ts-reset':
         specifier: catalog:dev
         version: 0.6.1
@@ -4719,6 +4722,9 @@ importers:
       rimraf:
         specifier: catalog:node
         version: 6.1.3
+      rollup:
+        specifier: catalog:build
+        version: 4.62.2
       semantic-release:
         specifier: catalog:cli
         version: 25.0.5(typescript@6.0.3)
@@ -48830,7 +48836,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60113,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
`renderError` destroyed the error it was asked to display. `getCode` checked
`existsSync` and then called `readFileSync` unguarded, so a stack frame naming
a directory threw `illegal operation on a directory`; `getRelativePath` called
`fileURLToPath` unguarded, so a `file:` URL naming a remote host threw. Both
are reachable on Node, and stacks are strings that can arrive deserialized or
untrusted. Each now degrades to the documented fallback.

The build also shipped Node interop into chunks that do not need it. Because
the bundler retains modules for their top-level statements, importing only
`serializeError` still pulled in the render and cause-formatting chunks purely
for their generated preamble, which carries a static `node:module` import. A
`renderChunk` pass now prunes that preamble and marks builtin lookups pure, so
consumers tree-shake it away; the `createRequire` fallback is dropped, since it
targets Node versions below this package's `engines` floor, and a runtime
without `process.getBuiltinModule` now gets a named error instead of an opaque
`TypeError`. Guards warn loudly, naming the bundler version, if the generated
shape ever stops matching.

A dist guard test asserts the built output has no static `node:` import and
that every builtin lookup is pure-annotated.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
