### PR TITLE
fix(tui): ignore the migration guide when linting

### DIFF
--- a/packages/terminal/tui/eslint.config.js
+++ b/packages/terminal/tui/eslint.config.js
@@ -39,6 +39,7 @@ export default createConfig(
             "package.json",
             "README.md",
             "CHANGELOG.md",
+            "MIGRATION-GUIDE.md",
             "prettier.config.js",
             "**/*.js",
             "**/*.d.ts",


### PR DESCRIPTION
`packages/terminal/tui/MIGRATION-GUIDE.md` is the only one of the repository's four migration guides missing from its package's ESLint `ignores`.

Its ```ts / ```tsx fences get extracted into virtual files like `MIGRATION-GUIDE.md/0_0.ts`, which no tsconfig can include, so the type-aware parser config rejects each one:

```
21:1  error  Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
The file was not found in any of the provided project(s): MIGRATION-GUIDE.md/0_0.ts
```

Four errors, which fail `lint:eslint` for the whole run.

## Why this fix

`pail`, `cerebro` and `package` all list their guide in `ignores` already, next to `README.md` and `CHANGELOG.md`. This restores that convention rather than inventing one. (Those three also avoid the problem incidentally by tagging fences ```typescript, which the processor doesn't lint at all.)

I tried the narrower fix first — an override scoping `parserOptions.project` off for `**/*.md/**` — and it doesn't work: type-aware rules remain enabled for those files and then fail to load with *"You have used a rule which requires type information"*.

## Note

This is failing on `main` today. The test/lint workflow only runs on pull requests and merge groups, so nothing surfaced it until a PR was opened. Verified by reproducing on a clean `main` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Excluded the migration guide from ESLint checks to prevent irrelevant linting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->