### PR TITLE
fix(pail): make edge reporter importable

### DIFF
--- a/packages/error-debugging/pail/LICENSE.md
+++ b/packages/error-debugging/pail/LICENSE.md
@@ -23,11 +23,14 @@ SOFTWARE.
 <!-- DEPENDENCIES -->
 
 # Licenses of bundled dependencies
+
 The published @visulima/pail artifact additionally contains code with the following licenses:
 MIT
 
 # Bundled dependencies:
+
 ## @visulima/error
+
 License: MIT
 By: Daniel Bannert
 Repository: git+https://github.com/visulima/visulima.git
@@ -53,8 +56,6 @@ Repository: git+https://github.com/visulima/visulima.git
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
->
->
 >
 > # Licenses of bundled dependencies
 >
@@ -79,16 +80,15 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
->
->
->
->
 > # Licenses of bundled types
+>
 > The published @visulima/error artifact additionally contains code with the following licenses:
 > Apache-2.0
 >
 > # Bundled types:
+>
 > ## ai
+>
 > License: Apache-2.0
 > Repository: https://github.com/vercel/ai
 >
@@ -106,9 +106,10 @@ Repository: git+https://github.com/visulima/visulima.git
 > > See the License for the specific language governing permissions and
 > > limitations under the License.
 
----------------------------------------
+---
 
 ## @visulima/fmt
+
 License: MIT
 By: Daniel Bannert
 Repository: git+https://github.com/visulima/visulima.git
@@ -135,9 +136,165 @@ Repository: git+https://github.com/visulima/visulima.git
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
----------------------------------------
+---
+
+## safe-stable-stringify
+
+License: MIT
+By: Ruben Bridgewater
+Repository: git+https://github.com/BridgeAR/safe-stable-stringify.git
+
+> The MIT License (MIT)
+>
+> Copyright (c) Ruben Bridgewater
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+<!-- /DEPENDENCIES -->
+
+<!-- TYPE_DEPENDENCIES -->
+
+# Licenses of bundled types
+
+The published @visulima/pail artifact additionally contains code with the following licenses:
+MIT, (MIT OR CC0-1.0)
+
+# Bundled types:
+
+## @visulima/error
+
+License: MIT
+By: Daniel Bannert
+Repository: git+https://github.com/visulima/visulima.git
+
+> MIT License
+>
+> Copyright (c) 2026 visulima
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+>
+> <!-- DEPENDENCIES -->
+>
+> # Licenses of bundled dependencies
+>
+> The published @visulima/error artifact additionally contains code with the following licenses:
+> MIT
+>
+> # Bundled dependencies:
+>
+> ## is-plain-obj
+>
+> License: MIT
+> By: Sindre Sorhus
+> Repository: sindresorhus/is-plain-obj
+>
+> > MIT License
+> >
+> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+> >
+> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+> >
+> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+> >
+> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+>
+> <!-- /DEPENDENCIES -->
+>
+> # Licenses of bundled types
+>
+> The published @visulima/error artifact additionally contains code with the following licenses:
+> Apache-2.0
+>
+> # Bundled types:
+>
+> ## ai
+>
+> License: Apache-2.0
+> Repository: https://github.com/vercel/ai
+>
+> > Copyright 2023 Vercel, Inc.
+> >
+> > Licensed under the Apache License, Version 2.0 (the "License");
+> > you may not use this file except in compliance with the License.
+> > You may obtain a copy of the License at
+> >
+> >     http://www.apache.org/licenses/LICENSE-2.0
+> >
+> > Unless required by applicable law or agreed to in writing, software
+> > distributed under the License is distributed on an "AS IS" BASIS,
+> > WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> > See the License for the specific language governing permissions and
+> > limitations under the License.
+
+---
+
+## @visulima/fmt
+
+License: MIT
+By: Daniel Bannert
+Repository: git+https://github.com/visulima/visulima.git
+
+> MIT License
+>
+> Copyright (c) 2026 visulima
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+>
+> <!-- DEPENDENCIES -->
+> <!-- /DEPENDENCIES -->
+
+---
 
 ## @visulima/inspector
+
 License: MIT
 By: Daniel Bannert
 Repository: git+https://github.com/visulima/visulima.git
@@ -178,17 +335,18 @@ Repository: git+https://github.com/visulima/visulima.git
 >
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
->
->
->
->
+> <!-- DEPENDENCIES -->
+> <!-- /DEPENDENCIES -->
 >
 > # Licenses of bundled types
+>
 > The published @visulima/inspector artifact additionally contains code with the following licenses:
 > (MIT OR CC0-1.0)
 >
 > # Bundled types:
+>
 > ## type-fest
+>
 > License: (MIT OR CC0-1.0)
 > By: Sindre Sorhus
 > Repository: sindresorhus/type-fest
@@ -233,91 +391,92 @@ Repository: git+https://github.com/visulima/visulima.git
 > > Work and the meaning and intended legal effect of CC0 on those rights.
 > >
 > > 1. Copyright and Related Rights. A Work made available under CC0 may be
-> > protected by copyright and related or neighboring rights ("Copyright and
-> > Related Rights"). Copyright and Related Rights include, but are not
-> > limited to, the following:
+> >    protected by copyright and related or neighboring rights ("Copyright and
+> >    Related Rights"). Copyright and Related Rights include, but are not
+> >    limited to, the following:
 > >
-> >   i. the right to reproduce, adapt, distribute, perform, display,
-> >      communicate, and translate a Work;
-> >  ii. moral rights retained by the original author(s) and/or performer(s);
+> > i. the right to reproduce, adapt, distribute, perform, display,
+> > communicate, and translate a Work;
+> > ii. moral rights retained by the original author(s) and/or performer(s);
 > > iii. publicity and privacy rights pertaining to a person's image or
-> >      likeness depicted in a Work;
-> >  iv. rights protecting against unfair competition in regards to a Work,
-> >      subject to the limitations in paragraph 4(a), below;
-> >   v. rights protecting the extraction, dissemination, use and reuse of data
-> >      in a Work;
-> >  vi. database rights (such as those arising under Directive 96/9/EC of the
-> >      European Parliament and of the Council of 11 March 1996 on the legal
-> >      protection of databases, and under any national implementation
-> >      thereof, including any amended or successor version of such
-> >      directive); and
+> > likeness depicted in a Work;
+> > iv. rights protecting against unfair competition in regards to a Work,
+> > subject to the limitations in paragraph 4(a), below;
+> > v. rights protecting the extraction, dissemination, use and reuse of data
+> > in a Work;
+> > vi. database rights (such as those arising under Directive 96/9/EC of the
+> > European Parliament and of the Council of 11 March 1996 on the legal
+> > protection of databases, and under any national implementation
+> > thereof, including any amended or successor version of such
+> > directive); and
 > > vii. other similar, equivalent or corresponding rights throughout the
-> >      world based on applicable law or treaty, and any national
-> >      implementations thereof.
+> > world based on applicable law or treaty, and any national
+> > implementations thereof.
 > >
 > > 2. Waiver. To the greatest extent permitted by, but not in contravention
-> > of, applicable law, Affirmer hereby overtly, fully, permanently,
-> > irrevocably and unconditionally waives, abandons, and surrenders all of
-> > Affirmer's Copyright and Related Rights and associated claims and causes
-> > of action, whether now known or unknown (including existing as well as
-> > future claims and causes of action), in the Work (i) in all territories
-> > worldwide, (ii) for the maximum duration provided by applicable law or
-> > treaty (including future time extensions), (iii) in any current or future
-> > medium and for any number of copies, and (iv) for any purpose whatsoever,
-> > including without limitation commercial, advertising or promotional
-> > purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-> > member of the public at large and to the detriment of Affirmer's heirs and
-> > successors, fully intending that such Waiver shall not be subject to
-> > revocation, rescission, cancellation, termination, or any other legal or
-> > equitable action to disrupt the quiet enjoyment of the Work by the public
-> > as contemplated by Affirmer's express Statement of Purpose.
+> >    of, applicable law, Affirmer hereby overtly, fully, permanently,
+> >    irrevocably and unconditionally waives, abandons, and surrenders all of
+> >    Affirmer's Copyright and Related Rights and associated claims and causes
+> >    of action, whether now known or unknown (including existing as well as
+> >    future claims and causes of action), in the Work (i) in all territories
+> >    worldwide, (ii) for the maximum duration provided by applicable law or
+> >    treaty (including future time extensions), (iii) in any current or future
+> >    medium and for any number of copies, and (iv) for any purpose whatsoever,
+> >    including without limitation commercial, advertising or promotional
+> >    purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+> >    member of the public at large and to the detriment of Affirmer's heirs and
+> >    successors, fully intending that such Waiver shall not be subject to
+> >    revocation, rescission, cancellation, termination, or any other legal or
+> >    equitable action to disrupt the quiet enjoyment of the Work by the public
+> >    as contemplated by Affirmer's express Statement of Purpose.
 > >
 > > 3. Public License Fallback. Should any part of the Waiver for any reason
-> > be judged legally invalid or ineffective under applicable law, then the
-> > Waiver shall be preserved to the maximum extent permitted taking into
-> > account Affirmer's express Statement of Purpose. In addition, to the
-> > extent the Waiver is so judged Affirmer hereby grants to each affected
-> > person a royalty-free, non transferable, non sublicensable, non exclusive,
-> > irrevocable and unconditional license to exercise Affirmer's Copyright and
-> > Related Rights in the Work (i) in all territories worldwide, (ii) for the
-> > maximum duration provided by applicable law or treaty (including future
-> > time extensions), (iii) in any current or future medium and for any number
-> > of copies, and (iv) for any purpose whatsoever, including without
-> > limitation commercial, advertising or promotional purposes (the
-> > "License"). The License shall be deemed effective as of the date CC0 was
-> > applied by Affirmer to the Work. Should any part of the License for any
-> > reason be judged legally invalid or ineffective under applicable law, such
-> > partial invalidity or ineffectiveness shall not invalidate the remainder
-> > of the License, and in such case Affirmer hereby affirms that he or she
-> > will not (i) exercise any of his or her remaining Copyright and Related
-> > Rights in the Work or (ii) assert any associated claims and causes of
-> > action with respect to the Work, in either case contrary to Affirmer's
-> > express Statement of Purpose.
+> >    be judged legally invalid or ineffective under applicable law, then the
+> >    Waiver shall be preserved to the maximum extent permitted taking into
+> >    account Affirmer's express Statement of Purpose. In addition, to the
+> >    extent the Waiver is so judged Affirmer hereby grants to each affected
+> >    person a royalty-free, non transferable, non sublicensable, non exclusive,
+> >    irrevocable and unconditional license to exercise Affirmer's Copyright and
+> >    Related Rights in the Work (i) in all territories worldwide, (ii) for the
+> >    maximum duration provided by applicable law or treaty (including future
+> >    time extensions), (iii) in any current or future medium and for any number
+> >    of copies, and (iv) for any purpose whatsoever, including without
+> >    limitation commercial, advertising or promotional purposes (the
+> >    "License"). The License shall be deemed effective as of the date CC0 was
+> >    applied by Affirmer to the Work. Should any part of the License for any
+> >    reason be judged legally invalid or ineffective under applicable law, such
+> >    partial invalidity or ineffectiveness shall not invalidate the remainder
+> >    of the License, and in such case Affirmer hereby affirms that he or she
+> >    will not (i) exercise any of his or her remaining Copyright and Related
+> >    Rights in the Work or (ii) assert any associated claims and causes of
+> >    action with respect to the Work, in either case contrary to Affirmer's
+> >    express Statement of Purpose.
 > >
 > > 4. Limitations and Disclaimers.
 > >
-> >  a. No trademark or patent rights held by Affirmer are waived, abandoned,
-> >     surrendered, licensed or otherwise affected by this document.
-> >  b. Affirmer offers the Work as-is and makes no representations or
-> >     warranties of any kind concerning the Work, express, implied,
-> >     statutory or otherwise, including without limitation warranties of
-> >     title, merchantability, fitness for a particular purpose, non
-> >     infringement, or the absence of latent or other defects, accuracy, or
-> >     the present or absence of errors, whether or not discoverable, all to
-> >     the greatest extent permissible under applicable law.
-> >  c. Affirmer disclaims responsibility for clearing rights of other persons
-> >     that may apply to the Work or any use thereof, including without
-> >     limitation any person's Copyright and Related Rights in the Work.
-> >     Further, Affirmer disclaims responsibility for obtaining any necessary
-> >     consents, permissions or other rights required for any use of the
-> >     Work.
-> >  d. Affirmer understands and acknowledges that Creative Commons is not a
-> >     party to this document and has no duty or obligation with respect to
-> >     this CC0 or use of the Work.
+> > a. No trademark or patent rights held by Affirmer are waived, abandoned,
+> > surrendered, licensed or otherwise affected by this document.
+> > b. Affirmer offers the Work as-is and makes no representations or
+> > warranties of any kind concerning the Work, express, implied,
+> > statutory or otherwise, including without limitation warranties of
+> > title, merchantability, fitness for a particular purpose, non
+> > infringement, or the absence of latent or other defects, accuracy, or
+> > the present or absence of errors, whether or not discoverable, all to
+> > the greatest extent permissible under applicable law.
+> > c. Affirmer disclaims responsibility for clearing rights of other persons
+> > that may apply to the Work or any use thereof, including without
+> > limitation any person's Copyright and Related Rights in the Work.
+> > Further, Affirmer disclaims responsibility for obtaining any necessary
+> > consents, permissions or other rights required for any use of the
+> > Work.
+> > d. Affirmer understands and acknowledges that Creative Commons is not a
+> > party to this document and has no duty or obligation with respect to
+> > this CC0 or use of the Work.
 
----------------------------------------
+---
 
-## @visulima/string
+## @visulima/redact
+
 License: MIT
 By: Daniel Bannert
 Repository: git+https://github.com/visulima/visulima.git
@@ -344,105 +503,20 @@ Repository: git+https://github.com/visulima/visulima.git
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 >
->
+> <!-- DEPENDENCIES -->
 >
 > # Licenses of bundled dependencies
-> The published @visulima/string artifact additionally contains code with the following licenses:
+>
+> The published @visulima/redact artifact additionally contains code with the following licenses:
 > MIT
 >
 > # Bundled dependencies:
-> ## codsen-utils
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
 >
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+> ## dot-prop
 >
-> ---------------------------------------
->
-> ## emoji-regex-xs
-> License: MIT
-> By: Steven Levithan
-> Repository: git+https://github.com/slevithan/emoji-regex-xs.git
->
-> > MIT License
-> >
-> > Copyright (c) 2025 Steven Levithan
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy
-> > of this software and associated documentation files (the "Software"), to deal
-> > in the Software without restriction, including without limitation the rights
-> > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> > copies of the Software, and to permit persons to whom the Software is
-> > furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all
-> > copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> > SOFTWARE.
->
-> ---------------------------------------
->
-> ## fastest-levenshtein
-> License: MIT
-> By: Kasper U. Weihe
-> Repository: git+https://github.com/ka-weihe/fastest-levenshtein.git
->
-> > MIT License
-> >
-> > Copyright (c) 2020 Kasper Unn Weihe
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy
-> > of this software and associated documentation files (the "Software"), to deal
-> > in the Software without restriction, including without limitation the rights
-> > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> > copies of the Software, and to permit persons to whom the Software is
-> > furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all
-> > copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> > SOFTWARE.
->
-> ---------------------------------------
->
-> ## get-east-asian-width
 > License: MIT
 > By: Sindre Sorhus
-> Repository: sindresorhus/get-east-asian-width
+> Repository: sindresorhus/dot-prop
 >
 > > MIT License
 > >
@@ -454,532 +528,12 @@ Repository: git+https://github.com/visulima/visulima.git
 > >
 > > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 >
-> ---------------------------------------
->
-> ## html-entities
-> License: MIT
-> By: Marat Dulin
-> Repository: https://github.com/mdevils/html-entities.git
->
-> > Copyright (c) 2021 Dulin Marat
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy
-> > of this software and associated documentation files (the "Software"), to deal
-> > in the Software without restriction, including without limitation the rights
-> > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> > copies of the Software, and to permit persons to whom the Software is
-> > furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in
-> > all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> > THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## indent-string
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/indent-string
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## lodash-es
-> License: MIT
-> By: John-David Dalton, Mathias Bynens
-> Repository: lodash/lodash
->
-> > Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
-> >
-> > Based on Underscore.js, copyright Jeremy Ashkenas,
-> > DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-> >
-> > This software consists of voluntary contributions made by many
-> > individuals. For exact contribution history, see the revision history
-> > available at https://github.com/lodash/lodash
-> >
-> > The following license applies to all parts of this software except as
-> > documented below:
-> >
-> > ====
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-> >
-> > ====
-> >
-> > Copyright and related rights for sample code are waived via CC0. Sample
-> > code is defined as all source code displayed within the prose of the
-> > documentation.
-> >
-> > CC0: http://creativecommons.org/publicdomain/zero/1.0/
-> >
-> > ====
-> >
-> > Files located in the node_modules and vendor directories are externally
-> > maintained libraries used by this software which have their own
-> > licenses; we recommend you read them, as their terms may differ from the
-> > terms above.
->
-> ---------------------------------------
->
-> ## ranges-apply
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## ranges-merge
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## ranges-push
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## ranges-sort
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## redent
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/redent
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## rfdc
-> License: MIT
-> By: David Mark Clements
-> Repository: git+https://github.com/davidmarkclements/rfdc.git
->
-> > Copyright 2019 "David Mark Clements <david.mark.clements@gmail.com>"
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-> > documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-> > the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
-> > to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions 
-> > of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-> > TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-> > THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-> > CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
-> > IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## string-collapse-leading-whitespace
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## string-left-right
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## string-strip-html
-> License: MIT
-> By: Roy Revelt
-> Repository: git+https://github.com/codsen/codsen.git
->
-> > MIT License
-> >
-> > Copyright © 2010-2025 Roy Revelt and other contributors
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining
-> > a copy of this software and associated documentation files (the
-> > "Software"), to deal in the Software without restriction, including
-> > without limitation the rights to use, copy, modify, merge, publish,
-> > distribute, sublicense, and/or sell copies of the Software, and to
-> > permit persons to whom the Software is furnished to do so, subject to
-> > the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be
-> > included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> > NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## strip-indent
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/strip-indent
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## tiny-invariant
-> License: MIT
-> By: Alex Reardon
-> Repository: https://github.com/alexreardon/tiny-invariant.git
->
-> > MIT License
-> >
-> > Copyright (c) 2019 Alexander Reardon
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy
-> > of this software and associated documentation files (the "Software"), to deal
-> > in the Software without restriction, including without limitation the rights
-> > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> > copies of the Software, and to permit persons to whom the Software is
-> > furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all
-> > copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> > SOFTWARE.
->
->
->
->
->
-> # Licenses of bundled types
-> The published @visulima/string artifact additionally contains code with the following licenses:
-> MIT
->
-> # Bundled types:
-> ## fastest-levenshtein
-> License: MIT
-> By: Kasper U. Weihe
-> Repository: git+https://github.com/ka-weihe/fastest-levenshtein.git
->
-> > MIT License
-> >
-> > Copyright (c) 2020 Kasper Unn Weihe
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy
-> > of this software and associated documentation files (the "Software"), to deal
-> > in the Software without restriction, including without limitation the rights
-> > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> > copies of the Software, and to permit persons to whom the Software is
-> > furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all
-> > copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> > SOFTWARE.
->
-> ---------------------------------------
->
-> ## get-east-asian-width
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/get-east-asian-width
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## indent-string
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/indent-string
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## redent
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/redent
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> ---------------------------------------
->
-> ## strip-indent
-> License: MIT
-> By: Sindre Sorhus
-> Repository: sindresorhus/strip-indent
->
-> > MIT License
-> >
-> > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> >
-> > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> >
-> > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> >
-> > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+> <!-- /DEPENDENCIES -->
 
----------------------------------------
+---
 
-## terminal-size
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/terminal-size
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-<!-- /DEPENDENCIES -->
-
-<!-- TYPE_DEPENDENCIES -->
-
-# Licenses of bundled types
-The published @visulima/pail artifact additionally contains code with the following licenses:
-MIT, (MIT OR CC0-1.0)
-
-# Bundled types:
 ## safe-stable-stringify
+
 License: MIT
 By: Ruben Bridgewater
 Repository: git+https://github.com/BridgeAR/safe-stable-stringify.git
@@ -1006,9 +560,10 @@ Repository: git+https://github.com/BridgeAR/safe-stable-stringify.git
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
----------------------------------------
+---
 
 ## type-fest
+
 License: (MIT OR CC0-1.0)
 By: Sindre Sorhus
 Repository: sindresorhus/type-fest
@@ -1053,86 +608,86 @@ Repository: sindresorhus/type-fest
 > Work and the meaning and intended legal effect of CC0 on those rights.
 >
 > 1. Copyright and Related Rights. A Work made available under CC0 may be
-> protected by copyright and related or neighboring rights ("Copyright and
-> Related Rights"). Copyright and Related Rights include, but are not
-> limited to, the following:
+>    protected by copyright and related or neighboring rights ("Copyright and
+>    Related Rights"). Copyright and Related Rights include, but are not
+>    limited to, the following:
 >
->   i. the right to reproduce, adapt, distribute, perform, display,
->      communicate, and translate a Work;
->  ii. moral rights retained by the original author(s) and/or performer(s);
+> i. the right to reproduce, adapt, distribute, perform, display,
+> communicate, and translate a Work;
+> ii. moral rights retained by the original author(s) and/or performer(s);
 > iii. publicity and privacy rights pertaining to a person's image or
->      likeness depicted in a Work;
->  iv. rights protecting against unfair competition in regards to a Work,
->      subject to the limitations in paragraph 4(a), below;
->   v. rights protecting the extraction, dissemination, use and reuse of data
->      in a Work;
->  vi. database rights (such as those arising under Directive 96/9/EC of the
->      European Parliament and of the Council of 11 March 1996 on the legal
->      protection of databases, and under any national implementation
->      thereof, including any amended or successor version of such
->      directive); and
+> likeness depicted in a Work;
+> iv. rights protecting against unfair competition in regards to a Work,
+> subject to the limitations in paragraph 4(a), below;
+> v. rights protecting the extraction, dissemination, use and reuse of data
+> in a Work;
+> vi. database rights (such as those arising under Directive 96/9/EC of the
+> European Parliament and of the Council of 11 March 1996 on the legal
+> protection of databases, and under any national implementation
+> thereof, including any amended or successor version of such
+> directive); and
 > vii. other similar, equivalent or corresponding rights throughout the
->      world based on applicable law or treaty, and any national
->      implementations thereof.
+> world based on applicable law or treaty, and any national
+> implementations thereof.
 >
 > 2. Waiver. To the greatest extent permitted by, but not in contravention
-> of, applicable law, Affirmer hereby overtly, fully, permanently,
-> irrevocably and unconditionally waives, abandons, and surrenders all of
-> Affirmer's Copyright and Related Rights and associated claims and causes
-> of action, whether now known or unknown (including existing as well as
-> future claims and causes of action), in the Work (i) in all territories
-> worldwide, (ii) for the maximum duration provided by applicable law or
-> treaty (including future time extensions), (iii) in any current or future
-> medium and for any number of copies, and (iv) for any purpose whatsoever,
-> including without limitation commercial, advertising or promotional
-> purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-> member of the public at large and to the detriment of Affirmer's heirs and
-> successors, fully intending that such Waiver shall not be subject to
-> revocation, rescission, cancellation, termination, or any other legal or
-> equitable action to disrupt the quiet enjoyment of the Work by the public
-> as contemplated by Affirmer's express Statement of Purpose.
+>    of, applicable law, Affirmer hereby overtly, fully, permanently,
+>    irrevocably and unconditionally waives, abandons, and surrenders all of
+>    Affirmer's Copyright and Related Rights and associated claims and causes
+>    of action, whether now known or unknown (including existing as well as
+>    future claims and causes of action), in the Work (i) in all territories
+>    worldwide, (ii) for the maximum duration provided by applicable law or
+>    treaty (including future time extensions), (iii) in any current or future
+>    medium and for any number of copies, and (iv) for any purpose whatsoever,
+>    including without limitation commercial, advertising or promotional
+>    purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+>    member of the public at large and to the detriment of Affirmer's heirs and
+>    successors, fully intending that such Waiver shall not be subject to
+>    revocation, rescission, cancellation, termination, or any other legal or
+>    equitable action to disrupt the quiet enjoyment of the Work by the public
+>    as contemplated by Affirmer's express Statement of Purpose.
 >
 > 3. Public License Fallback. Should any part of the Waiver for any reason
-> be judged legally invalid or ineffective under applicable law, then the
-> Waiver shall be preserved to the maximum extent permitted taking into
-> account Affirmer's express Statement of Purpose. In addition, to the
-> extent the Waiver is so judged Affirmer hereby grants to each affected
-> person a royalty-free, non transferable, non sublicensable, non exclusive,
-> irrevocable and unconditional license to exercise Affirmer's Copyright and
-> Related Rights in the Work (i) in all territories worldwide, (ii) for the
-> maximum duration provided by applicable law or treaty (including future
-> time extensions), (iii) in any current or future medium and for any number
-> of copies, and (iv) for any purpose whatsoever, including without
-> limitation commercial, advertising or promotional purposes (the
-> "License"). The License shall be deemed effective as of the date CC0 was
-> applied by Affirmer to the Work. Should any part of the License for any
-> reason be judged legally invalid or ineffective under applicable law, such
-> partial invalidity or ineffectiveness shall not invalidate the remainder
-> of the License, and in such case Affirmer hereby affirms that he or she
-> will not (i) exercise any of his or her remaining Copyright and Related
-> Rights in the Work or (ii) assert any associated claims and causes of
-> action with respect to the Work, in either case contrary to Affirmer's
-> express Statement of Purpose.
+>    be judged legally invalid or ineffective under applicable law, then the
+>    Waiver shall be preserved to the maximum extent permitted taking into
+>    account Affirmer's express Statement of Purpose. In addition, to the
+>    extent the Waiver is so judged Affirmer hereby grants to each affected
+>    person a royalty-free, non transferable, non sublicensable, non exclusive,
+>    irrevocable and unconditional license to exercise Affirmer's Copyright and
+>    Related Rights in the Work (i) in all territories worldwide, (ii) for the
+>    maximum duration provided by applicable law or treaty (including future
+>    time extensions), (iii) in any current or future medium and for any number
+>    of copies, and (iv) for any purpose whatsoever, including without
+>    limitation commercial, advertising or promotional purposes (the
+>    "License"). The License shall be deemed effective as of the date CC0 was
+>    applied by Affirmer to the Work. Should any part of the License for any
+>    reason be judged legally invalid or ineffective under applicable law, such
+>    partial invalidity or ineffectiveness shall not invalidate the remainder
+>    of the License, and in such case Affirmer hereby affirms that he or she
+>    will not (i) exercise any of his or her remaining Copyright and Related
+>    Rights in the Work or (ii) assert any associated claims and causes of
+>    action with respect to the Work, in either case contrary to Affirmer's
+>    express Statement of Purpose.
 >
 > 4. Limitations and Disclaimers.
 >
->  a. No trademark or patent rights held by Affirmer are waived, abandoned,
->     surrendered, licensed or otherwise affected by this document.
->  b. Affirmer offers the Work as-is and makes no representations or
->     warranties of any kind concerning the Work, express, implied,
->     statutory or otherwise, including without limitation warranties of
->     title, merchantability, fitness for a particular purpose, non
->     infringement, or the absence of latent or other defects, accuracy, or
->     the present or absence of errors, whether or not discoverable, all to
->     the greatest extent permissible under applicable law.
->  c. Affirmer disclaims responsibility for clearing rights of other persons
->     that may apply to the Work or any use thereof, including without
->     limitation any person's Copyright and Related Rights in the Work.
->     Further, Affirmer disclaims responsibility for obtaining any necessary
->     consents, permissions or other rights required for any use of the
->     Work.
->  d. Affirmer understands and acknowledges that Creative Commons is not a
->     party to this document and has no duty or obligation with respect to
->     this CC0 or use of the Work.
+> a. No trademark or patent rights held by Affirmer are waived, abandoned,
+> surrendered, licensed or otherwise affected by this document.
+> b. Affirmer offers the Work as-is and makes no representations or
+> warranties of any kind concerning the Work, express, implied,
+> statutory or otherwise, including without limitation warranties of
+> title, merchantability, fitness for a particular purpose, non
+> infringement, or the absence of latent or other defects, accuracy, or
+> the present or absence of errors, whether or not discoverable, all to
+> the greatest extent permissible under applicable law.
+> c. Affirmer disclaims responsibility for clearing rights of other persons
+> that may apply to the Work or any use thereof, including without
+> limitation any person's Copyright and Related Rights in the Work.
+> Further, Affirmer disclaims responsibility for obtaining any necessary
+> consents, permissions or other rights required for any use of the
+> Work.
+> d. Affirmer understands and acknowledges that Creative Commons is not a
+> party to this document and has no duty or obligation with respect to
+> this CC0 or use of the Work.
 
 <!-- /TYPE_DEPENDENCIES -->

--- a/packages/error-debugging/pail/README.md
+++ b/packages/error-debugging/pail/README.md
@@ -180,6 +180,23 @@ pail.complete({
 
 ![usage](./__assets__/usage.png)
 
+### Which build `@visulima/pail` resolves to
+
+The `.` entry point picks a build from the export conditions your runtime or bundler sets:
+
+| Runtime                                     | Condition matched        | Build                   | Default reporter       |
+| ------------------------------------------- | ------------------------ | ----------------------- | ---------------------- |
+| Node.js, Bun, Deno (Node compat)            | `import`                 | `dist/index.server.js`  | Pretty (stdout/stderr) |
+| Browsers and bundlers targeting the browser | `browser`                | `dist/index.browser.js` | JSON (console)         |
+| Cloudflare Workers, Vercel Edge             | `workerd` / `edge-light` | `dist/index.browser.js` | JSON (console)         |
+
+The server build writes to `process.stdout` / `process.stderr` and measures the terminal, so it needs
+Node's core modules. Edge runtimes get the console-based build instead, which keeps `.` importable on
+Cloudflare Workers **without** the `nodejs_compat` flag and on Vercel Edge.
+
+Importing `@visulima/pail/server` always gives you the server build, on every runtime — use it only
+where Node core is available (on Cloudflare Workers that means enabling `nodejs_compat`).
+
 ### Custom Loggers
 
 To create a custom logger define an `options` object yielding a types field with the logger data and pass it as argument to the createPail function.

--- a/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
+++ b/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
@@ -9,6 +9,12 @@ const distributionRoot = join(here, "..", "..", "dist");
 
 const EDGE_ENTRY = join(distributionRoot, "reporter/http/http-reporter.edge-light.js");
 
+/** The artefact the `edge-light` and `workerd` conditions on the `.` export resolve to. */
+const ROOT_EDGE_ENTRY = join(distributionRoot, "index.browser.js");
+
+/** The artefact the `import` (Node) condition on the `.` export resolves to. */
+const ROOT_NODE_ENTRY = join(distributionRoot, "index.server.js");
+
 /**
  * Control sample for the graph walk: a Node-only entry that is a bare re-export file, so the
  * `node:module` its bundle depends on can only be found by following the chunk it points at.
@@ -71,6 +77,52 @@ const bareStaticImportsInGraph = (entry: string): [string, string][] => {
 };
 
 /**
+ * Every built file reachable from `entry` through relative static imports, `entry` included.
+ * @param entry Absolute path of the built entry file.
+ * @returns The dist-relative path of each chunk in the graph.
+ */
+const filesInGraph = (entry: string): string[] => {
+    const seen = new Set<string>();
+    const queue = [entry];
+
+    while (queue.length > 0) {
+        const file = queue.pop() as string;
+
+        if (seen.has(file)) {
+            continue;
+        }
+
+        seen.add(file);
+
+        for (const specifier of staticSpecifiersIn(readFileSync(file, "utf8"))) {
+            if (specifier.startsWith(".")) {
+                queue.push(resolve(dirname(file), specifier));
+            }
+        }
+    }
+
+    return [...seen];
+};
+
+/**
+ * Module-scope reaches into Node core that survive bundling but are not `import` declarations:
+ * packem's `requireCJS` transform rewrites `import ... from "node:x"` into a `createRequire` /
+ * `process.getBuiltinModule` lookup, and a bare `process` fallback. All three throw on a runtime
+ * that ships no Node core, so an import-only check would miss them.
+ * @param entry Absolute path of the built entry file.
+ * @returns One `[file, marker]` pair per offending chunk.
+ */
+const nodeCoreReachesInGraph = (entry: string): [string, string][] => {
+    const markers = ["node:", "createRequire", "getBuiltinModule"];
+
+    return filesInGraph(entry).flatMap((file) => {
+        const source = readFileSync(file, "utf8");
+
+        return markers.filter((marker) => source.includes(marker)).map((marker): [string, string] => [file.replace(`${distributionRoot}/`, ""), marker]);
+    });
+};
+
+/**
  * The `edge-light` and `workerd` export conditions resolve to this built file, so it must load
  * on runtimes that ship no Node core. A static `node:*` import breaks that at *import* time —
  * and it does not have to come from our own source: the bundler emits a CJS-interop preamble
@@ -119,5 +171,62 @@ describe("built edge HTTP reporter", () => {
 
         expect(readFileSync(NODE_ENTRY_REACHING_NODE_MODULE, "utf8")).not.toContain("node:module");
         expect(specifiers).toContain("node:module");
+    });
+});
+
+/**
+ * The root (`.`) export is the entry every consumer reaches by importing the package name, so it
+ * is the one that decides whether `@visulima/pail` can be loaded at all on Cloudflare Workers
+ * without `nodejs_compat` or on Vercel Edge. Its `edge-light`/`workerd` conditions resolve to the
+ * browser build; that build has to stay free of *any* module-scope reach into Node core, not just
+ * of `import` declarations — packem rewrites `node:*` imports into `getBuiltinModule`/
+ * `createRequire` lookups, which fail exactly as hard at load time.
+ */
+describe("built edge root entry", () => {
+    it("is what the edge-light and workerd conditions on the `.` export point at", () => {
+        expect.assertions(3);
+
+        const manifest = JSON.parse(readFileSync(join(distributionRoot, "..", "package.json"), "utf8")) as {
+            exports: Record<string, Record<string, { default: string }>>;
+        };
+
+        const root = manifest.exports["."] as Record<string, { default: string }>;
+
+        expect(root["edge-light"]?.default).toBe("./dist/index.browser.js");
+        expect(root["workerd"]?.default).toBe("./dist/index.browser.js");
+        // Node must keep resolving the server build.
+        expect(root["import"]?.default).toBe("./dist/index.server.js");
+    });
+
+    it("exists so the assertions below are not vacuous", () => {
+        expect.assertions(2);
+
+        expect(existsSync(ROOT_EDGE_ENTRY), `${ROOT_EDGE_ENTRY} is missing — run \`pnpm run build\` first`).toBe(true);
+        expect(readFileSync(ROOT_EDGE_ENTRY, "utf8")).toContain("createPail");
+    });
+
+    it("declares no static node: import anywhere in its chunk graph", () => {
+        expect.assertions(1);
+
+        expect(bareStaticImportsInGraph(ROOT_EDGE_ENTRY).filter(([, specifier]) => specifier.startsWith("node:"))).toStrictEqual([]);
+    });
+
+    it("carries no module-scope reach into Node core anywhere in its chunk graph", () => {
+        expect.assertions(1);
+
+        expect(nodeCoreReachesInGraph(ROOT_EDGE_ENTRY)).toStrictEqual([]);
+    });
+
+    it("detects the Node core reaches in the sibling server root entry", () => {
+        expect.assertions(2);
+
+        // Control sample — proves the two checks above are not passing vacuously. The server root
+        // entry is the artefact the `import` condition resolves to, and it legitimately reaches
+        // Node core: `node:module` for the CJS interop preamble, plus `getBuiltinModule` calls
+        // that the bundled terminal-size makes at module scope.
+        const markers = nodeCoreReachesInGraph(ROOT_NODE_ENTRY).map(([, marker]) => marker);
+
+        expect(bareStaticImportsInGraph(ROOT_NODE_ENTRY).map(([, specifier]) => specifier)).toContain("node:module");
+        expect(markers).toContain("getBuiltinModule");
     });
 });

--- a/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
+++ b/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distributionRoot = join(here, "..", "..", "dist");
+
+const EDGE_ENTRY = join(distributionRoot, "reporter/http/http-reporter.edge-light.js");
+
+/**
+ * Control sample for the graph walk: a Node-only entry that is a bare re-export file, so the
+ * `node:module` its bundle depends on can only be found by following the chunk it points at.
+ */
+const NODE_ENTRY_REACHING_NODE_MODULE = join(distributionRoot, "reporter/json/index.js");
+
+const STATIC_SPECIFIER_REGEX = /^(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)["']|^import\s*["']([^"']+)["']/gmu;
+
+/**
+ * Every specifier reachable through *static* `import`/`export ... from` declarations.
+ * `await import("node:zlib")` is deliberately not collected: a dynamic import is only
+ * evaluated when the branch that needs it actually runs, so it cannot break module load.
+ * @param source The bundled module source text.
+ * @returns The specifier of each static declaration, verbatim.
+ */
+const staticSpecifiersIn = (source: string): string[] => {
+    const specifiers: string[] = [];
+
+    for (const match of source.matchAll(STATIC_SPECIFIER_REGEX)) {
+        const specifier = match[1] ?? match[2];
+
+        if (specifier !== undefined) {
+            specifiers.push(specifier);
+        }
+    }
+
+    return specifiers;
+};
+
+/**
+ * Walks the built entry and every relative chunk it pulls in, so the guard keeps holding
+ * if the bundler later splits this entry across chunks instead of inlining everything.
+ * @param entry Absolute path of the built entry file.
+ * @returns One `[file, specifier]` pair per bare (non-relative) static import found.
+ */
+const bareStaticImportsInGraph = (entry: string): [string, string][] => {
+    const found: [string, string][] = [];
+    const seen = new Set<string>();
+    const queue = [entry];
+
+    while (queue.length > 0) {
+        const file = queue.pop() as string;
+
+        if (seen.has(file)) {
+            continue;
+        }
+
+        seen.add(file);
+
+        for (const specifier of staticSpecifiersIn(readFileSync(file, "utf8"))) {
+            if (specifier.startsWith(".")) {
+                queue.push(resolve(dirname(file), specifier));
+            } else {
+                found.push([file.replace(`${distributionRoot}/`, ""), specifier]);
+            }
+        }
+    }
+
+    return found;
+};
+
+/**
+ * The `edge-light` and `workerd` export conditions resolve to this built file, so it must load
+ * on runtimes that ship no Node core. A static `node:*` import breaks that at *import* time —
+ * and it does not have to come from our own source: the bundler emits a CJS-interop preamble
+ * (`import { createRequire } from "node:module"`) into any chunk that inlines a dependency
+ * doing module-scope `getBuiltinModule(...)`. The source-level guard in
+ * `__tests__/workerd/reporter/edge-module-graph.test.ts` cannot see that, so assert it here,
+ * against what actually ships.
+ */
+describe("built edge HTTP reporter", () => {
+    it("exists so the assertions below are not vacuous", () => {
+        expect.assertions(2);
+
+        expect(existsSync(EDGE_ENTRY), `${EDGE_ENTRY} is missing — run \`pnpm run build\` first`).toBe(true);
+        expect(readFileSync(EDGE_ENTRY, "utf8")).toContain("HttpReporterEdgeLight");
+    });
+
+    it("declares no static node: import anywhere in its chunk graph", () => {
+        expect.assertions(1);
+
+        expect(bareStaticImportsInGraph(EDGE_ENTRY).filter(([, specifier]) => specifier.startsWith("node:"))).toStrictEqual([]);
+    });
+
+    it("carries no module-scope CJS interop for Node builtins", () => {
+        expect.assertions(2);
+
+        const source = readFileSync(EDGE_ENTRY, "utf8");
+
+        expect(source).not.toContain("createRequire");
+        expect(source).not.toContain("getBuiltinModule");
+    });
+
+    it("reaches node:zlib only through a dynamic import", () => {
+        expect.assertions(1);
+
+        expect(readFileSync(EDGE_ENTRY, "utf8")).toContain("await import('node:zlib')");
+    });
+
+    it("detects the interop preamble in a Node-only sibling entry", () => {
+        expect.assertions(2);
+
+        // Control sample — proves the graph walk above is not passing vacuously. The JSON reporter's
+        // Node entry is nothing but re-exports and reaches `node:module` only through the chunk it
+        // points at, so a check that stopped at the entry file would miss it. The preamble is
+        // correct there in any case: that entry is never resolved on an edge runtime.
+        const specifiers = bareStaticImportsInGraph(NODE_ENTRY_REACHING_NODE_MODULE).map(([, specifier]) => specifier);
+
+        expect(readFileSync(NODE_ENTRY_REACHING_NODE_MODULE, "utf8")).not.toContain("node:module");
+        expect(specifiers).toContain("node:module");
+    });
+});

--- a/packages/error-debugging/pail/__tests__/unit/processor/message-formatter-processor.test.ts
+++ b/packages/error-debugging/pail/__tests__/unit/processor/message-formatter-processor.test.ts
@@ -248,4 +248,86 @@ describe("messageFormatterProcessor", () => {
 
         expect(processedMeta.message).toStrictEqual({ arr: ["a"], nested: { k: "v" }, nul: null, num: 5, str: "hello" });
     });
+
+    // Passing `stringify` to `build()` replaces the guarded serializer `@visulima/fmt` would
+    // otherwise use, so every way that callback can throw has to be handled here instead.
+    describe("serializer failures", () => {
+        const createMeta = (message: string, context: unknown[]): Meta<string> => {
+            return {
+                badge: undefined,
+                context,
+                date: new Date(),
+                error: undefined,
+                groups: [],
+                label: undefined,
+                message,
+                prefix: undefined,
+                repeated: undefined,
+                scope: undefined,
+                suffix: undefined,
+                traceError: undefined,
+                type: {
+                    level: "info",
+                    name: "test",
+                },
+            };
+        };
+
+        it("renders an indirect cycle as [Circular] instead of throwing", () => {
+            expect.assertions(1);
+
+            const processor = new MessageFormatterProcessor();
+
+            const a: Record<string, unknown> = {};
+            const b: Record<string, unknown> = {};
+            const c: Record<string, unknown> = {};
+
+            a.b = b;
+            b.c = c;
+            c.a = a;
+
+            expect(processor.process(createMeta("Hello %o", [a])).message).toBe("Hello \"[Circular]\"");
+        });
+
+        it("serializes a repeated but acyclic reference normally", () => {
+            expect.assertions(1);
+
+            const processor = new MessageFormatterProcessor();
+            const shared = { id: 1 };
+
+            // The same object twice is not a cycle: `JSON.stringify` handles it, so the value must
+            // survive intact rather than be written off as circular.
+            expect(processor.process(createMeta("Hello %j", [{ left: shared, right: shared }])).message).toBe(
+                "Hello {\"left\":{\"id\":1},\"right\":{\"id\":1}}",
+            );
+        });
+
+        it("reports a supplied stringify that throws without crashing the log call", () => {
+            expect.assertions(1);
+
+            const processor = new MessageFormatterProcessor();
+
+            processor.setStringify(() => {
+                throw new Error("serializer exploded");
+            });
+
+            // A defect in the consumer's serializer must stay visible in the output — it is not a
+            // cycle, so it must not be disguised as one.
+            expect(processor.process(createMeta("Hello %o", [{ prop: "value" }])).message).toBe("Hello \"[unserializable: serializer exploded]\"");
+        });
+
+        it("prefers a supplied stringify over the built-in circular guard", () => {
+            expect.assertions(1);
+
+            const processor = new MessageFormatterProcessor();
+
+            processor.setStringify((value: unknown) => `<${typeof value}>`);
+
+            const object: Record<string, unknown> = { prop: "value" };
+
+            object.circular = object;
+
+            expect(processor.process(createMeta("Hello %o", [object])).message).toBe("Hello <object>");
+        });
+    });
 });

--- a/packages/error-debugging/pail/__tests__/workerd/core/helpers.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/helpers.ts
@@ -1,0 +1,92 @@
+/* eslint-disable max-classes-per-file -- two tiny reporter doubles shared by the workerd specs */
+import { Writable } from "node:stream";
+
+import type { Meta, ReadonlyMeta, Reporter, StreamAwareReporter } from "../../../src/types";
+import isStderrLevel from "../../../src/utils/is-stderr-level";
+import writeStream from "../../../src/utils/write-stream";
+
+/**
+ * An in-memory replacement for `process.stdout` / `process.stderr` built on
+ * `node:stream`'s `Writable`. Used to assert what pail wrote without depending
+ * on workerd's console-backed std streams.
+ */
+export interface MemoryStream {
+    chunks: string[];
+    stream: NodeJS.WriteStream;
+}
+
+/** Renders a `Meta.message` (a primitive, array or record) as text for stream assertions. */
+export const messageToText = (message: unknown): string => {
+    if (typeof message === "string") {
+        return message;
+    }
+
+    return JSON.stringify(message) ?? "";
+};
+
+export const createMemoryStream = (): MemoryStream => {
+    const chunks: string[] = [];
+
+    const stream = new Writable({
+        write(chunk: unknown, _encoding: unknown, callback: () => void): void {
+            chunks.push(String(chunk));
+            callback();
+        },
+    }) as unknown as NodeJS.WriteStream;
+
+    return { chunks, stream };
+};
+
+/**
+ * Minimal stream-aware reporter that exercises pail's own stream routing
+ * helpers (`is-stderr-level` + `write-stream`) instead of pulling in the
+ * package's shipped reporters.
+ */
+export class StreamCaptureReporter implements StreamAwareReporter<string> {
+    #stdout: NodeJS.WriteStream | undefined;
+
+    #stderr: NodeJS.WriteStream | undefined;
+
+    public setStdout(stdout: NodeJS.WriteStream): void {
+        this.#stdout = stdout;
+    }
+
+    public setStderr(stderr: NodeJS.WriteStream): void {
+        this.#stderr = stderr;
+    }
+
+    public log(meta: ReadonlyMeta<string>): void {
+        writeStream(messageToText(meta.message), isStderrLevel(meta.type.level) ? this.#stderr : this.#stdout);
+    }
+}
+
+/** Collects every `Meta` handed to it so tests can assert on the pipeline output. */
+export class MetaCaptureReporter implements Reporter<string> {
+    public readonly metas: ReadonlyMeta<string>[] = [];
+
+    public log(meta: ReadonlyMeta<string>): void {
+        this.metas.push(meta);
+    }
+
+    public get messages(): unknown[] {
+        return this.metas.map((meta) => meta.message);
+    }
+}
+
+/** Builds a `Meta` object shaped like the one pail's pipeline produces. */
+export const createMeta = (overrides: Partial<Meta<string>> = {}): Meta<string> =>
+    ({
+        badge: undefined,
+        context: undefined,
+        date: new Date(),
+        error: undefined,
+        groups: [],
+        label: undefined,
+        message: "message",
+        prefix: undefined,
+        scope: undefined,
+        suffix: undefined,
+        traceError: undefined,
+        type: { level: "informational", name: "info" },
+        ...overrides,
+    }) as Meta<string>;

--- a/packages/error-debugging/pail/__tests__/workerd/core/index-server.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/index-server.test.ts
@@ -1,0 +1,123 @@
+import { env, stderr, stdout } from "node:process";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createPail, pail } from "../../../src/index.server";
+import { MetaCaptureReporter } from "./helpers";
+
+const withEnvironment = <T>(patch: Record<string, string | undefined>, run: () => T): T => {
+    const previous: Record<string, string | undefined> = {};
+
+    for (const key of Object.keys(patch)) {
+        previous[key] = env[key];
+
+        if (patch[key] === undefined) {
+            Reflect.deleteProperty(env, key);
+        } else {
+            env[key] = patch[key];
+        }
+    }
+
+    try {
+        return run();
+    } finally {
+        for (const key of Object.keys(previous)) {
+            if (previous[key] === undefined) {
+                Reflect.deleteProperty(env, key);
+            } else {
+                env[key] = previous[key];
+            }
+        }
+    }
+};
+
+describe("index.server in workerd", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("exposes node:process env as a mutable record", () => {
+        expect.assertions(2);
+
+        // `nodejs_compat` maps worker bindings onto `process.env`. NODE_ENV is not set
+        // by the runtime, so `getDefaultLogLevel()` must fall through to its default
+        // rather than assuming a Node-style environment.
+        expect(env).toBeTypeOf("object");
+
+        withEnvironment({ PAIL_WORKERD_PROBE: "yes" }, () => {
+            expect(env.PAIL_WORKERD_PROBE).toBe("yes");
+        });
+    });
+
+    it("creates a usable logger that writes to the node:process streams", () => {
+        expect.assertions(2);
+
+        const outSpy = vi.spyOn(stdout, "write").mockImplementation(() => true);
+        const errorSpy = vi.spyOn(stderr, "write").mockImplementation(() => true);
+
+        const logger = createPail();
+
+        logger.info("workerd default reporter");
+        logger.error(new Error("workerd failure"));
+
+        expect(outSpy.mock.calls.map((call) => String(call[0])).join("")).toContain("workerd default reporter");
+        expect(errorSpy.mock.calls.map((call) => String(call[0])).join("")).toContain("workerd failure");
+    });
+
+    it("evaluates the eagerly constructed `pail` export at import time", () => {
+        expect.assertions(2);
+
+        const outSpy = vi.spyOn(stdout, "write").mockImplementation(() => true);
+
+        expect(pail.info).toBeTypeOf("function");
+
+        pail.info("module scope logger");
+
+        expect(outSpy.mock.calls.map((call) => String(call[0])).join("")).toContain("module scope logger");
+    });
+
+    it("reads the log level from PAIL_LOG_LEVEL in node:process env", () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+
+        withEnvironment({ DEBUG: undefined, NODE_ENV: undefined, PAIL_LOG_LEVEL: "error" }, () => {
+            const logger = createPail({ reporters: [reporter] });
+
+            logger.info("suppressed");
+            logger.error("kept");
+        });
+
+        expect(reporter.messages).toStrictEqual(["kept"]);
+        expect(reporter.metas[0].type.level).toBe("error");
+    });
+
+    it("falls back to the informational level when no environment hints are present", () => {
+        expect.assertions(1);
+
+        const reporter = new MetaCaptureReporter();
+
+        withEnvironment({ DEBUG: undefined, NODE_ENV: undefined, PAIL_LOG_LEVEL: undefined }, () => {
+            const logger = createPail({ reporters: [reporter] });
+
+            logger.debug("dropped below informational");
+            logger.info("kept at informational");
+        });
+
+        expect(reporter.messages).toStrictEqual(["kept at informational"]);
+    });
+
+    it("switches to debug when DEBUG is set in node:process env", () => {
+        expect.assertions(1);
+
+        const reporter = new MetaCaptureReporter();
+
+        withEnvironment({ DEBUG: "1", NODE_ENV: undefined, PAIL_LOG_LEVEL: undefined }, () => {
+            const logger = createPail({ reporters: [reporter] });
+
+            logger.debug("visible in debug mode");
+        });
+
+        expect(reporter.messages).toStrictEqual(["visible in debug mode"]);
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/middleware.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/middleware.test.ts
@@ -1,0 +1,244 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { describe, expect, it } from "vitest";
+
+import { pailPlugin, useLogger as useElysiaLogger } from "../../../src/middleware/elysia";
+import type { PailHonoContext } from "../../../src/middleware/hono";
+import { pailMiddleware as honoMiddleware, useLogger as useHonoLogger } from "../../../src/middleware/hono";
+import { createWithPail } from "../../../src/middleware/next/handler";
+import { useLogger as useNextLogger } from "../../../src/middleware/next/storage";
+import { extractSafeHeaders } from "../../../src/middleware/shared/headers";
+import { createLoggerStorage } from "../../../src/middleware/shared/storage";
+import type { PailBrowserType } from "../../../src/pail.browser";
+import { PailBrowser } from "../../../src/pail.browser";
+import { MetaCaptureReporter } from "./helpers";
+
+const createLogger = (): { logger: PailBrowserType; reporter: MetaCaptureReporter } => {
+    const reporter = new MetaCaptureReporter();
+    const logger = new PailBrowser({ reporters: [reporter], throttle: 0 });
+
+    return { logger, reporter };
+};
+
+const createHonoContext = (path: string, headers: Record<string, string> = {}): PailHonoContext => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- `Map`'s value parameter has no default in lib.es2015.collection.d.ts; typescript-eslint misreads it as `unknown` under TypeScript 6, and omitting it is a hard `tsc` error (TS2743).
+    const store = new Map<string, unknown>();
+    const requestHeaders = new Headers(headers);
+
+    return {
+        get: (key: string) => store.get(key),
+        req: {
+            header: (name: string) => requestHeaders.get(name) ?? undefined,
+            method: "GET",
+            path,
+            raw: { headers: requestHeaders },
+        },
+        res: { status: 200 },
+        set: (key: string, value: unknown) => {
+            store.set(key, value);
+        },
+    };
+};
+
+const ENTER_WITH_REGEX = /enterWith/;
+const UUID_REGEX = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/;
+
+interface ElysiaHooks {
+    afterHandle?: (context: { request: Request; set: { status?: number } }) => Promise<void>;
+    derive?: (context: { request: Request }) => Record<string, unknown>;
+}
+
+const registerElysiaPlugin = (): { hooks: ElysiaHooks; reporter: MetaCaptureReporter } => {
+    const { logger, reporter } = createLogger();
+    const hooks: ElysiaHooks = {};
+
+    const app = {
+        derive: (_options: { as: string }, handler: (context: { request: Request }) => Record<string, unknown>) => {
+            hooks.derive = handler;
+
+            return app;
+        },
+        onAfterHandle: (_options: { as: string }, handler: (context: { request: Request; set: { status?: number } }) => Promise<void>) => {
+            hooks.afterHandle = handler;
+
+            return app;
+        },
+        onError: () => app,
+    } as never;
+
+    pailPlugin(app, { pail: logger as never });
+
+    return { hooks, reporter };
+};
+
+describe("middleware in workerd", () => {
+    describe("node:async_hooks storage", () => {
+        it("propagates the store across awaited boundaries", async () => {
+            expect.assertions(2);
+
+            const { storage, useLogger } = createLoggerStorage("test context");
+            const event = { name: "scoped" } as never;
+
+            const seen = await storage.run(event, async () => {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 1);
+                });
+
+                return useLogger();
+            });
+
+            expect(seen).toBe(event);
+            expect(storage.getStore()).toBeUndefined();
+        });
+
+        it("throws an actionable error outside of a request scope", () => {
+            expect.assertions(1);
+
+            const { useLogger } = createLoggerStorage("Express middleware context");
+
+            expect(() => useLogger()).toThrow("[pail] useLogger() called outside of Express middleware context");
+        });
+
+        it("does not implement AsyncLocalStorage.enterWith()", () => {
+            expect.assertions(1);
+
+            const storage = new AsyncLocalStorage<string>();
+
+            // Documented workerd limitation: `run()` is supported but `enterWith()` is not.
+            // Anything in pail that relied on it has to degrade instead of throwing.
+            expect(() => {
+                storage.enterWith("value");
+            }).toThrow(ENTER_WITH_REGEX);
+        });
+    });
+
+    describe("next handler", () => {
+        it("runs the handler inside AsyncLocalStorage and emits one wide event", async () => {
+            expect.assertions(3);
+
+            const { logger, reporter } = createLogger();
+            const withPail = createWithPail({ pail: logger as never });
+
+            const handler = withPail(async (_request: Request) => {
+                const log = useNextLogger();
+
+                log.set({ handled: true });
+
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 1);
+                });
+
+                return new Response("ok", { status: 201 });
+            });
+
+            const response = await handler(new Request("https://example.com/api/users", { headers: { "x-request-id": "req-1" } }));
+            const payload = reporter.metas[0].message as Record<string, unknown>;
+
+            expect(response.status).toBe(201);
+            expect(payload.requestId).toBe("req-1");
+            expect({ handled: payload.handled, path: payload.path, status: payload.status }).toStrictEqual({
+                handled: true,
+                path: "/api/users",
+                status: 201,
+            });
+        });
+
+        it("emits the wide event with the error when the handler throws", async () => {
+            expect.assertions(2);
+
+            const { logger, reporter } = createLogger();
+            const withPail = createWithPail({ pail: logger as never });
+
+            const handler = withPail((_request: Request) => {
+                throw new Error("handler exploded");
+            });
+
+            await expect(handler(new Request("https://example.com/api/boom"))).rejects.toThrow("handler exploded");
+
+            const payload = reporter.metas[0].message as { error: { message: string }; status: number };
+
+            expect({ message: payload.error.message, status: payload.status }).toStrictEqual({ message: "handler exploded", status: 500 });
+        });
+    });
+
+    describe("hono middleware", () => {
+        it("uses web-standard Headers and crypto.randomUUID", async () => {
+            expect.assertions(3);
+
+            const { logger, reporter } = createLogger();
+            const middleware = honoMiddleware({ pail: logger as never });
+            const context = createHonoContext("/api/items", { authorization: "Bearer secret", "x-tenant": "acme" });
+
+            await middleware(context, async () => {
+                const log = useHonoLogger(context);
+
+                log.set({ items: 2 });
+            });
+
+            const payload = reporter.metas[0].message as { headers: Record<string, string>; items: number; requestId: string };
+
+            expect(payload.items).toBe(2);
+            expect(payload.headers).toStrictEqual({ "x-tenant": "acme" });
+            // No `x-request-id` header was sent, so the middleware falls back to Web Crypto.
+            expect(payload.requestId).toMatch(UUID_REGEX);
+        });
+
+        it("skips excluded routes without emitting", async () => {
+            expect.assertions(1);
+
+            const { logger, reporter } = createLogger();
+            const middleware = honoMiddleware({ exclude: ["/health"], pail: logger as never });
+
+            await middleware(createHonoContext("/health"), async () => {});
+
+            expect(reporter.metas).toStrictEqual([]);
+        });
+    });
+
+    describe("elysia plugin", () => {
+        it("still injects the logger into the handler context on runtimes without enterWith()", async () => {
+            expect.assertions(2);
+
+            const { hooks, reporter } = registerElysiaPlugin();
+            const request = new Request("https://example.com/api/orders");
+            const derived = hooks.derive?.({ request }) as { log: { set: (data: Record<string, unknown>) => void } };
+
+            derived.log.set({ orders: 4 });
+
+            await hooks.afterHandle?.({ request, set: { status: 200 } });
+
+            const payload = reporter.metas[0].message as { orders: number; path: string };
+
+            expect(payload.orders).toBe(4);
+            expect(payload.path).toBe("/api/orders");
+        });
+
+        it("reports that the ambient useLogger() accessor is unavailable", () => {
+            expect.assertions(1);
+
+            const { hooks } = registerElysiaPlugin();
+
+            hooks.derive?.({ request: new Request("https://example.com/api/orders") });
+
+            // `useLogger()` needs `AsyncLocalStorage.enterWith()`, which workerd does not
+            // implement — the accessor must explain that rather than surfacing a generic
+            // "outside of plugin context" error.
+            expect(() => useElysiaLogger()).toThrow(ENTER_WITH_REGEX);
+        });
+    });
+
+    describe("shared headers", () => {
+        it("filters sensitive entries from a web-standard Headers object", () => {
+            expect.assertions(1);
+
+            const headers = new Headers({
+                authorization: "Bearer secret",
+                cookie: "session=1",
+                "x-api-key": "key",
+                "x-trace": "abc",
+            });
+
+            expect(extractSafeHeaders(headers)).toStrictEqual({ "x-trace": "abc" });
+        });
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/pail-browser.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/pail-browser.test.ts
@@ -1,0 +1,200 @@
+import process from "node:process";
+
+import { describe, expect, it } from "vitest";
+
+import { PailBrowser } from "../../../src/pail.browser";
+import { messageToText, MetaCaptureReporter } from "./helpers";
+
+const TIMER_MESSAGE_REGEX = /^Timer run for: \d+ ms$/;
+
+describe("pailBrowser core pipeline in workerd", () => {
+    it("filters by log level and honours the force channel", () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ logLevel: "error", reporters: [reporter] });
+
+        logger.info("dropped");
+        logger.error("kept");
+        logger.force.info("forced through");
+
+        expect(reporter.messages).toStrictEqual(["kept", "forced through"]);
+        expect(reporter.metas[1].type.name).toBe("info");
+    });
+
+    it("queues while paused and flushes in order on resume", () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.pause();
+        logger.info("first");
+        logger.info("second");
+
+        expect(reporter.messages).toStrictEqual([]);
+
+        logger.resume();
+
+        expect(reporter.messages).toStrictEqual(["first", "second"]);
+    });
+
+    it("stops reporting when disabled and resumes when enabled", () => {
+        expect.assertions(3);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.disable();
+
+        expect(logger.isEnabled()).toBe(false);
+
+        logger.info("dropped");
+        logger.enable();
+        logger.info("kept");
+
+        expect(logger.isEnabled()).toBe(true);
+        expect(reporter.messages).toStrictEqual(["kept"]);
+    });
+
+    it("throttles repeated logs using Date and setTimeout", async () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter], throttle: 200, throttleMin: 2 });
+
+        for (let index = 0; index < 6; index += 1) {
+            logger.info("repeated");
+        }
+
+        // throttleMin + 1 records make it through before the dedup window kicks in.
+        expect(reporter.metas).toHaveLength(3);
+
+        // workerd advances timers on I/O; the deferred flush must still fire.
+        await new Promise((resolve) => {
+            setTimeout(resolve, 400);
+        });
+
+        expect(reporter.metas.at(-1)?.repeated).toBe(3);
+    });
+
+    it("tracks console groups internally because workerd has no window", () => {
+        expect.assertions(2);
+
+        expect(globalThis.window).toBeUndefined();
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.group("outer");
+        logger.info("grouped");
+
+        expect(reporter.metas[0].groups).toStrictEqual(["outer"]);
+
+        logger.groupEnd();
+    });
+
+    it("emits timer lifecycle records with a monotonic-enough Date clock", async () => {
+        expect.assertions(3);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.time("workerd-timer");
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+
+        logger.timeEnd("workerd-timer");
+
+        expect(reporter.metas[0].type.name).toBe("start");
+        expect(reporter.metas[1].type.name).toBe("stop");
+        expect(messageToText(reporter.metas[1].message)).toMatch(TIMER_MESSAGE_REGEX);
+    });
+
+    it("counts and resets counters", () => {
+        expect.assertions(1);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter], throttle: 0 });
+
+        logger.count("hits");
+        logger.count("hits");
+        logger.countReset("hits");
+        logger.count("hits");
+
+        expect(reporter.messages).toStrictEqual(["hits: 1", "hits: 2", "hits: 1"]);
+    });
+
+    it("wraps and restores the workerd console by behaviour", () => {
+        expect.assertions(5);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.wrapConsole();
+
+        // Pail-only types are added to console and recorded for removal.
+        expect(Object.hasOwn(console, "__log")).toBe(true);
+        expect(Object.hasOwn(console, "success")).toBe(true);
+
+        // eslint-disable-next-line no-console
+        console.log("through pail");
+
+        expect(reporter.messages).toStrictEqual(["through pail"]);
+
+        logger.restoreConsole();
+
+        // eslint-disable-next-line no-console
+        console.log("after restore");
+
+        // workerd's `console` is an exotic object: assigning a function to it stores a
+        // re-bound copy, so identity comparisons (`console.log === original`) can never
+        // hold. Assert the restored *behaviour* instead — nothing else reaches the logger.
+        expect(reporter.messages).toStrictEqual(["through pail"]);
+        expect(Object.hasOwn(console, "success")).toBe(false);
+    });
+
+    it("registers and removes node:process exception handlers exactly once", () => {
+        expect.assertions(4);
+
+        const logger = new PailBrowser({ reporters: [new MetaCaptureReporter()] });
+
+        const uncaughtBefore = process.listenerCount("uncaughtException");
+        const rejectionBefore = process.listenerCount("unhandledRejection");
+
+        logger.wrapException();
+
+        expect(process.listenerCount("uncaughtException")).toBe(uncaughtBefore + 1);
+
+        // Second call must not stack a duplicate listener.
+        logger.wrapException();
+
+        expect(process.listenerCount("uncaughtException")).toBe(uncaughtBefore + 1);
+
+        logger.restoreException();
+
+        expect(process.listenerCount("uncaughtException")).toBe(uncaughtBefore);
+        expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore);
+    });
+
+    it("reports an unhandled rejection through the logger when workerd emits one", () => {
+        expect.assertions(1);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter] });
+
+        logger.wrapException();
+
+        try {
+            const error = new Error("rejected");
+
+            process.emit("unhandledRejection", error, Promise.resolve());
+
+            expect(reporter.metas[0]?.error).toBe(error);
+        } finally {
+            logger.restoreException();
+        }
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/pail-server.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/pail-server.test.ts
@@ -1,0 +1,207 @@
+import { stderr, stdout } from "node:process";
+import { Writable } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { PailServer } from "../../../src/pail.server";
+import writeStream from "../../../src/utils/write-stream";
+import { createMemoryStream, MetaCaptureReporter, StreamCaptureReporter } from "./helpers";
+
+describe("pailServer in workerd", () => {
+    it("resolves node:process std streams to writable objects", () => {
+        expect.assertions(4);
+
+        // workerd's `nodejs_compat` shim exposes stdout/stderr as real Writables that
+        // forward to the console. They are never TTYs, so anything gated on `isTTY`
+        // has to degrade instead of assuming a terminal.
+        expect(stdout.write).toBeTypeOf("function");
+        expect(stderr.write).toBeTypeOf("function");
+        expect(stdout instanceof Writable).toBe(true);
+        expect(stdout.isTTY).toBeUndefined();
+    });
+
+    it("routes informational output to stdout and high-severity output to stderr", () => {
+        expect.assertions(2);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+
+        const logger = new PailServer({
+            reporters: [new StreamCaptureReporter()],
+            stderr: error.stream,
+            stdout: out.stream,
+        });
+
+        logger.info("info message");
+        logger.warn("warning message");
+        logger.error("error message");
+
+        expect(out.chunks).toStrictEqual(["info message"]);
+        expect(error.chunks).toStrictEqual(["warning message", "error message"]);
+    });
+
+    it("writes through the node:process stdout stream", () => {
+        expect.assertions(1);
+
+        const spy = vi.spyOn(stdout, "write").mockImplementation(() => true);
+
+        try {
+            const logger = new PailServer({ reporters: [new StreamCaptureReporter()], stderr, stdout });
+
+            logger.info("straight to workerd stdout");
+
+            expect(spy.mock.calls.map((call) => String(call[0]))).toStrictEqual(["straight to workerd stdout"]);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it("clear() writes the terminal reset sequence to both streams", () => {
+        expect.assertions(3);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+
+        const logger = new PailServer({ stderr: error.stream, stdout: out.stream });
+
+        logger.clear();
+
+        expect(out.chunks).toHaveLength(1);
+        expect(error.chunks).toHaveLength(1);
+        // The reset sequence is a plain ANSI escape string — nothing terminal-specific
+        // is probed, so it stays writable on a non-TTY workerd stream.
+        expect(out.chunks[0]).toContain("\u001B");
+    });
+
+    it("wrapStd() redirects raw stream writes through the logger and restoreStd() undoes it", () => {
+        expect.assertions(3);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+
+        const logger = new PailServer({ reporters: [new StreamCaptureReporter()], stderr: error.stream, stdout: out.stream });
+
+        logger.wrapStd();
+        out.stream.write("through the logger");
+
+        expect(out.chunks).toStrictEqual(["through the logger"]);
+
+        logger.restoreStd();
+        out.stream.write("direct write");
+
+        expect(out.chunks).toStrictEqual(["through the logger", "direct write"]);
+        expect((out.stream as unknown as Record<string, unknown>).__write).toBeUndefined();
+    });
+
+    it("creates an interactive manager even though workerd streams are not TTYs", () => {
+        expect.assertions(2);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+
+        const logger = new PailServer({
+            interactive: true,
+            reporters: [new StreamCaptureReporter()],
+            stderr: error.stream,
+            stdout: out.stream,
+        });
+
+        expect(logger.getInteractiveManager()).toBeDefined();
+
+        // Interactive rendering must fall back to a plain write when there is no TTY.
+        logger.info("interactive fallback");
+
+        expect(out.chunks).toStrictEqual(["interactive fallback"]);
+    });
+
+    it("child() inherits the parent streams", () => {
+        expect.assertions(2);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+
+        const parent = new PailServer({ reporters: [new StreamCaptureReporter()], stderr: error.stream, stdout: out.stream });
+        const child = parent.child({ scope: ["child"] });
+
+        child.info("from the child");
+
+        expect(out.chunks).toStrictEqual(["from the child"]);
+
+        const other = createMemoryStream();
+        const overridden = parent.child({ stdout: other.stream });
+
+        overridden.info("overridden stream");
+
+        expect(other.chunks).toStrictEqual(["overridden stream"]);
+    });
+
+    describe("when the runtime provides no std streams", () => {
+        // `node:process` does not expose `stdout`/`stderr` on every edge runtime — older
+        // workerd compatibility dates and `nodejs_compat`-less deployments hand
+        // `createPail()` a pair of `undefined` streams. The logger has to degrade instead
+        // of throwing on the first write.
+        const missing = undefined as unknown as NodeJS.WriteStream;
+
+        it("keeps the processing pipeline alive and drops stream writes", () => {
+            expect.assertions(2);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailServer({ reporters: [reporter, new StreamCaptureReporter()], stderr: missing, stdout: missing });
+
+            logger.info("still processed");
+            logger.error("still processed too");
+
+            expect(reporter.messages).toStrictEqual(["still processed", "still processed too"]);
+            expect(writeStream("dropped", missing)).toBe(false);
+        });
+
+        it("degrades clear(), wrapStd() and raw() to no-ops", () => {
+            expect.assertions(3);
+
+            const logger = new PailServer({ reporters: [], stderr: missing, stdout: missing });
+
+            expect(() => {
+                logger.clear();
+            }).not.toThrow();
+            expect(() => {
+                logger.wrapStd();
+                logger.restoreStd();
+            }).not.toThrow();
+            expect(() => {
+                logger.raw("raw payload");
+            }).not.toThrow();
+        });
+
+        it("stays non-interactive because the interactive hooks need real streams", () => {
+            expect.assertions(1);
+
+            const logger = new PailServer({ interactive: true, reporters: [], stderr: missing, stdout: missing });
+
+            expect(logger.getInteractiveManager()).toBeUndefined();
+        });
+    });
+
+    it("scope() nests scopes without mutating the receiver", () => {
+        expect.assertions(2);
+
+        const out = createMemoryStream();
+        const error = createMemoryStream();
+        const scopes: (string[] | undefined)[] = [];
+
+        const parent = new PailServer({
+            reporters: [{ log: (meta) => scopes.push(meta.scope) }],
+            stderr: error.stream,
+            stdout: out.stream,
+        });
+
+        const outer = parent.scope("outer");
+        const inner = outer.scope("inner");
+
+        outer.info("a");
+        inner.info("b");
+        parent.info("c");
+
+        expect(scopes).toStrictEqual([["outer"], ["outer", "inner"], []]);
+        expect(out.chunks).toStrictEqual([]);
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/processors.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/processors.test.ts
@@ -1,0 +1,146 @@
+import process, { env } from "node:process";
+
+import { describe, expect, it } from "vitest";
+
+import { PailBrowser } from "../../../src/pail.browser";
+import CallerProcessor from "../../../src/processor/caller/caller-processor";
+import getCallerFilename from "../../../src/processor/caller/get-caller-filename";
+import EnvironmentProcessor, { detectEnvironment } from "../../../src/processor/environment-processor";
+import MessageFormatterProcessor from "../../../src/processor/message-formatter-processor";
+import SamplingProcessor from "../../../src/processor/sampling-processor";
+import { createMeta, MetaCaptureReporter } from "./helpers";
+
+describe("processors in workerd", () => {
+    describe("environmentProcessor", () => {
+        it("reads platform hints from node:process env", () => {
+            expect.assertions(3);
+
+            env.SERVICE_NAME = "workerd-service";
+            env.CF_PAGES_COMMIT_SHA = "abcdef1234567890";
+
+            try {
+                const detected = detectEnvironment();
+
+                expect(detected.service).toBe("workerd-service");
+                expect(detected.commit).toBe("abcdef1");
+                // `process.pid` is shimmed by `nodejs_compat`; it must still be a number.
+                expect(detected.pid).toBeTypeOf("number");
+            } finally {
+                delete env.SERVICE_NAME;
+                delete env.CF_PAGES_COMMIT_SHA;
+            }
+        });
+
+        it("attaches the detected environment to the log meta", () => {
+            expect.assertions(2);
+
+            const processor = new EnvironmentProcessor({ includePid: true, overrides: { service: "pinned" } });
+            const enriched = processor.process(createMeta()) as ReturnType<EnvironmentProcessor["process"]> & {
+                envStorage?: { pid?: number; service?: string };
+            };
+
+            expect(enriched.envStorage?.service).toBe("pinned");
+            expect(enriched.envStorage?.pid).toBe(process.pid);
+        });
+    });
+
+    describe("callerProcessor", () => {
+        it("resolves a call site through V8's prepareStackTrace hook", () => {
+            expect.assertions(3);
+
+            const caller = getCallerFilename();
+
+            expect(caller.fileName).toBeTypeOf("string");
+            expect(caller.fileName).toContain("processors.test");
+            expect(caller.columnNumber).toBeTypeOf("number");
+        });
+
+        it("restores Error.prepareStackTrace after use", () => {
+            expect.assertions(2);
+
+            const before = Error.prepareStackTrace;
+
+            new CallerProcessor().process(createMeta());
+
+            expect(Error.prepareStackTrace).toBe(before);
+            expect(new Error("plain").stack).toBeTypeOf("string");
+        });
+
+        it("adds file information to a log record end to end", () => {
+            expect.assertions(2);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailBrowser({ processors: [new CallerProcessor()], reporters: [reporter] });
+
+            logger.info("with caller");
+
+            const { file } = reporter.metas[0] as { file?: { column?: number; line?: number; name?: string } };
+
+            expect(file).toStrictEqual({ column: expect.any(Number), line: expect.any(Number), name: expect.any(String) });
+            // A resolved path proves workerd surfaced real call sites rather than the
+            // "anonymous" fallback the helper uses when every frame is filtered out.
+            expect(file?.name).not.toBe("anonymous");
+        });
+    });
+
+    describe("samplingProcessor", () => {
+        it("drops records marked by head sampling before they reach reporters", () => {
+            expect.assertions(1);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailBrowser({
+                processors: [new SamplingProcessor({ head: { informational: 0 } })],
+                reporters: [reporter],
+            });
+
+            logger.info("sampled out");
+            logger.error("kept");
+
+            expect(reporter.messages).toStrictEqual(["kept"]);
+        });
+
+        it("force-keeps records matched by a tail condition", () => {
+            expect.assertions(1);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailBrowser({
+                processors: [
+                    new SamplingProcessor({
+                        head: { informational: 0 },
+                        tail: [(meta) => meta.scope?.includes("critical") ?? false],
+                    }),
+                ],
+                reporters: [reporter],
+                scope: ["critical"],
+            });
+
+            logger.info("kept by tail sampling");
+
+            expect(reporter.messages).toStrictEqual(["kept by tail sampling"]);
+        });
+    });
+
+    describe("messageFormatterProcessor", () => {
+        it("interpolates arguments without any Node-only formatting helpers", () => {
+            expect.assertions(1);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailBrowser({ processors: [new MessageFormatterProcessor()], reporters: [reporter] });
+
+            logger.info("hello %s, you are %d", "workerd", 42);
+
+            expect(reporter.messages).toStrictEqual(["hello workerd, you are 42"]);
+        });
+
+        it("serializes objects through the configured stringify implementation", () => {
+            expect.assertions(1);
+
+            const reporter = new MetaCaptureReporter();
+            const logger = new PailBrowser({ processors: [new MessageFormatterProcessor()], reporters: [reporter] });
+
+            logger.info("payload %j", { nested: { value: 1 } });
+
+            expect(String(reporter.messages[0])).toContain("\"nested\"");
+        });
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/runtime-surface.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/runtime-surface.test.ts
@@ -1,0 +1,83 @@
+import { Buffer } from "node:buffer";
+import process from "node:process";
+
+import { describe, expect, it } from "vitest";
+
+import { createPailError, PailError } from "../../../src/error";
+import { renderObjectTree } from "../../../src/object-tree";
+import { PailBrowser } from "../../../src/pail.browser";
+import MessageFormatterProcessor from "../../../src/processor/message-formatter-processor";
+import { MetaCaptureReporter } from "./helpers";
+
+const NODE_VERSION_REGEX = /^\d+\./;
+
+describe("runtime surface in workerd", () => {
+    it("loads pail as ESM without any CommonJS interop", () => {
+        expect.assertions(2);
+
+        // workerd modules are ESM-only: a stray `require(` on a core code path would
+        // have thrown at import time rather than reaching this assertion.
+        expect((globalThis as { require?: unknown }).require).toBeTypeOf("undefined");
+        expect(PailBrowser).toBeTypeOf("function");
+    });
+
+    it("reports a Node-compatible version string without a real Node runtime", () => {
+        expect.assertions(2);
+
+        // Feature detection based on `process.versions.node` cannot be used to tell
+        // workerd from Node — `nodejs_compat` reports a Node version, and every other
+        // key is blank.
+        expect(process.versions.node).toMatch(NODE_VERSION_REGEX);
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- `navigator` is always present in workerd
+        expect(navigator.userAgent).toBe("Cloudflare-Workers");
+    });
+
+    it("logs Buffer values through the default stringify implementation", () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ processors: [new MessageFormatterProcessor()], reporters: [reporter], throttle: 0 });
+
+        logger.info(Buffer.from("payload"));
+        logger.info("bytes %j", Buffer.from([1, 2]));
+
+        expect(String(reporter.messages[0])).toBe("payload");
+        expect(String(reporter.messages[1])).toContain("\"data\"");
+    });
+
+    it("renders object trees with no runtime-specific dependencies", () => {
+        expect.assertions(1);
+
+        expect(renderObjectTree({ age: 30, name: "John" })).toBe("├─ name: John\n└─ age: 30");
+    });
+
+    it("supports Error `cause` and structured PailError serialization", () => {
+        expect.assertions(4);
+
+        const error = createPailError({
+            cause: new Error("issuer down"),
+            fix: "retry with another card",
+            message: "payment failed",
+            status: 402,
+            why: "card declined",
+        });
+
+        expect(error).toBeInstanceOf(PailError);
+        expect(error.toJSON()).toMatchObject({ fix: "retry with another card", name: "PailError", status: 402, why: "card declined" });
+        expect(error.toString()).toContain("Cause: issuer down");
+        expect(error.stack).toBeTypeOf("string");
+    });
+
+    it("routes an Error argument onto meta.error", () => {
+        expect.assertions(2);
+
+        const reporter = new MetaCaptureReporter();
+        const logger = new PailBrowser({ reporters: [reporter], throttle: 0 });
+        const error = new PailError("boom");
+
+        logger.error(error, { requestId: "abc" });
+
+        expect(reporter.metas[0].error).toBe(error);
+        expect(reporter.metas[0].context).toStrictEqual([{ requestId: "abc" }]);
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/safe-stream-handler.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/safe-stream-handler.test.ts
@@ -1,0 +1,120 @@
+import { stdout } from "node:process";
+import { Writable } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import SafeStreamHandler from "../../../src/utils/stream/safe-stream-handler";
+
+describe("safeStreamHandler on node:stream in workerd", () => {
+    it("writes through a node:stream Writable", () => {
+        expect.assertions(2);
+
+        const chunks: string[] = [];
+        const stream = new Writable({
+            write(chunk: unknown, _encoding: unknown, callback: () => void): void {
+                chunks.push(String(chunk));
+                callback();
+            },
+        });
+
+        const handler = new SafeStreamHandler(stream, "workerd-stream");
+
+        handler.write("first");
+        handler.write("second");
+
+        expect(chunks).toStrictEqual(["first", "second"]);
+        expect(handler.isReady).toBe(true);
+    });
+
+    it("stops writing and reports non-fatally once the stream errors", () => {
+        expect.assertions(3);
+
+        const errors: [Error, string][] = [];
+        const stream = new Writable({
+            write(_chunk: unknown, _encoding: unknown, callback: (error?: Error) => void): void {
+                callback();
+            },
+        });
+
+        const handler = new SafeStreamHandler(stream, "failing", (error, name) => {
+            errors.push([error, name]);
+        });
+
+        // `error` events are emitted asynchronously by node:stream; the handler must
+        // absorb them instead of letting them escape to the runtime.
+        stream.emit("error", new Error("stream exploded"));
+
+        expect(errors).toHaveLength(1);
+        expect(handler.isReady).toBe(false);
+
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        try {
+            handler.write("dropped");
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    it("recovers on a drain event", () => {
+        expect.assertions(2);
+
+        const stream = new Writable({
+            highWaterMark: 1,
+            write(_chunk: unknown, _encoding: unknown, callback: () => void): void {
+                callback();
+            },
+        });
+
+        const handler = new SafeStreamHandler(stream, "draining");
+
+        stream.emit("error", new Error("boom"));
+
+        expect(handler.isReady).toBe(false);
+
+        stream.emit("drain");
+
+        expect(handler.isReady).toBe(true);
+    });
+
+    it("forwards end() to the underlying stream", async () => {
+        expect.assertions(1);
+
+        const stream = new Writable({
+            write(_chunk: unknown, _encoding: unknown, callback: () => void): void {
+                callback();
+            },
+        });
+
+        // `finish` is emitted asynchronously by node:stream in workerd, exactly as in Node.
+        const finished = new Promise<boolean>((resolve) => {
+            stream.on("finish", () => {
+                resolve(true);
+            });
+        });
+
+        const handler = new SafeStreamHandler(stream, "closing");
+
+        handler.end();
+
+        await expect(finished).resolves.toBe(true);
+    });
+
+    it("accepts the node:process stdout stream as a target", () => {
+        expect.assertions(1);
+
+        const spy = vi.spyOn(stdout, "write").mockImplementation(() => true);
+
+        try {
+            const handler = new SafeStreamHandler(stdout, "process.stdout");
+
+            handler.write("to workerd stdout");
+
+            expect(spy.mock.calls.map((call) => String(call[0]))).toStrictEqual(["to workerd stdout"]);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/core/wide-event.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/core/wide-event.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { PailBrowserType } from "../../../src/pail.browser";
+import { PailBrowser } from "../../../src/pail.browser";
+import { createWideEvent } from "../../../src/wide-event";
+import { MetaCaptureReporter } from "./helpers";
+
+const createLogger = (): { logger: PailBrowserType; reporter: MetaCaptureReporter } => {
+    const reporter = new MetaCaptureReporter();
+    const logger = new PailBrowser({ reporters: [reporter], throttle: 0 });
+
+    return { logger, reporter };
+};
+
+describe("wideEvent in workerd", () => {
+    it("measures duration with performance.now()", async () => {
+        expect.assertions(3);
+
+        // workerd exposes `performance.now()` as a wall-clock reading rather than a
+        // monotonic offset from `timeOrigin`. Durations must still come out finite,
+        // non-negative and in milliseconds.
+        expect(performance.now()).toBeTypeOf("number");
+
+        const { logger, reporter } = createLogger();
+        const event = createWideEvent({ name: "workerd.request", pail: logger as never });
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+
+        event.finish({ status: 200 });
+
+        const payload = reporter.metas[0].message as Record<string, unknown>;
+
+        expect(Number.isFinite(payload.duration_ms)).toBe(true);
+        expect(payload.duration_ms as number).toBeGreaterThanOrEqual(0);
+    });
+
+    it("emits a single record carrying the accumulated context", () => {
+        expect.assertions(3);
+
+        const { logger, reporter } = createLogger();
+        const event = createWideEvent<{ cart: { items: number }; user: { id: number } }>({
+            name: "api.checkout",
+            pail: logger as never,
+            service: "checkout",
+        });
+
+        event.set({ user: { id: 1 } });
+        event.info("validated cart");
+        event.set({ cart: { items: 3 } });
+        event.finish({ status: 201 });
+        event.finish({ status: 500 });
+
+        const payload = reporter.metas[0].message as Record<string, unknown>;
+
+        expect(reporter.metas).toHaveLength(1);
+        expect(payload.event).toBe("api.checkout");
+        expect({ cart: payload.cart, service: payload.service, status: payload.status, user: payload.user }).toStrictEqual({
+            cart: { items: 3 },
+            service: "checkout",
+            status: 201,
+            user: { id: 1 },
+        });
+    });
+
+    it("escalates the log type and serializes the attached error", () => {
+        expect.assertions(3);
+
+        const { logger, reporter } = createLogger();
+        const event = createWideEvent({ name: "api.fail", pail: logger as never });
+
+        event.error("payment failed", new Error("card declined", { cause: new Error("issuer down") }));
+        event.finish({ status: 402 });
+
+        const payload = reporter.metas[0].message as { error: { cause?: { message: string }; message: string; name: string } };
+
+        expect(reporter.metas[0].type.name).toBe("error");
+        expect(payload.error.message).toBe("card declined");
+        expect(payload.error.cause?.message).toBe("issuer down");
+    });
+
+    it("auto-emits through Symbol.dispose", () => {
+        expect.assertions(2);
+
+        // Explicit Resource Management relies on the runtime providing `Symbol.dispose`.
+        expect(Symbol.dispose).toBeTypeOf("symbol");
+
+        const { logger, reporter } = createLogger();
+
+        {
+            const event = createWideEvent({ name: "scoped.work", pail: logger as never });
+
+            event.set({ done: true });
+            event[Symbol.dispose]();
+        }
+
+        expect(reporter.metas).toHaveLength(1);
+    });
+
+    it("timestamps lifecycle entries with ISO dates", () => {
+        expect.assertions(2);
+
+        const { logger, reporter } = createLogger();
+        const event = createWideEvent({ name: "worker.job", pail: logger as never });
+
+        event.warn("retrying", { attempt: 2 });
+        event.emit();
+
+        const payload = reporter.metas[0].message as { requestLogs: { level: string; timestamp: string }[] };
+
+        expect(payload.requestLogs[0].level).toBe("warn");
+        expect(new Date(payload.requestLogs[0].timestamp).toISOString()).toBe(payload.requestLogs[0].timestamp);
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/compression.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/compression.test.ts
@@ -1,0 +1,156 @@
+// `DecompressionStream` is a workerd/Web global; the Node-version rule does not apply here.
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import HttpReporter from "../../../src/reporter/http/http-reporter";
+import compressData from "../../../src/reporter/http/utils/compression";
+import type { ReadonlyMeta } from "../../../src/types";
+
+const baseMeta = {
+    badge: undefined,
+    context: [],
+    date: new Date(0),
+    error: undefined,
+    file: undefined,
+    groups: [],
+    label: "informational",
+    message: "Test message",
+    prefix: undefined,
+    scope: undefined,
+    suffix: undefined,
+    traceError: undefined,
+    type: { level: "informational" as const, name: "informational" },
+} as unknown as ReadonlyMeta<never>;
+
+const settle = async (ms = 60): Promise<void> => {
+    await new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+/** Inflates gzip bytes with the Web-standard `DecompressionStream` available in workerd. */
+const gunzip = async (bytes: Uint8Array): Promise<string> => {
+    const stream = new DecompressionStream("gzip");
+    const writer = stream.writable.getWriter();
+
+    // Feed the stream concurrently with draining it, otherwise a payload larger than the
+    // internal queue deadlocks between `write()` and `read()`.
+    const pump = (async (): Promise<void> => {
+        await writer.write(bytes);
+        await writer.close();
+    })();
+
+    const chunks: Uint8Array[] = [];
+    const reader = stream.readable.getReader();
+
+    let done = false;
+
+    while (!done) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await reader.read();
+
+        done = result.done;
+
+        if (result.value) {
+            chunks.push(result.value);
+        }
+    }
+
+    await pump;
+
+    const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const merged = new Uint8Array(total);
+    let offset = 0;
+
+    for (const chunk of chunks) {
+        merged.set(chunk, offset);
+        offset += chunk.length;
+    }
+
+    return new TextDecoder().decode(merged);
+};
+
+describe("compressData in workerd", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("emits real gzip bytes through the Web CompressionStream", async () => {
+        expect.assertions(3);
+
+        const result = await compressData("hello workerd");
+
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect(result[0]).toBe(0x1F);
+        expect(result[1]).toBe(0x8B);
+    });
+
+    it("round-trips a payload through DecompressionStream", async () => {
+        expect.assertions(1);
+
+        const payload = JSON.stringify({ level: "info", message: "round trip".repeat(50) });
+
+        await expect(gunzip(await compressData(payload))).resolves.toBe(payload);
+    });
+
+    it("compresses multi-byte content without corrupting it", async () => {
+        expect.assertions(1);
+
+        const payload = "héllo wörld — ünïcode ✅";
+
+        await expect(gunzip(await compressData(payload))).resolves.toBe(payload);
+    });
+
+    it("falls back to a Node gzip implementation when CompressionStream is missing", async () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("CompressionStream", undefined);
+
+        const result = await compressData("fallback payload");
+
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect([result[0], result[1]]).toStrictEqual([0x1F, 0x8B]);
+    });
+
+    it("sends the payload uncompressed and reports the failure when gzip is unavailable", async () => {
+        expect.assertions(4);
+
+        // Simulate a runtime that exposes CompressionStream but cannot actually gzip.
+        vi.stubGlobal(
+            "CompressionStream",
+            // eslint-disable-next-line @typescript-eslint/no-extraneous-class -- stand-in for a broken runtime constructor
+            class {
+                public constructor() {
+                    throw new Error("gzip unsupported");
+                }
+            },
+        );
+
+        const calls: { body: BodyInit | null | undefined; headers: Record<string, string> }[] = [];
+
+        vi.stubGlobal("fetch", async (_url: string, init: RequestInit): Promise<Response> => {
+            calls.push({ body: init.body, headers: init.headers as Record<string, string> });
+
+            return new Response("ok", { status: 200 });
+        });
+
+        const onError = vi.fn();
+        const reporter = new HttpReporter({
+            compression: true,
+            enableBatchSend: false,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.setStringify(JSON.stringify as never);
+        reporter.log(baseMeta);
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBe("Test message");
+        expect(calls[0].headers["content-encoding"]).toBeUndefined();
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("Compression failed") }));
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/edge-module-graph.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/edge-module-graph.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error -- Vite `?raw` import: inlines the file contents as a string at transform time.
+import abstractHttpReporterSource from "../../../src/reporter/http/abstract-http-reporter.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import edgeLightSource from "../../../src/reporter/http/http-reporter.edge-light.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import httpReporterSource from "../../../src/reporter/http/http-reporter.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import compressionSource from "../../../src/reporter/http/utils/compression.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import logSizeErrorSource from "../../../src/reporter/http/utils/log-size-error.ts?raw";
+// @ts-expect-error -- Vite `?raw` import.
+import retrySource from "../../../src/reporter/http/utils/retry.ts?raw";
+// @ts-expect-error -- Vite `?raw` import. Control sample: this module legitimately imports `node:process`.
+import serverJsonReporterSource from "../../../src/reporter/json/json-reporter.server.ts?raw";
+
+/**
+ * Collects *static* `import`/`export ... "node:x"` declarations — the form that fails at
+ * module-load time. `await import("node:x")` is deliberately not reported: a dynamic import
+ * is only evaluated when the branch that needs it actually runs.
+ * @param source The module source text.
+ * @returns Every offending declaration, verbatim.
+ */
+const staticNodeImportsIn = (source: string): string[] =>
+    source
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => (line.startsWith("import ") || line.startsWith("export ")) && !line.includes("import(") && (line.includes("\"node:") || line.includes("'node:")));
+
+/**
+ * The `edge-light` export condition promises this reporter loads on runtimes with no
+ * Node builtins at all. A static `node:*` import anywhere in its own module graph breaks
+ * that promise at *import* time, long before any log line is written — and it cannot be
+ * caught by a runtime test on workerd, where `nodejs_compat` makes those imports resolve.
+ */
+describe("edge HTTP reporter module graph", () => {
+    const modules: [string, string][] = [
+        ["http-reporter.edge-light.ts", edgeLightSource as string],
+        ["http-reporter.ts", httpReporterSource as string],
+        ["abstract-http-reporter.ts", abstractHttpReporterSource as string],
+        ["utils/compression.ts", compressionSource as string],
+        ["utils/retry.ts", retrySource as string],
+        ["utils/log-size-error.ts", logSizeErrorSource as string],
+    ];
+
+    it.each(modules)("%s declares no static node: import", (_name, source) => {
+        expect.assertions(1);
+
+        expect(staticNodeImportsIn(source)).toStrictEqual([]);
+    });
+
+    it("detects a static node: import when one is present", () => {
+        expect.assertions(1);
+
+        // Control sample — proves the checks above are not passing vacuously.
+        expect(staticNodeImportsIn(serverJsonReporterSource as string)).toStrictEqual(["import { stderr, stdout } from \"node:process\";"]);
+    });
+
+    it("reaches node:zlib only through a dynamic import", () => {
+        expect.assertions(2);
+
+        expect(compressionSource as string).toContain("await import(\"node:zlib\")");
+        expect(staticNodeImportsIn(compressionSource as string)).toStrictEqual([]);
+    });
+
+    it("measures payload size with TextEncoder rather than Buffer", () => {
+        expect.assertions(2);
+
+        expect(abstractHttpReporterSource as string).not.toContain("Buffer.byteLength");
+        expect(abstractHttpReporterSource as string).toContain("new TextEncoder()");
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/file-reporter.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/file-reporter.test.ts
@@ -1,0 +1,91 @@
+// `/tmp` here is workerd's in-isolate virtual filesystem, not a shared host directory.
+/* eslint-disable sonarjs/publicly-writable-directories */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { JsonFileReporter } from "../../../src/reporter/file/json-file-reporter";
+import RotatingFileStream from "../../../src/reporter/file/utils/rotating-file-stream";
+import type { ReadonlyMeta } from "../../../src/types";
+
+const meta = (message: string): ReadonlyMeta<never> =>
+    ({
+        badge: undefined,
+        context: [],
+        date: new Date(0),
+        error: undefined,
+        file: undefined,
+        groups: [],
+        label: "info",
+        message,
+        prefix: undefined,
+        scope: undefined,
+        suffix: undefined,
+        traceError: undefined,
+        type: { level: "informational", name: "info" },
+    }) as unknown as ReadonlyMeta<never>;
+
+const settle = async (ms = 200): Promise<void> => {
+    await new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+describe("file reporter in workerd", () => {
+    it("imports without evaluating any filesystem access", () => {
+        expect.assertions(2);
+
+        // A logger that merely *includes* the file reporter in its bundle must not blow up
+        // at import time on a runtime without a filesystem.
+        expect(JsonFileReporter).toBeTypeOf("function");
+        expect(RotatingFileStream).toBeTypeOf("function");
+    });
+
+    it("either constructs or fails with an actionable error, never an obscure crash", () => {
+        expect.assertions(1);
+
+        let outcome: string;
+
+        try {
+            // eslint-disable-next-line no-new
+            new RotatingFileStream("/tmp/pail-workerd-probe.log", false, {});
+            outcome = "constructed";
+        } catch (error) {
+            outcome = (error as Error).message;
+        }
+
+        // workerd's `nodejs_compat` exposes an in-memory `node:fs`, so construction succeeds.
+        // On a runtime that lacks it, the documented failure is the explicit missing-package
+        // error rather than a `ReferenceError`/`TypeError` from deep inside a Node builtin.
+        expect(["constructed", "The 'rotating-file-stream' package is missing. Make sure to install the 'rotating-file-stream' package."]).toContain(outcome);
+    });
+
+    it("writes JSON lines into the workerd in-memory filesystem", async () => {
+        expect.assertions(2);
+
+        const filePath = `/tmp/pail-workerd-file-reporter-${String(Date.now())}.log`;
+        const reporter = new JsonFileReporter({ filePath });
+
+        reporter.setStringify(JSON.stringify as never);
+        reporter.log(meta("first"));
+        reporter.log(meta("second"));
+        reporter.close();
+
+        await settle();
+
+        const lines = readFileSync(filePath, "utf8").trim().split("\n");
+
+        expect(lines).toHaveLength(2);
+        expect(lines.map((line) => (JSON.parse(line) as { message: string }).message)).toStrictEqual(["first", "second"]);
+    });
+
+    it("exposes dispose() as an alias for close()", () => {
+        expect.assertions(1);
+
+        const reporter = new JsonFileReporter({ filePath: "/tmp/pail-workerd-dispose.log" });
+
+        reporter.setStringify(JSON.stringify as never);
+
+        expect(() => { reporter.dispose(); }).not.toThrow();
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/http-reporter.edge-light.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/http-reporter.edge-light.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import HttpReporterEdgeLight from "../../../src/reporter/http/http-reporter.edge-light";
+import type { ReadonlyMeta } from "../../../src/types";
+
+const baseMeta = {
+    badge: undefined,
+    context: [],
+    date: new Date(0),
+    error: undefined,
+    file: undefined,
+    groups: [],
+    label: "informational",
+    message: "Test message",
+    prefix: undefined,
+    scope: undefined,
+    suffix: undefined,
+    traceError: undefined,
+    type: { level: "informational" as const, name: "informational" },
+} as unknown as ReadonlyMeta<never>;
+
+type CapturedRequest = { body: BodyInit | null | undefined; headers: Record<string, string> };
+
+const interceptFetch = (): CapturedRequest[] => {
+    const calls: CapturedRequest[] = [];
+
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit): Promise<Response> => {
+        calls.push({ body: init.body, headers: init.headers as Record<string, string> });
+
+        return new Response("ok", { status: 200 });
+    });
+
+    return calls;
+};
+
+const settle = async (ms = 20): Promise<void> => {
+    await new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+const createReporter = (options: ConstructorParameters<typeof HttpReporterEdgeLight>[0]): HttpReporterEdgeLight => {
+    const reporter = new HttpReporterEdgeLight(options);
+
+    reporter.setStringify(JSON.stringify as never);
+
+    return reporter;
+};
+
+describe("httpReporterEdgeLight in workerd", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("ships a log entry over the edge fetch global", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBe("Test message");
+    });
+
+    it("keeps the payload uncompressed even when compression is requested", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            compression: true,
+            enableBatchSend: false,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle(100);
+
+        expect(calls[0].body).toBe("Test message");
+        expect(calls[0].headers["content-encoding"]).toBeUndefined();
+    });
+
+    it("measures the payload in UTF-8 bytes rather than UTF-16 code units", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+        const onError = vi.fn();
+
+        // 50 UTF-16 code units, 100 UTF-8 bytes. A UTF-16 based measurement would let it through.
+        const reporter = createReporter({
+            enableBatchSend: false,
+            maxLogSize: 60,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "é".repeat(50) });
+
+        await settle();
+
+        expect(calls).toHaveLength(0);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: "LogSizeError" }));
+    });
+
+    it("still measures the payload in UTF-8 bytes when TextEncoder is unavailable", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+        const onError = vi.fn();
+
+        // A bare edge runtime without `nodejs_compat` has neither `Buffer` nor, in the most
+        // stripped-down cases, a usable `TextEncoder`. Size accounting must still be correct.
+        vi.stubGlobal("TextEncoder", undefined);
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            maxLogSize: 60,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "é".repeat(50) });
+
+        await settle();
+
+        expect(calls).toHaveLength(0);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: "LogSizeError" }));
+    });
+
+    it("counts astral characters as four UTF-8 bytes without TextEncoder", async () => {
+        expect.assertions(4);
+
+        const calls = interceptFetch();
+        const onError = vi.fn();
+
+        vi.stubGlobal("TextEncoder", undefined);
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            maxLogSize: 60,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        // 10 emoji = 20 UTF-16 code units = 40 UTF-8 bytes -> fits.
+        reporter.log({ ...baseMeta, message: "😀".repeat(10) });
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(onError).not.toHaveBeenCalled();
+
+        // 20 emoji = 80 UTF-8 bytes -> rejected. A UTF-16 count (40) would have let it through.
+        reporter.log({ ...baseMeta, message: "😀".repeat(20) });
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: "LogSizeError" }));
+    });
+
+    it("lets an entry through when it fits the UTF-8 budget", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+        const onError = vi.fn();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            maxLogSize: 60,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "é".repeat(20) });
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("batches on the edge exactly like the default build", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            batchSendTimeout: 1_000_000,
+            batchSize: 2,
+            enableBatchSend: true,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "a" });
+        reporter.log({ ...baseMeta, message: "b" });
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBe("a\nb");
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/http-reporter.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/http-reporter.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import HttpReporter from "../../../src/reporter/http/http-reporter";
+import type { ReadonlyMeta } from "../../../src/types";
+
+const baseMeta = {
+    badge: undefined,
+    context: [],
+    date: new Date(0),
+    error: undefined,
+    file: undefined,
+    groups: [],
+    label: "informational",
+    message: "Test message",
+    prefix: undefined,
+    scope: undefined,
+    suffix: undefined,
+    traceError: undefined,
+    type: { level: "informational" as const, name: "informational" },
+} as unknown as ReadonlyMeta<never>;
+
+type CapturedRequest = { body: BodyInit | null | undefined; headers: Record<string, string>; method: string; url: string };
+
+/**
+ * Installs a `fetch` stub on the workerd global and records every outgoing request.
+ * @param responder Produces the response for the n-th call (defaults to `200 OK`).
+ */
+const interceptFetch = (responder?: (call: number) => Response): CapturedRequest[] => {
+    const calls: CapturedRequest[] = [];
+
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit): Promise<Response> => {
+        const index = calls.length;
+
+        calls.push({
+            body: init.body,
+            headers: init.headers as Record<string, string>,
+            method: init.method as string,
+            url,
+        });
+
+        return responder ? responder(index) : new Response("ok", { status: 200 });
+    });
+
+    return calls;
+};
+
+/** Yields to the event loop so floating sends started by `_log` can settle. */
+const settle = async (ms = 20): Promise<void> => {
+    await new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+const createReporter = (options: ConstructorParameters<typeof HttpReporter>[0]): HttpReporter => {
+    const reporter = new HttpReporter(options);
+
+    reporter.setStringify(JSON.stringify as never);
+
+    return reporter;
+};
+
+describe("httpReporter in workerd", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("sends a single entry through the workerd fetch global", async () => {
+        expect.assertions(4);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            payloadTemplate: ({ logLevel, message }) => JSON.stringify({ level: logLevel, message }),
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe("https://logs.example.com/ingest");
+        expect(calls[0].method).toBe("POST");
+        expect(calls[0].body).toBe(JSON.stringify({ level: "informational", message: "Test message" }));
+    });
+
+    it("defaults the content-type header and lets user headers win", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            headers: { authorization: "Bearer token" },
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle();
+
+        expect(calls[0].headers["content-type"]).toBe("application/json");
+        expect(calls[0].headers["authorization"]).toBe("Bearer token");
+    });
+
+    it("resolves a header factory per request", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+        let counter = 0;
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            headers: () => {
+                counter += 1;
+
+                return { authorization: `Bearer ${String(counter)}` };
+            },
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+        await settle();
+        reporter.log(baseMeta);
+        await settle();
+
+        expect(calls[0].headers["authorization"]).toBe("Bearer 1");
+        expect(calls[1].headers["authorization"]).toBe("Bearer 2");
+    });
+
+    it("joins batched entries with the delimiter once batchSize is reached", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            batchSendTimeout: 1_000_000,
+            batchSize: 3,
+            enableBatchSend: true,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "a" });
+        reporter.log({ ...baseMeta, message: "b" });
+        reporter.log({ ...baseMeta, message: "c" });
+
+        await settle();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body).toBe("a\nb\nc");
+    });
+
+    it("sends batched entries as a JSON array when batchMode is 'array'", async () => {
+        expect.assertions(1);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            batchMode: "array",
+            batchSendTimeout: 1_000_000,
+            batchSize: 2,
+            enableBatchSend: true,
+            payloadTemplate: ({ message }) => JSON.stringify({ message }),
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "a" });
+        reporter.log({ ...baseMeta, message: "b" });
+
+        await settle();
+
+        expect(calls[0].body).toBe(JSON.stringify([{ message: "a" }, { message: "b" }]));
+    });
+
+    it("wraps batched entries in a field when batchMode is 'field'", async () => {
+        expect.assertions(1);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            batchFieldName: "batch",
+            batchMode: "field",
+            batchSendTimeout: 1_000_000,
+            batchSize: 2,
+            enableBatchSend: true,
+            payloadTemplate: ({ message }) => JSON.stringify({ message }),
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "a" });
+        reporter.log({ ...baseMeta, message: "b" });
+
+        await settle();
+
+        expect(calls[0].body).toBe(JSON.stringify({ batch: [{ message: "a" }, { message: "b" }] }));
+    });
+
+    it("drains the queue on flush() without waiting for the batch timeout", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            batchSendTimeout: 1_000_000,
+            batchSize: 100,
+            enableBatchSend: true,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "a" });
+        reporter.log({ ...baseMeta, message: "b" });
+
+        expect(calls).toHaveLength(0);
+
+        await reporter.flush();
+
+        expect(calls[0].body).toBe("a\nb");
+    });
+
+    it("retries a 500 response and succeeds on the next attempt", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch((call) => {
+            if (call === 0) {
+                return new Response("boom", { status: 500 });
+            }
+
+            return new Response("ok", { status: 200 });
+        });
+
+        const onError = vi.fn();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            retryDelay: 1,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle(100);
+
+        expect(calls).toHaveLength(2);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("honours a Retry-After header on a 429 response", async () => {
+        expect.assertions(1);
+
+        const calls = interceptFetch((call) => {
+            if (call === 0) {
+                return new Response("slow down", { headers: { "retry-after": "0" }, status: 429 });
+            }
+
+            return new Response("ok", { status: 200 });
+        });
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            payloadTemplate: ({ message }) => message,
+            respectRateLimit: true,
+            retryDelay: 1,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle(100);
+
+        expect(calls).toHaveLength(2);
+    });
+
+    it("fails fast on a non-retryable 4xx response", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch(() => new Response("nope", { status: 400 }));
+        const onError = vi.fn();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            retryDelay: 1,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle(100);
+
+        expect(calls).toHaveLength(1);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("HTTP 400") }));
+    });
+
+    it("surfaces the request/response pair to onDebugRequestResponse", async () => {
+        expect.assertions(2);
+
+        interceptFetch(() => new Response("accepted", { headers: { "x-trace": "abc" }, status: 200 }));
+
+        const onDebugRequestResponse = vi.fn();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            onDebugRequestResponse,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log(baseMeta);
+
+        await settle();
+
+        expect(onDebugRequestResponse).toHaveBeenCalledTimes(1);
+        expect(onDebugRequestResponse.mock.calls[0][0].res).toStrictEqual(
+            expect.objectContaining({ body: "accepted", headers: expect.objectContaining({ "x-trace": "abc" }), status: 200 }),
+        );
+    });
+
+    it("reports a LogSizeError instead of sending an oversized entry", async () => {
+        expect.assertions(2);
+
+        const calls = interceptFetch();
+        const onError = vi.fn();
+
+        const reporter = createReporter({
+            enableBatchSend: false,
+            maxLogSize: 10,
+            onError,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "x".repeat(64) });
+
+        await settle();
+
+        expect(calls).toHaveLength(0);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: "LogSizeError" }));
+    });
+
+    it("gzip-compresses the body and sets content-encoding when compression is enabled", async () => {
+        expect.assertions(3);
+
+        const calls = interceptFetch();
+
+        const reporter = createReporter({
+            compression: true,
+            enableBatchSend: false,
+            payloadTemplate: ({ message }) => message,
+            url: "https://logs.example.com/ingest",
+        });
+
+        reporter.log({ ...baseMeta, message: "compress me".repeat(20) });
+
+        await settle(100);
+
+        const body = calls[0].body as unknown as Uint8Array;
+
+        expect(calls[0].headers["content-encoding"]).toBe("gzip");
+        expect(body).toBeInstanceOf(Uint8Array);
+        // gzip magic number: 0x1f 0x8b
+        expect([body[0], body[1]]).toStrictEqual([0x1F, 0x8B]);
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/reporter/stream-reporters.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/reporter/stream-reporters.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import JsonReporter from "../../../src/reporter/json/json-reporter.server";
+import { PrettyReporter } from "../../../src/reporter/pretty/pretty-reporter.server";
+import RawReporter from "../../../src/reporter/raw/raw-reporter.server";
+import { SimpleReporter } from "../../../src/reporter/simple/simple-reporter.server";
+import type { ReadonlyMeta } from "../../../src/types";
+
+const meta = (overrides: Record<string, unknown> = {}): ReadonlyMeta<never> =>
+    ({
+        badge: undefined,
+        context: [],
+        date: new Date(0),
+        error: undefined,
+        file: undefined,
+        groups: [],
+        label: "info",
+        message: "Test message",
+        prefix: undefined,
+        scope: undefined,
+        suffix: undefined,
+        traceError: undefined,
+        type: { level: "informational", name: "info" },
+        ...overrides,
+    }) as unknown as ReadonlyMeta<never>;
+
+/** Minimal stand-in for `NodeJS.WriteStream` that records everything written to it. */
+const createFakeStream = (): { lines: string[]; stream: NodeJS.WriteStream } => {
+    const lines: string[] = [];
+
+    const stream = {
+        isTTY: false,
+        on: () => stream,
+        write: (chunk: string): boolean => {
+            lines.push(chunk);
+
+            return true;
+        },
+    };
+
+    return { lines, stream: stream as unknown as NodeJS.WriteStream };
+};
+
+describe("stdout/stderr reporters in workerd", () => {
+    describe(JsonReporter, () => {
+        it("constructs against the workerd process streams without throwing", () => {
+            expect.assertions(1);
+
+            expect(() => new JsonReporter()).not.toThrow();
+        });
+
+        it("writes a JSON line to the injected stdout stream", () => {
+            expect.assertions(2);
+
+            const out = createFakeStream();
+            const error = createFakeStream();
+            const reporter = new JsonReporter();
+
+            reporter.setStringify(JSON.stringify as never);
+            reporter.setStdout(out.stream);
+            reporter.setStderr(error.stream);
+            reporter.log(meta());
+
+            expect(error.lines).toHaveLength(0);
+            expect(JSON.parse(out.lines[0])).toStrictEqual(expect.objectContaining({ message: "Test message" }));
+        });
+
+        it("routes error-level entries to stderr", () => {
+            expect.assertions(2);
+
+            const out = createFakeStream();
+            const error = createFakeStream();
+            const reporter = new JsonReporter();
+
+            reporter.setStringify(JSON.stringify as never);
+            reporter.setStdout(out.stream);
+            reporter.setStderr(error.stream);
+            reporter.log(meta({ type: { level: "error", name: "error" } }));
+
+            expect(out.lines).toHaveLength(0);
+            expect(error.lines).toHaveLength(1);
+        });
+
+        it("writes to the real workerd process.stdout without throwing", () => {
+            expect.assertions(1);
+
+            const reporter = new JsonReporter();
+
+            reporter.setStringify(JSON.stringify as never);
+
+            expect(() => { reporter.log(meta()); }).not.toThrow();
+        });
+    });
+
+    describe(RawReporter, () => {
+        it("writes the raw message to the injected stream", () => {
+            expect.assertions(1);
+
+            const out = createFakeStream();
+            const reporter = new RawReporter();
+
+            reporter.setStdout(out.stream);
+            reporter.setStderr(createFakeStream().stream);
+            reporter.log(meta());
+
+            expect(out.lines[0]).toBe("Test message");
+        });
+
+        it("writes to the real workerd process.stdout without throwing", () => {
+            expect.assertions(1);
+
+            const reporter = new RawReporter();
+
+            expect(() => { reporter.log(meta()); }).not.toThrow();
+        });
+    });
+
+    describe(SimpleReporter, () => {
+        it("constructs and formats without a TTY", () => {
+            expect.assertions(2);
+
+            const out = createFakeStream();
+            const reporter = new SimpleReporter();
+
+            reporter.setStdout(out.stream);
+            reporter.setStderr(createFakeStream().stream);
+            reporter.log(meta());
+
+            expect(out.lines).toHaveLength(1);
+            expect(out.lines[0]).toContain("Test message");
+        });
+
+        it("writes to the real workerd process.stdout without throwing", () => {
+            expect.assertions(1);
+
+            const reporter = new SimpleReporter();
+
+            expect(() => { reporter.log(meta()); }).not.toThrow();
+        });
+    });
+
+    describe(PrettyReporter, () => {
+        it("constructs and formats without a TTY", () => {
+            expect.assertions(2);
+
+            const out = createFakeStream();
+            const reporter = new PrettyReporter();
+
+            reporter.setStdout(out.stream);
+            reporter.setStderr(createFakeStream().stream);
+            reporter.log(meta());
+
+            expect(out.lines).toHaveLength(1);
+            expect(out.lines[0]).toContain("Test message");
+        });
+
+        it("routes error-level entries to stderr", () => {
+            expect.assertions(2);
+
+            const out = createFakeStream();
+            const error = createFakeStream();
+            const reporter = new PrettyReporter();
+
+            reporter.setStdout(out.stream);
+            reporter.setStderr(error.stream);
+            reporter.log(meta({ type: { level: "error", name: "error" } }));
+
+            expect(out.lines).toHaveLength(0);
+            expect(error.lines).toHaveLength(1);
+        });
+
+        it("writes to the real workerd process.stdout without throwing", () => {
+            expect.assertions(1);
+
+            const reporter = new PrettyReporter();
+
+            expect(() => { reporter.log(meta()); }).not.toThrow();
+        });
+    });
+});

--- a/packages/error-debugging/pail/__tests__/workerd/smoke.test.ts
+++ b/packages/error-debugging/pail/__tests__/workerd/smoke.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("workerd smoke", () => {
+    it("runs inside workerd, not node", () => {
+        expect.assertions(1);
+
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- workerd always provides `navigator`
+        expect(navigator.userAgent).toBe("Cloudflare-Workers");
+    });
+});

--- a/packages/error-debugging/pail/eslint.config.js
+++ b/packages/error-debugging/pail/eslint.config.js
@@ -11,6 +11,7 @@ export default createConfig(
             "__docs__",
             "examples",
             "vitest.config.ts",
+            "vitest.workerd.config.ts",
             "packem.config.ts",
             ".secretlintrc.cjs",
             "package.json",

--- a/packages/error-debugging/pail/package.json
+++ b/packages/error-debugging/pail/package.json
@@ -82,6 +82,14 @@
     "type": "module",
     "exports": {
         ".": {
+            "edge-light": {
+                "types": "./dist/index.browser.d.ts",
+                "default": "./dist/index.browser.js"
+            },
+            "workerd": {
+                "types": "./dist/index.browser.d.ts",
+                "default": "./dist/index.browser.js"
+            },
             "browser": {
                 "types": "./dist/index.browser.d.ts",
                 "default": "./dist/index.browser.js"

--- a/packages/error-debugging/pail/package.json
+++ b/packages/error-debugging/pail/package.json
@@ -57,12 +57,6 @@
     ],
     "homepage": "https://visulima.com/packages/pail/",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de",
-        "url": "https://danielbannert.com"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -78,27 +72,24 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist/**",
-        "README.md",
-        "CHANGELOG.md",
-        "LICENSE.md",
-        "MIGRATION-GUIDE.md"
-    ],
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de",
+        "url": "https://danielbannert.com"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
+            "browser": {
+                "types": "./dist/index.browser.d.ts",
+                "default": "./dist/index.browser.js"
+            },
             "import": {
                 "types": "./dist/index.server.d.ts",
                 "default": "./dist/index.server.js"
-            },
-            "browser": "./dist/index.browser.js"
+            }
         },
         "./browser": {
             "types": "./dist/index.browser.d.ts",
@@ -153,11 +144,14 @@
             }
         },
         "./reporter/json": {
+            "browser": {
+                "types": "./dist/reporter/json/index.browser.d.ts",
+                "default": "./dist/reporter/json/index.browser.js"
+            },
             "import": {
                 "types": "./dist/reporter/json/index.d.ts",
                 "default": "./dist/reporter/json/index.js"
-            },
-            "browser": "./dist/reporter/json/index.browser.js"
+            }
         },
         "./server/reporter/pretty": {
             "import": {
@@ -172,11 +166,14 @@
             }
         },
         "./reporter/pretty": {
+            "browser": {
+                "types": "./dist/reporter/pretty/index.browser.d.ts",
+                "default": "./dist/reporter/pretty/index.browser.js"
+            },
             "import": {
                 "types": "./dist/reporter/pretty/index.d.ts",
                 "default": "./dist/reporter/pretty/index.js"
-            },
-            "browser": "./dist/reporter/pretty/index.browser.js"
+            }
         },
         "./reporter/simple": {
             "types": "./dist/reporter/simple/simple-reporter.server.d.ts",
@@ -187,15 +184,19 @@
             "default": "./dist/reporter/http/abstract-http-reporter.js"
         },
         "./reporter/http": {
-            "import": {
-                "types": "./dist/reporter/http/http-reporter.d.ts",
-                "default": "./dist/reporter/http/http-reporter.js"
-            },
             "edge-light": {
                 "types": "./dist/reporter/http/http-reporter.edge-light.d.ts",
                 "default": "./dist/reporter/http/http-reporter.edge-light.js"
             },
+            "workerd": {
+                "types": "./dist/reporter/http/http-reporter.edge-light.d.ts",
+                "default": "./dist/reporter/http/http-reporter.edge-light.js"
+            },
             "browser": {
+                "types": "./dist/reporter/http/http-reporter.d.ts",
+                "default": "./dist/reporter/http/http-reporter.js"
+            },
+            "import": {
                 "types": "./dist/reporter/http/http-reporter.d.ts",
                 "default": "./dist/reporter/http/http-reporter.js"
             }
@@ -234,10 +235,13 @@
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist/**",
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE.md",
+        "MIGRATION-GUIDE.md"
+    ],
     "scripts": {
         "build": "packem build --development",
         "build:prod": "packem build --production",
@@ -256,7 +260,8 @@
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui --coverage.enabled=true",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
     "dependencies": {
         "@visulima/colorize": "2.0.1",
@@ -268,6 +273,7 @@
         "@anolilab/semantic-release-pnpm": "catalog:dev",
         "@anolilab/semantic-release-preset": "catalog:dev",
         "@arethetypeswrong/cli": "catalog:dev",
+        "@cloudflare/vitest-pool-workers": "catalog:test",
         "@opentelemetry/api": "catalog:dev",
         "@secretlint/secretlint-rule-preset-recommend": "catalog:lint",
         "@total-typescript/ts-reset": "catalog:dev",
@@ -339,5 +345,14 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "os": [
+        "darwin",
+        "linux",
+        "win32"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/error-debugging/pail/src/middleware/elysia.ts
+++ b/packages/error-debugging/pail/src/middleware/elysia.ts
@@ -25,8 +25,44 @@ const storage = new AsyncLocalStorage<WideEvent>();
 const activeLoggers = new WeakSet<WideEvent>();
 
 /**
+ * `AsyncLocalStorage.enterWith()` is optional: `node:async_hooks` is available on
+ * workerd/Cloudflare Workers (and other edge runtimes) but `enterWith()` throws
+ * "not implemented" there. Elysia's `derive` hook cannot wrap the rest of the
+ * request in `storage.run()`, so the ambient accessor is simply unavailable on
+ * those runtimes.
+ *
+ * Holds the last rejection rather than latching a "not supported" flag. A runtime
+ * that refuses `enterWith()` refuses it every time, so retrying costs one throw per
+ * request there and nothing at all elsewhere — while a one-off failure can no longer
+ * disable the accessor for the rest of the process, and the diagnostic below quotes
+ * what actually went wrong instead of asserting a cause it never observed.
+ */
+let lastEnterWithFailure: string | undefined;
+
+/**
+ * Binds `logger` to the ambient async context when the runtime allows it.
+ * @param logger The request-scoped wide event to bind.
+ * @returns `true` when the binding took effect, `false` when the runtime rejected it.
+ */
+const enterAmbientContext = (logger: WideEvent): boolean => {
+    try {
+        storage.enterWith(logger);
+        lastEnterWithFailure = undefined;
+
+        return true;
+    } catch (error) {
+        lastEnterWithFailure = error instanceof Error ? error.message : String(error);
+
+        return false;
+    }
+};
+
+/**
  * Retrieve the request-scoped WideEvent logger from AsyncLocalStorage.
  * Must be called within a request handler where pail middleware is active.
+ *
+ * Not available on runtimes that reject `AsyncLocalStorage.enterWith()` (workerd and
+ * other edge runtimes); use the `log` property on the handler context instead.
  * @returns The request-scoped WideEvent logger
  * @throws Error if called outside of the middleware context
  */
@@ -34,6 +70,12 @@ const useLogger = (): WideEvent => {
     const logger = storage.getStore();
 
     if (!logger || !activeLoggers.has(logger)) {
+        if (lastEnterWithFailure !== undefined) {
+            throw new Error(
+                `[pail] useLogger() is unavailable here: AsyncLocalStorage.enterWith() was rejected by this runtime with "${lastEnterWithFailure}". Use the \`log\` property on the Elysia handler context instead.`,
+            );
+        }
+
         throw new Error("[pail] useLogger() called outside of Elysia pail plugin context.");
     }
 
@@ -97,7 +139,7 @@ export const pailPlugin = <T extends string = string>(app: PailElysiaInstance, o
 
                 if (!result.skipped) {
                     activeLoggers.add(result.logger);
-                    storage.enterWith(result.logger);
+                    enterAmbientContext(result.logger);
                 }
 
                 return { log: result.logger };

--- a/packages/error-debugging/pail/src/pail.server.ts
+++ b/packages/error-debugging/pail/src/pail.server.ts
@@ -112,7 +112,12 @@ class PailServerImpl<T extends string = string, L extends string = string> exten
         this.stdout = stdout;
         this.stderr = stderr;
 
-        if (this.interactive) {
+        // Interactive rendering hooks straight into the stream's `write`, so it can only be
+        // set up when the runtime actually provides both streams. Edge runtimes (workerd and
+        // friends) expose `node:process` without `stdout`/`stderr`; there the logger stays
+        // non-interactive instead of throwing while constructing the hooks.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- streams are absent on runtimes without Node std streams
+        if (this.interactive && this.stdout && this.stderr) {
             this.interactiveManager = new InteractiveManager(new InteractiveStreamHook(this.stdout), new InteractiveStreamHook(this.stderr));
         }
 
@@ -312,8 +317,13 @@ class PailServerImpl<T extends string = string, L extends string = string> exten
      * ```
      */
     public override clear(): void {
-        this.stdout.write(resetTerminal);
-        this.stderr.write(resetTerminal);
+        // Mirrors `wrapStd()`: a runtime without Node std streams (workerd and other edge
+        // runtimes) has nothing to reset, so the call degrades to a no-op instead of
+        // throwing on `undefined.write`.
+        /* eslint-disable @typescript-eslint/no-unnecessary-condition -- streams are absent on runtimes without Node std streams */
+        this.stdout?.write(resetTerminal);
+        this.stderr?.write(resetTerminal);
+        /* eslint-enable @typescript-eslint/no-unnecessary-condition */
     }
 
     protected override extendReporter(reporter: Reporter<L>): Reporter<L> {

--- a/packages/error-debugging/pail/src/processor/message-formatter-processor.ts
+++ b/packages/error-debugging/pail/src/processor/message-formatter-processor.ts
@@ -5,6 +5,12 @@ import { build } from "@visulima/fmt";
 import type { Meta, StringifyAwareProcessor } from "../types";
 
 /**
+ * What `@visulima/fmt` substitutes when its own serializer throws. Pre-quoted, so the result
+ * stays valid JSON in the `%j`/`%o`/`%O` slot it replaces.
+ */
+const CIRCULAR_PLACEHOLDER = "\"[Circular]\"";
+
+/**
  * Message Formatter Processor.
  *
  * A processor that formats log messages using the {@link https://visulima.com/packages/fmt/|@visulima/fmt} library.
@@ -67,13 +73,7 @@ class MessageFormatterProcessor<L extends string = string> implements StringifyA
         if (this.#formatter === undefined) {
             this.#formatter = build({
                 formatters: this.#formatters,
-                stringify: (value: unknown) => {
-                    if (!this.#stringify) {
-                        return JSON.stringify(value);
-                    }
-
-                    return this.#stringify(value);
-                },
+                stringify: (value: unknown) => this.#serialize(value),
             });
         }
 
@@ -85,6 +85,38 @@ class MessageFormatterProcessor<L extends string = string> implements StringifyA
         }
 
         return meta;
+    }
+
+    /**
+     * Serializes one `%j`/`%o`/`%O` argument.
+     *
+     * Supplying `stringify` to `build()` replaces `@visulima/fmt`'s own guarded serializer, so
+     * whatever is passed here has to be at least as defensive as the one it displaces: a logger
+     * must not take down the call site because a logged value was awkward.
+     *
+     * The two failure modes are reported differently on purpose. A bare `JSON.stringify` throwing
+     * is almost always a cycle, and fmt already renders that as `"[Circular]"` — matching it keeps
+     * pail's output identical whether fmt or this processor did the stringifying. A *supplied*
+     * serializer throwing is a defect in that serializer, so it is named rather than disguised as
+     * a cycle.
+     * @param value The argument to serialize.
+     * @returns The serialized value, or a quoted placeholder when serialization failed.
+     * @private
+     */
+    #serialize(value: unknown): string {
+        if (this.#stringify === undefined) {
+            try {
+                return JSON.stringify(value);
+            } catch {
+                return CIRCULAR_PLACEHOLDER;
+            }
+        }
+
+        try {
+            return this.#stringify(value);
+        } catch (error) {
+            return JSON.stringify(`[unserializable: ${error instanceof Error ? error.message : String(error)}]`);
+        }
     }
 
     /**

--- a/packages/error-debugging/pail/src/reporter/http/abstract-http-reporter.ts
+++ b/packages/error-debugging/pail/src/reporter/http/abstract-http-reporter.ts
@@ -1,5 +1,3 @@
-import { Buffer } from "node:buffer";
-
 import type { LiteralUnion } from "type-fest";
 
 import type { ExtendedRfc5424LogLevels, StringifyAwareReporter } from "../../types";
@@ -9,16 +7,57 @@ import compressData from "./utils/compression";
 import LogSizeError from "./utils/log-size-error";
 import sendWithRetry from "./utils/retry";
 
-/** Reused across all reporter instances so measuring a payload never allocates a new encoder. */
-const sharedTextEncoder = typeof TextEncoder === "undefined" ? undefined : new TextEncoder();
+/**
+ * Counts the UTF-8 bytes of a string without `TextEncoder` or `Buffer`.
+ *
+ * Used only as a last resort on runtimes that expose neither. Unpaired surrogates
+ * are counted as the 3-byte replacement character, matching what `TextEncoder` emits.
+ * @param value The string to measure.
+ * @returns The UTF-8 byte length.
+ */
+const utf8ByteLength = (value: string): number => {
+    let bytes = 0;
 
-/** Measures the UTF-8 byte length of a payload without allocating a fresh encoder per call. */
-const byteLengthOf = (payload: string, edgeCompat: boolean): number => {
-    if (edgeCompat || sharedTextEncoder === undefined) {
-        return Buffer.byteLength(payload, "utf8");
+    // Iterating a string yields whole code points, so surrogate pairs are visited once.
+    for (const character of value) {
+        const code = character.codePointAt(0) as number;
+
+        if (code < 0x80) {
+            bytes += 1;
+        } else if (code < 0x8_00) {
+            bytes += 2;
+        } else if (code < 0x1_00_00) {
+            // Includes unpaired surrogates, which encode as the 3-byte replacement character.
+            bytes += 3;
+        } else {
+            bytes += 4;
+        }
     }
 
-    return sharedTextEncoder.encode(payload).length;
+    return bytes;
+};
+
+/** Reused across all reporter instances so measuring a payload never allocates a new encoder. */
+let sharedTextEncoder: TextEncoder | undefined;
+
+/**
+ * Measures the UTF-8 byte length of a payload.
+ *
+ * Prefers the Web-standard `TextEncoder`, which every supported runtime (Node, browsers,
+ * Cloudflare Workers, Vercel Edge) provides — deliberately *not* `Buffer`, which would tie
+ * the edge builds to `node:buffer`. The encoder is resolved on first use rather than at module
+ * load so the reporter can be imported before the runtime finishes installing its globals.
+ * @param payload The payload to measure.
+ * @returns The UTF-8 byte length of `payload`.
+ */
+const byteLengthOf = (payload: string): number => {
+    if (typeof TextEncoder === "function") {
+        sharedTextEncoder ??= new TextEncoder();
+
+        return sharedTextEncoder.encode(payload).length;
+    }
+
+    return utf8ByteLength(payload);
 };
 
 /**
@@ -77,8 +116,11 @@ export type AbstractHttpReporterOptions = AbstractJsonReporterOptions & {
     contentType?: string;
 
     /**
-     * Whether to enable Edge Runtime compatibility mode
-     * When enabled, TextEncoder and compression are disabled
+     * Whether to enable Edge Runtime compatibility mode.
+     *
+     * When enabled, gzip compression is skipped so the reporter never depends on a
+     * compression implementation the runtime may not provide. Payload size accounting
+     * always uses the Web-standard `TextEncoder` and is unaffected by this flag.
      * @default false
      */
     edgeCompat?: boolean;
@@ -378,7 +420,7 @@ export abstract class AbstractHttpReporter<L extends string = string> extends Ab
             }
 
             // Check log entry size
-            const logEntrySize = byteLengthOf(payload, this.edgeCompat);
+            const logEntrySize = byteLengthOf(payload);
 
             if (logEntrySize > this.maxLogSize) {
                 const error = new LogSizeError(

--- a/packages/error-debugging/pail/src/reporter/http/utils/compression.ts
+++ b/packages/error-debugging/pail/src/reporter/http/utils/compression.ts
@@ -1,16 +1,37 @@
 /* eslint-disable n/no-unsupported-features/node-builtins */
 
-import { gzipSync } from "node:zlib";
-
 interface CompressionStreamLike {
     readable: { getReader: () => ReadableStreamDefaultReader<Uint8Array> };
     writable: { getWriter: () => WritableStreamDefaultWriter<Uint8Array> };
 }
 
 /**
+ * Loads `gzipSync` from `node:zlib` on demand.
+ *
+ * The import is deliberately dynamic: edge runtimes (Cloudflare Workers without
+ * `nodejs_compat`, Vercel Edge) do not provide `node:zlib`, and a static import
+ * would make merely *loading* the HTTP reporter fail there — even though those
+ * runtimes never reach this branch because they ship `CompressionStream`.
+ * @returns The `gzipSync` implementation, or `undefined` when `node:zlib` is unavailable.
+ */
+const loadNodeGzip = async (): Promise<((input: string) => Uint8Array) | undefined> => {
+    try {
+        const { gzipSync } = (await import("node:zlib")) as { gzipSync?: (input: string) => Uint8Array };
+
+        return typeof gzipSync === "function" ? gzipSync : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
  * Compresses data using gzip compression.
+ *
+ * Prefers the Web-standard `CompressionStream` (browsers, Cloudflare Workers, Deno,
+ * modern Node) and falls back to `node:zlib` only when it is absent.
  * @param data The data to compress as a string
  * @returns A Promise that resolves to the compressed data as Uint8Array
+ * @throws {Error} When the runtime provides neither `CompressionStream` nor `node:zlib`.
  */
 const compressData = async (data: string): Promise<Uint8Array> => {
     // Use CompressionStream API if available (browser/edge)
@@ -59,6 +80,12 @@ const compressData = async (data: string): Promise<Uint8Array> => {
     }
 
     // Node.js environment - use zlib
+    const gzipSync = await loadNodeGzip();
+
+    if (gzipSync === undefined) {
+        throw new Error("gzip compression is unavailable: this runtime provides neither CompressionStream nor node:zlib.");
+    }
+
     return gzipSync(data);
 };
 

--- a/packages/error-debugging/pail/src/utils/write-stream.ts
+++ b/packages/error-debugging/pail/src/utils/write-stream.ts
@@ -1,4 +1,20 @@
-const writeStream = (data: string, stream: NodeJS.WriteStream): boolean => {
+/**
+ * Writes `data` to `stream`, preferring the original `write` implementation that
+ * `PailServer.wrapStd()` stashes on `__write` so wrapped streams do not recurse.
+ *
+ * Runtimes without Node's standard streams (workerd and other edge runtimes where
+ * `node:process` exposes no `stdout`/`stderr`) hand reporters an `undefined` stream.
+ * Writing is skipped there instead of throwing, mirroring how `wrapStd()` already
+ * treats a missing stream as a no-op.
+ * @param data The already-formatted payload to write.
+ * @param stream The destination stream, or `undefined` when the runtime has none.
+ * @returns `true` when the payload was handed to the stream, `false` when it was dropped.
+ */
+const writeStream = (data: string, stream: NodeJS.WriteStream | undefined): boolean => {
+    if (!stream) {
+        return false;
+    }
+
     const write: NodeJS.WriteStream["write"]
         = ((stream as unknown as Record<string, unknown>)["__write"] as NodeJS.WriteStream["write"] | undefined) ?? stream.write.bind(stream);
 

--- a/packages/error-debugging/pail/vitest.workerd.config.ts
+++ b/packages/error-debugging/pail/vitest.workerd.config.ts
@@ -1,0 +1,5 @@
+import { getWorkerdVitestConfig } from "../../../tools/get-workerd-vitest-config";
+
+const config = getWorkerdVitestConfig();
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5213,6 +5213,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: catalog:dev
         version: 0.18.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:test
+        version: 0.19.0(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@opentelemetry/api':
         specifier: catalog:dev
         version: 1.9.1
@@ -48830,7 +48833,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
@@ -60107,7 +60110,7 @@ snapshots:
   standard@17.1.2(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)):
     dependencies:
       eslint: 8.57.1
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-n@15.7.0(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-promise@6.6.0(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.37.5(eslint@10.6.0(jiti@2.7.0)))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-n: 15.7.0(eslint@8.57.1)


### PR DESCRIPTION
The HTTP reporter's `edge-light` build could not be resolved on any runtime,
and would not have loaded if it were.

Its export entry sat behind `import`, which matches for every ESM consumer, so
the edge build was unreachable even on Vercel. `./reporter/json`, `./reporter/pretty`
and the root entry had the mirror-image problem, with `browser` behind `import`,
so browser bundlers received the Node build. Runtime conditions now precede the
generic ones, and `workerd` is added. Node resolution is byte-identical.

The build itself was not edge-safe either: `compression.ts` statically imported
`node:zlib` into that entry, so importing it failed on runtimes without Node
builtins even though edge mode never gzips. It is now loaded on demand behind a
`CompressionStream` check. `abstract-http-reporter.ts` had the flag inverted —
`edgeCompat` routed to `Buffer.byteLength` while the default path used
`TextEncoder`, so the edge build depended on Node more than the Node build did.

Elsewhere: `AsyncLocalStorage.enterWith()` is not implemented on workerd, and
the Elysia plugin called it unconditionally, so every request through it threw;
`clear()`, the interactive manager and the raw write path assumed
`process.stdout`/`stderr` exist; and the message formatter supplied its own
`stringify` to the formatter, displacing its circular guard so a self-referential
logged value crashed the caller. A logger must not do that.

A guard test reads the edge reporter's module graph and asserts no static
`node:*` import, with a control case so it cannot pass vacuously — the runtime
suite cannot catch this, since `nodejs_compat` resolves every builtin.

BREAKING CHANGE: browser bundlers now resolve `@visulima/pail`, `./reporter/json`
and `./reporter/pretty` to the browser builds instead of the Node ones. That is
the documented intent, but it changes the module a browser build receives.



---

### Notes that apply to every PR in this stack

- **`package.json` key reordering is not a deliberate edit.** The `sort-package-json` pre-commit hook re-sorts on any commit touching the file, and `main`'s files are already out of order relative to the installed version of that tool. Nothing in the reordering is meaningful — the real changes are the `test:workerd` script and the `@cloudflare/vitest-pool-workers` devDependency.
- **`pnpm-lock.yaml` carries this package's importer entry only**, regenerated with `--lockfile-only`. A couple of unrelated peer-resolution lines get reshuffled nondeterministically by pnpm; they're noise.
- Based on the workerd harness PR; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
