### PR TITLE
fix(disposable-email-domains): make the domains subpath importable

### DIFF
--- a/packages/email/disposable-email-domains/__fixtures__/package/mjs/test.mjs
+++ b/packages/email/disposable-email-domains/__fixtures__/package/mjs/test.mjs
@@ -1,4 +1,9 @@
 import * as pkg from "@visulima/disposable-email-domains";
+// Imported without an import attribute on purpose. The `./domains` subpath used
+// to resolve straight to `domains.json`, so this line threw
+// ERR_IMPORT_ATTRIBUTE_MISSING at runtime while still type-checking. The types
+// fixture is compile-only and could not catch that.
+import domains from "@visulima/disposable-email-domains/domains";
 
 if (typeof pkg !== "object" || pkg === null) {
     throw new Error("expected exports to be an object");
@@ -6,6 +11,14 @@ if (typeof pkg !== "object" || pkg === null) {
 
 if (Object.keys(pkg).length === 0) {
     throw new Error("expected non-empty exports");
+}
+
+if (!Array.isArray(domains)) {
+    throw new TypeError("expected the ./domains subpath to default-export an array");
+}
+
+if (domains.length === 0) {
+    throw new Error("expected a non-empty domains list");
 }
 
 console.log("ok");

--- a/packages/email/disposable-email-domains/__tests__/sync-manager.test.ts
+++ b/packages/email/disposable-email-domains/__tests__/sync-manager.test.ts
@@ -155,6 +155,25 @@ describe("disposableEmailSyncManager generated ./domains declaration", () => {
         expect(declaration).toContain("export default domains;");
         expect(declaration).not.toContain("export =");
     });
+
+    // The `./domains` subpath resolves to this wrapper, not to `domains.json`.
+    // Exporting the JSON directly made a plain `import domains from
+    // "@visulima/disposable-email-domains/domains"` throw
+    // ERR_IMPORT_ATTRIBUTE_MISSING, since Node requires `with { type: "json" }`
+    // on a JSON module, and made bundler resolution read it as `module.exports =`
+    // against the `export default` declaration above.
+    it("emits a wrapper carrying the json import attribute", async () => {
+        expect.assertions(3);
+
+        await manager.generateDomainsList([]);
+
+        const wrapper = await readFile(join(outputPath, "domains.js"), "utf8");
+
+        expect(wrapper).toContain("with { type: \"json\" }");
+        expect(wrapper).toContain("export default domains;");
+        // Re-exported, never inlined: the list is ~2.4 MB and ships once.
+        expect(wrapper).not.toContain("[");
+    });
 });
 
 describe("repositories.json config", () => {

--- a/packages/email/disposable-email-domains/package.json
+++ b/packages/email/disposable-email-domains/package.json
@@ -14,11 +14,6 @@
     ],
     "homepage": "https://visulima.com/packages/disposable-email-domains",
     "bugs": "https://github.com/visulima/visulima/issues",
-    "license": "MIT",
-    "author": {
-        "name": "Daniel Bannert",
-        "email": "d.bannert@anolilab.de"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/visulima/visulima.git",
@@ -34,13 +29,13 @@
             "url": "https://anolilab.com/support"
         }
     ],
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "type": "module",
+    "license": "MIT",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
     "sideEffects": false,
+    "type": "module",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -48,14 +43,15 @@
         },
         "./domains": {
             "types": "./dist/domains.d.ts",
-            "default": "./dist/domains.json"
+            "default": "./dist/domains.js"
         },
         "./package.json": "./package.json"
     },
-    "publishConfig": {
-        "access": "public",
-        "provenance": true
-    },
+    "files": [
+        "dist",
+        "README.md",
+        "CHANGELOG.md"
+    ],
     "scripts": {
         "build": "packem build --development && pnpm run generate:domains",
         "build:prod": "packem build --production && pnpm run generate:domains",
@@ -104,5 +100,9 @@
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"
+    },
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/packages/email/disposable-email-domains/scripts/disposable-email-sync-manager.js
+++ b/packages/email/disposable-email-domains/scripts/disposable-email-sync-manager.js
@@ -469,8 +469,24 @@ ${repo.error ? `- **Error**: ${repo.error}` : ""}
     async generateDomainsList(finalDomains = this.buildFinalDomainsList()) {
         await fs.writeFile(join(this.syncOptions.outputPath, "domains.json"), JSON.stringify(finalDomains), "utf8");
 
-        // Emit a type declaration so the `./domains` subpath export carries types
-        // (`import domains from "@visulima/disposable-email-domains/domains" with { type: "json" }`).
+        // The `./domains` subpath resolves to this wrapper rather than the JSON
+        // itself. Pointing the export straight at `domains.json` made a plain
+        // `import domains from "@visulima/disposable-email-domains/domains"` fail
+        // at runtime with ERR_IMPORT_ATTRIBUTE_MISSING, because Node requires
+        // `with { type: "json" }` on a JSON module. It also made bundler
+        // resolution read the JSON as `module.exports =`, which contradicts the
+        // `export default` declaration below.
+        //
+        // The wrapper carries the attribute so callers do not have to, and gives
+        // the subpath a genuine ESM default export. It re-exports rather than
+        // inlining, so the ~2.4 MB list is still shipped exactly once.
+        await fs.writeFile(
+            join(this.syncOptions.outputPath, "domains.js"),
+            "import domains from \"./domains.json\" with { type: \"json\" };\n\nexport default domains;\n",
+            "utf8",
+        );
+
+        // Emit a type declaration so the `./domains` subpath export carries types.
         await fs.writeFile(join(this.syncOptions.outputPath, "domains.d.ts"), "declare const domains: string[];\nexport default domains;\n", "utf8");
     }
 


### PR DESCRIPTION
The `./domains` subpath resolved straight to `dist/domains.json`. That broke it two ways — one of which is a runtime bug, not just a tooling complaint.

## 1. It could not be imported at runtime

```console
$ node --input-type=module -e "import d from '@visulima/disposable-email-domains/domains'; console.log(d.length)"
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module ".../dist/domains.json" needs an
import attribute of "type: json"
```

Node requires `with { type: "json" }` on a JSON module. `__fixtures__/package/types/index.ts` imports the subpath in exactly that plain form — but it is **compile-only** (`tsc --noEmit`), so it type-checked happily while the same line threw at runtime.

## 2. It failed `lint:attw`

Bundler resolution reads a JSON file as `module.exports =`, which contradicts the `export default` in the generated declaration:

```
"@visulima/disposable-email-domains/domains"
  node16 (from ESM): 🟢 (ESM)
  bundler:           ❗️ Incorrect default export
```

## The fix

`./domains` now resolves to a generated ESM wrapper that carries the attribute itself:

```js
import domains from "./domains.json" with { type: "json" };

export default domains;
```

- Callers no longer need the attribute — the plain import works.
- The subpath has a genuine ESM default export, so `bundler` is 🟢 and attw exits 0 **with no suppression**.
- It re-exports rather than inlines: the ~2.4 MB list still ships exactly once. The wrapper is **85 bytes**.

The declaration keeps `export default`. `export =` would be wrong for an ESM-only package, and both `__tests__/sync-manager.test.ts` and the types fixture deliberately guard against it — so that intent is preserved rather than overturned.

## Verification

`__fixtures__/package/mjs/test.mjs` now imports the subpath without an attribute and asserts a non-empty array. Proven non-vacuous by rebuilding against `main`'s export map:

| export map | fixture |
|---|---|
| `main` (`./dist/domains.json`) | ❌ `ERR_IMPORT_ATTRIBUTE_MISSING` |
| this branch (`./dist/domains.js`) | ✅ `ok` — 141,131 domains |

Package suite **43 passed**; `tsc --noEmit`, `eslint`, `publint --strict` and `attw --pack --profile esm-only` all exit 0.

## Why it is surfacing now

It has been failing on `main`. `lint:affected:attw` only runs for projects a change touches, and nothing had touched this package recently. Any PR altering root configuration makes every project affected and hits it.

Note a plain `packem build` does not reproduce it — the package's `build` also runs `generate:domains`, without which `./domains` fails to resolve for a different reason.

*Supersedes the earlier revision of this PR, which suppressed the attw rule instead of fixing the cause.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
