### PR TITLE
fix(error): load node builtins lazily

### DIFF
--- a/packages/error-debugging/error/__tests__/integration/dist-node-interop.test.ts
+++ b/packages/error-debugging/error/__tests__/integration/dist-node-interop.test.ts
@@ -1,17 +1,50 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const distributionRoot = join(here, "..", "..", "dist");
 
-/** Any `import`/`export … from` declaration, plus bare side-effect imports. */
-const STATIC_SPECIFIER_REGEX = /^(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)["']|^import\s*["']([^"']+)["']/gmu;
+/**
+ * The specifier of an `import`/`export … from` declaration. Matched on `from` rather than on the
+ * statement start, because a production build ships each chunk on one line and drops the space
+ * after `import`. A dynamic `import("…")` has no `from` and is deliberately not collected: it is
+ * evaluated only when the branch that needs it runs, so it cannot break module load.
+ */
+const FROM_SPECIFIER_REGEX = /\bfrom\s*["']([^"']+)["']/gu;
 
-/** A `__cjs_getBuiltinModule("node:…")` call site, with whatever immediately precedes it. */
-const BUILTIN_LOOKUP_REGEX = /(.{0,18})__cjs_getBuiltinModule\(/gu;
+/** A bare `import "…"`, which has no `from` to match on. */
+// eslint-disable-next-line sonarjs/slow-regex -- disjoint alternatives, so no super-linear backtracking
+const SIDE_EFFECT_IMPORT_REGEX = /(?:^|[;}])\s*import\s*["']([^"']+)["']/gmu;
+
+/**
+ * A `"node:…"` string literal, which is how a Node-builtin reach survives minification — the
+ * identifier that consumes it does not, so the literal is the only stable handle on one.
+ */
+const NODE_SPECIFIER_REGEX = /["'](node:[^"']+)["']/gu;
+
+/**
+ * The built entries a consumer can reach without a peer dependency. `solution/ai` is left out: it
+ * needs the optional `ai` peer, so a failed import there says nothing about Node core.
+ */
+const PUBLIC_ENTRIES = ["index.js", "error/index.js", "stacktrace/index.js", "code-frame/index.js", "solution/index.js"];
+
+/**
+ * Imports a built entry in a fresh Node process with `process.getBuiltinModule` removed, which is
+ * what an edge runtime effectively looks like to this package.
+ * @param entry Absolute path of the built entry to import.
+ * @returns Whatever the import wrote to stdout, which is nothing on success.
+ * @throws When the entry reaches into Node core while its module scope is being evaluated.
+ */
+const importWithoutNodeCore = (entry: string): string =>
+    execFileSync(process.execPath, ["--input-type=module", "--eval", "delete process.getBuiltinModule; await import(process.env.ENTRY);"], {
+        encoding: "utf8",
+        env: { ...process.env, ENTRY: pathToFileURL(entry).href },
+        stdio: "pipe",
+    });
 
 const distributionFiles = (): string[] => {
     const found: string[] = [];
@@ -32,31 +65,21 @@ const distributionFiles = (): string[] => {
     return found.toSorted((a, b) => a.localeCompare(b));
 };
 
-const staticSpecifiersIn = (source: string): string[] => {
-    const specifiers: string[] = [];
-
-    for (const match of source.matchAll(STATIC_SPECIFIER_REGEX)) {
-        const specifier = match[1] ?? match[2];
-
-        if (specifier !== undefined) {
-            specifiers.push(specifier);
-        }
-    }
-
-    return specifiers;
-};
+const staticSpecifiersIn = (source: string): string[] =>
+    [...source.matchAll(FROM_SPECIFIER_REGEX), ...source.matchAll(SIDE_EFFECT_IMPORT_REGEX)].map((match) => match[1] as string);
 
 /**
- * This package declares `"sideEffects": false`, and consumers bundle it on that promise. The
- * bundler's `requireCJS` pass would otherwise break it: it rewrites `import … from "node:*"` into a
- * module-scope `__cjs_getBuiltinModule("node:*")` call backed by a static
- * `import { createRequire } from "node:module"`, so a chunk stays alive for its top-level statements
- * alone and drags `node:module` into consumer bundles that never touch the exports it provides.
+ * This package declares `"sideEffects": false`, and consumers bundle it on that promise. A
+ * module-scope reach into Node core breaks it two ways: a bundler has to assume the statement
+ * matters and keeps the chunk alive even when none of its exports are used, and on a runtime with
+ * no Node core (Cloudflare Workers without `nodejs_compat`, Vercel Edge) the reach fails while the
+ * module is still being imported — so a consumer importing only `serializeError` from `./error`
+ * crashes because `renderError` sits in the same barrel.
  *
- * On a runtime with no Node core (Cloudflare Workers without `nodejs_compat`, Vercel Edge) a static
- * `node:module` import fails at import time, so this is a correctness property and not just a size
- * one. `packem.config.ts` strips the dead `createRequire` fallback and annotates the remaining
- * lookups as pure; these assertions are what keeps it honest.
+ * `src/util/node-builtin.ts` keeps every reach inside the function that needs it. These assertions
+ * are what keeps that honest, and they run against whatever `dist` currently holds — production
+ * builds included, where minification would hide a reach from any check written against identifier
+ * names.
  */
 describe("built `@visulima/error` distribution", () => {
     it("exists so the assertions below are not vacuous", () => {
@@ -88,29 +111,23 @@ describe("built `@visulima/error` distribution", () => {
         ).toStrictEqual([]);
     });
 
-    it("annotates every Node-builtin lookup as pure so consumers can drop it", () => {
-        expect.assertions(2);
+    it.each(PUBLIC_ENTRIES)("loads %s on a runtime with no Node core", (entry) => {
+        expect.assertions(1);
 
-        const lookups: string[] = [];
-        const unannotated: string[] = [];
+        // Asserted by running rather than by reading: minification renames every identifier a
+        // textual check could anchor on, and "is this statement at module scope" is not a question
+        // a regex can answer over a one-line chunk. Importing with `process.getBuiltinModule`
+        // removed reproduces exactly what an edge runtime does to a module-scope reach.
+        expect(() => importWithoutNodeCore(join(distributionRoot, entry))).not.toThrow();
+    });
 
-        for (const file of distributionFiles()) {
-            for (const match of readFileSync(file, "utf8").matchAll(BUILTIN_LOOKUP_REGEX)) {
-                // The helper's own declaration is not a call site.
-                if (match[1]?.endsWith("const ")) {
-                    continue;
-                }
+    it("still reaches Node core, so the check above is not vacuous", () => {
+        expect.assertions(1);
 
-                lookups.push(`${relative(distributionRoot, file)}: ${match[0]}`);
+        const reaches = distributionFiles().flatMap((file) =>
+            [...readFileSync(file, "utf8").matchAll(NODE_SPECIFIER_REGEX)].map((match) => `${relative(distributionRoot, file)}: ${match[1] as string}`),
+        );
 
-                if (!match[1]?.endsWith("/* @__PURE__ */ ")) {
-                    unannotated.push(`${relative(distributionRoot, file)}: ${match[0]}`);
-                }
-            }
-        }
-
-        // Guards against the whole check going vacuous if `requireCJS` is ever turned off.
-        expect(lookups.length).toBeGreaterThan(0);
-        expect(unannotated).toStrictEqual([]);
+        expect(reaches.length).toBeGreaterThan(0);
     });
 });

--- a/packages/error-debugging/error/packem.config.ts
+++ b/packages/error-debugging/error/packem.config.ts
@@ -1,189 +1,22 @@
-import { createRequire } from "node:module";
-
 import type { BuildConfig } from "@visulima/packem/config";
 import { defineConfig } from "@visulima/packem/config";
 import transformer from "@visulima/packem/transformer/esbuild";
-import type { Plugin } from "rollup";
 
 /**
- * `requireCJS.builtinNodeModules` rewrites every `import … from "node:*"` into a module-scope
- * `__cjs_getBuiltinModule("node:*")` call, and prepends an interop preamble that resolves the
- * builtin through `process.getBuiltinModule` with a `createRequire` fallback for Node < 20.16 /
- * < 22.3. That preamble is what makes the emitted chunks contradict this package's
- * `"sideEffects": false`:
+ * This package declares `"sideEffects": false`, and consumers bundle it on that promise. Keeping
+ * that promise means shipping chunks whose *module scope* never reaches into Node core — see
+ * `src/util/node-builtin.ts` for why, and `__tests__/integration/dist-node-interop.test.ts` for the
+ * guard on the built output.
  *
- * - the destructuring is a module-scope *call*, so a bundler that assumes side effects keeps the
- *   whole chunk alive even when none of its exports are used;
- * - the `createRequire` fallback needs a static `import { createRequire } from "node:module"`,
- *   which then rides along into every consumer bundle — including ones targeting runtimes that
- *   have no Node core at all, where a static `node:module` import fails at *import* time.
- *
- * A consumer importing only `serializeError` from `./error` therefore inherits `node:module`
- * purely because `renderError` and `getErrorCauses` sit in the same barrel.
- *
- * Both halves of that are avoidable here:
- *
- * 1. This package's `engines.node` is `^22.14.0 || >=24.10.0`, so `process.getBuiltinModule` is
- *    always present and the `createRequire` fallback is dead code. Dropping it removes the only
- *    static `node:module` import from the output.
- * 2. Resolving a Node core module has no observable side effect, so the lookup can carry a
- *    `@__PURE__` annotation. With it, a consumer's bundler drops the destructuring — and then the
- *    rest of the preamble — as soon as the imported binding is unused.
- *
- * This has to be fixed here rather than in a consumer's build. Rollup honours our
- * `"sideEffects": false` and drops the unused chunks outright — but only while the consumer
- * registers no build plugin of its own: with one present, packem falls back to
- * `treeshake.moduleSideEffects: true` for the whole graph and the chunks come back. Whether a
- * consumer's bundle stays free of `node:module` must not depend on that.
- *
- * ## What this narrows
- *
- * `engines.node` only constrains Node. Point 1 also drops the fallback for *non-Node* runtimes
- * that report a `process.versions.node` while implementing no `process.getBuiltinModule` — older
- * Deno and Bun releases both do, and they used to land on `createRequire`. Restoring the fallback
- * is not an option: its static `import { createRequire } from "node:module"` is the very thing
- * that has to go. Those runtimes are therefore no longer supported, and the replacement helper
- * below says so explicitly instead of letting them fail with an opaque
- * `TypeError: __cjs_getProcess.getBuiltinModule is not a function`.
- *
- * ## What keeps this honest
- *
- * Every rewrite below asserts the packem fragment it expects and throws when it is missing, so a
- * preamble reshuffle surfaces as a build failure rather than silently reinstating `node:module`.
- * Two paths cannot throw — a chunk with no interop at all is the normal case, and a chunk whose
- * `__cjs_require` call count is unexpected may legitimately have a second CJS dependency — so
- * those warn instead, and the plugin's `generateBundle` hook warns once per build if *no* chunk
- * matched at all (which is what a helper rename upstream would look like).
- *
- * `__tests__/integration/dist-node-interop.test.ts` guards the output shape directly and fails
- * hard on any of those warnings' underlying causes;
- * `packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts` guards the
- * end-to-end effect, on a built edge entry that pulls `serializeError` out of this package.
+ * That is a source-level property here, so this config needs nothing to enforce it. It used to:
+ * with `node:*` imports at module scope, `requireCJS.builtinNodeModules` rewrote each one into a
+ * module-scope `__cjs_getBuiltinModule` call backed by a static `import { createRequire } from
+ * "node:module"`, and a plugin then rewrote *that* back out of every chunk. The rewrite was pinned
+ * to one packem version's preamble, and the `@__PURE__` annotations it added to make the remaining
+ * lookups droppable did not survive a consumer whose own build minifies before it tree-shakes — so
+ * the chunks came back anyway. Reaching for the builtin inside the function that needs it removes
+ * the module-scope statement instead of trying to make bundlers discard it.
  */
-
-/** Named in every diagnostic below: the preamble shape is version-specific, so say which version. */
-const PACKEM_VERSION: string = (createRequire(import.meta.url)("@visulima/packem/package.json") as { version: string }).version;
-
-/** Static import that only exists to back the `createRequire` fallback. */
-const CREATE_REQUIRE_IMPORT_REGEX = /^import \{ createRequire as __cjs_createRequire \} from "node:module";\n+/mu;
-
-/** The memoised `createRequire` wrapper the fallback calls. */
-const CJS_REQUIRE_HELPER_REGEX = /^let __cjs_cachedRequire;\nconst __cjs_require = \(id\) => \{\n(?:.*\n)*?\};\n+/mu;
-
-/** The builtin resolver, whose Node-version branch and fallback are both dead under our engines. */
-const GET_BUILTIN_MODULE_HELPER_REGEX = /^const __cjs_getBuiltinModule = \(module\) => \{\n(?:.*\n)*?\};\n/mu;
-
-/**
- * Replacement for the helper above. The shape matters: when a consumer inlines one of our chunks
- * and its own `requireCJS` pass prepends a second preamble, packem de-duplicates the two by
- * matching `const __cjs_getBuiltinModule = (…) => { … };` textually. An expression-bodied arrow
- * would slip past that and leave the identifier declared twice in the consumer's chunk, so keep the
- * block body — and keep it free of any `};` before the closing one, which is where that match ends.
- *
- * The capability check is what replaces packem's `versions.node` branch: without the
- * `createRequire` fallback there is nothing to degrade to, so a runtime that cannot satisfy the
- * lookup should say which capability it is missing rather than throw `… is not a function` from
- * somewhere inside a bundled chunk.
- */
-const GET_BUILTIN_MODULE_HELPER = `const __cjs_getBuiltinModule = (module) => {
-    if (typeof __cjs_getProcess?.getBuiltinModule !== "function") {
-        throw new Error("[@visulima/error] Cannot load " + module + ": this runtime implements no process.getBuiltinModule(). Requires Node >= 20.16 / >= 22.3, or another runtime providing process.getBuiltinModule().");
-    }
-    return __cjs_getProcess.getBuiltinModule(module);
-};
-`;
-
-/** Call sites of the resolver that are not already annotated. */
-const BUILTIN_LOOKUP_REGEX = /(?<!\/\* @__PURE__ \*\/ )__cjs_getBuiltinModule\(/gu;
-
-/** Emitted when a rewrite is skipped, so the packem upgrade that caused it is identifiable. */
-const shapeChanged = (detail: string): string =>
-    `${detail} Verified against @visulima/packem@${PACKEM_VERSION}; the CJS-interop preamble shape appears to have changed — update packem.config.ts.`;
-
-const dropDeadNodeInterop = (code: string, chunkName: string, warn: (message: string) => void): string => {
-    let next = code;
-
-    // `__cjs_require` is also the generic CJS-require helper. This package has no runtime
-    // dependencies, so its only caller is the builtin fallback below; if that ever stops being
-    // true, leave the fallback in place and settle for the annotation.
-    const requireCallSites = (code.match(/__cjs_require\(/gu) ?? []).length;
-
-    if (requireCallSites === 1) {
-        for (const [what, pattern] of [
-            ["the `node:module` import", CREATE_REQUIRE_IMPORT_REGEX],
-            ["the `__cjs_require` helper", CJS_REQUIRE_HELPER_REGEX],
-        ] as const) {
-            if (!pattern.test(next)) {
-                throw new Error(shapeChanged(`Could not find ${what} in the CJS-interop preamble of "${chunkName}".`));
-            }
-
-            next = next.replace(pattern, "");
-        }
-
-        if (!GET_BUILTIN_MODULE_HELPER_REGEX.test(next)) {
-            throw new Error(shapeChanged(`Could not find the \`__cjs_getBuiltinModule\` helper in "${chunkName}".`));
-        }
-
-        next = next.replace(GET_BUILTIN_MODULE_HELPER_REGEX, GET_BUILTIN_MODULE_HELPER);
-    } else {
-        // Zero means the fallback stopped calling `__cjs_require`; two or more means a real CJS
-        // dependency shares the helper. Either way the removal above is unsafe, so only the
-        // annotation applies — and `node:module` stays in the chunk. Not fatal (a stray CJS dep
-        // must not break the build outright), but never silent: `dist-node-interop.test.ts` turns
-        // it into a hard CI failure.
-        warn(
-            shapeChanged(
-                `Expected exactly one \`__cjs_require(\` call site — the dead builtin fallback — in "${chunkName}", found ${String(requireCallSites)}. Left the \`createRequire\` fallback and its \`node:module\` import in place.`,
-            ),
-        );
-    }
-
-    return next.replaceAll(BUILTIN_LOOKUP_REGEX, "/* @__PURE__ */ __cjs_getBuiltinModule(");
-};
-
-/**
- * A chunk without `__cjs_getBuiltinModule(` is the overwhelmingly common case, so that check
- * cannot throw. But if it short-circuits *every* chunk of a build, the helper was renamed upstream
- * and this whole plugin quietly became a no-op — which is exactly the failure it exists to prevent.
- */
-const createPruneNodeBuiltinInterop = (): Plugin => {
-    let chunksRewritten = 0;
-
-    return {
-        generateBundle: {
-            handler() {
-                if (chunksRewritten === 0) {
-                    this.warn(
-                        shapeChanged(
-                            "No chunk contained a `__cjs_getBuiltinModule(` call, so the CJS-interop preamble was never rewritten and the build may ship a `createRequire` fallback.",
-                        ),
-                    );
-                }
-            },
-            order: "post",
-        },
-        name: "error:prune-node-builtin-interop",
-        renderChunk: {
-            handler(code, chunk) {
-                if (!code.includes("__cjs_getBuiltinModule(")) {
-                    return null;
-                }
-
-                chunksRewritten += 1;
-
-                return {
-                    code: dropDeadNodeInterop(code, chunk.fileName, (message) => {
-                        this.warn(message);
-                    }),
-                    map: null,
-                };
-            },
-            // `packem:plugin-require-cjs` emits the preamble from its own `renderChunk` hook, which
-            // runs in the default ("pre") slot.
-            order: "post",
-        },
-    };
-};
 
 // eslint-disable-next-line import/no-unused-modules
 export default defineConfig({
@@ -194,15 +27,6 @@ export default defineConfig({
         },
         license: {
             path: "./LICENSE.md",
-        },
-        plugins: [
-            {
-                plugin: createPruneNodeBuiltinInterop(),
-                type: "build",
-            },
-        ],
-        requireCJS: {
-            builtinNodeModules: true,
         },
     },
     transformer,

--- a/packages/error-debugging/error/src/error/get-error-causes.ts
+++ b/packages/error-debugging/error/src/error/get-error-causes.ts
@@ -4,6 +4,30 @@ import type { VisulimaError } from "./visulima-error";
 const nodeUtility = nodeBuiltin("node:util");
 
 /**
+ * Describes an error for the diagnostic below, without ever throwing in the attempt.
+ *
+ * Nothing else in this module needs Node core, so it stays loadable and callable on an edge
+ * runtime — but only if this one cosmetic `inspect` cannot take the walk down with it. `inspect`
+ * is unavailable there, and a `toString` that throws (or a symbol) would defeat the plain fallback
+ * too, so both are guarded: a diagnostic must never replace the error being examined.
+ * @param error The value whose cause chain turned out to be circular.
+ * @returns The richest description that could be produced.
+ */
+const describeError = (error: unknown): string => {
+    try {
+        return nodeUtility().inspect(error);
+    } catch {
+        // No `node:util` on this runtime — fall back to plain stringification.
+    }
+
+    try {
+        return String(error);
+    } catch {
+        return "<unprintable>";
+    }
+};
+
+/**
  * Will return an array of all causes in the error in the order they occurred.
  */
 
@@ -17,7 +41,7 @@ const getErrorCauses = <E = Error | VisulimaError>(error: E): E[] => {
         // Check for circular reference
         if (seen.has(currentError)) {
             // eslint-disable-next-line no-console
-            console.error(`Circular reference detected in error causes: ${nodeUtility().inspect(error)}`);
+            console.error(`Circular reference detected in error causes: ${describeError(error)}`);
 
             break;
         }

--- a/packages/error-debugging/error/src/error/get-error-causes.ts
+++ b/packages/error-debugging/error/src/error/get-error-causes.ts
@@ -1,6 +1,7 @@
-import { inspect } from "node:util";
-
+import nodeBuiltin from "../util/node-builtin";
 import type { VisulimaError } from "./visulima-error";
+
+const nodeUtility = nodeBuiltin("node:util");
 
 /**
  * Will return an array of all causes in the error in the order they occurred.
@@ -16,7 +17,7 @@ const getErrorCauses = <E = Error | VisulimaError>(error: E): E[] => {
         // Check for circular reference
         if (seen.has(currentError)) {
             // eslint-disable-next-line no-console
-            console.error(`Circular reference detected in error causes: ${inspect(error)}`);
+            console.error(`Circular reference detected in error causes: ${nodeUtility().inspect(error)}`);
 
             break;
         }

--- a/packages/error-debugging/error/src/error/render/error.ts
+++ b/packages/error-debugging/error/src/error/render/error.ts
@@ -1,13 +1,14 @@
-import { existsSync, readFileSync } from "node:fs";
-import { relative, resolve, sep } from "node:path";
-import { cwd } from "node:process";
-import { fileURLToPath } from "node:url";
-
 import type { CodeFrameOptions, ColorizeMethod } from "../../code-frame";
 import { codeFrame } from "../../code-frame";
 import type { Trace } from "../../stacktrace";
 import { parseStacktrace } from "../../stacktrace";
+import nodeBuiltin from "../../util/node-builtin";
 import type { VisulimaError } from "../visulima-error";
+
+const nodeFs = nodeBuiltin("node:fs");
+const nodePath = nodeBuiltin("node:path");
+const nodeProcess = nodeBuiltin("node:process");
+const nodeUrl = nodeBuiltin("node:url");
 
 /**
  * Error types that can be rendered.
@@ -49,7 +50,7 @@ const toDisplayPath = (path: string): string => {
     }
 
     try {
-        return fileURLToPath(path);
+        return nodeUrl().fileURLToPath(path);
     } catch {
         return path;
     }
@@ -62,7 +63,7 @@ const getRelativePath = (filePath: string, cwdPath: string) => {
      */
     const path = filePath.replace("async file:", "file:");
 
-    return normalizePathSeparators(relative(cwdPath, toDisplayPath(path)));
+    return normalizePathSeparators(nodePath().relative(cwdPath, toDisplayPath(path)));
 };
 
 /**
@@ -170,10 +171,10 @@ const isReadableSourcePath = (filePath: string, options: Options): boolean => {
         return true;
     }
 
-    const root = resolve(options.cwd);
-    const resolved = resolve(root, filePath);
+    const root = nodePath().resolve(options.cwd);
+    const resolved = nodePath().resolve(root, filePath);
 
-    return resolved === root || resolved.startsWith(root + sep);
+    return resolved === root || resolved.startsWith(root + nodePath().sep);
 };
 
 /**
@@ -188,11 +189,11 @@ const isReadableSourcePath = (filePath: string, options: Options): boolean => {
  */
 const readSourceFile = (filePath: string): string | undefined => {
     try {
-        if (!existsSync(filePath)) {
+        if (!nodeFs().existsSync(filePath)) {
             return undefined;
         }
 
-        return readFileSync(filePath, "utf8");
+        return nodeFs().readFileSync(filePath, "utf8");
     } catch {
         return undefined;
     }
@@ -338,7 +339,7 @@ const getStacktrace = (stack: Trace[], options: Options): string =>
 const internalRenderError = (error: AggregateError | Error | VisulimaError, options: Partial<Options>, deep: number): string => {
     const config = {
         allowAllFilePaths: false,
-        cwd: cwd(),
+        cwd: nodeProcess().cwd(),
         displayShortPath: false,
         filterStacktrace: undefined,
         framesMaxLimit: Number.POSITIVE_INFINITY,

--- a/packages/error-debugging/error/src/solution/ai/ai-finder.ts
+++ b/packages/error-debugging/error/src/solution/ai/ai-finder.ts
@@ -1,14 +1,15 @@
-import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 import type { LanguageModel } from "ai";
 import { generateText } from "ai";
 
+import nodeBuiltin from "../../util/node-builtin";
 import type { Solution, SolutionFinder, SolutionFinderFile } from "../types";
 import aiPrompt from "./ai-prompt";
 import aiSolutionResponse from "./ai-solution-response";
+
+const nodeCrypto = nodeBuiltin("node:crypto");
+const nodeFs = nodeBuiltin("node:fs");
+const nodeOs = nodeBuiltin("node:os");
+const nodePath = nodeBuiltin("node:path");
 
 const DEFAULT_HEADER = "## Ai Generated Solution";
 
@@ -41,7 +42,7 @@ const generateCacheKey = (error: Error, file: SolutionFinderFile, temperature?: 
         temperature,
     };
 
-    return createHash("sha256").update(JSON.stringify(keyData)).digest("hex");
+    return nodeCrypto().createHash("sha256").update(JSON.stringify(keyData)).digest("hex");
 };
 
 // Get cache directory path.
@@ -56,9 +57,9 @@ const getCacheDirectory = (directory?: string): string => {
     }
 
     const xdgCacheHome = typeof process === "undefined" ? undefined : process.env.XDG_CACHE_HOME;
-    const base = xdgCacheHome && xdgCacheHome.length > 0 ? xdgCacheHome : join(homedir(), ".cache");
+    const base = xdgCacheHome && xdgCacheHome.length > 0 ? xdgCacheHome : nodePath().join(nodeOs().homedir(), ".cache");
 
-    return join(base, "visulima-error-cache");
+    return nodePath().join(base, "visulima-error-cache");
 };
 
 // Ensure cache directory exists (owner-only permissions to avoid cross-user cache poisoning).
@@ -72,10 +73,10 @@ const ensureCacheDirectory = (cacheDirectory: string): void => {
     let stats;
 
     try {
-        stats = lstatSync(cacheDirectory);
+        stats = nodeFs().lstatSync(cacheDirectory);
     } catch {
         // Does not exist yet — create it with owner-only permissions.
-        mkdirSync(cacheDirectory, { mode: 0o700, recursive: true });
+        nodeFs().mkdirSync(cacheDirectory, { mode: 0o700, recursive: true });
 
         return;
     }
@@ -86,16 +87,16 @@ const ensureCacheDirectory = (cacheDirectory: string): void => {
 };
 
 // Get cache file path
-const getCacheFilePath = (cacheDirectory: string, key: string): string => join(cacheDirectory, `${key}.json`);
+const getCacheFilePath = (cacheDirectory: string, key: string): string => nodePath().join(cacheDirectory, `${key}.json`);
 
 // Read from cache
 const readFromCache = (cacheFilePath: string, ttl: number): Solution | undefined => {
     try {
-        if (!existsSync(cacheFilePath)) {
+        if (!nodeFs().existsSync(cacheFilePath)) {
             return undefined;
         }
 
-        const cacheContent = readFileSync(cacheFilePath, "utf8");
+        const cacheContent = nodeFs().readFileSync(cacheFilePath, "utf8");
         const cacheEntry = JSON.parse(cacheContent) as CacheEntry;
 
         // Check if cache entry is still valid
@@ -121,7 +122,7 @@ const writeToCache = (cacheFilePath: string, solution: Solution, ttl: number): v
         };
 
         // eslint-disable-next-line unicorn/no-null
-        writeFileSync(cacheFilePath, JSON.stringify(cacheEntry, null, 2), "utf8");
+        nodeFs().writeFileSync(cacheFilePath, JSON.stringify(cacheEntry, null, 2), "utf8");
     } catch {
         // Silently fail if cache write fails
     }

--- a/packages/error-debugging/error/src/util/node-builtin.ts
+++ b/packages/error-debugging/error/src/util/node-builtin.ts
@@ -1,0 +1,58 @@
+import process from "./process";
+
+/** The Node core modules this package reaches for, and what each one resolves to. */
+interface NodeBuiltins {
+    "node:crypto": typeof import("node:crypto");
+    "node:fs": typeof import("node:fs");
+    "node:os": typeof import("node:os");
+    "node:path": typeof import("node:path");
+    "node:process": typeof import("node:process");
+    "node:url": typeof import("node:url");
+    "node:util": typeof import("node:util");
+}
+
+/** Resolves, and from then on returns, one of the modules above. */
+type NodeBuiltinAccessor<S extends keyof NodeBuiltins> = () => NodeBuiltins[S];
+
+/**
+ * Resolves a Node core module the first time it is actually needed.
+ *
+ * A module-scope `import … from "node:*"` is what makes this package unloadable on a runtime that
+ * ships no Node core. It survives bundling as a module-scope statement — either the `import` itself
+ * or, once a bundler's CJS-interop pass has rewritten it, a `getBuiltinModule` call — and a bundler
+ * has to assume that statement matters. So importing `serializeError` from `./error` evaluates the
+ * whole barrel, `renderError`'s `node:fs` included, and the import throws on Cloudflare Workers
+ * without `nodejs_compat` or on Vercel Edge before any of our code runs.
+ *
+ * Reaching for the module inside the function that needs it keeps module load free of Node core and
+ * moves the failure to the call that genuinely cannot work there — `renderError` reads source files
+ * off disk and was never going to run on an edge runtime, but `serializeError` alongside it is
+ * fine. `__tests__/integration/dist-node-interop.test.ts` guards the built output against a
+ * module-scope reach creeping back in.
+ *
+ * `process.getBuiltinModule` rather than `createRequire`: it needs no `node:module` import of its
+ * own, and this package's `engines.node` (`^22.14.0 || >=24.10.0`) is past the versions that lack
+ * it. A non-Node runtime that reports a `process` without implementing it is told which capability
+ * is missing, instead of failing with `… is not a function` from somewhere inside a bundled chunk.
+ * @param specifier The `node:`-prefixed module to resolve.
+ * @returns An accessor that resolves the module on first call and memoises it.
+ */
+const nodeBuiltin = <S extends keyof NodeBuiltins>(specifier: S): NodeBuiltinAccessor<S> => {
+    let module: NodeBuiltins[S] | undefined;
+
+    return (): NodeBuiltins[S] => {
+        if (module === undefined) {
+            if (typeof process.getBuiltinModule !== "function") {
+                throw new TypeError(
+                    `[@visulima/error] Cannot load ${specifier}: this runtime implements no process.getBuiltinModule(). Requires Node >= 20.16 / >= 22.3, or another runtime providing process.getBuiltinModule().`,
+                );
+            }
+
+            module = process.getBuiltinModule(specifier);
+        }
+
+        return module;
+    };
+};
+
+export default nodeBuiltin;

--- a/packages/error-debugging/error/src/util/node-builtin.ts
+++ b/packages/error-debugging/error/src/util/node-builtin.ts
@@ -44,7 +44,7 @@ const nodeBuiltin = <S extends keyof NodeBuiltins>(specifier: S): NodeBuiltinAcc
         if (module === undefined) {
             if (typeof process.getBuiltinModule !== "function") {
                 throw new TypeError(
-                    `[@visulima/error] Cannot load ${specifier}: this runtime implements no process.getBuiltinModule(). Requires Node >= 20.16 / >= 22.3, or another runtime providing process.getBuiltinModule().`,
+                    `[@visulima/error] Cannot load ${specifier}: this runtime implements no process.getBuiltinModule(). Requires Node ^22.14.0 || >=24.10.0, or another runtime providing process.getBuiltinModule().`,
                 );
             }
 

--- a/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
+++ b/packages/error-debugging/pail/__tests__/integration/edge-reporter-dist.test.ts
@@ -21,7 +21,20 @@ const ROOT_NODE_ENTRY = join(distributionRoot, "index.server.js");
  */
 const NODE_ENTRY_REACHING_NODE_MODULE = join(distributionRoot, "reporter/json/index.js");
 
-const STATIC_SPECIFIER_REGEX = /^(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)["']|^import\s*["']([^"']+)["']/gmu;
+/**
+ * The specifier of an `import`/`export … from` declaration. Matched on `from` rather than on the
+ * statement start, because a production build ships each chunk on one line and drops the space
+ * after `import` — an anchor of `^import\s` silently collects nothing there, which would make
+ * every graph walk below pass vacuously.
+ */
+const FROM_SPECIFIER_REGEX = /\bfrom\s*["']([^"']+)["']/gu;
+
+/** A bare `import "…"`, which has no `from` to match on. */
+// eslint-disable-next-line sonarjs/slow-regex -- disjoint alternatives, so no super-linear backtracking
+const SIDE_EFFECT_IMPORT_REGEX = /(?:^|[;}])\s*import\s*["']([^"']+)["']/gmu;
+
+/** `await import("node:zlib")`, in either quote style a build might emit. */
+const DYNAMIC_ZLIB_IMPORT_REGEX = /\bimport\(\s*["']node:zlib["']\s*\)/u;
 
 /**
  * Every specifier reachable through *static* `import`/`export ... from` declarations.
@@ -30,19 +43,8 @@ const STATIC_SPECIFIER_REGEX = /^(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)[
  * @param source The bundled module source text.
  * @returns The specifier of each static declaration, verbatim.
  */
-const staticSpecifiersIn = (source: string): string[] => {
-    const specifiers: string[] = [];
-
-    for (const match of source.matchAll(STATIC_SPECIFIER_REGEX)) {
-        const specifier = match[1] ?? match[2];
-
-        if (specifier !== undefined) {
-            specifiers.push(specifier);
-        }
-    }
-
-    return specifiers;
-};
+const staticSpecifiersIn = (source: string): string[] =>
+    [...source.matchAll(FROM_SPECIFIER_REGEX), ...source.matchAll(SIDE_EFFECT_IMPORT_REGEX)].map((match) => match[1]);
 
 /**
  * Walks the built entry and every relative chunk it pulls in, so the guard keeps holding
@@ -136,7 +138,10 @@ describe("built edge HTTP reporter", () => {
         expect.assertions(2);
 
         expect(existsSync(EDGE_ENTRY), `${EDGE_ENTRY} is missing — run \`pnpm run build\` first`).toBe(true);
-        expect(readFileSync(EDGE_ENTRY, "utf8")).toContain("HttpReporterEdgeLight");
+        // `edgeCompat` rather than the class name: this entry's default export carries its name
+        // only in the source, and a production build mangles it away. Property names survive, and
+        // forcing `edgeCompat` on is what makes this reporter the edge one.
+        expect(readFileSync(EDGE_ENTRY, "utf8")).toContain("edgeCompat");
     });
 
     it("declares no static node: import anywhere in its chunk graph", () => {
@@ -157,7 +162,7 @@ describe("built edge HTTP reporter", () => {
     it("reaches node:zlib only through a dynamic import", () => {
         expect.assertions(1);
 
-        expect(readFileSync(EDGE_ENTRY, "utf8")).toContain("await import('node:zlib')");
+        expect(readFileSync(EDGE_ENTRY, "utf8")).toMatch(DYNAMIC_ZLIB_IMPORT_REGEX);
     });
 
     it("detects the interop preamble in a Node-only sibling entry", () => {


### PR DESCRIPTION
Unblocks the `test and coverage` step of the Semantic Release job on `main`, which failed on `error-debugging/error:test:coverage` ([run 30707606821](https://github.com/visulima/visulima/actions/runs/30707606821/job/91390680520)).

## Why it only broke in the release job

The release job builds with `build:packages:prod`; PR CI builds development. Two dist-shape guards were written against a development build and only ever held there.

## The defect

Every `node:*` import in `@visulima/error` sat at module scope, so a bundler had to treat it as a statement that matters. Importing `serializeError` from `./error` evaluated the whole barrel — `renderError`'s `node:fs` included — and threw on a runtime with no Node core before any of our code ran. The same statements contradict the package's `"sideEffects": false`.

Both existing mitigations sat downstream of that and failed under minification:

- The `packem.config.ts` plugin asked for `renderChunk` order `"post"` to run after the CJS-interop pass, but the minifier renders from the *default* slot — so it also ran after minification, matched nothing, and shipped the `createRequire` fallback plus its static `import … from "node:module"`. **This is the assertion CI tripped on.**
- Even with that corrected, the `@__PURE__` annotations it added do not survive a consumer whose build minifies before it tree-shakes: esbuild's `minifyWhitespace` drops annotation comments at the *transform* stage, before rollup can use them. That is why `@visulima/pail`'s edge bundle kept eager `getBuiltinModule("node:fs")` calls — which throw at import time on workerd without `nodejs_compat`.

## The fix

Resolve builtins inside the function that needs them (`src/util/node-builtin.ts`), so there is no module-scope statement for a bundler to discard. `renderError` still needs Node and still fails there, but only when *called* — not when the barrel is imported. This lets `requireCJS` and the whole packem-version-pinned interop-rewriting plugin go.

## Guards

The dist guard now asserts the property by running rather than by reading: it imports each built entry in a fresh Node process with `process.getBuiltinModule` removed. Verified non-vacuous — a module-scope reach makes it throw.

`pail`'s `edge-reporter-dist.test.ts` had the same development-build assumption: a `^(?:import|export)\s` anchor matches nothing in a one-line minified chunk, so its graph walk collected zero specifiers and **three assertions were passing vacuously** while the edge entry really did reach Node core.

## Verification

Against a full `build:packages:prod`, six affected packages pass — `error`, `pail`, `ono`, `vite-overlay`, `error-handler`, `inspector`: 2,556 tests. Also re-verified against a development build. `tsc --noEmit`, ESLint and Prettier clean.

Not verified locally: the release job also depends on downloaded native artifacts for `task-runner`, `tui` and `vis`, which fail in a local checkout for lack of bindings. Unrelated to this change, but that path is untested here.

## Follow-up worth a look

`pail` still sets `requireCJS.builtinNodeModules: true`, correctly for its Node-only entries. But any other package bundling for edge runtimes has the exposure `@visulima/error` just had, and the `@__PURE__` escape hatch demonstrably does not work through a minifying consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQv7nZ9XMcvTa22jbuzh7y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when running error diagnostics across supported Node.js environments.
  - Preserved existing error rendering, source inspection, path handling, and AI-assisted solution caching behavior.
  - Improved circular-error diagnostics with more reliable built-in module access.

- **Refactor**
  - Updated internal Node.js integration to load supported system capabilities safely and consistently.
  - Added clearer handling for environments that cannot provide required Node.js built-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->