### PR TITLE
fix(ono): load sanitizer without a DOM

### DIFF
--- a/packages/error-debugging/ono/__tests__/workerd/import-safety.test.ts
+++ b/packages/error-debugging/ono/__tests__/workerd/import-safety.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * The single most important property on the edge: importing the package must not throw.
+ *
+ * Every public entry point is pulled in dynamically inside the assertion so a module-evaluation
+ * failure surfaces as a failing expectation rather than a collection-time crash that hides which
+ * entry point broke.
+ */
+describe("`@visulima/ono` import safety on workerd", () => {
+    it("should run inside workerd", () => {
+        expect.assertions(1);
+
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- workerd always provides `navigator`
+        expect(navigator.userAgent).toBe("Cloudflare-Workers");
+    });
+
+    it("should import the root entry point without throwing", async () => {
+        expect.assertions(1);
+
+        await expect(import("../../src/index")).resolves.toBeDefined();
+    });
+
+    it("should expose the documented root API", async () => {
+        expect.assertions(1);
+
+        const module = await import("../../src/index");
+
+        expect(Object.keys(module).toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["Ono", "renderAnsi", "renderHtml", "renderJson"]);
+    });
+
+    it("should import the `./page/context` sub-path without throwing", async () => {
+        expect.assertions(1);
+
+        // This one is the canary for DOM-less runtimes: it reaches the sanitizer, which is backed by
+        // DOMPurify and used to blow up at module scope when there was no `window.document`.
+        await expect(import("../../src/error-inspector/page/create-request-context")).resolves.toBeDefined();
+    });
+
+    it("should import the HTML template and its sanitizer without throwing", async () => {
+        expect.assertions(3);
+
+        await expect(import("../../src/error-inspector/index")).resolves.toBeDefined();
+        await expect(import("../../src/error-inspector/layout")).resolves.toBeDefined();
+        await expect(import("../../src/error-inspector/utils/sanitize")).resolves.toBeDefined();
+    });
+
+    it("should keep `node:http` off every runtime import path", async () => {
+        expect.assertions(2);
+
+        // `node:http` appears only in `import type` positions (request/response typings), which are
+        // erased at build time. A value import would be unusable here — workerd has no HTTP server.
+        await expect(import("../../src/error-inspector/page/types")).resolves.toBeDefined();
+
+        const { runtime } = await import("../../src/error-inspector/page/types");
+
+        expect(runtime.hasNativeRequest).toBe(true);
+    });
+
+    it("should keep the filesystem-backed editor middleware off the root entry point", async () => {
+        expect.assertions(1);
+
+        // `./server/open-in-editor` shells out to a local editor via `node:fs`; it is a separate
+        // sub-path export precisely so an edge bundle never pulls it in.
+        const module = await import("../../src/index");
+
+        expect("createOpenInEditorMiddleware" in module).toBe(false);
+    });
+});

--- a/packages/error-debugging/ono/__tests__/workerd/render.test.ts
+++ b/packages/error-debugging/ono/__tests__/workerd/render.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { renderAnsi, renderHtml, renderJson } from "../../src/index";
+
+const withStack = (message: string, ...frames: string[]): Error => {
+    const error = new Error(message);
+
+    error.stack = [`Error: ${message}`, ...frames].join("\n");
+
+    return error;
+};
+
+describe("`renderJson` on workerd", () => {
+    it("should report `workerd` as the detected runtime", async () => {
+        expect.assertions(1);
+
+        const payload = await renderJson(new Error("boom"));
+
+        expect(payload.runtime).toBe("workerd");
+    });
+
+    it("should parse workerd-shaped frames into the payload", async () => {
+        expect.assertions(2);
+
+        const payload = await renderJson(withStack("boom", "    at handler (index.js:5:11)", "    at fetch (worker.js:1:1)"));
+
+        expect(payload.stack[0]?.frames.map((frame) => frame.file)).toStrictEqual(["index.js", "worker.js"]);
+        expect(payload.stack[0]?.frames[0]).toStrictEqual({
+            column: 11,
+            file: "index.js",
+            line: 5,
+            methodName: "handler",
+            raw: "at handler (index.js:5:11)",
+            type: undefined,
+        });
+    });
+
+    it("should include the full cause chain", async () => {
+        expect.assertions(2);
+
+        const payload = await renderJson(new Error("outer", { cause: new Error("inner") }));
+
+        expect(payload.stack).toHaveLength(2);
+        expect(payload.stack.map((entry) => entry.message)).toStrictEqual(["outer", "inner"]);
+    });
+
+    it("should coerce a thrown non-Error value", async () => {
+        expect.assertions(2);
+
+        const payload = await renderJson("string throw");
+
+        expect(payload.stack[0]?.name).toBe("Error");
+        expect(payload.stack[0]?.message).toBe("string throw");
+    });
+
+    it("should stay JSON-serialisable so it can be returned from a `fetch` handler", async () => {
+        expect.assertions(1);
+
+        const payload = await renderJson(new Error("boom", { cause: new TypeError("root") }));
+
+        expect(() => Response.json(payload)).not.toThrow();
+    });
+
+    it("should not reject when a solution finder needs a source file it cannot read", async () => {
+        expect.assertions(1);
+
+        // Solution finders are handed the frame's source snippet; on workerd the read always fails.
+        // That must degrade to an empty snippet, not a rejected promise.
+        const payload = await renderJson(withStack("boom", "    at handler (/app/src/index.ts:5:11)"));
+
+        expect(payload.stack).toHaveLength(1);
+    });
+});
+
+describe("`renderHtml` on workerd", () => {
+    it("should render a complete HTML document", async () => {
+        expect.assertions(3);
+
+        const html = await renderHtml(withStack("boom", "    at handler (index.js:5:11)"));
+
+        expect(html).toContain("<!DOCTYPE html>");
+        expect(html).toContain("</html>");
+        expect(html).toContain("boom");
+    });
+
+    it("should neutralise markup in the error message even without DOMPurify", async () => {
+        expect.assertions(2);
+
+        // DOMPurify cannot run without a DOM, so the sanitizer falls back to HTML-entity escaping.
+        // That is strictly stronger than sanitizing — no markup survives — so the page stays safe.
+        const html = await renderHtml(withStack("<img src=x onerror=\"alert(1)\">", "    at handler (index.js:1:1)"));
+
+        expect(html).not.toContain("<img src=x");
+        expect(html).toContain("&lt;img src=x");
+    });
+
+    it("should report that no DOMPurify sanitizer resolved on this runtime", async () => {
+        expect.assertions(1);
+
+        // Pins the documented degradation: on workerd the escaping fallback is what runs.
+        const { hasSanitizer } = await import("../../src/error-inspector/utils/dompurify");
+
+        expect(hasSanitizer()).toBe(false);
+    });
+
+    it("should render a cause chain into the page", async () => {
+        expect.assertions(2);
+
+        const html = await renderHtml(new Error("outer", { cause: new Error("inner-cause-marker") }));
+
+        expect(html).toContain("outer");
+        expect(html).toContain("inner-cause-marker");
+    });
+
+    it("should render an AggregateError", async () => {
+        expect.assertions(1);
+
+        const html = await renderHtml(new AggregateError([new Error("a"), new Error("b")], "many failures"));
+
+        expect(html).toContain("many failures");
+    });
+
+    it("should coerce a thrown non-Error value", async () => {
+        expect.assertions(1);
+
+        const html = await renderHtml({ not: "an error" });
+
+        expect(html).toContain("<!DOCTYPE html>");
+    });
+
+    it("should reject an invalid `solutionFinders` option rather than rendering garbage", async () => {
+        expect.assertions(1);
+
+        await expect(renderHtml(new Error("boom"), { solutionFinders: "nope" as never })).rejects.toThrow(TypeError);
+    });
+});
+
+describe("`renderAnsi` on workerd", () => {
+    it("should render terminal output for an edge stack", async () => {
+        expect.assertions(2);
+
+        const { errorAnsi } = await renderAnsi(withStack("boom", "    at handler (index.js:5:11)"));
+
+        expect(errorAnsi).toContain("boom");
+        expect(errorAnsi).toContain("index.js");
+    });
+
+    it("should omit the code frame when the source cannot be read", async () => {
+        expect.assertions(1);
+
+        // No filesystem on the edge: the frame line is still rendered, the source excerpt is not.
+        const { errorAnsi } = await renderAnsi(withStack("boom", "    at handler (/app/src/index.ts:5:11)"));
+
+        expect(errorAnsi).toContain("/app/src/index.ts");
+    });
+});

--- a/packages/error-debugging/ono/__tests__/workerd/request-context.test.ts
+++ b/packages/error-debugging/ono/__tests__/workerd/request-context.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import createRequestContext from "../../src/error-inspector/page/create-request-context";
+
+describe("request context on workerd", () => {
+    it("should build a context page from a native `Request`", async () => {
+        expect.assertions(4);
+
+        // The shape a Worker's `fetch` handler actually receives. Native `Request`/`Headers` methods
+        // brand-check their receiver, so any detached method call fails with "Illegal invocation".
+        const request = new Request("https://example.com/api/items?page=2", {
+            headers: { "content-type": "application/json", "user-agent": "workerd-test" },
+            method: "GET",
+        });
+
+        const page = await createRequestContext(request, {});
+
+        expect(page).toBeDefined();
+        expect(page?.id).toBe("context");
+        expect(page?.code.html).toContain("example.com");
+        expect(page?.code.html).toContain("workerd-test");
+    });
+
+    it("should read the body of a native `Request` without consuming the original", async () => {
+        expect.assertions(2);
+
+        const request = new Request("https://example.com/api/items", {
+            body: JSON.stringify({ marker: "body-marker" }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+        });
+
+        const page = await createRequestContext(request, {});
+
+        expect(page?.code.html).toContain("body-marker");
+        // The context page clones before reading, so the caller's request is still usable.
+        expect(request.bodyUsed).toBe(false);
+    });
+
+    it("should mask sensitive headers coming from a native `Headers` object", async () => {
+        expect.assertions(2);
+
+        const request = new Request("https://example.com/", {
+            headers: { authorization: "Bearer super-secret-token", "x-safe": "visible" },
+        });
+
+        const page = await createRequestContext(request, { maskValue: "[masked]" });
+
+        expect(page?.code.html).not.toContain("super-secret-token");
+        expect(page?.code.html).toContain("visible");
+    });
+
+    it("should read cookies through the native `Headers` getter", async () => {
+        expect.assertions(1);
+
+        const request = new Request("https://example.com/", { headers: { cookie: "session=abc; theme=dark" } });
+
+        const page = await createRequestContext(request, {});
+
+        expect(page?.code.html).toContain("theme");
+    });
+
+    it("should still accept a plain header record", async () => {
+        expect.assertions(2);
+
+        const page = await createRequestContext({ headers: { "content-type": "application/json" }, method: "GET", url: "https://example.com/plain" }, {});
+
+        expect(page?.id).toBe("context");
+        expect(page?.code.html).toContain("example.com/plain");
+    });
+
+    it("should escape markup in a request URL without a DOM sanitizer", async () => {
+        expect.assertions(1);
+
+        const page = await createRequestContext({ headers: {}, method: "GET", url: "https://example.com/<script>alert(1)</script>" }, {});
+
+        expect(page?.code.html).not.toContain("<script>alert(1)</script>");
+    });
+});

--- a/packages/error-debugging/ono/__tests__/workerd/runtime-capabilities.test.ts
+++ b/packages/error-debugging/ono/__tests__/workerd/runtime-capabilities.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeAttribute, sanitizeCodeHtml, sanitizeHtml, sanitizeUrlAttribute } from "../../src/error-inspector/utils/sanitize";
+import process, { getProcessPlatform, getProcessVersion } from "../../src/utils/process";
+import revisionHash from "../../src/utils/revision-hash";
+import runtime from "../../src/utils/runtimes";
+
+describe("runtime detection on workerd", () => {
+    it("should detect the workerd runtime from `navigator.userAgent`", () => {
+        expect.assertions(1);
+
+        expect(runtime).toBe("workerd");
+    });
+
+    it("should read `process` through the shim without throwing", () => {
+        expect.assertions(3);
+
+        expect(() => getProcessPlatform()).not.toThrow();
+        expect(() => getProcessVersion()).not.toThrow();
+        expect(process.versions).toBeDefined();
+    });
+
+    it("should return undefined for a key present on neither `process` nor the shim", () => {
+        expect.assertions(1);
+
+        expect((process as unknown as Record<string, unknown>).thisKeyDoesNotExist).toBeUndefined();
+    });
+
+    it("should tolerate `process.env` lookups on the solution-finder path", () => {
+        expect.assertions(1);
+
+        expect(() => process.env?.DEBUG).not.toThrow();
+    });
+});
+
+describe("hashing on workerd", () => {
+    it("should hash with `node:crypto` under nodejs_compat", () => {
+        expect.assertions(2);
+
+        // `createHash` is one of the `node:crypto` primitives workerd implements, so the revision
+        // hash keeps working; Web Crypto is the portable alternative if that ever changes.
+        expect(revisionHash("abc")).toBe("ba7816bf8f01cfea");
+        expect(revisionHash("abc")).toHaveLength(16);
+    });
+
+    it("should reject a non-string input", () => {
+        expect.assertions(1);
+
+        expect(() => revisionHash(1 as unknown as string)).toThrow(TypeError);
+    });
+
+    it("should offer Web Crypto as the portable alternative", async () => {
+        expect.assertions(2);
+
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Web Crypto is always present on workerd
+        expect(crypto.randomUUID()).toBeTypeOf("string");
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Web Crypto is always present on workerd
+        await expect(crypto.subtle.digest("SHA-256", new TextEncoder().encode("abc"))).resolves.toBeInstanceOf(ArrayBuffer);
+    });
+});
+
+describe("sanitization fallback on workerd", () => {
+    it("should escape markup when DOMPurify cannot load", () => {
+        expect.assertions(2);
+
+        // Documented degradation: with no DOM there is no DOMPurify, so everything is entity-escaped
+        // instead of sanitized. Escaping is the stricter of the two — no markup survives it.
+        expect(sanitizeHtml("<script>alert(1)</script>")).toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(sanitizeCodeHtml("<span class=\"token\">x</span>")).not.toContain("<span");
+    });
+
+    it("should escape quotes so an attribute value cannot break out", () => {
+        expect.assertions(2);
+
+        expect(sanitizeAttribute("x\" onfocus=\"alert(1)")).not.toContain("\" onfocus");
+        expect(sanitizeAttribute("x\" onfocus=\"alert(1)")).toContain("&quot;");
+    });
+
+    it("should keep allowed URLs usable instead of collapsing every link to `#`", () => {
+        expect.assertions(3);
+
+        expect(sanitizeUrlAttribute("https://example.com/a")).toBe("https://example.com/a");
+        expect(sanitizeUrlAttribute("/local/path")).toBe("/local/path");
+        // eslint-disable-next-line no-script-url -- the point of the assertion is that this scheme is rejected
+        expect(sanitizeUrlAttribute("javascript:alert(1)")).toBe("#");
+    });
+
+    it("should reject a `data:` URL", () => {
+        expect.assertions(1);
+
+        expect(sanitizeUrlAttribute("data:text/html,<script>alert(1)</script>")).toBe("#");
+    });
+});

--- a/packages/error-debugging/ono/eslint.config.js
+++ b/packages/error-debugging/ono/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "prettier.config.js",

--- a/packages/error-debugging/ono/package.json
+++ b/packages/error-debugging/ono/package.json
@@ -31,11 +31,6 @@
         "youch"
     ],
     "homepage": "https://visulima.com/packages/ono/",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/visulima/visulima.git",
@@ -51,14 +46,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": true,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -74,10 +68,12 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -97,7 +93,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "dependencies": {
         "@shikijs/langs": "catalog:prod",
@@ -111,6 +108,7 @@
         "@anolilab/prettier-config": "catalog:lint",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@eslint/css": "catalog:lint",
         "@shikijs/themes": "catalog:dev",
         "@tailwindcss/forms": "catalog:frontend",
@@ -143,5 +141,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/ono/src/error-inspector/components/error-card/solutions.ts
+++ b/packages/error-debugging/ono/src/error-inspector/components/error-card/solutions.ts
@@ -1,6 +1,5 @@
 import type { VisulimaError } from "@visulima/error/error";
 import type { Solution, SolutionError, SolutionFinder } from "@visulima/error/solution";
-import { sanitize as dompurifySanitize } from "isomorphic-dompurify";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import infoIcon from "lucide-static/icons/info.svg?data-uri&encoding=css";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -9,6 +8,8 @@ import closeIcon from "lucide-static/icons/x.svg?data-uri&encoding=css";
 import { parse } from "marked";
 
 import findSolution from "../../../utils/find-solution";
+import { purify } from "../../utils/dompurify";
+import { escapeHtml } from "../../utils/sanitize";
 
 const solutions = async (
     error: Error | SolutionError | VisulimaError,
@@ -40,12 +41,12 @@ const solutions = async (
 
                 const parsedHeader = await parse(hint.header);
 
-                return dompurifySanitize(parsedHeader);
+                return purify(parsedHeader) ?? escapeHtml(parsedHeader);
             })()}
             ${await (async () => {
                 const parsedBody = await parse(hint.body);
 
-                return dompurifySanitize(parsedBody);
+                return purify(parsedBody) ?? escapeHtml(parsedBody);
             })()}
         </div>
     </div>

--- a/packages/error-debugging/ono/src/error-inspector/layout.ts
+++ b/packages/error-debugging/ono/src/error-inspector/layout.ts
@@ -1,6 +1,5 @@
-import { sanitize as dompurifySanitize } from "isomorphic-dompurify";
-
 import type { Theme } from "../types";
+import { purify } from "./utils/dompurify";
 import { sanitizeCspNonce } from "./utils/sanitize";
 
 // HTML escape function for text content
@@ -72,7 +71,10 @@ const layout = ({
 
     // Optimize stack processing - only indent if stack exists and contains newlines
     const rawStack = error.stack ?? error.toString();
-    const errorStack = dompurifySanitize(rawStack.includes("\n") ? rawStack.replaceAll("\n", "\n\t") : rawStack);
+    const indentedStack = rawStack.includes("\n") ? rawStack.replaceAll("\n", "\n\t") : rawStack;
+    // The stack is embedded in an HTML comment; entity-escaping is the fallback when DOMPurify is
+    // unavailable (DOM-less runtimes such as workerd) and also neutralises a `-->` in the stack.
+    const errorStack = purify(indentedStack) ?? escapeHtml(indentedStack);
 
     return `<!--
     ${errorStack}

--- a/packages/error-debugging/ono/src/error-inspector/page/create-request-context.ts
+++ b/packages/error-debugging/ono/src/error-inspector/page/create-request-context.ts
@@ -27,10 +27,17 @@ const safeGetProperty = (object: unknown, property: string): unknown => {
     return undefined;
 };
 
+/**
+ * Look up a method on a request-like object and return it **bound to its owner**.
+ *
+ * Every caller invokes the result as a bare function, so an unbound method loses its receiver. Web
+ * platform classes (`Request`, `Headers`) brand-check `this`: on workerd that surfaces as
+ * `TypeError: Illegal invocation`, taking the whole request panel down for a native `Request`.
+ */
 const safeGetMethod = (object: unknown, property: string): ((...arguments_: unknown[]) => unknown) | undefined => {
     const method = safeGetProperty(object, property);
 
-    return typeof method === "function" ? (method as (...arguments_: unknown[]) => unknown) : undefined;
+    return typeof method === "function" ? (method as (...arguments_: unknown[]) => unknown).bind(object) : undefined;
 };
 
 const safeGetString = (object: unknown, property: string): string | undefined => {

--- a/packages/error-debugging/ono/src/error-inspector/utils/dompurify.ts
+++ b/packages/error-debugging/ono/src/error-inspector/utils/dompurify.ts
@@ -1,0 +1,52 @@
+/**
+ * DOMPurify sanitizer, resolved without taking DOM-less runtimes down at import time.
+ *
+ * `isomorphic-dompurify` cannot be imported statically: its browser build binds
+ * `DOMPurify.sanitize` at module scope, and DOMPurify leaves `sanitize` undefined when the runtime
+ * has no DOM. On DOM-less edge runtimes (Cloudflare Workers / workerd, and anything else without
+ * `window.document`) a static `import` therefore throws `TypeError: Cannot read properties of
+ * undefined (reading 'bind')` while merely *loading* the module — taking the whole package down
+ * before a single line of user code runs.
+ *
+ * It is pulled in with a top-level `await import(...)` inside `try`/`catch` instead. The await keeps
+ * the resolution synchronous from every consumer's point of view (an importing module's body does
+ * not run until this one has settled), so {@link purify} stays a plain synchronous function, while
+ * the `catch` turns "no DOM" into a missing sanitizer rather than a crash.
+ *
+ * When no sanitizer resolves, callers fall back to plain HTML-entity escaping. That is stricter than
+ * DOMPurify — no markup survives it — so the page degrades to escaped output instead of crashing.
+ */
+
+/** Signature of `DOMPurify.sanitize` as this package uses it. */
+type SanitizeFunction = (source: string, config?: Record<string, unknown>) => string;
+
+let sanitizeImplementation: SanitizeFunction | undefined;
+
+try {
+    const module = await import("isomorphic-dompurify");
+
+    if (typeof module.sanitize === "function") {
+        sanitizeImplementation = module.sanitize;
+    }
+} catch {
+    // No DOM in this runtime (e.g. workerd). Callers fall back to entity escaping.
+}
+
+/**
+ * Sanitize `value` with DOMPurify, or return `undefined` when no sanitizer is available (or it
+ * threw) so the caller can apply its own escaping fallback.
+ */
+export const purify = (value: string, config?: Record<string, unknown>): string | undefined => {
+    if (sanitizeImplementation === undefined) {
+        return undefined;
+    }
+
+    try {
+        return config === undefined ? sanitizeImplementation(value) : sanitizeImplementation(value, config);
+    } catch {
+        return undefined;
+    }
+};
+
+/** Whether a DOMPurify sanitizer resolved for this runtime. Exposed for diagnostics and tests. */
+export const hasSanitizer = (): boolean => sanitizeImplementation !== undefined;

--- a/packages/error-debugging/ono/src/error-inspector/utils/sanitize.ts
+++ b/packages/error-debugging/ono/src/error-inspector/utils/sanitize.ts
@@ -1,6 +1,5 @@
-import { sanitize as dompurifySanitize } from "isomorphic-dompurify";
-
 import type { TemplateOptions } from "../types";
+import { purify } from "./dompurify";
 
 /**
  * Constants for URL validation and character escaping
@@ -44,17 +43,20 @@ const toString = (value: unknown): string => {
     return String(value).trim();
 };
 
-// Escapes HTML entities for safe use in HTML attributes
-const escapeHtml = (value: string): string => value.replaceAll(/[&<>"']/g, (char) => HTML_ENTITIES[char as keyof typeof HTML_ENTITIES]);
+/**
+ * Escapes HTML entities for safe use in HTML attributes.
+ *
+ * Also the sanitization fallback for runtimes where DOMPurify cannot load (no DOM — e.g. workerd).
+ * Escaping is strictly stronger than sanitizing: no markup survives it, so the output is safe even
+ * though formatting is lost.
+ */
+export const escapeHtml = (value: string): string => value.replaceAll(/[&<>"']/g, (char) => HTML_ENTITIES[char as keyof typeof HTML_ENTITIES]);
 
 // Sanitizes HTML content using DOMPurify to prevent XSS attacks
 export const sanitizeHtml = (value: unknown): string => {
-    try {
-        return dompurifySanitize(toString(value));
-    } catch {
-        // Fallback to basic escaping if DOMPurify fails
-        return escapeHtml(toString(value));
-    }
+    const stringValue = toString(value);
+
+    return purify(stringValue) ?? escapeHtml(stringValue);
 };
 
 // Sanitizes values for use in HTML attributes with additional HTML entity escaping
@@ -65,15 +67,15 @@ export const sanitizeAttribute = (value: unknown): string => {
         return "";
     }
 
-    try {
-        // DOMPurify sanitizes but we need to ensure quotes are escaped for attribute safety
-        const sanitized = dompurifySanitize(stringValue);
+    const sanitized = purify(stringValue);
 
-        return sanitized.replaceAll("\"", "&quot;").replaceAll("'", "&#39;");
-    } catch {
-        // Fallback to manual escaping if DOMPurify fails
+    if (sanitized === undefined) {
+        // Fallback to manual escaping when DOMPurify is unavailable in this runtime.
         return escapeHtml(stringValue);
     }
+
+    // DOMPurify sanitizes but we need to ensure quotes are escaped for attribute safety
+    return sanitized.replaceAll("\"", "&quot;").replaceAll("'", "&#39;");
 };
 
 // Validates and sanitizes URLs for safe use in HTML attributes
@@ -85,19 +87,17 @@ export const sanitizeUrlAttribute = (value: unknown): string => {
         return FALLBACK_URL;
     }
 
-    try {
-        const sanitized = dompurifySanitize(rawUrl);
-        const lowerUrl = sanitized.toLowerCase();
+    // Without DOMPurify, entity-escaping the URL is the safe equivalent: the allowlist below still
+    // decides whether the scheme may be emitted at all, so dropping to `#` would needlessly break
+    // legitimate links on DOM-less runtimes.
+    const sanitized = purify(rawUrl) ?? escapeHtml(rawUrl);
+    const lowerUrl = sanitized.toLowerCase();
 
-        // Check if URL starts with allowed prefixes
-        const isAllowed = ALLOWED_URL_PREFIXES.some((prefix) => lowerUrl.startsWith(prefix));
+    // Check if URL starts with allowed prefixes
+    const isAllowed = ALLOWED_URL_PREFIXES.some((prefix) => lowerUrl.startsWith(prefix));
 
-        // Escape quotes so a value like `/x" onfocus="…` cannot break out of the surrounding attribute
-        return isAllowed ? sanitized.replaceAll("\"", "&quot;").replaceAll("'", "&#39;") : FALLBACK_URL;
-    } catch {
-        // Return safe fallback if sanitization fails
-        return FALLBACK_URL;
-    }
+    // Escape quotes so a value like `/x" onfocus="…` cannot break out of the surrounding attribute
+    return isAllowed ? sanitized.replaceAll("\"", "&quot;").replaceAll("'", "&#39;") : FALLBACK_URL;
 };
 
 // Sanitizes HTML content while preserving code syntax highlighting classes
@@ -108,15 +108,14 @@ export const sanitizeCodeHtml = (value: unknown): string => {
         return "";
     }
 
-    try {
-        // Preserve styling/classes produced by syntax highlighters like Shiki
-        return dompurifySanitize(stringValue, {
+    // Preserve styling/classes produced by syntax highlighters like Shiki
+    return (
+        purify(stringValue, {
             ADD_ATTR: ["class", "style"],
-        });
-    } catch {
-        // Fallback to basic HTML sanitization if advanced options fail
-        return sanitizeHtml(stringValue);
-    }
+        })
+        // Fallback to basic HTML sanitization if advanced options fail or DOMPurify is unavailable.
+        ?? sanitizeHtml(stringValue)
+    );
 };
 
 // Validates and sanitizes Content Security Policy nonces

--- a/packages/error-debugging/ono/vitest.config.ts
+++ b/packages/error-debugging/ono/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
             exclude: [...(configDefaults.coverage.exclude ?? []), "**/__fixtures__/**"],
         },
         environment: "node",
-        exclude: [...(configDefaults.exclude ?? []), "**/__fixtures__/**"],
+        // `__tests__/workerd/**` belongs to the workerd pool (`vitest.workerd.config.ts`). Those
+        // specs assert workerd-only globals, so the Node pool must not pick them up.
+        exclude: [...(configDefaults.exclude ?? []), "**/__fixtures__/**", "__tests__/workerd/**"],
     },
 });

--- a/packages/error-debugging/ono/vitest.workerd.config.ts
+++ b/packages/error-debugging/ono/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5034,6 +5034,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@eslint/css':
         specifier: catalog:lint
         version: 1.4.0
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
The package was unusable on any runtime without a DOM. `isomorphic-dompurify`
binds `DOMPurify.sanitize` at module scope, and DOMPurify leaves that undefined
with no DOM, so a static import threw at load and took down the root entry,
`./page/context`, `layout` and `page/stack` alike.

It is now loaded through a guarded top-level `await import`. That form is
deliberate: it keeps resolution synchronous from every consumer's view, so
direct synchronous callers on Node still get the real sanitizer. With no DOM,
`sanitizeHtml` falls back to HTML-entity escaping, which is stricter than
sanitising — markup does not survive, so the page stays safe while syntax
highlighting renders as escaped text. URL attributes still run the allowlist
gate, so `javascript:` and entity-encoded schemes resolve to the fallback.

`createRequestContext` also threw `TypeError: Illegal invocation` for a native
`Request` — precisely what a Worker's fetch handler receives — because accessor
methods were detached from their owner and `Request`/`Headers` brand-check
`this`.

Adds a workerd suite whose first assertion is that every public entry imports
without throwing.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
