### PR TITLE
feat(notification): add inbound channel receivers with one-call replies

### DIFF
--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -309,7 +309,8 @@ export default { fetch: (request: Request) => slack.handle(request) };
 
 Receivers: `createSlackInbound` (Events API, slash commands, interactions), `createDiscordInbound`
 (Ed25519 interactions), `createTelegramInbound` (bot webhooks), `createTwilioInbound` (SMS &
-WhatsApp). `createInboundRouter` mounts several behind one fetch handler.
+WhatsApp), `createMsTeamsInbound` (outgoing-webhook HMAC), `createTelnyxInbound` (SMS, Ed25519).
+`createInboundRouter` mounts several behind one fetch handler.
 
 For the full receive → think → reply loop in one call, pass the matching outbound `provider` to
 the receiver and answer with `context.reply(...)` — it maps the inbound message to the right

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -309,8 +309,9 @@ export default { fetch: (request: Request) => slack.handle(request) };
 
 Receivers: `createSlackInbound` (Events API, slash commands, interactions), `createDiscordInbound`
 (Ed25519 interactions), `createTelegramInbound` (bot webhooks), `createTwilioInbound` (SMS &
-WhatsApp), `createMsTeamsInbound` (outgoing-webhook HMAC), `createTelnyxInbound` (SMS, Ed25519).
-`createInboundRouter` mounts several behind one fetch handler.
+WhatsApp), `createMsTeamsInbound` (outgoing-webhook HMAC), `createTelnyxInbound` (SMS, Ed25519),
+`createMessageBirdInbound` and `createVonageInbound` (SMS, signed-JWT). `createInboundRouter`
+mounts several behind one fetch handler.
 
 For the full receive → think → reply loop in one call, pass the matching outbound `provider` to
 the receiver and answer with `context.reply(...)` — it maps the inbound message to the right

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -281,6 +281,37 @@ bus.on("sent", (event) => console.log(event.messageId));
 bus.on("*", (event) => store.append(event));
 ```
 
+## Inbound (two-way channels for bots & AI agents)
+
+Channels are two-way. `@visulima/notification/inbound` verifies and normalises incoming
+webhooks — a Slack mention, a Discord slash command, a Telegram message, an inbound
+SMS/WhatsApp — into a single `InboundMessage` you can hand to an AI agent, which then replies
+through the matching outbound provider. Receivers are framework-agnostic (`handle(request:
+Request) => Promise<Response>`) and edge-safe (Web Crypto only).
+
+```typescript
+import { createSlackInbound } from "@visulima/notification/inbound/slack";
+
+const slack = createSlackInbound({
+    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    onMessage: async (message) => {
+        if (message.type === "message") {
+            return { text: await runAgent(message.text ?? "") };
+        }
+
+        return undefined; // acknowledge; reply out-of-band via the outbound provider
+    },
+});
+
+// Cloudflare Workers / Deno / Bun / Hono / Next.js route handlers …
+export default { fetch: (request: Request) => slack.handle(request) };
+```
+
+Receivers: `createSlackInbound` (Events API, slash commands, interactions), `createDiscordInbound`
+(Ed25519 interactions), `createTelegramInbound` (bot webhooks), `createTwilioInbound` (SMS &
+WhatsApp). `createInboundRouter` mounts several behind one fetch handler. See the
+[inbound docs](./docs/inbound.mdx).
+
 ## Supported Node.js Versions
 
 Libraries in this ecosystem make the best effort to track [Node.js' release schedule](https://github.com/nodejs/release#release-schedule).

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -283,14 +283,16 @@ bus.on("*", (event) => store.append(event));
 
 ## Inbound (two-way channels for bots & AI agents)
 
-Channels are two-way. `@visulima/notification/inbound` verifies and normalises incoming
-webhooks — a Slack mention, a Discord slash command, a Telegram message, an inbound
-SMS/WhatsApp — into a single `InboundMessage` you can hand to an AI agent, which then replies
-through the matching outbound provider. Receivers are framework-agnostic (`handle(request:
-Request) => Promise<Response>`) and edge-safe (Web Crypto only).
+Channels are two-way. Each `@visulima/notification/providers/<name>` subpath ships both halves —
+the outbound provider (`<name>Provider`) and the inbound receiver (`create<Name>Inbound`), which
+verifies and normalises incoming webhooks (a Slack mention, a Discord slash command, a Telegram
+message, an inbound SMS/WhatsApp) into a single `InboundMessage` you can hand to an AI agent that
+then replies through the same provider. Receivers are framework-agnostic (`handle(request:
+Request) => Promise<Response>`) and edge-safe (Web Crypto only). The `@visulima/notification/inbound`
+barrel holds the shared types, `createInboundRouter` and verification/reply helpers.
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/inbound/slack";
+import { createSlackInbound } from "@visulima/notification/providers/slack";
 
 const slack = createSlackInbound({
     signingSecret: process.env.SLACK_SIGNING_SECRET!,
@@ -318,6 +320,8 @@ the receiver and answer with `context.reply(...)` — it maps the inbound messag
 outbound payload (recipient, thread, WhatsApp prefix) and sends it:
 
 ```typescript
+import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
+
 const slack = createSlackInbound({
     signingSecret,
     provider: slackProvider({ token }),

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -162,7 +162,11 @@ Wrap several same-channel providers to gain resilience or load balancing:
 
 ```typescript
 import { createFailoverProvider } from "@visulima/notification/providers/failover";
+import { createPlivoProvider } from "@visulima/notification/providers/plivo";
 import { createRoundRobinProvider } from "@visulima/notification/providers/roundrobin";
+import { createTelnyxProvider } from "@visulima/notification/providers/telnyx";
+import { createTwilioProvider } from "@visulima/notification/providers/twilio";
+import { createVonageProvider } from "@visulima/notification/providers/vonage";
 
 const sms = createFailoverProvider([createTwilioProvider({ … }), createVonageProvider({ … })]); // try Twilio, fall back to Vonage
 const balanced = createRoundRobinProvider([createPlivoProvider({ … }), createTelnyxProvider({ … })]);

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -284,7 +284,7 @@ bus.on("*", (event) => store.append(event));
 ## Inbound (two-way channels for bots & AI agents)
 
 Channels are two-way. Each `@visulima/notification/providers/<name>` subpath ships both halves —
-the outbound provider (`<name>Provider`) and the inbound receiver (`create<Name>Inbound`), which
+the outbound provider (`create<Name>Provider`) and the inbound receiver (`create<Name>Receiver`), which
 verifies and normalises incoming webhooks (a Slack mention, a Discord slash command, a Telegram
 message, an inbound SMS/WhatsApp) into a single `InboundMessage` you can hand to an AI agent that
 then replies through the same provider. Receivers are framework-agnostic (`handle(request:
@@ -292,9 +292,9 @@ Request) => Promise<Response>`) and edge-safe (Web Crypto only). The `@visulima/
 barrel holds the shared types, `createInboundRouter` and verification/reply helpers.
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/providers/slack";
+import { createSlackReceiver } from "@visulima/notification/providers/slack";
 
-const slack = createSlackInbound({
+const slack = createSlackReceiver({
     signingSecret: process.env.SLACK_SIGNING_SECRET!,
     onMessage: async (message) => {
         if (message.type === "message") {
@@ -309,10 +309,10 @@ const slack = createSlackInbound({
 export default { fetch: (request: Request) => slack.handle(request) };
 ```
 
-Receivers: `createSlackInbound` (Events API, slash commands, interactions), `createDiscordInbound`
-(Ed25519 interactions), `createTelegramInbound` (bot webhooks), `createTwilioInbound` (SMS &
-WhatsApp), `createMsTeamsInbound` (outgoing-webhook HMAC), `createTelnyxInbound` (SMS, Ed25519),
-`createMessageBirdInbound` and `createVonageInbound` (SMS, signed-JWT). `createInboundRouter`
+Receivers: `createSlackReceiver` (Events API, slash commands, interactions), `createDiscordReceiver`
+(Ed25519 interactions), `createTelegramReceiver` (bot webhooks), `createTwilioReceiver` (SMS &
+WhatsApp), `createMsTeamsReceiver` (outgoing-webhook HMAC), `createTelnyxReceiver` (SMS, Ed25519),
+`createMessageBirdReceiver` and `createVonageReceiver` (SMS, signed-JWT). `createInboundRouter`
 mounts several behind one fetch handler.
 
 For the full receive → think → reply loop in one call, pass the matching outbound `provider` to
@@ -320,11 +320,11 @@ the receiver and answer with `context.reply(...)` — it maps the inbound messag
 outbound payload (recipient, thread, WhatsApp prefix) and sends it:
 
 ```typescript
-import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
+import { createSlackProvider, createSlackReceiver } from "@visulima/notification/providers/slack";
 
-const slack = createSlackInbound({
+const slack = createSlackReceiver({
     signingSecret,
-    provider: slackProvider({ token }),
+    provider: createSlackProvider({ token }),
     onMessage: async (message, context) => {
         await context.reply(await runAgent(message.text ?? ""));
     },

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -309,8 +309,23 @@ export default { fetch: (request: Request) => slack.handle(request) };
 
 Receivers: `createSlackInbound` (Events API, slash commands, interactions), `createDiscordInbound`
 (Ed25519 interactions), `createTelegramInbound` (bot webhooks), `createTwilioInbound` (SMS &
-WhatsApp). `createInboundRouter` mounts several behind one fetch handler. See the
-[inbound docs](./docs/inbound.mdx).
+WhatsApp). `createInboundRouter` mounts several behind one fetch handler.
+
+For the full receive → think → reply loop in one call, pass the matching outbound `provider` to
+the receiver and answer with `context.reply(...)` — it maps the inbound message to the right
+outbound payload (recipient, thread, WhatsApp prefix) and sends it:
+
+```typescript
+const slack = createSlackInbound({
+    signingSecret,
+    provider: slackProvider({ token }),
+    onMessage: async (message, context) => {
+        await context.reply(await runAgent(message.text ?? ""));
+    },
+});
+```
+
+See the [inbound docs](./docs/inbound.mdx).
 
 ## Supported Node.js Versions
 

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -68,23 +68,23 @@ pnpm add @visulima/notification
 
 ```typescript
 import { send } from "@visulima/notification";
-import { twilioProvider } from "@visulima/notification/providers/twilio";
+import { createTwilioProvider } from "@visulima/notification/providers/twilio";
 
-await send("sms", twilioProvider({ accountSid: "AC…", authToken: "…", from: "+15555550100" }), { to: "+15555550100", text: "Your code is 123" });
+await send("sms", createTwilioProvider({ accountSid: "AC…", authToken: "…", from: "+15555550100" }), { to: "+15555550100", text: "Your code is 123" });
 ```
 
 ### Multi-channel send
 
 ```typescript
 import { createNotification } from "@visulima/notification";
-import { twilioProvider } from "@visulima/notification/providers/twilio";
-import { slackProvider } from "@visulima/notification/providers/slack";
-import { fcmProvider } from "@visulima/notification/providers/fcm";
+import { createTwilioProvider } from "@visulima/notification/providers/twilio";
+import { createSlackProvider } from "@visulima/notification/providers/slack";
+import { createFcmProvider } from "@visulima/notification/providers/fcm";
 
 const notify = createNotification({
-    sms: twilioProvider({ accountSid: "AC…", authToken: "…", from: "+15555550100" }),
-    chat: slackProvider({ token: "xoxb-…", defaultChannel: "C123" }),
-    push: fcmProvider({ projectId: "my-app", getAccessToken: async () => getGoogleToken() }),
+    sms: createTwilioProvider({ accountSid: "AC…", authToken: "…", from: "+15555550100" }),
+    chat: createSlackProvider({ token: "xoxb-…", defaultChannel: "C123" }),
+    push: createFcmProvider({ projectId: "my-app", getAccessToken: async () => getGoogleToken() }),
 });
 
 // Each present channel is delivered in parallel; you get one receipt per channel.
@@ -126,7 +126,7 @@ Providers are imported from `@visulima/notification/providers/<name>` so unused 
 | **SMS**      | `twilio`, `vonage`, `plivo`, `messagebird`, `telnyx`, `sns`     |
 | **Push**     | `fcm`, `expo`, `web-push`, `apns`                               |
 | **Chat**     | `slack`, `discord`, `msteams`, `telegram`                       |
-| **In-app**   | `inAppProvider` (memory or unstorage store)                     |
+| **In-app**   | `createInAppProvider` (memory or unstorage store)               |
 | **Webhook**  | `webhook`                                                       |
 | **Email**    | `emailChannel(...)` → wraps a `@visulima/email` `Mail` instance |
 | **Wrappers** | `failover`, `roundrobin`, `opentelemetry`, `mock`               |
@@ -161,11 +161,11 @@ export const myProvider = defineProvider<MyConfig, SmsPayload>((config) => ({
 Wrap several same-channel providers to gain resilience or load balancing:
 
 ```typescript
-import { failoverProvider } from "@visulima/notification/providers/failover";
-import { roundRobinProvider } from "@visulima/notification/providers/roundrobin";
+import { createFailoverProvider } from "@visulima/notification/providers/failover";
+import { createRoundRobinProvider } from "@visulima/notification/providers/roundrobin";
 
-const sms = failoverProvider([twilioProvider({ … }), vonageProvider({ … })]); // try Twilio, fall back to Vonage
-const balanced = roundRobinProvider([plivoProvider({ … }), telnyxProvider({ … })]);
+const sms = createFailoverProvider([createTwilioProvider({ … }), createVonageProvider({ … })]); // try Twilio, fall back to Vonage
+const balanced = createRoundRobinProvider([createPlivoProvider({ … }), createTelnyxProvider({ … })]);
 
 const notify = createNotification({ sms });
 ```
@@ -239,9 +239,9 @@ const queue = new UnstorageQueue(createStorage());
 ## In-app inbox
 
 ```typescript
-import { inAppProvider } from "@visulima/notification/channels/inapp";
+import { createInAppProvider } from "@visulima/notification/channels/inapp";
 
-const inapp = inAppProvider();
+const inapp = createInAppProvider();
 const notify = createNotification({ inapp });
 
 await notify.sendToChannel("inapp", { to: "user-1", title: "Welcome", body: "Thanks for joining" });

--- a/packages/notification/notification/README.md
+++ b/packages/notification/notification/README.md
@@ -298,8 +298,12 @@ barrel holds the shared types, `createInboundRouter` and verification/reply help
 ```typescript
 import { createSlackReceiver } from "@visulima/notification/providers/slack";
 
+// Read the secret however your runtime exposes it: an `env` binding on
+// Cloudflare Workers, `Deno.env.get`, `process.env` on Node.
+declare const signingSecret: string;
+
 const slack = createSlackReceiver({
-    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    signingSecret,
     onMessage: async (message) => {
         if (message.type === "message") {
             return { text: await runAgent(message.text ?? "") };

--- a/packages/notification/notification/__tests__/apns.test.ts
+++ b/packages/notification/notification/__tests__/apns.test.ts
@@ -10,7 +10,7 @@ vi.mock(import("node:http2"), () => {
     };
 });
 
-const { apnsProvider } = await import("../src/providers/push/apns");
+const { createApnsProvider } = await import("../src/providers/push/apns");
 
 const BEARER_JWT_RE = /^bearer eyJ/;
 const FAILED_TOKEN_RE = /BadDeviceToken/;
@@ -118,7 +118,7 @@ describe("apns provider", () => {
 
         connectMock.mockReturnValue(session);
 
-        const provider = apnsProvider(baseConfig);
+        const provider = createApnsProvider(baseConfig);
         const result = await provider.send({ body: "hello", title: "Hi", to: "device-token-1" });
 
         expect(connectMock).toHaveBeenCalledWith("https://api.sandbox.push.apple.com");
@@ -142,7 +142,7 @@ describe("apns provider", () => {
 
         connectMock.mockReturnValue(session);
 
-        const provider = apnsProvider({ ...baseConfig, production: true });
+        const provider = createApnsProvider({ ...baseConfig, production: true });
         const result = await provider.send({ badge: 3, body: "b", data: { custom: "x" }, sound: "ping", title: "t", to: "tok" });
 
         expect(connectMock).toHaveBeenCalledWith("https://api.push.apple.com");
@@ -160,7 +160,7 @@ describe("apns provider", () => {
 
         connectMock.mockReturnValue(session);
 
-        const provider = apnsProvider(baseConfig);
+        const provider = createApnsProvider(baseConfig);
         const result = await provider.send({ body: "x", to: "tok" });
 
         expect(result.success).toBe(false);
@@ -174,7 +174,7 @@ describe("apns provider", () => {
 
         connectMock.mockReturnValue(session);
 
-        const provider = apnsProvider(baseConfig);
+        const provider = createApnsProvider(baseConfig);
         const result = await provider.send({ body: "x", to: ["good", "bad"] });
 
         expect(result.success).toBe(true);
@@ -190,7 +190,7 @@ describe("apns provider", () => {
 
         connectMock.mockReturnValue(session);
 
-        const provider = apnsProvider(baseConfig);
+        const provider = createApnsProvider(baseConfig);
 
         await provider.send({ body: "1", to: "a" });
         await provider.send({ body: "2", to: "b" });
@@ -206,6 +206,6 @@ describe("apns provider", () => {
     it("throws when required options are missing", () => {
         expect.assertions(1);
 
-        expect(() => apnsProvider({ ...baseConfig, teamId: "" })).toThrow(TEAM_ID_RE);
+        expect(() => createApnsProvider({ ...baseConfig, teamId: "" })).toThrow(TEAM_ID_RE);
     });
 });

--- a/packages/notification/notification/__tests__/chat-push-branches.test.ts
+++ b/packages/notification/notification/__tests__/chat-push-branches.test.ts
@@ -2,13 +2,13 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { discordProvider } from "../src/providers/chat/discord";
-import { msTeamsProvider } from "../src/providers/chat/msteams";
-import { slackProvider } from "../src/providers/chat/slack";
-import { telegramProvider } from "../src/providers/chat/telegram";
-import { expoProvider } from "../src/providers/push/expo";
-import { fcmProvider } from "../src/providers/push/fcm";
-import { webPushProvider } from "../src/providers/push/web-push";
+import { createDiscordProvider } from "../src/providers/chat/discord";
+import { createMsTeamsProvider } from "../src/providers/chat/msteams";
+import { createSlackProvider } from "../src/providers/chat/slack";
+import { createTelegramProvider } from "../src/providers/chat/telegram";
+import { createExpoProvider } from "../src/providers/push/expo";
+import { createFcmProvider } from "../src/providers/push/fcm";
+import { createWebPushProvider } from "../src/providers/push/web-push";
 
 const SLACK_CONFIG_RE = /token.*webhookUrl/;
 const VAPID_CONFIG_RE = /vapidPublicKey/;
@@ -21,7 +21,7 @@ vi.mock(import("node:http2"), () => {
     };
 });
 
-const { apnsProvider } = await import("../src/providers/push/apns");
+const { createApnsProvider } = await import("../src/providers/push/apns");
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
@@ -82,7 +82,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(textResponse("ok"));
 
-            const provider = slackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
+            const provider = createSlackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(true);
@@ -94,7 +94,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(textResponse("invalid_payload", 400));
 
-            const provider = slackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
+            const provider = createSlackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -104,7 +104,7 @@ describe("chat + push provider branches", () => {
         it("web API fails when no channel is provided", async () => {
             expect.assertions(2);
 
-            const provider = slackProvider({ token: "xoxb-1" });
+            const provider = createSlackProvider({ token: "xoxb-1" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -116,7 +116,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ error: "channel_not_found", ok: false }));
 
-            const provider = slackProvider({ defaultChannel: "C1", token: "xoxb-1" });
+            const provider = createSlackProvider({ defaultChannel: "C1", token: "xoxb-1" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -126,7 +126,7 @@ describe("chat + push provider branches", () => {
         it("factory throws when neither token nor webhookUrl is given", () => {
             expect.assertions(1);
 
-            expect(() => slackProvider({})).toThrow(SLACK_CONFIG_RE);
+            expect(() => createSlackProvider({})).toThrow(SLACK_CONFIG_RE);
         });
     });
 
@@ -136,7 +136,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ message: "Unknown Webhook" }, 404));
 
-            const provider = discordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
+            const provider = createDiscordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -148,7 +148,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({}));
 
-            const provider = discordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
+            const provider = createDiscordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(true);
@@ -160,7 +160,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ id: "d2" }));
 
-            const provider = discordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
+            const provider = createDiscordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
             const result = await provider.send({ text: "hi", threadId: "thread-9" });
 
             expect(result.success).toBe(true);
@@ -177,7 +177,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(textResponse("nope", 400));
 
-            const provider = msTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
+            const provider = createMsTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -189,7 +189,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(textResponse("1"));
 
-            const provider = msTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
+            const provider = createMsTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
             const result = await provider.send({ blocks: { custom: "card" }, text: "hi" });
 
             expect(result.success).toBe(true);
@@ -204,7 +204,7 @@ describe("chat + push provider branches", () => {
         it("fails when no chat id is available", async () => {
             expect.assertions(2);
 
-            const provider = telegramProvider({ botToken: "1:abc" });
+            const provider = createTelegramProvider({ botToken: "1:abc" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -216,7 +216,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ description: "chat not found", ok: false }));
 
-            const provider = telegramProvider({ botToken: "1:abc", defaultChatId: 99, parseMode: "Markdown" });
+            const provider = createTelegramProvider({ botToken: "1:abc", defaultChatId: 99, parseMode: "Markdown" });
             const result = await provider.send({ text: "hi" });
 
             expect(result.success).toBe(false);
@@ -229,7 +229,7 @@ describe("chat + push provider branches", () => {
             expect.assertions(2);
 
             const getAccessToken = vi.fn().mockRejectedValue(new Error("boom"));
-            const provider = fcmProvider({ getAccessToken, projectId: "p" });
+            const provider = createFcmProvider({ getAccessToken, projectId: "p" });
             const result = await provider.send({ body: "hi", title: "T", to: "tok" });
 
             expect(result.success).toBe(false);
@@ -241,7 +241,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ name: "projects/p/messages/0:1" }));
 
-            const provider = fcmProvider({ accessToken: "ya29.static", projectId: "p" });
+            const provider = createFcmProvider({ accessToken: "ya29.static", projectId: "p" });
             const result = await provider.send({ body: "hi", data: { count: 3, nested: { a: 1 } }, title: "T", to: "tok" });
 
             expect(result.success).toBe(true);
@@ -258,7 +258,7 @@ describe("chat + push provider branches", () => {
                 .mockResolvedValueOnce(jsonResponse({ name: "projects/p/messages/ok" }))
                 .mockResolvedValueOnce(jsonResponse({ error: { message: "Invalid token" } }, 400));
 
-            const provider = fcmProvider({ accessToken: "ya29.static", projectId: "p" });
+            const provider = createFcmProvider({ accessToken: "ya29.static", projectId: "p" });
             const result = await provider.send({ body: "hi", title: "T", to: ["good", "bad"] });
 
             expect(result.success).toBe(true);
@@ -271,7 +271,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ error: { message: "Invalid token" } }, 400));
 
-            const provider = fcmProvider({ accessToken: "ya29.static", projectId: "p" });
+            const provider = createFcmProvider({ accessToken: "ya29.static", projectId: "p" });
             const result = await provider.send({ body: "hi", title: "T", to: "bad" });
 
             expect(result.success).toBe(false);
@@ -292,7 +292,7 @@ describe("chat + push provider branches", () => {
                 }),
             );
 
-            const provider = expoProvider({ accessToken: "expo-token" });
+            const provider = createExpoProvider({ accessToken: "expo-token" });
             const result = await provider.send({ body: "hi", title: "T", to: ["ExpoTok1", "ExpoTok2"] });
 
             expect(result.success).toBe(true);
@@ -304,7 +304,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ data: [{ message: "bad token", status: "error" }] }));
 
-            const provider = expoProvider({});
+            const provider = createExpoProvider({});
             const result = await provider.send({ body: "hi", to: "ExpoTok1" });
 
             expect(result.success).toBe(false);
@@ -316,7 +316,7 @@ describe("chat + push provider branches", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({}, 400));
 
-            const provider = expoProvider({});
+            const provider = createExpoProvider({});
             const result = await provider.send({ body: "hi", to: "ExpoTok1" });
 
             expect(result.success).toBe(false);
@@ -329,7 +329,7 @@ describe("chat + push provider branches", () => {
             expect.assertions(2);
 
             const keys = await generateVapidKeys();
-            const provider = webPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
+            const provider = createWebPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
             const result = await provider.send({ body: "hi", to: JSON.stringify({ endpoint: "https://push.example.com/x" }) });
 
             expect(result.success).toBe(false);
@@ -343,7 +343,7 @@ describe("chat + push provider branches", () => {
 
             const keys = await generateVapidKeys();
             const subscription = await generateSubscription("https://push.example.com/sub/dead");
-            const provider = webPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
+            const provider = createWebPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
             const result = await provider.send({ body: "hi", to: subscription });
 
             expect(result.success).toBe(false);
@@ -353,7 +353,7 @@ describe("chat + push provider branches", () => {
         it("throws when the vapid config is missing", () => {
             expect.assertions(1);
 
-            expect(() => webPushProvider({ vapidPrivateKey: "", vapidPublicKey: "", vapidSubject: "" })).toThrow(VAPID_CONFIG_RE);
+            expect(() => createWebPushProvider({ vapidPrivateKey: "", vapidPublicKey: "", vapidSubject: "" })).toThrow(VAPID_CONFIG_RE);
         });
     });
 
@@ -449,7 +449,7 @@ describe("chat + push provider branches", () => {
 
             connectMock.mockReturnValue(session);
 
-            const provider = apnsProvider(baseConfig);
+            const provider = createApnsProvider(baseConfig);
             const result = await provider.send({ body: "x", to: "tok" });
 
             expect(result.success).toBe(false);
@@ -463,7 +463,7 @@ describe("chat + push provider branches", () => {
 
             connectMock.mockReturnValue(session);
 
-            const provider = apnsProvider(baseConfig);
+            const provider = createApnsProvider(baseConfig);
             const result = await provider.send({ body: "x", to: ["a", "b", "c"] });
 
             expect(result.success).toBe(true);
@@ -478,7 +478,7 @@ describe("chat + push provider branches", () => {
 
             connectMock.mockReturnValue(session);
 
-            const provider = apnsProvider(baseConfig);
+            const provider = createApnsProvider(baseConfig);
 
             await provider.send({ body: "1", to: "a" });
             await provider.send({ body: "2", to: "b" });

--- a/packages/notification/notification/__tests__/chat-push-providers.test.ts
+++ b/packages/notification/notification/__tests__/chat-push-providers.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { discordProvider } from "../src/providers/chat/discord";
-import { msTeamsProvider } from "../src/providers/chat/msteams";
-import { slackProvider } from "../src/providers/chat/slack";
-import { telegramProvider } from "../src/providers/chat/telegram";
-import { expoProvider } from "../src/providers/push/expo";
-import { fcmProvider } from "../src/providers/push/fcm";
+import { createDiscordProvider } from "../src/providers/chat/discord";
+import { createMsTeamsProvider } from "../src/providers/chat/msteams";
+import { createSlackProvider } from "../src/providers/chat/slack";
+import { createTelegramProvider } from "../src/providers/chat/telegram";
+import { createExpoProvider } from "../src/providers/push/expo";
+import { createFcmProvider } from "../src/providers/push/fcm";
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
@@ -28,7 +28,7 @@ describe("chat + push providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ ok: true, ts: "1700000000.0001" }));
 
-        const provider = slackProvider({ defaultChannel: "C1", token: "xoxb-1" });
+        const provider = createSlackProvider({ defaultChannel: "C1", token: "xoxb-1" });
         const result = await provider.send({ text: "hi" });
 
         expect(result.success).toBe(true);
@@ -40,7 +40,7 @@ describe("chat + push providers", () => {
 
         fetchMock.mockResolvedValue(textResponse("ok"));
 
-        const provider = slackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
+        const provider = createSlackProvider({ webhookUrl: "https://hooks.slack.com/services/x" });
         const result = await provider.send({ text: "hi" });
 
         expect(result.success).toBe(true);
@@ -51,7 +51,7 @@ describe("chat + push providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ id: "d1" }));
 
-        const provider = discordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
+        const provider = createDiscordProvider({ webhookUrl: "https://discord.com/api/webhooks/1/abc" });
         const result = await provider.send({ text: "hi" });
 
         expect(result.data?.messageId).toBe("d1");
@@ -63,7 +63,7 @@ describe("chat + push providers", () => {
 
         fetchMock.mockResolvedValue(textResponse("1"));
 
-        const provider = msTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
+        const provider = createMsTeamsProvider({ webhookUrl: "https://outlook.office.com/webhook/x" });
         const result = await provider.send({ text: "hi" });
 
         expect(result.success).toBe(true);
@@ -78,12 +78,12 @@ describe("chat + push providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ ok: true, result: { message_id: 42 } }));
 
-        const provider = telegramProvider({ botToken: "1:abc", defaultChatId: 99 });
+        const provider = createTelegramProvider({ botToken: "1:abc", defaultChatId: 99 });
         const result = await provider.send({ text: "hi" });
 
         expect(result.data?.messageId).toBe("42");
 
-        const noChat = telegramProvider({ botToken: "1:abc" });
+        const noChat = createTelegramProvider({ botToken: "1:abc" });
         const failed = await noChat.send({ text: "hi" });
 
         expect(failed.success).toBe(false);
@@ -101,7 +101,7 @@ describe("chat + push providers", () => {
             }),
         );
 
-        const provider = expoProvider({});
+        const provider = createExpoProvider({});
         const result = await provider.send({ body: "hi", title: "T", to: ["ExpoTok1", "ExpoTok2"] });
 
         expect(result.success).toBe(true);
@@ -114,7 +114,7 @@ describe("chat + push providers", () => {
         fetchMock.mockResolvedValue(jsonResponse({ name: "projects/p/messages/0:1" }));
 
         const getAccessToken = vi.fn().mockResolvedValue("ya29.token");
-        const provider = fcmProvider({ getAccessToken, projectId: "p" });
+        const provider = createFcmProvider({ getAccessToken, projectId: "p" });
         const result = await provider.send({ body: "hi", title: "T", to: "devtoken" });
 
         expect(result.success).toBe(true);

--- a/packages/notification/notification/__tests__/core-branches.test.ts
+++ b/packages/notification/notification/__tests__/core-branches.test.ts
@@ -7,10 +7,10 @@ import { telemetryMiddleware } from "../src/middleware/telemetry";
 import type { SendContext } from "../src/middleware/types";
 import { createNotification } from "../src/notification";
 import { MemoryPreferenceStore, preferencesGate } from "../src/preferences";
-import { failoverProvider } from "../src/providers/failover";
-import { mockProvider } from "../src/providers/mock";
+import { createFailoverProvider } from "../src/providers/failover";
+import { createMockProvider } from "../src/providers/mock";
 import type { Provider } from "../src/providers/provider";
-import { roundRobinProvider } from "../src/providers/roundrobin";
+import { createRoundRobinProvider } from "../src/providers/roundrobin";
 import { isRetryableStatus, makeRequest, requestWithRetry } from "../src/providers/utils/http";
 import generateMessageId from "../src/providers/utils/id";
 import { route } from "../src/routing";
@@ -31,7 +31,7 @@ describe("notification facade branches", () => {
     it("throws when send() is called with an empty message", async () => {
         expect.assertions(1);
 
-        const notify = createNotification({ sms: mockProvider({ channel: "sms" }) });
+        const notify = createNotification({ sms: createMockProvider({ channel: "sms" }) });
 
         await expect(notify.send({})).rejects.toThrow("empty message");
     });
@@ -39,7 +39,7 @@ describe("notification facade branches", () => {
     it("getProvider returns the registered provider or undefined", () => {
         expect.assertions(2);
 
-        const sms = mockProvider({ channel: "sms", id: "sms-1" });
+        const sms = createMockProvider({ channel: "sms", id: "sms-1" });
         const notify = createNotification({ sms });
 
         expect(notify.getProvider("sms")).toBe(sms);
@@ -49,8 +49,8 @@ describe("notification facade branches", () => {
     it("initialize() initializes every registered provider once", async () => {
         expect.assertions(2);
 
-        const sms = mockProvider({ channel: "sms", id: "sms-init" });
-        const push = mockProvider({ channel: "push", id: "push-init" });
+        const sms = createMockProvider({ channel: "sms", id: "sms-init" });
+        const push = createMockProvider({ channel: "push", id: "push-init" });
         const smsInit = vi.spyOn(sms, "initialize");
         const pushInit = vi.spyOn(push, "initialize");
 
@@ -66,8 +66,8 @@ describe("notification facade branches", () => {
         expect.assertions(2);
 
         const shutdown = vi.fn();
-        const sms = mockProvider({ channel: "sms", id: "sms-shut" });
-        const push = { ...mockProvider({ channel: "push", id: "push-shut" }), shutdown } as Provider;
+        const sms = createMockProvider({ channel: "sms", id: "sms-shut" });
+        const push = { ...createMockProvider({ channel: "push", id: "push-shut" }), shutdown } as Provider;
 
         const notify = createNotification({ push, sms });
 
@@ -79,7 +79,7 @@ describe("notification facade branches", () => {
         expect.assertions(2);
 
         const provider = {
-            ...mockProvider({ channel: "sms", id: "init-throws" }),
+            ...createMockProvider({ channel: "sms", id: "init-throws" }),
             initialize: () => {
                 throw new Error("init blew up");
             },
@@ -96,7 +96,7 @@ describe("notification facade branches", () => {
     it("sendMany processes multiple messages across batches", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ channel: "sms", id: "many" });
+        const provider = createMockProvider({ channel: "sms", id: "many" });
         const notify = createNotification({ sms: provider });
 
         const messages = [
@@ -122,7 +122,7 @@ describe("failover provider branches", () => {
     it("aggregates messages when all providers fail", async () => {
         expect.assertions(2);
 
-        const provider = failoverProvider([mockProvider({ failWith: "a", id: "p1" }), mockProvider({ failWith: "b", id: "p2" })]);
+        const provider = createFailoverProvider([createMockProvider({ failWith: "a", id: "p1" }), createMockProvider({ failWith: "b", id: "p2" })]);
         const result = await provider.send({ text: "hi", to: "+1" } as never);
 
         expect(result.success).toBe(false);
@@ -132,10 +132,10 @@ describe("failover provider branches", () => {
     it("isAvailable is true when any provider is available", async () => {
         expect.assertions(1);
 
-        const down = { ...mockProvider({ id: "down" }), isAvailable: () => false } as Provider;
-        const up = mockProvider({ id: "up" });
+        const down = { ...createMockProvider({ id: "down" }), isAvailable: () => false } as Provider;
+        const up = createMockProvider({ id: "up" });
 
-        const provider = failoverProvider([down, up]);
+        const provider = createFailoverProvider([down, up]);
 
         await expect(provider.isAvailable()).resolves.toBe(true);
     });
@@ -143,7 +143,7 @@ describe("failover provider branches", () => {
     it("throws when constructed with an empty provider array", () => {
         expect.assertions(1);
 
-        expect(() => failoverProvider([])).toThrow("At least one provider is required");
+        expect(() => createFailoverProvider([])).toThrow("At least one provider is required");
     });
 });
 
@@ -151,9 +151,9 @@ describe("roundrobin provider branches", () => {
     it("rotation wraps back to the first provider", async () => {
         expect.assertions(3);
 
-        const a = mockProvider({ channel: "sms", id: "a" });
-        const b = mockProvider({ channel: "sms", id: "b" });
-        const provider = roundRobinProvider([a, b]);
+        const a = createMockProvider({ channel: "sms", id: "a" });
+        const b = createMockProvider({ channel: "sms", id: "b" });
+        const provider = createRoundRobinProvider([a, b]);
 
         const first = await provider.send({ text: "1", to: "+1" } as never);
         const second = await provider.send({ text: "2", to: "+2" } as never);
@@ -167,11 +167,11 @@ describe("roundrobin provider branches", () => {
     it("with failover:false only tries one provider", async () => {
         expect.assertions(2);
 
-        const failing = mockProvider({ channel: "sms", failWith: "down", id: "first" });
-        const healthy = mockProvider({ channel: "sms", id: "second" });
+        const failing = createMockProvider({ channel: "sms", failWith: "down", id: "first" });
+        const healthy = createMockProvider({ channel: "sms", id: "second" });
         const healthySend = vi.spyOn(healthy, "send");
 
-        const provider = roundRobinProvider([failing, healthy], { failover: false });
+        const provider = createRoundRobinProvider([failing, healthy], { failover: false });
         const result = await provider.send({ text: "x", to: "+1" } as never);
 
         expect(result.success).toBe(false);
@@ -181,7 +181,7 @@ describe("roundrobin provider branches", () => {
     it("fails when all providers fail with failover", async () => {
         expect.assertions(2);
 
-        const provider = roundRobinProvider([mockProvider({ failWith: "a", id: "p1" }), mockProvider({ failWith: "b", id: "p2" })]);
+        const provider = createRoundRobinProvider([createMockProvider({ failWith: "a", id: "p1" }), createMockProvider({ failWith: "b", id: "p2" })]);
         const result = await provider.send({ text: "x", to: "+1" } as never);
 
         expect(result.success).toBe(false);
@@ -191,16 +191,16 @@ describe("roundrobin provider branches", () => {
     it("isAvailable is true when any provider is available", async () => {
         expect.assertions(1);
 
-        const down = { ...mockProvider({ id: "rr-down" }), isAvailable: () => false } as Provider;
-        const up = mockProvider({ id: "rr-up" });
+        const down = { ...createMockProvider({ id: "rr-down" }), isAvailable: () => false } as Provider;
+        const up = createMockProvider({ id: "rr-up" });
 
-        await expect(roundRobinProvider([down, up]).isAvailable()).resolves.toBe(true);
+        await expect(createRoundRobinProvider([down, up]).isAvailable()).resolves.toBe(true);
     });
 
     it("throws when constructed with an empty provider array", () => {
         expect.assertions(1);
 
-        expect(() => roundRobinProvider([])).toThrow("At least one provider is required");
+        expect(() => createRoundRobinProvider([])).toThrow("At least one provider is required");
     });
 });
 
@@ -364,8 +364,8 @@ describe("routing branches", () => {
     it("skips channels whose gate returns false", async () => {
         expect.assertions(1);
 
-        const sms = mockProvider({ channel: "sms", id: "sms" });
-        const push = mockProvider({ channel: "push", id: "push" });
+        const sms = createMockProvider({ channel: "sms", id: "sms" });
+        const push = createMockProvider({ channel: "push", id: "push" });
         const notify = createNotification({ push, sms });
 
         const receipts = await route(notify, { push: { body: "hi", to: "tok" }, sms: { text: "hi", to: "+1" } }, { gate: (channel) => channel === "push" });
@@ -376,8 +376,8 @@ describe("routing branches", () => {
     it("mode:all broadcasts to every allowed channel", async () => {
         expect.assertions(2);
 
-        const sms = mockProvider({ channel: "sms", id: "sms" });
-        const push = mockProvider({ channel: "push", id: "push" });
+        const sms = createMockProvider({ channel: "sms", id: "sms" });
+        const push = createMockProvider({ channel: "push", id: "push" });
         const notify = createNotification({ push, sms });
 
         const receipts = await route(notify, { push: { body: "hi", to: "tok" }, sms: { text: "hi", to: "+1" } }, { mode: "all" });
@@ -389,8 +389,8 @@ describe("routing branches", () => {
     it("best-of continues past a failure and stops at the first success", async () => {
         expect.assertions(3);
 
-        const sms = mockProvider({ channel: "sms", failWith: "down", id: "sms" });
-        const push = mockProvider({ channel: "push", id: "push" });
+        const sms = createMockProvider({ channel: "sms", failWith: "down", id: "sms" });
+        const push = createMockProvider({ channel: "push", id: "push" });
         const notify = createNotification({ push, sms });
 
         const receipts = await route(notify, { push: { body: "hi", to: "tok" }, sms: { text: "hi", to: "+1" } }, { order: ["sms", "push"] });

--- a/packages/notification/notification/__tests__/email-inapp-preferences.test.ts
+++ b/packages/notification/notification/__tests__/email-inapp-preferences.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { emailChannel } from "../src/channels/email";
 import type { InAppStore } from "../src/channels/inapp";
-import { inAppProvider } from "../src/channels/inapp";
+import { createInAppProvider } from "../src/channels/inapp";
 import { createNotification } from "../src/notification";
 import { MemoryPreferenceStore, preferencesGate } from "../src/preferences";
 import { route } from "../src/routing";
@@ -38,7 +38,7 @@ describe("in-app channel", () => {
     it("persists notifications to the store and exposes unread count", async () => {
         expect.assertions(3);
 
-        const provider = inAppProvider();
+        const provider = createInAppProvider();
         const notify = createNotification({ inapp: provider });
 
         await notify.sendToChannel("inapp", { body: "Welcome", title: "Hi", to: "user-1" });
@@ -66,7 +66,7 @@ describe("preferences", () => {
 
         prefs.set("+1", { channels: { sms: false } });
 
-        const notify = createNotification({ sms: inAppProvider() as never });
+        const notify = createNotification({ sms: createInAppProvider() as never });
 
         const blocked = await route(notify, { sms: { text: "hi", to: "+1" } }, { gate: preferencesGate(prefs) });
 

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { createDiscordInbound } from "../src/inbound/channels/discord";
+import { createMessageBirdInbound } from "../src/inbound/channels/messagebird";
 import { createMsTeamsInbound } from "../src/inbound/channels/msteams";
 import { createSlackInbound } from "../src/inbound/channels/slack";
 import { createTelegramInbound } from "../src/inbound/channels/telegram";
 import { createTelnyxInbound } from "../src/inbound/channels/telnyx";
 import { createTwilioInbound } from "../src/inbound/channels/twilio";
+import { createVonageInbound } from "../src/inbound/channels/vonage";
 import { createInboundRouter } from "../src/inbound/router";
 import type { InboundMessage } from "../src/inbound/types";
 import { mockProvider } from "../src/providers/mock/provider";
@@ -31,6 +33,20 @@ const hmac = async (secret: string, message: string, hash: "SHA-1" | "SHA-256"):
 
     return globalThis.crypto.subtle.sign("HMAC", key, encoder.encode(message));
 };
+
+const toBase64Url = (value: string): string => btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+
+const sha256Hex = async (value: string): Promise<string> => toHex(await globalThis.crypto.subtle.digest("SHA-256", encoder.encode(value)));
+
+const signJwt = async (secret: string, claims: Record<string, unknown>): Promise<string> => {
+    const header = toBase64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = toBase64Url(JSON.stringify(claims));
+    const signature = toBase64(await hmac(secret, `${header}.${payload}`, "SHA-256")).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+
+    return `${header}.${payload}.${signature}`;
+};
+
+const inFiveMinutes = (): number => Math.floor(Date.now() / 1000) + 300;
 
 describe(createSlackInbound, () => {
     const secret = "slack-signing-secret";
@@ -443,6 +459,86 @@ describe(createTelnyxInbound, () => {
         const channel = createTelnyxInbound({ onMessage: () => undefined, publicKey: await publicKeyBase64(otherKey) });
         const payload = { data: { event_type: "message.received", payload: { from: { phone_number: "+1" }, id: "m", text: "x", to: [{ phone_number: "+2" }] } } };
         const response = await channel.handle(await signedRequest(keyPair, payload));
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe(createMessageBirdInbound, () => {
+    const signingKey = "messagebird-signing-key";
+    const url = "https://example.com/webhooks/messagebird";
+
+    it("verifies the signed JWT, parses the message and replies through the provider", async () => {
+        expect.assertions(3);
+
+        const body = JSON.stringify({ body: "hey there", createdDatetime: "2026-01-01T00:00:00+00:00", id: "mb1", originator: "+15551230001", recipient: "+15551230009" });
+        const token = await signJwt(signingKey, { exp: inFiveMinutes(), iss: "MessageBird", jti: "j1", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
+        const provider = mockProvider({ channel: "sms", id: "messagebird" });
+        let received: InboundMessage | undefined;
+        const channel = createMessageBirdInbound({
+            onMessage: async (message, context) => {
+                received = message;
+
+                await context.reply("thanks");
+            },
+            provider,
+            signingKey,
+            url,
+        });
+        const response = await channel.handle(new Request(url, { body, headers: { "content-type": "application/json", "messagebird-signature-jwt": token }, method: "POST" }));
+
+        expect(received?.text).toBe("hey there");
+        expect(response.status).toBe(204);
+        expect(provider.getInstance?.().last()?.payload).toMatchObject({ from: "+15551230009", text: "thanks", to: "+15551230001" });
+    });
+
+    it("rejects a JWT signed with the wrong key with 401", async () => {
+        expect.assertions(1);
+
+        const body = JSON.stringify({ id: "mb2", originator: "+1", recipient: "+2" });
+        const token = await signJwt("wrong-key", { exp: inFiveMinutes(), iss: "MessageBird", jti: "j2", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
+        const channel = createMessageBirdInbound({ onMessage: () => undefined, signingKey, url });
+        const response = await channel.handle(new Request(url, { body, headers: { "messagebird-signature-jwt": token }, method: "POST" }));
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe(createVonageInbound, () => {
+    const signatureSecret = "vonage-signature-secret";
+    const url = "https://example.com/webhooks/vonage";
+
+    it("verifies the Bearer JWT and payload_hash, parses and replies", async () => {
+        expect.assertions(3);
+
+        const body = JSON.stringify({ channel: "sms", from: "15551230001", message_type: "text", message_uuid: "v1", text: "hi vonage", timestamp: "2026-01-01T00:00:00Z", to: "15551230009" });
+        const token = await signJwt(signatureSecret, { exp: inFiveMinutes(), payload_hash: await sha256Hex(body) });
+        const provider = mockProvider({ channel: "sms", id: "vonage" });
+        let received: InboundMessage | undefined;
+        const channel = createVonageInbound({
+            onMessage: async (message, context) => {
+                received = message;
+
+                await context.reply("reply");
+            },
+            provider,
+            signatureSecret,
+        });
+        const response = await channel.handle(new Request(url, { body, headers: { authorization: `Bearer ${token}` }, method: "POST" }));
+
+        expect(received?.text).toBe("hi vonage");
+        expect(response.status).toBe(204);
+        expect(provider.getInstance?.().last()?.payload).toMatchObject({ from: "15551230009", text: "reply", to: "15551230001" });
+    });
+
+    it("rejects a tampered body (payload_hash mismatch) with 401", async () => {
+        expect.assertions(1);
+
+        const body = JSON.stringify({ from: "1", text: "original", to: "2" });
+        const token = await signJwt(signatureSecret, { exp: inFiveMinutes(), payload_hash: await sha256Hex(body) });
+        const channel = createVonageInbound({ onMessage: () => undefined, signatureSecret });
+        const tampered = JSON.stringify({ from: "1", text: "changed", to: "2" });
+        const response = await channel.handle(new Request(url, { body: tampered, headers: { authorization: `Bearer ${token}` }, method: "POST" }));
 
         expect(response.status).toBe(401);
     });

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { createDiscordInbound } from "../src/inbound/channels/discord";
-import { createMessageBirdInbound } from "../src/inbound/channels/messagebird";
-import { createMsTeamsInbound } from "../src/inbound/channels/msteams";
-import { createSlackInbound } from "../src/inbound/channels/slack";
-import { createTelegramInbound } from "../src/inbound/channels/telegram";
-import { createTelnyxInbound } from "../src/inbound/channels/telnyx";
-import { createTwilioInbound } from "../src/inbound/channels/twilio";
-import { createVonageInbound } from "../src/inbound/channels/vonage";
 import { createInboundRouter } from "../src/inbound/router";
 import type { InboundMessage } from "../src/inbound/types";
+import { createDiscordInbound } from "../src/providers/chat/discord";
+import { createMsTeamsInbound } from "../src/providers/chat/msteams";
+import { createSlackInbound } from "../src/providers/chat/slack";
+import { createTelegramInbound } from "../src/providers/chat/telegram";
 import { mockProvider } from "../src/providers/mock/provider";
+import { createMessageBirdInbound } from "../src/providers/sms/messagebird";
+import { createTelnyxInbound } from "../src/providers/sms/telnyx";
+import { createTwilioInbound } from "../src/providers/sms/twilio";
+import { createVonageInbound } from "../src/providers/sms/vonage";
 
 const encoder = new TextEncoder();
 

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -6,6 +6,7 @@ import { createTelegramInbound } from "../src/inbound/channels/telegram";
 import { createTwilioInbound } from "../src/inbound/channels/twilio";
 import { createInboundRouter } from "../src/inbound/router";
 import type { InboundMessage } from "../src/inbound/types";
+import { mockProvider } from "../src/providers/mock/provider";
 
 const encoder = new TextEncoder();
 
@@ -89,6 +90,30 @@ describe(createSlackInbound, () => {
 
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toMatchObject({ text: "pong" });
+    });
+
+    it("replies to an Events API message out-of-band through the provider", async () => {
+        expect.assertions(3);
+
+        const provider = mockProvider({ channel: "chat", id: "slack" });
+        const channel = createSlackInbound({
+            onMessage: async (_message, context) => {
+                await context.reply("hello back");
+            },
+            provider,
+            signingSecret: secret,
+        });
+        const body = JSON.stringify({
+            event: { channel: "C1", text: "hi", ts: "1700000000.0001", type: "app_mention", user: "U1" },
+            event_id: "Ev2",
+            type: "event_callback",
+        });
+        const response = await channel.handle(await signedRequest(body, "application/json"));
+        const sent = provider.getInstance?.().last();
+
+        expect(response.status).toBe(200);
+        expect(sent?.payload).toMatchObject({ text: "hello back", to: "C1" });
+        expect((sent?.payload as { threadId?: string }).threadId).toBe("1700000000.0001");
     });
 
     it("rejects a tampered signature with 401", async () => {
@@ -279,6 +304,38 @@ describe(createTwilioInbound, () => {
 
         expect(received?.from.id).toBe("+15555550100");
         expect(received?.metadata?.transport).toBe("whatsapp");
+    });
+
+    it("replies to the sender through the provider, re-applying the WhatsApp prefix", async () => {
+        expect.assertions(1);
+
+        const provider = mockProvider({ channel: "sms", id: "twilio" });
+        const channel = createTwilioInbound({
+            authToken,
+            onMessage: async (_message, context) => {
+                await context.reply("got it");
+            },
+            provider,
+        });
+
+        await channel.handle(await signedRequest({ Body: "hi", From: "whatsapp:+15555550100", MessageSid: "SM3", To: "whatsapp:+15555550111" }));
+
+        expect(provider.getInstance?.().last()?.payload).toMatchObject({ from: "whatsapp:+15555550111", text: "got it", to: "whatsapp:+15555550100" });
+    });
+
+    it("rejects context.reply when no provider is configured", async () => {
+        expect.assertions(1);
+
+        const channel = createTwilioInbound({
+            authToken,
+            onMessage: async (_message, context) => {
+                await context.reply("nope");
+            },
+        });
+
+        const request = await signedRequest({ Body: "hi", From: "+15555550100", MessageSid: "SM4", To: "+15555550111" });
+
+        await expect(channel.handle(request)).rejects.toThrow("No `provider` configured to send replies");
     });
 });
 

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+
+import { createDiscordInbound } from "../src/inbound/channels/discord";
+import { createSlackInbound } from "../src/inbound/channels/slack";
+import { createTelegramInbound } from "../src/inbound/channels/telegram";
+import { createTwilioInbound } from "../src/inbound/channels/twilio";
+import { createInboundRouter } from "../src/inbound/router";
+import type { InboundMessage } from "../src/inbound/types";
+
+const encoder = new TextEncoder();
+
+const toHex = (buffer: ArrayBuffer): string => [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const toBase64 = (buffer: ArrayBuffer): string => {
+    let binary = "";
+
+    for (const byte of new Uint8Array(buffer)) {
+        binary += String.fromCodePoint(byte);
+    }
+
+    return btoa(binary);
+};
+
+const hmac = async (secret: string, message: string, hash: "SHA-1" | "SHA-256"): Promise<ArrayBuffer> => {
+    const key = await globalThis.crypto.subtle.importKey("raw", encoder.encode(secret), { hash, name: "HMAC" }, false, ["sign"]);
+
+    return globalThis.crypto.subtle.sign("HMAC", key, encoder.encode(message));
+};
+
+describe(createSlackInbound, () => {
+    const secret = "slack-signing-secret";
+
+    const signedRequest = async (body: string, contentType: string): Promise<Request> => {
+        const timestamp = String(Math.floor(Date.now() / 1000));
+        const signature = `v0=${toHex(await hmac(secret, `v0:${timestamp}:${body}`, "SHA-256"))}`;
+
+        return new Request("https://example.com/webhooks/slack", {
+            body,
+            headers: { "content-type": contentType, "x-slack-request-timestamp": timestamp, "x-slack-signature": signature },
+            method: "POST",
+        });
+    };
+
+    it("answers the url_verification handshake with the challenge", async () => {
+        expect.assertions(2);
+
+        const channel = createSlackInbound({ onMessage: () => undefined, signingSecret: secret });
+        const body = JSON.stringify({ challenge: "abc123", type: "url_verification" });
+        const response = await channel.handle(await signedRequest(body, "application/json"));
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ challenge: "abc123" });
+    });
+
+    it("parses an Events API message and acknowledges with 200", async () => {
+        expect.assertions(4);
+
+        let received: InboundMessage | undefined;
+        const channel = createSlackInbound({
+            onMessage: (message) => {
+                received = message;
+            },
+            signingSecret: secret,
+        });
+        const body = JSON.stringify({
+            event: { channel: "C1", text: "hello bot", ts: "1700000000.0001", type: "app_mention", user: "U1" },
+            event_id: "Ev1",
+            type: "event_callback",
+        });
+        const response = await channel.handle(await signedRequest(body, "application/json"));
+
+        expect(response.status).toBe(200);
+        expect(received?.type).toBe("message");
+        expect(received?.text).toBe("hello bot");
+        expect(received?.conversationId).toBe("C1");
+    });
+
+    it("serialises a slash-command reply into the JSON response", async () => {
+        expect.assertions(2);
+
+        const channel = createSlackInbound({
+            onMessage: () => {
+                return { text: "pong" };
+            },
+            signingSecret: secret,
+        });
+        const body = new URLSearchParams({ channel_id: "C9", command: "/ping", text: "", user_id: "U2" }).toString();
+        const response = await channel.handle(await signedRequest(body, "application/x-www-form-urlencoded"));
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ text: "pong" });
+    });
+
+    it("rejects a tampered signature with 401", async () => {
+        expect.assertions(1);
+
+        const channel = createSlackInbound({ onMessage: () => undefined, signingSecret: secret });
+        const request = new Request("https://example.com/webhooks/slack", {
+            body: "{}",
+            headers: { "content-type": "application/json", "x-slack-request-timestamp": String(Math.floor(Date.now() / 1000)), "x-slack-signature": "v0=deadbeef" },
+            method: "POST",
+        });
+
+        const response = await channel.handle(request);
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe(createDiscordInbound, () => {
+    const generateKey = async (): Promise<CryptoKeyPair> =>
+        await globalThis.crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+
+    const signedRequest = async (keyPair: CryptoKeyPair, body: string): Promise<Request> => {
+        const timestamp = "1700000000";
+        const signature = await globalThis.crypto.subtle.sign({ name: "Ed25519" }, keyPair.privateKey, encoder.encode(`${timestamp}${body}`));
+
+        return new Request("https://example.com/webhooks/discord", {
+            body,
+            headers: { "content-type": "application/json", "x-signature-ed25519": toHex(signature), "x-signature-timestamp": timestamp },
+            method: "POST",
+        });
+    };
+
+    const publicKeyHex = async (keyPair: CryptoKeyPair): Promise<string> => toHex(await globalThis.crypto.subtle.exportKey("raw", keyPair.publicKey));
+
+    it("answers the PING handshake with a PONG", async () => {
+        expect.assertions(2);
+
+        const keyPair = await generateKey();
+        const channel = createDiscordInbound({ onMessage: () => undefined, publicKey: await publicKeyHex(keyPair) });
+        const response = await channel.handle(await signedRequest(keyPair, JSON.stringify({ type: 1 })));
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ type: 1 });
+    });
+
+    it("parses an application command and replies with a channel message", async () => {
+        expect.assertions(3);
+
+        const keyPair = await generateKey();
+        let received: InboundMessage | undefined;
+        const channel = createDiscordInbound({
+            onMessage: (message) => {
+                received = message;
+
+                return { text: "hi" };
+            },
+            publicKey: await publicKeyHex(keyPair),
+        });
+        const body = JSON.stringify({ channel_id: "C1", data: { name: "ask" }, id: "I1", member: { user: { id: "U1", username: "ada" } }, type: 2 });
+        const response = await channel.handle(await signedRequest(keyPair, body));
+
+        expect(received?.command?.name).toBe("ask");
+        expect(received?.from.username).toBe("ada");
+        await expect(response.json()).resolves.toStrictEqual({ data: { content: "hi" }, type: 4 });
+    });
+
+    it("rejects an invalid signature with 401", async () => {
+        expect.assertions(1);
+
+        const keyPair = await generateKey();
+        const otherKey = await generateKey();
+        const channel = createDiscordInbound({ onMessage: () => undefined, publicKey: await publicKeyHex(otherKey) });
+        const response = await channel.handle(await signedRequest(keyPair, JSON.stringify({ type: 1 })));
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe(createTelegramInbound, () => {
+    const secretToken = "telegram-secret";
+
+    const request = (body: unknown, token?: string): Request =>
+        new Request("https://example.com/webhooks/telegram", {
+            body: JSON.stringify(body),
+            headers: { "content-type": "application/json", ...token === undefined ? {} : { "x-telegram-bot-api-secret-token": token } },
+            method: "POST",
+        });
+
+    it("verifies the secret token and serialises a sendMessage reply", async () => {
+        expect.assertions(3);
+
+        let received: InboundMessage | undefined;
+        const channel = createTelegramInbound({
+            onMessage: (message) => {
+                received = message;
+
+                return { text: "pong" };
+            },
+            secretToken,
+        });
+        const response = await channel.handle(
+            request({ message: { chat: { id: 42, type: "private" }, date: 1_700_000_000, from: { first_name: "Ada", id: 7 }, message_id: 5, text: "ping" }, update_id: 1 }, secretToken),
+        );
+
+        expect(received?.text).toBe("ping");
+        expect(received?.conversationId).toBe("42");
+        await expect(response.json()).resolves.toMatchObject({ chat_id: "42", method: "sendMessage", text: "pong" });
+    });
+
+    it("rejects a mismatched secret token with 401", async () => {
+        expect.assertions(1);
+
+        const channel = createTelegramInbound({ onMessage: () => undefined, secretToken });
+        const response = await channel.handle(request({ update_id: 1 }, "wrong"));
+
+        expect(response.status).toBe(401);
+    });
+
+    it("detects bot commands", async () => {
+        expect.assertions(2);
+
+        let received: InboundMessage | undefined;
+        const channel = createTelegramInbound({
+            onMessage: (message) => {
+                received = message;
+            },
+            secretToken,
+        });
+
+        await channel.handle(request({ message: { chat: { id: 1 }, from: { id: 1 }, message_id: 1, text: "/start now" }, update_id: 2 }, secretToken));
+
+        expect(received?.type).toBe("command");
+        expect(received?.command).toStrictEqual({ args: "now", name: "start" });
+    });
+});
+
+describe(createTwilioInbound, () => {
+    const authToken = "twilio-auth-token";
+    const url = "https://example.com/webhooks/twilio";
+
+    const signedRequest = async (parameters: Record<string, string>): Promise<Request> => {
+        const body = new URLSearchParams(parameters).toString();
+        const keys = Object.keys(parameters).toSorted((a, b) => a.localeCompare(b));
+        let base = url;
+
+        for (const key of keys) {
+            base += `${key}${parameters[key] ?? ""}`;
+        }
+
+        const signature = toBase64(await hmac(authToken, base, "SHA-1"));
+
+        return new Request(url, { body, headers: { "content-type": "application/x-www-form-urlencoded", "x-twilio-signature": signature }, method: "POST" });
+    };
+
+    it("parses an inbound SMS and replies with TwiML", async () => {
+        expect.assertions(4);
+
+        let received: InboundMessage | undefined;
+        const channel = createTwilioInbound({
+            authToken,
+            onMessage: (message) => {
+                received = message;
+
+                return { text: "got it" };
+            },
+        });
+        const response = await channel.handle(await signedRequest({ Body: "hello", From: "+15555550100", MessageSid: "SM1", To: "+15555550111" }));
+
+        expect(received?.text).toBe("hello");
+        expect(received?.from.id).toBe("+15555550100");
+        expect(response.headers.get("content-type")).toContain("text/xml");
+        await expect(response.text()).resolves.toContain("<Message>got it</Message>");
+    });
+
+    it("flags WhatsApp transport and strips the prefix", async () => {
+        expect.assertions(2);
+
+        let received: InboundMessage | undefined;
+        const channel = createTwilioInbound({
+            authToken,
+            onMessage: (message) => {
+                received = message;
+            },
+        });
+
+        await channel.handle(await signedRequest({ Body: "hi", From: "whatsapp:+15555550100", MessageSid: "SM2", To: "whatsapp:+15555550111" }));
+
+        expect(received?.from.id).toBe("+15555550100");
+        expect(received?.metadata?.transport).toBe("whatsapp");
+    });
+});
+
+describe(createInboundRouter, () => {
+    it("dispatches by path and 404s unknown paths", async () => {
+        expect.assertions(2);
+
+        const channel = createTelegramInbound({ onMessage: () => undefined });
+        const router = createInboundRouter({ "/webhooks/telegram": channel });
+
+        const ok = await router(new Request("https://example.com/webhooks/telegram", { body: JSON.stringify({ update_id: 1 }), method: "POST" }));
+        const missing = await router(new Request("https://example.com/nope", { method: "POST" }));
+
+        expect(ok.status).toBe(204);
+        expect(missing.status).toBe(404);
+    });
+});

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { createDiscordInbound } from "../src/inbound/channels/discord";
+import { createMsTeamsInbound } from "../src/inbound/channels/msteams";
 import { createSlackInbound } from "../src/inbound/channels/slack";
 import { createTelegramInbound } from "../src/inbound/channels/telegram";
+import { createTelnyxInbound } from "../src/inbound/channels/telnyx";
 import { createTwilioInbound } from "../src/inbound/channels/twilio";
 import { createInboundRouter } from "../src/inbound/router";
 import type { InboundMessage } from "../src/inbound/types";
@@ -21,6 +23,8 @@ const toBase64 = (buffer: ArrayBuffer): string => {
 
     return btoa(binary);
 };
+
+const base64ToBytes = (value: string): Uint8Array => Uint8Array.from(atob(value), (character) => character.codePointAt(0) ?? 0);
 
 const hmac = async (secret: string, message: string, hash: "SHA-1" | "SHA-256"): Promise<ArrayBuffer> => {
     const key = await globalThis.crypto.subtle.importKey("raw", encoder.encode(secret), { hash, name: "HMAC" }, false, ["sign"]);
@@ -336,6 +340,111 @@ describe(createTwilioInbound, () => {
         const request = await signedRequest({ Body: "hi", From: "+15555550100", MessageSid: "SM4", To: "+15555550111" });
 
         await expect(channel.handle(request)).rejects.toThrow("No `provider` configured to send replies");
+    });
+});
+
+describe(createMsTeamsInbound, () => {
+    const securityToken = btoa("teams-security-token-value-0123456789");
+
+    const signedRequest = async (activity: unknown): Promise<Request> => {
+        const body = JSON.stringify(activity);
+        const key = await globalThis.crypto.subtle.importKey("raw", base64ToBytes(securityToken), { hash: "SHA-256", name: "HMAC" }, false, ["sign"]);
+        const signature = toBase64(await globalThis.crypto.subtle.sign("HMAC", key, encoder.encode(body)));
+
+        return new Request("https://example.com/webhooks/teams", {
+            body,
+            headers: { authorization: `HMAC ${signature}`, "content-type": "application/json" },
+            method: "POST",
+        });
+    };
+
+    it("verifies the HMAC and replies with a message activity", async () => {
+        expect.assertions(3);
+
+        let received: InboundMessage | undefined;
+        const channel = createMsTeamsInbound({
+            onMessage: (message) => {
+                received = message;
+
+                return { text: "hello back" };
+            },
+            securityToken,
+        });
+        const response = await channel.handle(await signedRequest({ conversation: { id: "19:abc" }, from: { id: "U1", name: "Ada" }, id: "A1", text: "hi bot", type: "message" }));
+
+        expect(received?.text).toBe("hi bot");
+        expect(received?.from.name).toBe("Ada");
+        await expect(response.json()).resolves.toMatchObject({ text: "hello back", type: "message" });
+    });
+
+    it("rejects a tampered HMAC with 401", async () => {
+        expect.assertions(1);
+
+        const channel = createMsTeamsInbound({ onMessage: () => undefined, securityToken });
+        const request = new Request("https://example.com/webhooks/teams", {
+            body: JSON.stringify({ text: "hi", type: "message" }),
+            headers: { authorization: "HMAC bm90LXZhbGlk", "content-type": "application/json" },
+            method: "POST",
+        });
+        const response = await channel.handle(request);
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe(createTelnyxInbound, () => {
+    const generateKey = async (): Promise<CryptoKeyPair> =>
+        await globalThis.crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+
+    const publicKeyBase64 = async (keyPair: CryptoKeyPair): Promise<string> => toBase64(await globalThis.crypto.subtle.exportKey("raw", keyPair.publicKey));
+
+    const signedRequest = async (keyPair: CryptoKeyPair, payload: unknown): Promise<Request> => {
+        const body = JSON.stringify(payload);
+        const timestamp = String(Math.floor(Date.now() / 1000));
+        const signature = toBase64(await globalThis.crypto.subtle.sign({ name: "Ed25519" }, keyPair.privateKey, encoder.encode(`${timestamp}|${body}`)));
+
+        return new Request("https://example.com/webhooks/telnyx", {
+            body,
+            headers: { "content-type": "application/json", "telnyx-signature-ed25519": signature, "telnyx-timestamp": timestamp },
+            method: "POST",
+        });
+    };
+
+    it("verifies Ed25519, parses the message and replies through the provider", async () => {
+        expect.assertions(3);
+
+        const keyPair = await generateKey();
+        const provider = mockProvider({ channel: "sms", id: "telnyx" });
+        let received: InboundMessage | undefined;
+        const channel = createTelnyxInbound({
+            onMessage: async (message, context) => {
+                received = message;
+
+                await context.reply("ok");
+            },
+            provider,
+            publicKey: await publicKeyBase64(keyPair),
+        });
+        const payload = {
+            data: { event_type: "message.received", payload: { from: { phone_number: "+15551230001" }, id: "msg1", text: "hey", to: [{ phone_number: "+15551230009" }], type: "SMS" } },
+        };
+        const response = await channel.handle(await signedRequest(keyPair, payload));
+
+        expect(received?.text).toBe("hey");
+        expect(response.status).toBe(204);
+        expect(provider.getInstance?.().last()?.payload).toMatchObject({ from: "+15551230009", text: "ok", to: "+15551230001" });
+    });
+
+    it("rejects a signature made with a different key with 401", async () => {
+        expect.assertions(1);
+
+        const keyPair = await generateKey();
+        const otherKey = await generateKey();
+        const channel = createTelnyxInbound({ onMessage: () => undefined, publicKey: await publicKeyBase64(otherKey) });
+        const payload = { data: { event_type: "message.received", payload: { from: { phone_number: "+1" }, id: "m", text: "x", to: [{ phone_number: "+2" }] } } };
+        const response = await channel.handle(await signedRequest(keyPair, payload));
+
+        expect(response.status).toBe(401);
     });
 });
 

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -201,6 +201,32 @@ describe(createDiscordReceiver, () => {
         await expect(response.json()).resolves.toStrictEqual({ data: { content: "hi" }, type: 4 });
     });
 
+    it("defers the interaction when the handler outruns the deadline", async () => {
+        expect.assertions(2);
+
+        const keyPair = await generateKey();
+        let finished = false;
+        const channel = createDiscordReceiver({
+            deferAfterMs: 10,
+            onMessage: async () => {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 60);
+                });
+                finished = true;
+
+                return { text: "too late" };
+            },
+            publicKey: await publicKeyHex(keyPair),
+        });
+        const body = JSON.stringify({ channel_id: "C1", data: { name: "slow" }, id: "I2", member: { user: { id: "U1" } }, type: 2 });
+        const response = await channel.handle(await signedRequest(keyPair, body));
+
+        // Discord discards an interaction that is unanswered after three seconds, so a slow
+        // handler has to be deferred rather than waited on.
+        await expect(response.json()).resolves.toStrictEqual({ type: 5 });
+        expect(finished).toBe(false);
+    });
+
     it("rejects an invalid signature with 401", async () => {
         expect.assertions(1);
 
@@ -251,6 +277,23 @@ describe(createTelegramReceiver, () => {
         const response = await channel.handle(request({ update_id: 1 }, "wrong"));
 
         expect(response.status).toBe(401);
+    });
+
+    it("sends a topic reply as message_thread_id, not as a quoted message", async () => {
+        expect.assertions(2);
+
+        const channel = createTelegramReceiver({ onMessage: (message) => ({ text: "pong", threadId: message.threadId }), secretToken });
+        const response = await channel.handle(
+            request(
+                { message: { chat: { id: 42, type: "supergroup" }, date: 1_700_000_000, from: { id: 7 }, message_id: 5, message_thread_id: 99, text: "ping" }, update_id: 1 },
+                secretToken,
+            ),
+        );
+        const payload = (await response.json()) as Record<string, unknown>;
+
+        // 99 is a forum topic, not message 99 — quoting it would target the wrong message.
+        expect(payload.message_thread_id).toBe(99);
+        expect(payload.reply_parameters).toBeUndefined();
     });
 
     it("detects bot commands", async () => {
@@ -307,6 +350,19 @@ describe(createTwilioReceiver, () => {
         expect(received?.from.id).toBe("+15555550100");
         expect(response.headers.get("content-type")).toContain("text/xml");
         await expect(response.text()).resolves.toContain("<Message>got it</Message>");
+    });
+
+    it("drops XML-illegal control characters from the reply", async () => {
+        expect.assertions(2);
+
+        // A handler echoing the inbound Body can carry anything the sender typed; a control
+        // character reaches TwiML and Twilio answers with a document-parse error instead.
+        const channel = createTwilioReceiver({ authToken, onMessage: (message) => ({ text: message.text }) });
+        const response = await channel.handle(await signedRequest({ Body: "ok\u0000 <bad>\u0007", From: "+15555550100", MessageSid: "SM9", To: "+15555550111" }));
+        const document = await response.text();
+
+        expect(document).toContain("<Message>ok &lt;bad&gt;</Message>");
+        expect(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/u.test(document)).toBe(false);
     });
 
     it("flags WhatsApp transport and strips the prefix", async () => {
@@ -391,6 +447,23 @@ describe(createMsTeamsReceiver, () => {
         expect(received?.text).toBe("hi bot");
         expect(received?.from.name).toBe("Ada");
         await expect(response.json()).resolves.toMatchObject({ text: "hello back", type: "message" });
+    });
+
+    it("falls back to now when the activity timestamp is malformed", async () => {
+        expect.assertions(1);
+
+        let received: InboundMessage | undefined;
+        const channel = createMsTeamsReceiver({
+            onMessage: (message) => {
+                received = message;
+            },
+            securityToken,
+        });
+
+        await channel.handle(await signedRequest({ from: { id: "U1" }, id: "A2", text: "hi", timestamp: "not-a-date", type: "message" }));
+
+        // An `Invalid Date` passes silently through assignment and only throws in the consumer.
+        expect(Number.isNaN(received?.timestamp.getTime())).toBe(false);
     });
 
     it("rejects a tampered HMAC with 401", async () => {
@@ -492,6 +565,27 @@ describe(createMessageBirdReceiver, () => {
         expect(provider.getInstance?.().last()?.payload).toMatchObject({ from: "+15551230009", text: "thanks", to: "+15551230001" });
     });
 
+    it("ignores a message with no provider id", async () => {
+        expect.assertions(2);
+
+        // Normalising a missing id to "" makes every id-less message look like the same one to a
+        // consumer that deduplicates or persists on it.
+        const body = JSON.stringify({ body: "no id", createdDatetime: "2026-01-01T00:00:00+00:00", originator: "+15551230001", recipient: "+15551230009" });
+        const token = await signJwt(signingKey, { exp: inFiveMinutes(), iss: "MessageBird", jti: "j3", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
+        let called = false;
+        const channel = createMessageBirdReceiver({
+            onMessage: () => {
+                called = true;
+            },
+            signingKey,
+            url,
+        });
+        const response = await channel.handle(new Request(url, { body, headers: { "content-type": "application/json", "messagebird-signature-jwt": token }, method: "POST" }));
+
+        expect(called).toBe(false);
+        expect(response.status).toBe(204);
+    });
+
     it("rejects a JWT signed with the wrong key with 401", async () => {
         expect.assertions(1);
 
@@ -556,5 +650,39 @@ describe(createInboundRouter, () => {
 
         expect(ok.status).toBe(204);
         expect(missing.status).toBe(404);
+    });
+
+    it("matches a route only at a path-segment boundary", async () => {
+        expect.assertions(1);
+
+        const router = createInboundRouter({ telegram: createTelegramReceiver({ onMessage: () => undefined }) });
+
+        // The path ends with "telegram", but as part of "evil-telegram" — a different endpoint.
+        const response = await router(new Request("https://example.com/webhooks/evil-telegram", { body: "{}", method: "POST" }));
+
+        expect(response.status).toBe(404);
+    });
+
+    it("prefers the most specific route over declaration order", async () => {
+        expect.assertions(1);
+
+        let reached: string | undefined;
+        const receiver = (name: string) =>
+            createTelegramReceiver({
+                onMessage: () => {
+                    reached = name;
+                },
+            });
+        // The short route is declared first; an unordered scan would let it swallow the request.
+        const router = createInboundRouter({ "/telegram": receiver("short"), "/inbound/telegram": receiver("specific") });
+
+        await router(
+            new Request("https://example.com/inbound/telegram", {
+                body: JSON.stringify({ message: { chat: { id: 1 }, from: { id: 1 }, message_id: 1, text: "hi" }, update_id: 1 }),
+                method: "POST",
+            }),
+        );
+
+        expect(reached).toBe("specific");
     });
 });

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { createInboundRouter } from "../src/inbound/router";
 import type { InboundMessage } from "../src/inbound/types";
-import { createDiscordInbound } from "../src/providers/chat/discord";
-import { createMsTeamsInbound } from "../src/providers/chat/msteams";
-import { createSlackInbound } from "../src/providers/chat/slack";
-import { createTelegramInbound } from "../src/providers/chat/telegram";
+import { createDiscordReceiver } from "../src/providers/chat/discord";
+import { createMsTeamsReceiver } from "../src/providers/chat/msteams";
+import { createSlackReceiver } from "../src/providers/chat/slack";
+import { createTelegramReceiver } from "../src/providers/chat/telegram";
 import { mockProvider } from "../src/providers/mock/provider";
-import { createMessageBirdInbound } from "../src/providers/sms/messagebird";
-import { createTelnyxInbound } from "../src/providers/sms/telnyx";
-import { createTwilioInbound } from "../src/providers/sms/twilio";
-import { createVonageInbound } from "../src/providers/sms/vonage";
+import { createMessageBirdReceiver } from "../src/providers/sms/messagebird";
+import { createTelnyxReceiver } from "../src/providers/sms/telnyx";
+import { createTwilioReceiver } from "../src/providers/sms/twilio";
+import { createVonageReceiver } from "../src/providers/sms/vonage";
 
 const encoder = new TextEncoder();
 
@@ -48,7 +48,7 @@ const signJwt = async (secret: string, claims: Record<string, unknown>): Promise
 
 const inFiveMinutes = (): number => Math.floor(Date.now() / 1000) + 300;
 
-describe(createSlackInbound, () => {
+describe(createSlackReceiver, () => {
     const secret = "slack-signing-secret";
 
     const signedRequest = async (body: string, contentType: string): Promise<Request> => {
@@ -65,7 +65,7 @@ describe(createSlackInbound, () => {
     it("answers the url_verification handshake with the challenge", async () => {
         expect.assertions(2);
 
-        const channel = createSlackInbound({ onMessage: () => undefined, signingSecret: secret });
+        const channel = createSlackReceiver({ onMessage: () => undefined, signingSecret: secret });
         const body = JSON.stringify({ challenge: "abc123", type: "url_verification" });
         const response = await channel.handle(await signedRequest(body, "application/json"));
 
@@ -77,7 +77,7 @@ describe(createSlackInbound, () => {
         expect.assertions(4);
 
         let received: InboundMessage | undefined;
-        const channel = createSlackInbound({
+        const channel = createSlackReceiver({
             onMessage: (message) => {
                 received = message;
             },
@@ -99,7 +99,7 @@ describe(createSlackInbound, () => {
     it("serialises a slash-command reply into the JSON response", async () => {
         expect.assertions(2);
 
-        const channel = createSlackInbound({
+        const channel = createSlackReceiver({
             onMessage: () => {
                 return { text: "pong" };
             },
@@ -116,7 +116,7 @@ describe(createSlackInbound, () => {
         expect.assertions(3);
 
         const provider = mockProvider({ channel: "chat", id: "slack" });
-        const channel = createSlackInbound({
+        const channel = createSlackReceiver({
             onMessage: async (_message, context) => {
                 await context.reply("hello back");
             },
@@ -139,7 +139,7 @@ describe(createSlackInbound, () => {
     it("rejects a tampered signature with 401", async () => {
         expect.assertions(1);
 
-        const channel = createSlackInbound({ onMessage: () => undefined, signingSecret: secret });
+        const channel = createSlackReceiver({ onMessage: () => undefined, signingSecret: secret });
         const request = new Request("https://example.com/webhooks/slack", {
             body: "{}",
             headers: { "content-type": "application/json", "x-slack-request-timestamp": String(Math.floor(Date.now() / 1000)), "x-slack-signature": "v0=deadbeef" },
@@ -152,7 +152,7 @@ describe(createSlackInbound, () => {
     });
 });
 
-describe(createDiscordInbound, () => {
+describe(createDiscordReceiver, () => {
     const generateKey = async (): Promise<CryptoKeyPair> =>
         await globalThis.crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
 
@@ -173,7 +173,7 @@ describe(createDiscordInbound, () => {
         expect.assertions(2);
 
         const keyPair = await generateKey();
-        const channel = createDiscordInbound({ onMessage: () => undefined, publicKey: await publicKeyHex(keyPair) });
+        const channel = createDiscordReceiver({ onMessage: () => undefined, publicKey: await publicKeyHex(keyPair) });
         const response = await channel.handle(await signedRequest(keyPair, JSON.stringify({ type: 1 })));
 
         expect(response.status).toBe(200);
@@ -185,7 +185,7 @@ describe(createDiscordInbound, () => {
 
         const keyPair = await generateKey();
         let received: InboundMessage | undefined;
-        const channel = createDiscordInbound({
+        const channel = createDiscordReceiver({
             onMessage: (message) => {
                 received = message;
 
@@ -206,14 +206,14 @@ describe(createDiscordInbound, () => {
 
         const keyPair = await generateKey();
         const otherKey = await generateKey();
-        const channel = createDiscordInbound({ onMessage: () => undefined, publicKey: await publicKeyHex(otherKey) });
+        const channel = createDiscordReceiver({ onMessage: () => undefined, publicKey: await publicKeyHex(otherKey) });
         const response = await channel.handle(await signedRequest(keyPair, JSON.stringify({ type: 1 })));
 
         expect(response.status).toBe(401);
     });
 });
 
-describe(createTelegramInbound, () => {
+describe(createTelegramReceiver, () => {
     const secretToken = "telegram-secret";
 
     const request = (body: unknown, token?: string): Request =>
@@ -227,7 +227,7 @@ describe(createTelegramInbound, () => {
         expect.assertions(3);
 
         let received: InboundMessage | undefined;
-        const channel = createTelegramInbound({
+        const channel = createTelegramReceiver({
             onMessage: (message) => {
                 received = message;
 
@@ -247,7 +247,7 @@ describe(createTelegramInbound, () => {
     it("rejects a mismatched secret token with 401", async () => {
         expect.assertions(1);
 
-        const channel = createTelegramInbound({ onMessage: () => undefined, secretToken });
+        const channel = createTelegramReceiver({ onMessage: () => undefined, secretToken });
         const response = await channel.handle(request({ update_id: 1 }, "wrong"));
 
         expect(response.status).toBe(401);
@@ -257,7 +257,7 @@ describe(createTelegramInbound, () => {
         expect.assertions(2);
 
         let received: InboundMessage | undefined;
-        const channel = createTelegramInbound({
+        const channel = createTelegramReceiver({
             onMessage: (message) => {
                 received = message;
             },
@@ -271,7 +271,7 @@ describe(createTelegramInbound, () => {
     });
 });
 
-describe(createTwilioInbound, () => {
+describe(createTwilioReceiver, () => {
     const authToken = "twilio-auth-token";
     const url = "https://example.com/webhooks/twilio";
 
@@ -293,7 +293,7 @@ describe(createTwilioInbound, () => {
         expect.assertions(4);
 
         let received: InboundMessage | undefined;
-        const channel = createTwilioInbound({
+        const channel = createTwilioReceiver({
             authToken,
             onMessage: (message) => {
                 received = message;
@@ -313,7 +313,7 @@ describe(createTwilioInbound, () => {
         expect.assertions(2);
 
         let received: InboundMessage | undefined;
-        const channel = createTwilioInbound({
+        const channel = createTwilioReceiver({
             authToken,
             onMessage: (message) => {
                 received = message;
@@ -330,7 +330,7 @@ describe(createTwilioInbound, () => {
         expect.assertions(1);
 
         const provider = mockProvider({ channel: "sms", id: "twilio" });
-        const channel = createTwilioInbound({
+        const channel = createTwilioReceiver({
             authToken,
             onMessage: async (_message, context) => {
                 await context.reply("got it");
@@ -346,7 +346,7 @@ describe(createTwilioInbound, () => {
     it("rejects context.reply when no provider is configured", async () => {
         expect.assertions(1);
 
-        const channel = createTwilioInbound({
+        const channel = createTwilioReceiver({
             authToken,
             onMessage: async (_message, context) => {
                 await context.reply("nope");
@@ -359,7 +359,7 @@ describe(createTwilioInbound, () => {
     });
 });
 
-describe(createMsTeamsInbound, () => {
+describe(createMsTeamsReceiver, () => {
     const securityToken = btoa("teams-security-token-value-0123456789");
 
     const signedRequest = async (activity: unknown): Promise<Request> => {
@@ -378,7 +378,7 @@ describe(createMsTeamsInbound, () => {
         expect.assertions(3);
 
         let received: InboundMessage | undefined;
-        const channel = createMsTeamsInbound({
+        const channel = createMsTeamsReceiver({
             onMessage: (message) => {
                 received = message;
 
@@ -396,7 +396,7 @@ describe(createMsTeamsInbound, () => {
     it("rejects a tampered HMAC with 401", async () => {
         expect.assertions(1);
 
-        const channel = createMsTeamsInbound({ onMessage: () => undefined, securityToken });
+        const channel = createMsTeamsReceiver({ onMessage: () => undefined, securityToken });
         const request = new Request("https://example.com/webhooks/teams", {
             body: JSON.stringify({ text: "hi", type: "message" }),
             headers: { authorization: "HMAC bm90LXZhbGlk", "content-type": "application/json" },
@@ -408,7 +408,7 @@ describe(createMsTeamsInbound, () => {
     });
 });
 
-describe(createTelnyxInbound, () => {
+describe(createTelnyxReceiver, () => {
     const generateKey = async (): Promise<CryptoKeyPair> =>
         await globalThis.crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
 
@@ -432,7 +432,7 @@ describe(createTelnyxInbound, () => {
         const keyPair = await generateKey();
         const provider = mockProvider({ channel: "sms", id: "telnyx" });
         let received: InboundMessage | undefined;
-        const channel = createTelnyxInbound({
+        const channel = createTelnyxReceiver({
             onMessage: async (message, context) => {
                 received = message;
 
@@ -456,7 +456,7 @@ describe(createTelnyxInbound, () => {
 
         const keyPair = await generateKey();
         const otherKey = await generateKey();
-        const channel = createTelnyxInbound({ onMessage: () => undefined, publicKey: await publicKeyBase64(otherKey) });
+        const channel = createTelnyxReceiver({ onMessage: () => undefined, publicKey: await publicKeyBase64(otherKey) });
         const payload = { data: { event_type: "message.received", payload: { from: { phone_number: "+1" }, id: "m", text: "x", to: [{ phone_number: "+2" }] } } };
         const response = await channel.handle(await signedRequest(keyPair, payload));
 
@@ -464,7 +464,7 @@ describe(createTelnyxInbound, () => {
     });
 });
 
-describe(createMessageBirdInbound, () => {
+describe(createMessageBirdReceiver, () => {
     const signingKey = "messagebird-signing-key";
     const url = "https://example.com/webhooks/messagebird";
 
@@ -475,7 +475,7 @@ describe(createMessageBirdInbound, () => {
         const token = await signJwt(signingKey, { exp: inFiveMinutes(), iss: "MessageBird", jti: "j1", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
         const provider = mockProvider({ channel: "sms", id: "messagebird" });
         let received: InboundMessage | undefined;
-        const channel = createMessageBirdInbound({
+        const channel = createMessageBirdReceiver({
             onMessage: async (message, context) => {
                 received = message;
 
@@ -497,14 +497,14 @@ describe(createMessageBirdInbound, () => {
 
         const body = JSON.stringify({ id: "mb2", originator: "+1", recipient: "+2" });
         const token = await signJwt("wrong-key", { exp: inFiveMinutes(), iss: "MessageBird", jti: "j2", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
-        const channel = createMessageBirdInbound({ onMessage: () => undefined, signingKey, url });
+        const channel = createMessageBirdReceiver({ onMessage: () => undefined, signingKey, url });
         const response = await channel.handle(new Request(url, { body, headers: { "messagebird-signature-jwt": token }, method: "POST" }));
 
         expect(response.status).toBe(401);
     });
 });
 
-describe(createVonageInbound, () => {
+describe(createVonageReceiver, () => {
     const signatureSecret = "vonage-signature-secret";
     const url = "https://example.com/webhooks/vonage";
 
@@ -515,7 +515,7 @@ describe(createVonageInbound, () => {
         const token = await signJwt(signatureSecret, { exp: inFiveMinutes(), payload_hash: await sha256Hex(body) });
         const provider = mockProvider({ channel: "sms", id: "vonage" });
         let received: InboundMessage | undefined;
-        const channel = createVonageInbound({
+        const channel = createVonageReceiver({
             onMessage: async (message, context) => {
                 received = message;
 
@@ -536,7 +536,7 @@ describe(createVonageInbound, () => {
 
         const body = JSON.stringify({ from: "1", text: "original", to: "2" });
         const token = await signJwt(signatureSecret, { exp: inFiveMinutes(), payload_hash: await sha256Hex(body) });
-        const channel = createVonageInbound({ onMessage: () => undefined, signatureSecret });
+        const channel = createVonageReceiver({ onMessage: () => undefined, signatureSecret });
         const tampered = JSON.stringify({ from: "1", text: "changed", to: "2" });
         const response = await channel.handle(new Request(url, { body: tampered, headers: { authorization: `Bearer ${token}` }, method: "POST" }));
 
@@ -548,7 +548,7 @@ describe(createInboundRouter, () => {
     it("dispatches by path and 404s unknown paths", async () => {
         expect.assertions(2);
 
-        const channel = createTelegramInbound({ onMessage: () => undefined });
+        const channel = createTelegramReceiver({ onMessage: () => undefined });
         const router = createInboundRouter({ "/webhooks/telegram": channel });
 
         const ok = await router(new Request("https://example.com/webhooks/telegram", { body: JSON.stringify({ update_id: 1 }), method: "POST" }));

--- a/packages/notification/notification/__tests__/inbound.test.ts
+++ b/packages/notification/notification/__tests__/inbound.test.ts
@@ -6,11 +6,19 @@ import { createDiscordReceiver } from "../src/providers/chat/discord";
 import { createMsTeamsReceiver } from "../src/providers/chat/msteams";
 import { createSlackReceiver } from "../src/providers/chat/slack";
 import { createTelegramReceiver } from "../src/providers/chat/telegram";
-import { mockProvider } from "../src/providers/mock/provider";
+import { createMockProvider } from "../src/providers/mock";
 import { createMessageBirdReceiver } from "../src/providers/sms/messagebird";
 import { createTelnyxReceiver } from "../src/providers/sms/telnyx";
 import { createTwilioReceiver } from "../src/providers/sms/twilio";
 import { createVonageReceiver } from "../src/providers/sms/vonage";
+
+/**
+ * The control characters TwiML must never carry. Matching them is the
+ * assertion, so `no-control-regex` is suppressed rather than satisfied — and
+ * it lives at module scope so the pattern is compiled once.
+ */
+// eslint-disable-next-line no-control-regex -- the control characters are what this asserts against
+const CONTROL_CHARACTERS_RE = /[\u0000-\u0008\v\f\u000E-\u001F]/u;
 
 const encoder = new TextEncoder();
 
@@ -115,7 +123,7 @@ describe(createSlackReceiver, () => {
     it("replies to an Events API message out-of-band through the provider", async () => {
         expect.assertions(3);
 
-        const provider = mockProvider({ channel: "chat", id: "slack" });
+        const provider = createMockProvider({ channel: "chat", id: "slack" });
         const channel = createSlackReceiver({
             onMessage: async (_message, context) => {
                 await context.reply("hello back");
@@ -282,7 +290,12 @@ describe(createTelegramReceiver, () => {
     it("sends a topic reply as message_thread_id, not as a quoted message", async () => {
         expect.assertions(2);
 
-        const channel = createTelegramReceiver({ onMessage: (message) => ({ text: "pong", threadId: message.threadId }), secretToken });
+        const channel = createTelegramReceiver({
+            onMessage: (message) => {
+                return { text: "pong", threadId: message.threadId };
+            },
+            secretToken,
+        });
         const response = await channel.handle(
             request(
                 { message: { chat: { id: 42, type: "supergroup" }, date: 1_700_000_000, from: { id: 7 }, message_id: 5, message_thread_id: 99, text: "ping" }, update_id: 1 },
@@ -357,12 +370,17 @@ describe(createTwilioReceiver, () => {
 
         // A handler echoing the inbound Body can carry anything the sender typed; a control
         // character reaches TwiML and Twilio answers with a document-parse error instead.
-        const channel = createTwilioReceiver({ authToken, onMessage: (message) => ({ text: message.text }) });
+        const channel = createTwilioReceiver({
+            authToken,
+            onMessage: (message) => {
+                return { text: message.text };
+            },
+        });
         const response = await channel.handle(await signedRequest({ Body: "ok\u0000 <bad>\u0007", From: "+15555550100", MessageSid: "SM9", To: "+15555550111" }));
         const document = await response.text();
 
         expect(document).toContain("<Message>ok &lt;bad&gt;</Message>");
-        expect(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/u.test(document)).toBe(false);
+        expect(CONTROL_CHARACTERS_RE.test(document)).toBe(false);
     });
 
     it("flags WhatsApp transport and strips the prefix", async () => {
@@ -385,7 +403,7 @@ describe(createTwilioReceiver, () => {
     it("replies to the sender through the provider, re-applying the WhatsApp prefix", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms", id: "twilio" });
+        const provider = createMockProvider({ channel: "sms", id: "twilio" });
         const channel = createTwilioReceiver({
             authToken,
             onMessage: async (_message, context) => {
@@ -503,7 +521,7 @@ describe(createTelnyxReceiver, () => {
         expect.assertions(3);
 
         const keyPair = await generateKey();
-        const provider = mockProvider({ channel: "sms", id: "telnyx" });
+        const provider = createMockProvider({ channel: "sms", id: "telnyx" });
         let received: InboundMessage | undefined;
         const channel = createTelnyxReceiver({
             onMessage: async (message, context) => {
@@ -546,7 +564,7 @@ describe(createMessageBirdReceiver, () => {
 
         const body = JSON.stringify({ body: "hey there", createdDatetime: "2026-01-01T00:00:00+00:00", id: "mb1", originator: "+15551230001", recipient: "+15551230009" });
         const token = await signJwt(signingKey, { exp: inFiveMinutes(), iss: "MessageBird", jti: "j1", payload_hash: await sha256Hex(body), url_hash: await sha256Hex(url) });
-        const provider = mockProvider({ channel: "sms", id: "messagebird" });
+        const provider = createMockProvider({ channel: "sms", id: "messagebird" });
         let received: InboundMessage | undefined;
         const channel = createMessageBirdReceiver({
             onMessage: async (message, context) => {
@@ -607,7 +625,7 @@ describe(createVonageReceiver, () => {
 
         const body = JSON.stringify({ channel: "sms", from: "15551230001", message_type: "text", message_uuid: "v1", text: "hi vonage", timestamp: "2026-01-01T00:00:00Z", to: "15551230009" });
         const token = await signJwt(signatureSecret, { exp: inFiveMinutes(), payload_hash: await sha256Hex(body) });
-        const provider = mockProvider({ channel: "sms", id: "vonage" });
+        const provider = createMockProvider({ channel: "sms", id: "vonage" });
         let received: InboundMessage | undefined;
         const channel = createVonageReceiver({
             onMessage: async (message, context) => {
@@ -674,7 +692,7 @@ describe(createInboundRouter, () => {
                 },
             });
         // The short route is declared first; an unordered scan would let it swallow the request.
-        const router = createInboundRouter({ "/telegram": receiver("short"), "/inbound/telegram": receiver("specific") });
+        const router = createInboundRouter({ "/inbound/telegram": receiver("specific"), "/telegram": receiver("short") });
 
         await router(
             new Request("https://example.com/inbound/telegram", {

--- a/packages/notification/notification/__tests__/logging-ratelimit-middleware.test.ts
+++ b/packages/notification/notification/__tests__/logging-ratelimit-middleware.test.ts
@@ -3,14 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loggingMiddleware } from "../src/middleware/logging";
 import { rateLimitMiddleware } from "../src/middleware/rate-limit";
 import { createNotification } from "../src/notification";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 
 describe(loggingMiddleware, () => {
     it("logs the attempt and the success outcome", async () => {
         expect.assertions(3);
 
         const logger = { debug: vi.fn(), warn: vi.fn() } as unknown as Console;
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider }).use(loggingMiddleware({ logger }));
 
         const receipt = await notify.sendToChannel("sms", { text: "x", to: "+1" });
@@ -24,7 +24,7 @@ describe(loggingMiddleware, () => {
         expect.assertions(3);
 
         const logger = { debug: vi.fn(), warn: vi.fn() } as unknown as Console;
-        const provider = mockProvider({ channel: "sms", failWith: "down" });
+        const provider = createMockProvider({ channel: "sms", failWith: "down" });
         const notify = createNotification({ sms: provider }).use(loggingMiddleware({ logger }));
 
         const receipt = await notify.sendToChannel("sms", { text: "x", to: "+1" });
@@ -43,7 +43,7 @@ describe(rateLimitMiddleware, () => {
     it("passes sends within the rate through immediately", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider }).use(rateLimitMiddleware({ interval: 1000, rate: 3 }));
 
         await notify.sendToChannel("sms", { text: "1", to: "+1" });
@@ -58,7 +58,7 @@ describe(rateLimitMiddleware, () => {
 
         vi.useFakeTimers();
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider }).use(rateLimitMiddleware({ interval: 1000, rate: 1 }));
 
         await notify.sendToChannel("sms", { text: "1", to: "+1" });

--- a/packages/notification/notification/__tests__/mock-provider.test.ts
+++ b/packages/notification/notification/__tests__/mock-provider.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 import { isOk } from "../src/utils/result";
 
-describe(mockProvider, () => {
+describe(createMockProvider, () => {
     it("records sent payloads and returns a successful result", async () => {
         expect.assertions(4);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
 
         await provider.initialize();
 
@@ -25,7 +25,7 @@ describe(mockProvider, () => {
     it("fails deterministically when configured", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ failWith: "boom" });
+        const provider = createMockProvider({ failWith: "boom" });
         const result = await provider.send({ text: "x", to: "+15555550100" } as never);
 
         expect(result.success).toBe(false);

--- a/packages/notification/notification/__tests__/notification-message.test.ts
+++ b/packages/notification/notification/__tests__/notification-message.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createNotification } from "../src/notification";
 import { createNotificationMessage, NotificationMessageBuilder } from "../src/notification-message";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 
 describe("notificationMessageBuilder", () => {
     it("builds a multi-channel message with the expected shape", () => {
@@ -45,8 +45,8 @@ describe("notificationMessageBuilder", () => {
     it("round-trips through createNotification().send()", async () => {
         expect.assertions(3);
 
-        const sms = mockProvider({ channel: "sms", id: "sms-mock" });
-        const chat = mockProvider({ channel: "chat", id: "chat-mock" });
+        const sms = createMockProvider({ channel: "sms", id: "sms-mock" });
+        const chat = createMockProvider({ channel: "chat", id: "chat-mock" });
 
         const builder = createNotificationMessage().sms({ text: "your code is 123", to: "+15555550100" }).chat({ text: "deploy finished", to: "C123" });
 

--- a/packages/notification/notification/__tests__/notification.test.ts
+++ b/packages/notification/notification/__tests__/notification.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Middleware } from "../src/middleware/types";
 import { createNotification } from "../src/notification";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 import type { Provider } from "../src/providers/provider";
 
 describe(createNotification, () => {
     it("dispatches a multi-channel message to the matching providers", async () => {
         expect.assertions(4);
 
-        const sms = mockProvider({ channel: "sms", id: "sms-mock" });
-        const chat = mockProvider({ channel: "chat", id: "chat-mock" });
+        const sms = createMockProvider({ channel: "sms", id: "sms-mock" });
+        const chat = createMockProvider({ channel: "chat", id: "chat-mock" });
 
         const notify = createNotification({ chat, sms });
 
@@ -28,7 +28,7 @@ describe(createNotification, () => {
     it("returns a failed receipt when no provider is registered for a channel", async () => {
         expect.assertions(2);
 
-        const notify = createNotification({ sms: mockProvider({ channel: "sms" }) });
+        const notify = createNotification({ sms: createMockProvider({ channel: "sms" }) });
 
         const receipt = await notify.sendToChannel("push", { body: "hi", to: "tok" });
 
@@ -61,7 +61,7 @@ describe(createNotification, () => {
             return result;
         };
 
-        const notify = createNotification({ sms: mockProvider({ channel: "sms" }) })
+        const notify = createNotification({ sms: createMockProvider({ channel: "sms" }) })
             .use(first)
             .use(second);
 
@@ -74,7 +74,7 @@ describe(createNotification, () => {
     it("turns a throwing provider into a failed receipt while sibling channels still deliver", async () => {
         expect.assertions(4);
 
-        const sms = mockProvider({ channel: "sms", id: "sms-mock" });
+        const sms = createMockProvider({ channel: "sms", id: "sms-mock" });
         const throwing: Provider = {
             channel: "webhook",
             id: "boom-webhook",
@@ -104,7 +104,7 @@ describe(createNotification, () => {
     it("initializes a provider once under concurrent first sends", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const initSpy = vi.spyOn(provider, "initialize");
 
         const notify = createNotification({ sms: provider });
@@ -121,7 +121,7 @@ describe(createNotification, () => {
     it("only initializes a provider once across sends", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const initSpy = vi.spyOn(provider, "initialize");
 
         const notify = createNotification({ sms: provider });
@@ -135,7 +135,7 @@ describe(createNotification, () => {
     it("sendMany yields receipts for every message", async () => {
         expect.assertions(2);
 
-        const notify = createNotification({ sms: mockProvider({ channel: "sms" }) });
+        const notify = createNotification({ sms: createMockProvider({ channel: "sms" }) });
 
         const messages = [{ sms: { text: "1", to: "+1" } }, { sms: { text: "2", to: "+2" } }, { sms: { text: "3", to: "+3" } }];
 

--- a/packages/notification/notification/__tests__/opentelemetry.test.ts
+++ b/packages/notification/notification/__tests__/opentelemetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { otelProvider } from "../src/providers/opentelemetry";
+import { createOtelProvider } from "../src/providers/opentelemetry";
 import type { Provider } from "../src/providers/provider";
 import type { NotificationResult, PushPayload, Result } from "../src/types";
 
@@ -10,7 +10,7 @@ const successResult: Result<NotificationResult> = {
 };
 
 /** Builds a minimal mock push provider whose `send` returns the supplied result. */
-const mockProvider = (result: Result<NotificationResult>, sendImpl?: () => Promise<Result<NotificationResult>>): Provider<unknown, PushPayload> => {
+const createMockProvider = (result: Result<NotificationResult>, sendImpl?: () => Promise<Result<NotificationResult>>): Provider<unknown, PushPayload> => {
     return {
         channel: "push",
         id: "mock",
@@ -33,7 +33,7 @@ describe("otel provider wrapper", () => {
     it("delegates send and returns the inner result without a tracer", async () => {
         expect.assertions(1);
 
-        const wrapped = otelProvider(mockProvider(successResult));
+        const wrapped = createOtelProvider(createMockProvider(successResult));
         const result = await wrapped.send({ body: "x", to: "tok" });
 
         expect(result).toStrictEqual(successResult);
@@ -45,7 +45,7 @@ describe("otel provider wrapper", () => {
         const span = createSpan();
         const startSpan = vi.fn(() => span);
 
-        const wrapped = otelProvider(mockProvider(successResult), { tracer: { startSpan } as never });
+        const wrapped = createOtelProvider(createMockProvider(successResult), { tracer: { startSpan } as never });
         const result = await wrapped.send({ body: "x", to: "tok" });
 
         expect(result.success).toBe(true);
@@ -61,7 +61,7 @@ describe("otel provider wrapper", () => {
         const span = createSpan();
         const failure: Result<NotificationResult> = { error: new Error("boom"), success: false };
 
-        const wrapped = otelProvider(mockProvider(failure), { tracer: { startSpan: () => span } as never });
+        const wrapped = createOtelProvider(createMockProvider(failure), { tracer: { startSpan: () => span } as never });
         const result = await wrapped.send({ body: "x", to: "tok" });
 
         expect(result.success).toBe(false);
@@ -72,9 +72,9 @@ describe("otel provider wrapper", () => {
         expect.assertions(2);
 
         const span = createSpan();
-        const thrower = mockProvider(successResult, () => Promise.reject(new Error("kaboom")));
+        const thrower = createMockProvider(successResult, () => Promise.reject(new Error("kaboom")));
 
-        const wrapped = otelProvider(thrower, { tracer: { startSpan: () => span } as never });
+        const wrapped = createOtelProvider(thrower, { tracer: { startSpan: () => span } as never });
 
         await expect(wrapped.send({ body: "x", to: "tok" })).rejects.toThrow("kaboom");
         expect(span.recordException).toHaveBeenCalledTimes(1);

--- a/packages/notification/notification/__tests__/queue-worker.test.ts
+++ b/packages/notification/notification/__tests__/queue-worker.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createNotification } from "../src/notification";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 import { createQueueWorker, MemoryQueue } from "../src/queue";
 
 describe(createQueueWorker, () => {
@@ -12,7 +12,7 @@ describe(createQueueWorker, () => {
     it("drain processes all due jobs then resolves", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider });
         const queue = new MemoryQueue();
 
@@ -31,7 +31,7 @@ describe(createQueueWorker, () => {
         vi.useFakeTimers();
         vi.setSystemTime(0);
 
-        const provider = mockProvider({ channel: "sms", failWith: "boom" });
+        const provider = createMockProvider({ channel: "sms", failWith: "boom" });
         const notify = createNotification({ sms: provider });
         const queue = new MemoryQueue();
         const onDrop = vi.fn();
@@ -64,7 +64,7 @@ describe(createQueueWorker, () => {
 
         vi.useFakeTimers();
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider });
         const onError = vi.fn();
 
@@ -136,7 +136,7 @@ describe(createQueueWorker, () => {
 
         vi.useFakeTimers();
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider });
         const queue = new MemoryQueue();
 

--- a/packages/notification/notification/__tests__/routing-middleware-queue.test.ts
+++ b/packages/notification/notification/__tests__/routing-middleware-queue.test.ts
@@ -5,9 +5,9 @@ import { circuitBreakerMiddleware } from "../src/middleware/circuit-breaker";
 import { dedupeMiddleware } from "../src/middleware/dedupe";
 import { retryMiddleware } from "../src/middleware/retry";
 import { createNotification } from "../src/notification";
-import { failoverProvider } from "../src/providers/failover";
-import { mockProvider } from "../src/providers/mock";
-import { roundRobinProvider } from "../src/providers/roundrobin";
+import { createFailoverProvider } from "../src/providers/failover";
+import { createMockProvider } from "../src/providers/mock";
+import { createRoundRobinProvider } from "../src/providers/roundrobin";
 import { createQueueWorker, MemoryQueue } from "../src/queue";
 import { route } from "../src/routing";
 
@@ -15,10 +15,10 @@ describe("failover + roundrobin", () => {
     it("failover falls through to the next provider on failure", async () => {
         expect.assertions(2);
 
-        const failing = mockProvider({ channel: "sms", failWith: "down", id: "p1" });
-        const healthy = mockProvider({ channel: "sms", id: "p2" });
+        const failing = createMockProvider({ channel: "sms", failWith: "down", id: "p1" });
+        const healthy = createMockProvider({ channel: "sms", id: "p2" });
 
-        const provider = failoverProvider([failing, healthy]);
+        const provider = createFailoverProvider([failing, healthy]);
         const result = await provider.send({ text: "hi", to: "+1" } as never);
 
         expect(result.success).toBe(true);
@@ -28,7 +28,7 @@ describe("failover + roundrobin", () => {
     it("failover fails when all providers fail", async () => {
         expect.assertions(1);
 
-        const provider = failoverProvider([mockProvider({ failWith: "a", id: "p1" }), mockProvider({ failWith: "b", id: "p2" })]);
+        const provider = createFailoverProvider([createMockProvider({ failWith: "a", id: "p1" }), createMockProvider({ failWith: "b", id: "p2" })]);
         const result = await provider.send({ text: "hi", to: "+1" } as never);
 
         expect(result.success).toBe(false);
@@ -37,9 +37,9 @@ describe("failover + roundrobin", () => {
     it("roundrobin alternates providers across calls", async () => {
         expect.assertions(2);
 
-        const a = mockProvider({ channel: "sms", id: "a" });
-        const b = mockProvider({ channel: "sms", id: "b" });
-        const provider = roundRobinProvider([a, b]);
+        const a = createMockProvider({ channel: "sms", id: "a" });
+        const b = createMockProvider({ channel: "sms", id: "b" });
+        const provider = createRoundRobinProvider([a, b]);
 
         const first = await provider.send({ text: "1", to: "+1" } as never);
         const second = await provider.send({ text: "2", to: "+2" } as never);
@@ -54,7 +54,7 @@ describe("middleware", () => {
         expect.assertions(2);
 
         let attempts = 0;
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
 
         vi.spyOn(provider, "send").mockImplementation((() => {
             attempts += 1;
@@ -76,7 +76,7 @@ describe("middleware", () => {
     it("circuit breaker opens after the threshold", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms", failWith: "boom" });
+        const provider = createMockProvider({ channel: "sms", failWith: "boom" });
         const notify = createNotification({ sms: provider }).use(circuitBreakerMiddleware({ threshold: 2 }));
 
         await notify.sendToChannel("sms", { text: "1", to: "+1" });
@@ -89,7 +89,7 @@ describe("middleware", () => {
     it("dedupe suppresses a repeated idempotency key", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider }).use(dedupeMiddleware());
 
         await notify.sendToChannel("sms", { idempotencyKey: "k1", text: "x", to: "+1" });
@@ -107,8 +107,8 @@ describe("routing", () => {
     it("best-of stops at the first successful channel", async () => {
         expect.assertions(2);
 
-        const sms = mockProvider({ channel: "sms", failWith: "down", id: "sms" });
-        const push = mockProvider({ channel: "push", id: "push" });
+        const sms = createMockProvider({ channel: "sms", failWith: "down", id: "sms" });
+        const push = createMockProvider({ channel: "push", id: "push" });
 
         const notify = createNotification({ push, sms });
 
@@ -121,7 +121,7 @@ describe("routing", () => {
     it("gate skips channels that return false", async () => {
         expect.assertions(1);
 
-        const sms = mockProvider({ channel: "sms", id: "sms" });
+        const sms = createMockProvider({ channel: "sms", id: "sms" });
         const notify = createNotification({ sms });
 
         const receipts = await route(notify, { sms: { text: "hi", to: "+1" } }, { gate: () => false });
@@ -134,7 +134,7 @@ describe("queue + worker", () => {
     it("drains enqueued messages through the facade", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ channel: "sms" });
+        const provider = createMockProvider({ channel: "sms" });
         const notify = createNotification({ sms: provider });
         const queue = new MemoryQueue();
 

--- a/packages/notification/notification/__tests__/send.test.ts
+++ b/packages/notification/notification/__tests__/send.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { send } from "../src/notification";
 import type { MockProviderInstance } from "../src/providers/mock";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 
 describe(send, () => {
     it("delivers a one-shot send through a single provider", async () => {
         expect.assertions(2);
 
-        const provider = mockProvider({ channel: "sms", id: "sms-mock" });
+        const provider = createMockProvider({ channel: "sms", id: "sms-mock" });
         const receipt = await send("sms", provider, { text: "hi", to: "+15555550100" });
 
         expect(receipt.successful).toBe(true);
@@ -18,7 +18,7 @@ describe(send, () => {
     it("returns a failure receipt when the provider fails", async () => {
         expect.assertions(1);
 
-        const provider = mockProvider({ channel: "sms", failWith: "down", id: "sms-mock" });
+        const provider = createMockProvider({ channel: "sms", failWith: "down", id: "sms-mock" });
         const receipt = await send("sms", provider, { text: "hi", to: "+15555550100" });
 
         expect(receipt.successful).toBe(false);

--- a/packages/notification/notification/__tests__/sms-branches.test.ts
+++ b/packages/notification/notification/__tests__/sms-branches.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import RequiredOptionError from "../src/errors/required-option-error";
-import { messageBirdProvider } from "../src/providers/sms/messagebird";
-import { plivoProvider } from "../src/providers/sms/plivo";
-import { snsProvider } from "../src/providers/sms/sns";
-import { telnyxProvider } from "../src/providers/sms/telnyx";
-import { twilioProvider } from "../src/providers/sms/twilio";
-import { vonageProvider } from "../src/providers/sms/vonage";
+import { createMessageBirdProvider } from "../src/providers/sms/messagebird";
+import { createPlivoProvider } from "../src/providers/sms/plivo";
+import { createSnsProvider } from "../src/providers/sms/sns";
+import { createTelnyxProvider } from "../src/providers/sms/telnyx";
+import { createTwilioProvider } from "../src/providers/sms/twilio";
+import { createVonageProvider } from "../src/providers/sms/vonage";
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
@@ -33,7 +33,7 @@ describe("sms provider branch coverage", () => {
         it("vonage fails without a sender", async () => {
             expect.assertions(2);
 
-            const provider = vonageProvider({ apiKey: "k", apiSecret: "s" });
+            const provider = createVonageProvider({ apiKey: "k", apiSecret: "s" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -43,7 +43,7 @@ describe("sms provider branch coverage", () => {
         it("plivo fails without a sender", async () => {
             expect.assertions(2);
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok" });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -53,7 +53,7 @@ describe("sms provider branch coverage", () => {
         it("messagebird fails without an originator", async () => {
             expect.assertions(2);
 
-            const provider = messageBirdProvider({ accessKey: "key" });
+            const provider = createMessageBirdProvider({ accessKey: "key" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -63,7 +63,7 @@ describe("sms provider branch coverage", () => {
         it("telnyx fails without a sender or messaging profile", async () => {
             expect.assertions(2);
 
-            const provider = telnyxProvider({ apiKey: "key" });
+            const provider = createTelnyxProvider({ apiKey: "key" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -75,7 +75,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ sid: "SM-msg" }, 201));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", messagingServiceSid: "MG1" });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", messagingServiceSid: "MG1" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -92,7 +92,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ messages: [{ "error-text": "Invalid Credentials", status: "4" }] }, 401));
 
-            const provider = vonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 0 });
+            const provider = createVonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -104,7 +104,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ error: "invalid destination" }, 400));
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 0 });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -116,7 +116,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ errors: [{ detail: "Invalid phone number" }] }, 422));
 
-            const provider = telnyxProvider({ apiKey: "key", from: "+15550000000", retries: 0 });
+            const provider = createTelnyxProvider({ apiKey: "key", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -128,7 +128,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(textResponse("<ErrorResponse><Error><Message>Invalid parameter</Message></Error></ErrorResponse>", 400));
 
-            const provider = snsProvider({ accessKeyId: "AKIA", retries: 0, secretAccessKey: "secret" });
+            const provider = createSnsProvider({ accessKeyId: "AKIA", retries: 0, secretAccessKey: "secret" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -140,7 +140,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ status: 400 }, 400));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -154,7 +154,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("socket hang up"));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -166,7 +166,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("ECONNRESET"));
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 0 });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -178,7 +178,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("dns failure"));
 
-            const provider = telnyxProvider({ apiKey: "key", from: "+15550000000", retries: 0 });
+            const provider = createTelnyxProvider({ apiKey: "key", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -190,7 +190,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("aborted"));
 
-            const provider = vonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 0 });
+            const provider = createVonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -202,7 +202,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("timeout"));
 
-            const provider = messageBirdProvider({ accessKey: "key", from: "App", retries: 0 });
+            const provider = createMessageBirdProvider({ accessKey: "key", from: "App", retries: 0 });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -214,7 +214,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockRejectedValue(new Error("connection refused"));
 
-            const provider = snsProvider({ accessKeyId: "AKIA", retries: 0, secretAccessKey: "secret" });
+            const provider = createSnsProvider({ accessKeyId: "AKIA", retries: 0, secretAccessKey: "secret" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -233,7 +233,7 @@ describe("sms provider branch coverage", () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({ error_message: "busy" }, 503));
             fetchMock.mockResolvedValueOnce(jsonResponse({ sid: "SM-retry" }, 201));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 1 });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 1 });
             const promise = provider.send({ text: "hi", to: "+1" });
 
             await vi.runAllTimersAsync();
@@ -250,7 +250,7 @@ describe("sms provider branch coverage", () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
             fetchMock.mockResolvedValueOnce(jsonResponse({ messages: [{ "message-id": "v-retry", status: "0" }] }));
 
-            const provider = vonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 1 });
+            const provider = createVonageProvider({ apiKey: "k", apiSecret: "s", from: "App", retries: 1 });
             const promise = provider.send({ text: "hi", to: "+1" });
 
             await vi.runAllTimersAsync();
@@ -267,7 +267,7 @@ describe("sms provider branch coverage", () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
             fetchMock.mockResolvedValueOnce(jsonResponse({ message_uuid: ["p-retry"] }, 202));
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 1 });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000", retries: 1 });
             const promise = provider.send({ text: "hi", to: "+1" });
 
             await vi.runAllTimersAsync();
@@ -284,7 +284,7 @@ describe("sms provider branch coverage", () => {
             fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
             fetchMock.mockResolvedValueOnce(jsonResponse({ id: "mb-retry" }, 201));
 
-            const provider = messageBirdProvider({ accessKey: "key", from: "App", retries: 1 });
+            const provider = createMessageBirdProvider({ accessKey: "key", from: "App", retries: 1 });
             const promise = provider.send({ text: "hi", to: "+1" });
 
             await vi.runAllTimersAsync();
@@ -305,7 +305,7 @@ describe("sms provider branch coverage", () => {
             fetchMock.mockResolvedValueOnce(textResponse("unavailable", 503));
             fetchMock.mockResolvedValueOnce(textResponse("<PublishResponse><PublishResult><MessageId>sns-retry</MessageId></PublishResult></PublishResponse>"));
 
-            const provider = snsProvider({ accessKeyId: "AKIA", retries: 1, secretAccessKey: "secret" });
+            const provider = createSnsProvider({ accessKeyId: "AKIA", retries: 1, secretAccessKey: "secret" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -319,7 +319,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({}, 201));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000" });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -331,7 +331,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({}));
 
-            const provider = vonageProvider({ apiKey: "k", apiSecret: "s", from: "App" });
+            const provider = createVonageProvider({ apiKey: "k", apiSecret: "s", from: "App" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(false);
@@ -342,7 +342,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({}));
 
-            const provider = telnyxProvider({ apiKey: "key", from: "+15550000000" });
+            const provider = createTelnyxProvider({ apiKey: "key", from: "+15550000000" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -354,7 +354,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(textResponse("<PublishResponse></PublishResponse>"));
 
-            const provider = snsProvider({ accessKeyId: "AKIA", secretAccessKey: "secret" });
+            const provider = createSnsProvider({ accessKeyId: "AKIA", secretAccessKey: "secret" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -366,7 +366,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ message_uuid: [] }, 202));
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
             const result = await provider.send({ text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);
@@ -378,55 +378,55 @@ describe("sms provider branch coverage", () => {
         it("twilio throws without accountSid", () => {
             expect.assertions(1);
 
-            expect(() => twilioProvider({ authToken: "tok" } as never)).toThrow(RequiredOptionError);
+            expect(() => createTwilioProvider({ authToken: "tok" } as never)).toThrow(RequiredOptionError);
         });
 
         it("twilio throws without authToken", () => {
             expect.assertions(1);
 
-            expect(() => twilioProvider({ accountSid: "AC1" } as never)).toThrow(RequiredOptionError);
+            expect(() => createTwilioProvider({ accountSid: "AC1" } as never)).toThrow(RequiredOptionError);
         });
 
         it("vonage throws without apiKey", () => {
             expect.assertions(1);
 
-            expect(() => vonageProvider({ apiSecret: "s" } as never)).toThrow(RequiredOptionError);
+            expect(() => createVonageProvider({ apiSecret: "s" } as never)).toThrow(RequiredOptionError);
         });
 
         it("vonage throws without apiSecret", () => {
             expect.assertions(1);
 
-            expect(() => vonageProvider({ apiKey: "k" } as never)).toThrow(RequiredOptionError);
+            expect(() => createVonageProvider({ apiKey: "k" } as never)).toThrow(RequiredOptionError);
         });
 
         it("plivo throws without authId", () => {
             expect.assertions(1);
 
-            expect(() => plivoProvider({ authToken: "tok" } as never)).toThrow(RequiredOptionError);
+            expect(() => createPlivoProvider({ authToken: "tok" } as never)).toThrow(RequiredOptionError);
         });
 
         it("plivo throws without authToken", () => {
             expect.assertions(1);
 
-            expect(() => plivoProvider({ authId: "id" } as never)).toThrow(RequiredOptionError);
+            expect(() => createPlivoProvider({ authId: "id" } as never)).toThrow(RequiredOptionError);
         });
 
         it("messagebird throws without accessKey", () => {
             expect.assertions(1);
 
-            expect(() => messageBirdProvider({} as never)).toThrow(RequiredOptionError);
+            expect(() => createMessageBirdProvider({} as never)).toThrow(RequiredOptionError);
         });
 
         it("telnyx throws without apiKey", () => {
             expect.assertions(1);
 
-            expect(() => telnyxProvider({} as never)).toThrow(RequiredOptionError);
+            expect(() => createTelnyxProvider({} as never)).toThrow(RequiredOptionError);
         });
 
         it("sns throws without accessKeyId and secretAccessKey", () => {
             expect.assertions(1);
 
-            expect(() => snsProvider({} as never)).toThrow(RequiredOptionError);
+            expect(() => createSnsProvider({} as never)).toThrow(RequiredOptionError);
         });
     });
 
@@ -436,7 +436,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ error_message: "blocked" }, 400));
 
-            const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
+            const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
             const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
             expect(result.success).toBe(false);
@@ -448,7 +448,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ message_uuid: ["u1", "u2"] }, 202));
 
-            const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
+            const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
             const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
             expect(result.success).toBe(true);
@@ -464,7 +464,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(jsonResponse({ id: "mb-batch" }, 201));
 
-            const provider = messageBirdProvider({ accessKey: "key", from: "App" });
+            const provider = createMessageBirdProvider({ accessKey: "key", from: "App" });
             const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
             expect(result.success).toBe(true);
@@ -482,7 +482,7 @@ describe("sms provider branch coverage", () => {
 
             fetchMock.mockResolvedValue(textResponse("<PublishResponse><PublishResult><MessageId>m-1</MessageId></PublishResult></PublishResponse>"));
 
-            const provider = snsProvider({ accessKeyId: "AKIDEXAMPLE", region: "eu-west-1", secretAccessKey: "secret" });
+            const provider = createSnsProvider({ accessKeyId: "AKIDEXAMPLE", region: "eu-west-1", secretAccessKey: "secret" });
             const result = await provider.send({ from: "Sender", text: "hi", to: "+1" });
 
             expect(result.success).toBe(true);

--- a/packages/notification/notification/__tests__/sms-providers-failures.test.ts
+++ b/packages/notification/notification/__tests__/sms-providers-failures.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { messageBirdProvider } from "../src/providers/sms/messagebird";
-import { twilioProvider } from "../src/providers/sms/twilio";
+import { createMessageBirdProvider } from "../src/providers/sms/messagebird";
+import { createTwilioProvider } from "../src/providers/sms/twilio";
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
@@ -22,7 +22,7 @@ describe("sms provider failure branches", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ error_message: "The 'To' number is invalid", status: 400 }, 400));
 
-        const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
+        const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(false);
@@ -36,7 +36,7 @@ describe("sms provider failure branches", () => {
         fetchMock.mockResolvedValueOnce(jsonResponse({ sid: "SM-ok" }, 201));
         fetchMock.mockResolvedValueOnce(jsonResponse({ error_message: "blocked", status: 400 }, 400));
 
-        const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
+        const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000", retries: 0 });
         const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
         expect(result.success).toBe(true);
@@ -54,7 +54,7 @@ describe("sms provider failure branches", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ errors: [{ description: "request not allowed" }] }, 401));
 
-        const provider = messageBirdProvider({ accessKey: "key", from: "App", retries: 0 });
+        const provider = createMessageBirdProvider({ accessKey: "key", from: "App", retries: 0 });
         const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
         expect(result.success).toBe(false);

--- a/packages/notification/notification/__tests__/sms-providers.test.ts
+++ b/packages/notification/notification/__tests__/sms-providers.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { messageBirdProvider } from "../src/providers/sms/messagebird";
-import { plivoProvider } from "../src/providers/sms/plivo";
-import { telnyxProvider } from "../src/providers/sms/telnyx";
-import { twilioProvider } from "../src/providers/sms/twilio";
-import { vonageProvider } from "../src/providers/sms/vonage";
+import { createMessageBirdProvider } from "../src/providers/sms/messagebird";
+import { createPlivoProvider } from "../src/providers/sms/plivo";
+import { createTelnyxProvider } from "../src/providers/sms/telnyx";
+import { createTwilioProvider } from "../src/providers/sms/twilio";
+import { createVonageProvider } from "../src/providers/sms/vonage";
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
@@ -25,7 +25,7 @@ describe("sms providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ sid: "SM123" }, 201));
 
-        const provider = twilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000" });
+        const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok", from: "+15550000000" });
         const result = await provider.send({ text: "hi", to: "+15555550100" });
 
         expect(result.success).toBe(true);
@@ -40,7 +40,7 @@ describe("sms providers", () => {
     it("twilio fails when no sender is configured", async () => {
         expect.assertions(1);
 
-        const provider = twilioProvider({ accountSid: "AC1", authToken: "tok" });
+        const provider = createTwilioProvider({ accountSid: "AC1", authToken: "tok" });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(false);
@@ -51,7 +51,7 @@ describe("sms providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ messages: [{ "error-text": "bad", status: "2" }] }));
 
-        const provider = vonageProvider({ apiKey: "k", apiSecret: "s", from: "App" });
+        const provider = createVonageProvider({ apiKey: "k", apiSecret: "s", from: "App" });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(false);
@@ -63,7 +63,7 @@ describe("sms providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ message_uuid: ["u1", "u2"] }, 202));
 
-        const provider = plivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
+        const provider = createPlivoProvider({ authId: "id", authToken: "tok", from: "+15550000000" });
         const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
         expect(result.success).toBe(true);
@@ -79,7 +79,7 @@ describe("sms providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ id: "mb1" }, 201));
 
-        const provider = messageBirdProvider({ accessKey: "key", from: "App" });
+        const provider = createMessageBirdProvider({ accessKey: "key", from: "App" });
         const result = await provider.send({ text: "hi", to: ["+1", "+2"] });
 
         expect(result.success).toBe(true);
@@ -91,7 +91,7 @@ describe("sms providers", () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ data: { id: "tx1" } }, 200));
 
-        const provider = telnyxProvider({ apiKey: "key", from: "+15550000000" });
+        const provider = createTelnyxProvider({ apiKey: "key", from: "+15550000000" });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(true);
@@ -104,7 +104,7 @@ describe("sms providers", () => {
         fetchMock.mockResolvedValueOnce(jsonResponse({ errors: [{ detail: "unavailable" }] }, 503));
         fetchMock.mockResolvedValueOnce(jsonResponse({ data: { id: "tx-retry" } }, 200));
 
-        const provider = telnyxProvider({ apiKey: "key", from: "+15550000000", retries: 1 });
+        const provider = createTelnyxProvider({ apiKey: "key", from: "+15550000000", retries: 1 });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(true);

--- a/packages/notification/notification/__tests__/sns.test.ts
+++ b/packages/notification/notification/__tests__/sns.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { snsProvider } from "../src/providers/sms/sns";
+import { createSnsProvider } from "../src/providers/sms/sns";
 
 const SIGV4_PREFIX = /^AWS4-HMAC-SHA256 /;
 const ACCESS_KEY_ID = /accessKeyId/;
@@ -31,7 +31,7 @@ describe("aws sns provider", () => {
 
         fetchMock.mockResolvedValue(xmlResponse(PUBLISH_OK, 200));
 
-        const provider = snsProvider({ accessKeyId: "AKIAEXAMPLE", region: "eu-central-1", secretAccessKey: "secret" });
+        const provider = createSnsProvider({ accessKeyId: "AKIAEXAMPLE", region: "eu-central-1", secretAccessKey: "secret" });
         const result = await provider.send({ text: "hello", to: "+15555550100" });
 
         expect(result.success).toBe(true);
@@ -49,7 +49,7 @@ describe("aws sns provider", () => {
 
         fetchMock.mockResolvedValue(xmlResponse(PUBLISH_OK, 200));
 
-        const provider = snsProvider({ accessKeyId: "AKIAEXAMPLE", secretAccessKey: "secret" });
+        const provider = createSnsProvider({ accessKeyId: "AKIAEXAMPLE", secretAccessKey: "secret" });
 
         await provider.send({ from: "MyApp", text: "hi", to: "+1" });
 
@@ -63,7 +63,7 @@ describe("aws sns provider", () => {
 
         fetchMock.mockResolvedValue(xmlResponse(`<ErrorResponse><Error><Message>Invalid parameter</Message></Error></ErrorResponse>`, 400));
 
-        const provider = snsProvider({ accessKeyId: "AKIAEXAMPLE", secretAccessKey: "secret" });
+        const provider = createSnsProvider({ accessKeyId: "AKIAEXAMPLE", secretAccessKey: "secret" });
         const result = await provider.send({ text: "hi", to: "+1" });
 
         expect(result.success).toBe(false);
@@ -73,6 +73,6 @@ describe("aws sns provider", () => {
     it("throws when credentials are missing", () => {
         expect.assertions(1);
 
-        expect(() => snsProvider({ accessKeyId: "", secretAccessKey: "" })).toThrow(ACCESS_KEY_ID);
+        expect(() => createSnsProvider({ accessKeyId: "", secretAccessKey: "" })).toThrow(ACCESS_KEY_ID);
     });
 });

--- a/packages/notification/notification/__tests__/web-push.test.ts
+++ b/packages/notification/notification/__tests__/web-push.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { webPushProvider } from "../src/providers/push/web-push";
+import { createWebPushProvider } from "../src/providers/push/web-push";
 
 const VAPID_HEADER = /^vapid t=.+,k=.+/;
 const MISSING_PUBLIC_KEY = /vapidPublicKey/;
@@ -67,7 +67,7 @@ describe("web-push provider", () => {
         const keys = await generateVapidKeys();
         const subscription = await generateSubscription("https://push.example.com/sub/abc");
 
-        const provider = webPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
+        const provider = createWebPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
         const result = await provider.send({ body: "hi there", title: "Hello", to: subscription });
 
         expect(result.success).toBe(true);
@@ -89,7 +89,7 @@ describe("web-push provider", () => {
         const keys = await generateVapidKeys();
         const subscription = await generateSubscription("https://push.example.com/sub/dead");
 
-        const provider = webPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
+        const provider = createWebPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
         const result = await provider.send({ body: "hi", to: subscription });
 
         expect(result.success).toBe(false);
@@ -100,7 +100,7 @@ describe("web-push provider", () => {
         expect.assertions(2);
 
         const keys = await generateVapidKeys();
-        const provider = webPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
+        const provider = createWebPushProvider({ vapidPrivateKey: keys.privateKey, vapidPublicKey: keys.publicKey, vapidSubject: "mailto:dev@example.com" });
         const result = await provider.send({ body: "hi", to: "not-json" });
 
         expect(result.success).toBe(false);
@@ -110,6 +110,6 @@ describe("web-push provider", () => {
     it("throws when VAPID config is missing", () => {
         expect.assertions(1);
 
-        expect(() => webPushProvider({ vapidPrivateKey: "", vapidPublicKey: "", vapidSubject: "" })).toThrow(MISSING_PUBLIC_KEY);
+        expect(() => createWebPushProvider({ vapidPrivateKey: "", vapidPublicKey: "", vapidSubject: "" })).toThrow(MISSING_PUBLIC_KEY);
     });
 });

--- a/packages/notification/notification/__tests__/webhook-provider.test.ts
+++ b/packages/notification/notification/__tests__/webhook-provider.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import RequiredOptionError from "../src/errors/required-option-error";
-import { webhookProvider } from "../src/providers/webhook";
+import { createWebhookProvider } from "../src/providers/webhook";
 
 const jsonResponse = (body: unknown, status = 200): Response => Response.json(body, { headers: { "Content-Type": "application/json" }, status });
 
-describe(webhookProvider, () => {
+describe(createWebhookProvider, () => {
     const fetchMock = vi.fn();
 
     beforeEach(() => {
@@ -22,7 +22,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ ok: true }, 200));
 
-        const provider = webhookProvider({ url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ url: "https://example.com/hook" });
         const result = await provider.send({ body: { hello: "world" } });
 
         expect(result.success).toBe(true);
@@ -40,7 +40,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({}, 200));
 
-        const provider = webhookProvider({ url: "https://config.example/hook" });
+        const provider = createWebhookProvider({ url: "https://config.example/hook" });
         const result = await provider.send({ body: {}, url: "https://payload.example/hook" });
 
         expect(result.success).toBe(true);
@@ -52,7 +52,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({}, 200));
 
-        const provider = webhookProvider({ headers: { "X-Config": "c", "X-Shared": "from-config" }, url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ headers: { "X-Config": "c", "X-Shared": "from-config" }, url: "https://example.com/hook" });
 
         await provider.send({ body: {}, headers: { "X-Payload": "p", "X-Shared": "from-payload" } });
 
@@ -68,7 +68,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({}, 200));
 
-        const provider = webhookProvider({ method: "PUT", url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ method: "PUT", url: "https://example.com/hook" });
 
         await provider.send({ body: {}, method: "PATCH" });
 
@@ -80,7 +80,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({}, 200));
 
-        const provider = webhookProvider({ url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ url: "https://example.com/hook" });
 
         await provider.send({ body: { a: 1, b: "two" } });
 
@@ -92,7 +92,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({}, 200));
 
-        const provider = webhookProvider({ url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ url: "https://example.com/hook" });
 
         await provider.send({ body: "raw-string-body" });
 
@@ -104,7 +104,7 @@ describe(webhookProvider, () => {
 
         fetchMock.mockResolvedValue(jsonResponse({ error: "nope" }, 500));
 
-        const provider = webhookProvider({ retries: 0, url: "https://example.com/hook" });
+        const provider = createWebhookProvider({ retries: 0, url: "https://example.com/hook" });
         const result = await provider.send({ body: {} });
 
         expect(result.success).toBe(false);
@@ -114,7 +114,7 @@ describe(webhookProvider, () => {
     it("returns a RequiredOptionError failure when no url is configured", async () => {
         expect.assertions(2);
 
-        const provider = webhookProvider();
+        const provider = createWebhookProvider();
 
         const result = await provider.send({ body: {} });
 

--- a/packages/notification/notification/__tests__/webhooks.test.ts
+++ b/packages/notification/notification/__tests__/webhooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { slackWebhook, snsWebhook, standardWebhook, twilioWebhook } from "../src/webhooks";
 
@@ -149,27 +149,97 @@ describe("standardWebhook", () => {
 });
 
 describe("snsWebhook", () => {
-    it("fails closed: verify always returns false pending cert-chain verification", async () => {
+    // Minimal DER encoder used to wrap an exported SPKI in a valid-enough X.509 certificate.
+    const derLength = (length: number): number[] => {
+        if (length < 0x80) {
+            return [length];
+        }
+
+        const bytes: number[] = [];
+        let remaining = length;
+
+        while (remaining > 0) {
+            bytes.unshift(remaining % 256);
+            remaining = Math.floor(remaining / 256);
+        }
+
+        return [128 + bytes.length, ...bytes];
+    };
+
+    const der = (tag: number, content: number[]): number[] => [tag, ...derLength(content.length), ...content];
+
+    // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }, where
+    // tbsCertificate ::= SEQUENCE { version[0], serialNumber, signature, issuer, validity,
+    // subject, subjectPublicKeyInfo }. Only the SPKI is real; the rest are skippable stubs.
+    const buildCertificate = (spki: Uint8Array): string => {
+        const version = der(0xa0, der(0x02, [0x02]));
+        const serial = der(0x02, [0x01]);
+        const empty = der(0x30, []);
+        const tbs = der(0x30, [...version, ...serial, ...empty, ...empty, ...empty, ...empty, ...spki]);
+        const certificate = der(0x30, [...tbs, ...der(0x30, []), ...der(0x03, [0x00])]);
+
+        return `-----BEGIN CERTIFICATE-----\n${toBase64(new Uint8Array(certificate).buffer)}\n-----END CERTIFICATE-----\n`;
+    };
+
+    const stringToSign = (message: Record<string, string>): string => {
+        const keys = ["Message", "MessageId", "Subject", "SubscribeURL", "Timestamp", "TopicArn", "Type"];
+        let result = "";
+
+        for (const key of keys) {
+            if (message[key] !== undefined) {
+                result += `${key}\n${message[key]}\n`;
+            }
+        }
+
+        return result;
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("verifies a genuine SignatureVersion 2 (RSA-SHA256) message and rejects a tampered one", async () => {
         expect.assertions(3);
 
-        const valid = JSON.stringify({
-            Message: "hi",
+        const keyPair = await globalThis.crypto.subtle.generateKey(
+            { hash: "SHA-256", modulusLength: 2048, name: "RSASSA-PKCS1-v1_5", publicExponent: new Uint8Array([1, 0, 1]) },
+            true,
+            ["sign", "verify"],
+        );
+        const spki = new Uint8Array(await globalThis.crypto.subtle.exportKey("spki", keyPair.publicKey));
+        const pem = buildCertificate(spki);
+
+        vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(pem, { status: 200 }))));
+
+        const message: Record<string, string> = {
+            Message: "inbound sms",
             MessageId: "id-1",
-            Signature: "abc",
-            SigningCertURL: "https://sns.us-east-1.amazonaws.com/cert.pem",
+            SignatureVersion: "2",
+            SigningCertURL: "https://sns.us-east-1.amazonaws.com/SimpleNotificationService.pem",
+            Timestamp: "2026-01-01T00:00:00.000Z",
+            TopicArn: "arn:aws:sns:us-east-1:1:topic",
             Type: "Notification",
-        });
+        };
+        const signature = toBase64(await globalThis.crypto.subtle.sign({ name: "RSASSA-PKCS1-v1_5" }, keyPair.privateKey, encoder.encode(stringToSign(message))));
 
-        // Intentionally fail-closed: real RSA cert-chain verification is not yet implemented,
-        // so verify() must never accept a payload on structure alone (that would be an auth bypass).
-        await expect(snsWebhook.verify(valid, {}, "")).resolves.toBe(false);
+        await expect(snsWebhook.verify(JSON.stringify({ ...message, Signature: signature }), {}, "")).resolves.toBe(true);
+        await expect(snsWebhook.verify(JSON.stringify({ ...message, Message: "tampered", Signature: signature }), {}, "")).resolves.toBe(false);
 
-        const spoofed = JSON.stringify({ MessageId: "id-2", Signature: "abc", SigningCertURL: "https://evil.example.com/cert.pem", Type: "Notification" });
-
-        await expect(snsWebhook.verify(spoofed, {}, "")).resolves.toBe(false);
-
-        const event = snsWebhook.parse(valid);
+        const event = snsWebhook.parse(JSON.stringify(message));
 
         expect(event).toMatchObject({ messageId: "id-1", provider: "sns" });
+    });
+
+    it("rejects a certificate URL that is not an AWS SNS host without fetching", async () => {
+        expect.assertions(2);
+
+        const fetchSpy = vi.fn(() => Promise.resolve(new Response("", { status: 200 })));
+
+        vi.stubGlobal("fetch", fetchSpy);
+
+        const spoofed = JSON.stringify({ MessageId: "id-2", Signature: "abc", SignatureVersion: "2", SigningCertURL: "https://evil.example.com/cert.pem", Type: "Notification" });
+
+        await expect(snsWebhook.verify(spoofed, {}, "")).resolves.toBe(false);
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/notification/notification/__tests__/webhooks.test.ts
+++ b/packages/notification/notification/__tests__/webhooks.test.ts
@@ -199,7 +199,7 @@ describe("snsWebhook", () => {
     });
 
     it("verifies a genuine SignatureVersion 2 (RSA-SHA256) message and rejects a tampered one", async () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const keyPair = await globalThis.crypto.subtle.generateKey(
             { hash: "SHA-256", modulusLength: 2048, name: "RSASSA-PKCS1-v1_5", publicExponent: new Uint8Array([1, 0, 1]) },
@@ -216,7 +216,7 @@ describe("snsWebhook", () => {
             MessageId: "id-1",
             SignatureVersion: "2",
             SigningCertURL: "https://sns.us-east-1.amazonaws.com/SimpleNotificationService.pem",
-            Timestamp: "2026-01-01T00:00:00.000Z",
+            Timestamp: new Date().toISOString(),
             TopicArn: "arn:aws:sns:us-east-1:1:topic",
             Type: "Notification",
         };
@@ -224,6 +224,13 @@ describe("snsWebhook", () => {
 
         await expect(snsWebhook.verify(JSON.stringify({ ...message, Signature: signature }), {}, "")).resolves.toBe(true);
         await expect(snsWebhook.verify(JSON.stringify({ ...message, Message: "tampered", Signature: signature }), {}, "")).resolves.toBe(false);
+
+        // A captured delivery stays signature-valid for the certificate's lifetime, so age is the
+        // only thing standing between the endpoint and an indefinite replay.
+        const stale = { ...message, Timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() };
+        const staleSignature = toBase64(await globalThis.crypto.subtle.sign({ name: "RSASSA-PKCS1-v1_5" }, keyPair.privateKey, encoder.encode(stringToSign(stale))));
+
+        await expect(snsWebhook.verify(JSON.stringify({ ...stale, Signature: staleSignature }), {}, "")).resolves.toBe(false);
 
         const event = snsWebhook.parse(JSON.stringify(message));
 

--- a/packages/notification/notification/__tests__/workflow.test.ts
+++ b/packages/notification/notification/__tests__/workflow.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from "vitest";
 
 import { createNotification } from "../src/notification";
 import type { MockProviderInstance } from "../src/providers/mock";
-import { mockProvider } from "../src/providers/mock";
+import { createMockProvider } from "../src/providers/mock";
 import createNotificationWorkflow from "../src/workflow/create-notification-workflow";
 
 const buildNotify = () => {
     const notification = createNotification({
-        email: mockProvider({ channel: "email", id: "email-mock" }),
-        sms: mockProvider({ channel: "sms", id: "sms-mock" }),
+        email: createMockProvider({ channel: "email", id: "email-mock" }),
+        sms: createMockProvider({ channel: "sms", id: "sms-mock" }),
     });
 
     const sent = (channel: "email" | "sms") => (notification.getProvider(channel)?.getInstance() as MockProviderInstance).sent;
@@ -93,7 +93,7 @@ describe(createNotificationWorkflow, () => {
     it("records a failed send as completed by default (failure does not throw)", async () => {
         expect.assertions(1);
 
-        const notification = createNotification({ sms: mockProvider({ channel: "sms", failWith: "provider down", id: "sms-mock" }) });
+        const notification = createNotification({ sms: createMockProvider({ channel: "sms", failWith: "provider down", id: "sms-mock" }) });
         const workflow = createNotificationWorkflow<{ to: string }>(notification, {
             id: "best-effort",
             run: async ({ payload, step }) => {
@@ -112,7 +112,7 @@ describe(createNotificationWorkflow, () => {
     it("fails the run when a send fails and throwOnFailure is set", async () => {
         expect.assertions(2);
 
-        const notification = createNotification({ sms: mockProvider({ channel: "sms", failWith: "provider down", id: "sms-mock" }) });
+        const notification = createNotification({ sms: createMockProvider({ channel: "sms", failWith: "provider down", id: "sms-mock" }) });
         const workflow = createNotificationWorkflow<{ to: string }>(notification, {
             id: "must-deliver",
             run: async ({ payload, step }) => {

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -52,18 +52,18 @@ acknowledgement without invoking your handler.
 
 ```typescript
 interface InboundMessage {
-    channel: ChannelType;            // "chat" | "sms"
-    provider: string;               // "slack" | "discord" | "telegram" | "twilio"
+    channel: ChannelType; // "chat" | "sms"
+    provider: string; // "slack" | "discord" | "telegram" | "twilio"
     type: "message" | "command" | "callback" | "event" | "unknown";
     id: string;
     text?: string;
     from: { id: string; name?: string; username?: string; isBot?: boolean };
-    conversationId?: string;        // channel / chat / room id
-    threadId?: string;              // thread anchor, for threaded replies
+    conversationId?: string; // channel / chat / room id
+    threadId?: string; // thread anchor, for threaded replies
     command?: { name: string; args?: string };
     attachments?: { url?: string; contentType?: string }[];
     timestamp: Date;
-    raw: unknown;                   // the untouched provider payload
+    raw: unknown; // the untouched provider payload
     metadata?: Record<string, unknown>;
 }
 ```
@@ -106,16 +106,16 @@ exports both the outbound provider (`create<Name>Provider`) and the inbound rece
 (`create<Name>Receiver`). The `@visulima/notification/inbound` barrel holds only the shared types,
 `createInboundRouter` and the verification/reply helpers.
 
-| Import                                     | Receiver                   | Verification                                              | Synchronous reply                  |
-| ------------------------------------------ | -------------------------- | -------------------------------------------------------- | ---------------------------------- |
-| `@visulima/notification/providers/slack`   | `createSlackReceiver`       | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions      |
-| `@visulima/notification/providers/discord` | `createDiscordReceiver`     | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response               |
-| `@visulima/notification/providers/telegram`| `createTelegramReceiver`    | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method               |
-| `@visulima/notification/providers/twilio`  | `createTwilioReceiver`      | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element              |
-| `@visulima/notification/providers/msteams` | `createMsTeamsReceiver`     | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
-| `@visulima/notification/providers/telnyx`  | `createTelnyxReceiver`      | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
-| `@visulima/notification/providers/messagebird` | `createMessageBirdReceiver` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
-| `@visulima/notification/providers/vonage`  | `createVonageReceiver`      | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
+| Import                                         | Receiver                    | Verification                                                      | Synchronous reply              |
+| ---------------------------------------------- | --------------------------- | ----------------------------------------------------------------- | ------------------------------ |
+| `@visulima/notification/providers/slack`       | `createSlackReceiver`       | v0 signature + 5-min replay; `url_verification` handled           | Slash commands & interactions  |
+| `@visulima/notification/providers/discord`     | `createDiscordReceiver`     | Ed25519 over `timestamp+body`; `PING` → `PONG` handled            | Interaction response           |
+| `@visulima/notification/providers/telegram`    | `createTelegramReceiver`    | `X-Telegram-Bot-Api-Secret-Token` (when set)                      | `sendMessage` method           |
+| `@visulima/notification/providers/twilio`      | `createTwilioReceiver`      | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params             | TwiML message element          |
+| `@visulima/notification/providers/msteams`     | `createMsTeamsReceiver`     | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body            | Bot Framework message activity |
+| `@visulima/notification/providers/telnyx`      | `createTelnyxReceiver`      | Ed25519 over `{timestamp}\|{body}` + 5-min replay                 | via `context.reply()` (async)  |
+| `@visulima/notification/providers/messagebird` | `createMessageBirdReceiver` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async)  |
+| `@visulima/notification/providers/vonage`      | `createVonageReceiver`      | `Authorization: Bearer` HS256 JWT + `payload_hash`                | via `context.reply()` (async)  |
 
 Slack receivers cover the Events API, slash commands and interactive components; Twilio, Telnyx,
 MessageBird and Vonage cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with
@@ -132,7 +132,7 @@ to this exact request body and URL).
   normalise the body yourself — the `InboundMessage` shape and `context.reply()` mapping are the
   same for any channel.
 
-AWS SNS is a signature *verifier*, not an inbound-message receiver: `snsWebhook.verify` now
+AWS SNS is a signature _verifier_, not an inbound-message receiver: `snsWebhook.verify` now
 implements the full RSA certificate-chain scheme (see the [webhooks docs](/docs/webhooks)).
 
 ## Routing several channels

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -107,25 +107,28 @@ const slack = createSlackInbound({
 | `@visulima/notification/inbound/discord`  | `createDiscordInbound`   | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response                  |
 | `@visulima/notification/inbound/telegram` | `createTelegramInbound`  | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method in the response  |
 | `@visulima/notification/inbound/twilio`   | `createTwilioInbound`    | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element                 |
-| `@visulima/notification/inbound/msteams`  | `createMsTeamsInbound`   | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity        |
-| `@visulima/notification/inbound/telnyx`   | `createTelnyxInbound`    | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)         |
+| `@visulima/notification/inbound/msteams`  | `createMsTeamsInbound`      | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
+| `@visulima/notification/inbound/telnyx`   | `createTelnyxInbound`       | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
+| `@visulima/notification/inbound/messagebird` | `createMessageBirdInbound` | `messagebird-signature-jwt` — HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
+| `@visulima/notification/inbound/vonage`   | `createVonageInbound`       | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
 
-Slack receivers cover the Events API, slash commands and interactive components; Twilio and
-Telnyx cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with the `whatsapp:`
-prefix stripped from ids); Microsoft Teams covers outgoing-webhook message activities.
+Slack receivers cover the Events API, slash commands and interactive components; Twilio, Telnyx,
+MessageBird and Vonage cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with
+the `whatsapp:` prefix stripped from ids); Microsoft Teams covers outgoing-webhook message
+activities. The MessageBird and Vonage receivers verify the full signed-JWT scheme (HS256
+signature plus the `payload_hash` — and, for MessageBird, `url_hash` — claims that bind the JWT
+to this exact request body and URL).
 
 ### Not yet built in
 
-Some providers this package ships outbound do not have an inbound receiver yet, because their
-webhook signature schemes warrant a dedicated, separately-verified implementation:
+- **Plivo** — `X-Plivo-Signature-V3` (HMAC-SHA256 with a nonce and multiple comma-separated
+  signatures). The exact canonicalisation isn't pinned down from a verifiable source, so it is
+  intentionally left out rather than guessed. Verify with the Plivo SDK's own validator, then
+  normalise the body yourself — the `InboundMessage` shape and `context.reply()` mapping are the
+  same for any channel.
 
-- **Plivo** — `X-Plivo-Signature-V3` (HMAC-SHA256 with nonce, multi-signature).
-- **MessageBird / Bird** — `MessageBird-Signature-JWT` (a full JWT with `url_hash` / `payload_hash` / timing claims).
-- **Vonage** — signed webhooks (JWT for the Messages API, `sig`/`nonce`/`timestamp` for the classic SMS API).
-- **AWS SNS** — RSA certificate-chain verification (the existing [`snsWebhook`](/docs/webhooks) verifier fails closed pending that work).
-
-Until they land, verify with the provider's own SDK helper, then normalise the body yourself —
-the `InboundMessage` shape and `context.reply()` mapping are the same for any channel.
+AWS SNS is a signature *verifier*, not an inbound-message receiver: `snsWebhook.verify` now
+implements the full RSA certificate-chain scheme (see the [webhooks docs](/docs/webhooks)).
 
 ## Routing several channels
 

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -76,6 +76,29 @@ A handler returns one of:
 - a raw **`Response`** — passed through unchanged;
 - **nothing** — the channel sends its default acknowledgement.
 
+### `context.reply` — the one-call loop
+
+Returning an `InboundReply` only works where the channel can answer synchronously in the HTTP
+response. For everything else (Slack Events API, Discord deferred replies), pass the matching
+**outbound provider** to the receiver and answer with `context.reply()` — it maps the inbound
+message to the right outbound payload (recipient, thread, WhatsApp prefix) and sends it:
+
+```typescript
+import { createSlackInbound } from "@visulima/notification/inbound/slack";
+import slackProvider from "@visulima/notification/providers/slack";
+
+const slack = createSlackInbound({
+    signingSecret,
+    provider: slackProvider({ token }), // enables context.reply()
+    onMessage: async (message, context) => {
+        await context.reply(await runAgent(message.text ?? "")); // string shorthand for { text }
+    },
+});
+```
+
+`reply()` accepts a string or a full `InboundReply` and resolves to the provider's send
+`Result`. It rejects if no `provider` was configured.
+
 ## Channels
 
 | Import                                    | Factory                  | Verification                                              | Synchronous reply                     |
@@ -108,28 +131,24 @@ export default { fetch: handler };
 
 ## Closing the loop with an AI agent
 
-Inbound + outbound together give you a receive → think → reply loop:
+Inbound + outbound together give you a receive → think → reply loop in a single call — pass
+the outbound provider once and answer with `context.reply()`:
 
 ```typescript
-import { createNotification } from "@visulima/notification";
-import slackProvider from "@visulima/notification/providers/slack";
 import { createSlackInbound } from "@visulima/notification/inbound/slack";
-
-const notifier = createNotification({ chat: slackProvider({ token }) });
+import slackProvider from "@visulima/notification/providers/slack";
 
 const slack = createSlackInbound({
     signingSecret,
-    onMessage: async (message) => {
-        if (message.type !== "message") {
-            return undefined;
+    provider: slackProvider({ token }),
+    onMessage: async (message, context) => {
+        if (message.type === "message") {
+            await context.reply(await runAgent(message.text ?? ""));
         }
-
-        const reply = await runAgent(message.text ?? "");
-
-        // Events API can't reply in the HTTP response — send through the provider.
-        await notifier.send({ chat: { to: message.conversationId, text: reply, threadId: message.threadId } });
-
-        return undefined;
     },
 });
 ```
+
+The Twilio receiver works the same way with an SMS provider — `context.reply("…")` addresses
+the response back to the sender (re-applying the `whatsapp:` prefix for WhatsApp) with no
+manual payload wiring.

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -20,7 +20,7 @@ standard `Request`/`Response`.
 ## Quick start
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/inbound/slack";
+import { createSlackInbound } from "@visulima/notification/providers/slack";
 
 const slack = createSlackInbound({
     signingSecret: process.env.SLACK_SIGNING_SECRET!,
@@ -84,8 +84,8 @@ response. For everything else (Slack Events API, Discord deferred replies), pass
 message to the right outbound payload (recipient, thread, WhatsApp prefix) and sends it:
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/inbound/slack";
-import slackProvider from "@visulima/notification/providers/slack";
+// The inbound receiver and the outbound provider ship from the same channel subpath.
+import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
 
 const slack = createSlackInbound({
     signingSecret,
@@ -101,16 +101,21 @@ const slack = createSlackInbound({
 
 ## Channels
 
-| Import                                    | Factory                  | Verification                                              | Synchronous reply                     |
-| ----------------------------------------- | ------------------------ | -------------------------------------------------------- | ------------------------------------- |
-| `@visulima/notification/inbound/slack`    | `createSlackInbound`     | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions         |
-| `@visulima/notification/inbound/discord`  | `createDiscordInbound`   | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response                  |
-| `@visulima/notification/inbound/telegram` | `createTelegramInbound`  | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method in the response  |
-| `@visulima/notification/inbound/twilio`   | `createTwilioInbound`    | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element                 |
-| `@visulima/notification/inbound/msteams`  | `createMsTeamsInbound`      | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
-| `@visulima/notification/inbound/telnyx`   | `createTelnyxInbound`       | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
-| `@visulima/notification/inbound/messagebird` | `createMessageBirdInbound` | `messagebird-signature-jwt` — HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
-| `@visulima/notification/inbound/vonage`   | `createVonageInbound`       | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
+A channel's two halves ship together: each `@visulima/notification/providers/<name>` subpath
+exports both the outbound provider (`<name>Provider`) and the inbound receiver
+(`create<Name>Inbound`). The `@visulima/notification/inbound` barrel holds only the shared types,
+`createInboundRouter` and the verification/reply helpers.
+
+| Import                                     | Receiver                   | Verification                                              | Synchronous reply                  |
+| ------------------------------------------ | -------------------------- | -------------------------------------------------------- | ---------------------------------- |
+| `@visulima/notification/providers/slack`   | `createSlackInbound`       | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions      |
+| `@visulima/notification/providers/discord` | `createDiscordInbound`     | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response               |
+| `@visulima/notification/providers/telegram`| `createTelegramInbound`    | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method               |
+| `@visulima/notification/providers/twilio`  | `createTwilioInbound`      | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element              |
+| `@visulima/notification/providers/msteams` | `createMsTeamsInbound`     | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
+| `@visulima/notification/providers/telnyx`  | `createTelnyxInbound`      | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
+| `@visulima/notification/providers/messagebird` | `createMessageBirdInbound` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
+| `@visulima/notification/providers/vonage`  | `createVonageInbound`      | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
 
 Slack receivers cover the Events API, slash commands and interactive components; Twilio, Telnyx,
 MessageBird and Vonage cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with
@@ -136,8 +141,8 @@ implements the full RSA certificate-chain scheme (see the [webhooks docs](/docs/
 
 ```typescript
 import { createInboundRouter } from "@visulima/notification/inbound";
-import { createSlackInbound } from "@visulima/notification/inbound/slack";
-import { createTelegramInbound } from "@visulima/notification/inbound/telegram";
+import { createSlackInbound } from "@visulima/notification/providers/slack";
+import { createTelegramInbound } from "@visulima/notification/providers/telegram";
 
 const handler = createInboundRouter({
     "/webhooks/slack": createSlackInbound({ signingSecret, onMessage }),
@@ -153,8 +158,7 @@ Inbound + outbound together give you a receive → think → reply loop in a sin
 the outbound provider once and answer with `context.reply()`:
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/inbound/slack";
-import slackProvider from "@visulima/notification/providers/slack";
+import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
 
 const slack = createSlackInbound({
     signingSecret,

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -1,0 +1,135 @@
+---
+title: Inbound
+description: Receive and normalise inbound messages from chat and SMS channels — the two-way half for bots and AI agents
+---
+
+# Inbound
+
+A channel is two-way. The rest of this package covers the **outbound** half — sending a
+`NotificationPayload` through a provider. `@visulima/notification/inbound` covers the
+**inbound** half: verifying and normalising incoming webhooks (a Slack mention, a Discord
+slash command, a Telegram message, an inbound SMS/WhatsApp) into a single `InboundMessage`
+shape you can hand to a bot or an AI agent — which can then reply through the matching
+outbound provider.
+
+Like the [webhook verifiers](/docs/webhooks), every receiver uses Web Crypto only, so it runs
+on Cloudflare Workers, Deno, Bun and other edge runtimes. Receivers are framework-agnostic:
+each exposes a single `handle(request: Request) => Promise<Response>` built on the web
+standard `Request`/`Response`.
+
+## Quick start
+
+```typescript
+import { createSlackInbound } from "@visulima/notification/inbound/slack";
+
+const slack = createSlackInbound({
+    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    onMessage: async (message, context) => {
+        // `message` is normalised across every channel.
+        if (message.type === "message") {
+            const answer = await runAgent(message.text ?? "");
+
+            // Slash commands / interactions can reply in the HTTP response…
+            return { text: answer };
+        }
+
+        // …Events API deliveries are acknowledged with 200; reply out-of-band
+        // through the outbound Slack provider instead.
+        return undefined;
+    },
+});
+
+// Any web-standard server: Cloudflare Workers, Deno, Bun, Hono, Next.js route handlers…
+export default { fetch: (request: Request) => slack.handle(request) };
+```
+
+The `handle` method performs the full pipeline: **verify signature → answer platform
+handshakes → parse → dispatch to `onMessage` → serialise the reply**. Invalid signatures get
+`401`, malformed bodies `400` (override via `onError`), and unrecognised payloads a `204`
+acknowledgement without invoking your handler.
+
+## The normalised message
+
+```typescript
+interface InboundMessage {
+    channel: ChannelType;            // "chat" | "sms"
+    provider: string;               // "slack" | "discord" | "telegram" | "twilio"
+    type: "message" | "command" | "callback" | "event" | "unknown";
+    id: string;
+    text?: string;
+    from: { id: string; name?: string; username?: string; isBot?: boolean };
+    conversationId?: string;        // channel / chat / room id
+    threadId?: string;              // thread anchor, for threaded replies
+    command?: { name: string; args?: string };
+    attachments?: { url?: string; contentType?: string }[];
+    timestamp: Date;
+    raw: unknown;                   // the untouched provider payload
+    metadata?: Record<string, unknown>;
+}
+```
+
+A handler returns one of:
+
+- an **`InboundReply`** (`{ text?, blocks?, threadId?, raw? }`) — serialised into the correct
+  provider response (Slack message JSON, Discord interaction response, Telegram `sendMessage`
+  method call, Twilio TwiML);
+- a raw **`Response`** — passed through unchanged;
+- **nothing** — the channel sends its default acknowledgement.
+
+## Channels
+
+| Import                                    | Factory                  | Verification                                              | Synchronous reply                     |
+| ----------------------------------------- | ------------------------ | -------------------------------------------------------- | ------------------------------------- |
+| `@visulima/notification/inbound/slack`    | `createSlackInbound`     | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions         |
+| `@visulima/notification/inbound/discord`  | `createDiscordInbound`   | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response                  |
+| `@visulima/notification/inbound/telegram` | `createTelegramInbound`  | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method in the response  |
+| `@visulima/notification/inbound/twilio`   | `createTwilioInbound`    | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML `<Message>`                     |
+
+Slack receivers cover the Events API, slash commands and interactive components; Twilio covers
+both SMS and WhatsApp (WhatsApp is flagged in `metadata.transport`, with the `whatsapp:` prefix
+stripped from ids).
+
+## Routing several channels
+
+`createInboundRouter` mounts multiple receivers behind one fetch handler, dispatching by path:
+
+```typescript
+import { createInboundRouter } from "@visulima/notification/inbound";
+import { createSlackInbound } from "@visulima/notification/inbound/slack";
+import { createTelegramInbound } from "@visulima/notification/inbound/telegram";
+
+const handler = createInboundRouter({
+    "/webhooks/slack": createSlackInbound({ signingSecret, onMessage }),
+    "/webhooks/telegram": createTelegramInbound({ secretToken, onMessage }),
+});
+
+export default { fetch: handler };
+```
+
+## Closing the loop with an AI agent
+
+Inbound + outbound together give you a receive → think → reply loop:
+
+```typescript
+import { createNotification } from "@visulima/notification";
+import slackProvider from "@visulima/notification/providers/slack";
+import { createSlackInbound } from "@visulima/notification/inbound/slack";
+
+const notifier = createNotification({ chat: slackProvider({ token }) });
+
+const slack = createSlackInbound({
+    signingSecret,
+    onMessage: async (message) => {
+        if (message.type !== "message") {
+            return undefined;
+        }
+
+        const reply = await runAgent(message.text ?? "");
+
+        // Events API can't reply in the HTTP response — send through the provider.
+        await notifier.send({ chat: { to: message.conversationId, text: reply, threadId: message.threadId } });
+
+        return undefined;
+    },
+});
+```

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -20,9 +20,9 @@ standard `Request`/`Response`.
 ## Quick start
 
 ```typescript
-import { createSlackInbound } from "@visulima/notification/providers/slack";
+import { createSlackReceiver } from "@visulima/notification/providers/slack";
 
-const slack = createSlackInbound({
+const slack = createSlackReceiver({
     signingSecret: process.env.SLACK_SIGNING_SECRET!,
     onMessage: async (message, context) => {
         // `message` is normalised across every channel.
@@ -85,11 +85,11 @@ message to the right outbound payload (recipient, thread, WhatsApp prefix) and s
 
 ```typescript
 // The inbound receiver and the outbound provider ship from the same channel subpath.
-import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
+import { createSlackReceiver, createSlackProvider } from "@visulima/notification/providers/slack";
 
-const slack = createSlackInbound({
+const slack = createSlackReceiver({
     signingSecret,
-    provider: slackProvider({ token }), // enables context.reply()
+    provider: createSlackProvider({ token }), // enables context.reply()
     onMessage: async (message, context) => {
         await context.reply(await runAgent(message.text ?? "")); // string shorthand for { text }
     },
@@ -102,20 +102,20 @@ const slack = createSlackInbound({
 ## Channels
 
 A channel's two halves ship together: each `@visulima/notification/providers/<name>` subpath
-exports both the outbound provider (`<name>Provider`) and the inbound receiver
-(`create<Name>Inbound`). The `@visulima/notification/inbound` barrel holds only the shared types,
+exports both the outbound provider (`create<Name>Provider`) and the inbound receiver
+(`create<Name>Receiver`). The `@visulima/notification/inbound` barrel holds only the shared types,
 `createInboundRouter` and the verification/reply helpers.
 
 | Import                                     | Receiver                   | Verification                                              | Synchronous reply                  |
 | ------------------------------------------ | -------------------------- | -------------------------------------------------------- | ---------------------------------- |
-| `@visulima/notification/providers/slack`   | `createSlackInbound`       | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions      |
-| `@visulima/notification/providers/discord` | `createDiscordInbound`     | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response               |
-| `@visulima/notification/providers/telegram`| `createTelegramInbound`    | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method               |
-| `@visulima/notification/providers/twilio`  | `createTwilioInbound`      | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element              |
-| `@visulima/notification/providers/msteams` | `createMsTeamsInbound`     | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
-| `@visulima/notification/providers/telnyx`  | `createTelnyxInbound`      | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
-| `@visulima/notification/providers/messagebird` | `createMessageBirdInbound` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
-| `@visulima/notification/providers/vonage`  | `createVonageInbound`      | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
+| `@visulima/notification/providers/slack`   | `createSlackReceiver`       | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions      |
+| `@visulima/notification/providers/discord` | `createDiscordReceiver`     | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response               |
+| `@visulima/notification/providers/telegram`| `createTelegramReceiver`    | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method               |
+| `@visulima/notification/providers/twilio`  | `createTwilioReceiver`      | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element              |
+| `@visulima/notification/providers/msteams` | `createMsTeamsReceiver`     | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity     |
+| `@visulima/notification/providers/telnyx`  | `createTelnyxReceiver`      | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)      |
+| `@visulima/notification/providers/messagebird` | `createMessageBirdReceiver` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | via `context.reply()` (async) |
+| `@visulima/notification/providers/vonage`  | `createVonageReceiver`      | `Authorization: Bearer` HS256 JWT + `payload_hash`       | via `context.reply()` (async)      |
 
 Slack receivers cover the Events API, slash commands and interactive components; Twilio, Telnyx,
 MessageBird and Vonage cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with
@@ -141,12 +141,12 @@ implements the full RSA certificate-chain scheme (see the [webhooks docs](/docs/
 
 ```typescript
 import { createInboundRouter } from "@visulima/notification/inbound";
-import { createSlackInbound } from "@visulima/notification/providers/slack";
-import { createTelegramInbound } from "@visulima/notification/providers/telegram";
+import { createSlackReceiver } from "@visulima/notification/providers/slack";
+import { createTelegramReceiver } from "@visulima/notification/providers/telegram";
 
 const handler = createInboundRouter({
-    "/webhooks/slack": createSlackInbound({ signingSecret, onMessage }),
-    "/webhooks/telegram": createTelegramInbound({ secretToken, onMessage }),
+    "/webhooks/slack": createSlackReceiver({ signingSecret, onMessage }),
+    "/webhooks/telegram": createTelegramReceiver({ secretToken, onMessage }),
 });
 
 export default { fetch: handler };
@@ -158,11 +158,11 @@ Inbound + outbound together give you a receive → think → reply loop in a sin
 the outbound provider once and answer with `context.reply()`:
 
 ```typescript
-import { createSlackInbound, slackProvider } from "@visulima/notification/providers/slack";
+import { createSlackReceiver, createSlackProvider } from "@visulima/notification/providers/slack";
 
-const slack = createSlackInbound({
+const slack = createSlackReceiver({
     signingSecret,
-    provider: slackProvider({ token }),
+    provider: createSlackProvider({ token }),
     onMessage: async (message, context) => {
         if (message.type === "message") {
             await context.reply(await runAgent(message.text ?? ""));

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -106,11 +106,26 @@ const slack = createSlackInbound({
 | `@visulima/notification/inbound/slack`    | `createSlackInbound`     | v0 signature + 5-min replay; `url_verification` handled  | Slash commands & interactions         |
 | `@visulima/notification/inbound/discord`  | `createDiscordInbound`   | Ed25519 over `timestamp+body`; `PING` → `PONG` handled   | Interaction response                  |
 | `@visulima/notification/inbound/telegram` | `createTelegramInbound`  | `X-Telegram-Bot-Api-Secret-Token` (when set)             | `sendMessage` method in the response  |
-| `@visulima/notification/inbound/twilio`   | `createTwilioInbound`    | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML `<Message>`                     |
+| `@visulima/notification/inbound/twilio`   | `createTwilioInbound`    | `X-Twilio-Signature` HMAC-SHA1 of URL + sorted params    | TwiML message element                 |
+| `@visulima/notification/inbound/msteams`  | `createMsTeamsInbound`   | `Authorization: HMAC` — base64 HMAC-SHA256 of raw body   | Bot Framework message activity        |
+| `@visulima/notification/inbound/telnyx`   | `createTelnyxInbound`    | Ed25519 over `{timestamp}\|{body}` + 5-min replay        | via `context.reply()` (async)         |
 
-Slack receivers cover the Events API, slash commands and interactive components; Twilio covers
-both SMS and WhatsApp (WhatsApp is flagged in `metadata.transport`, with the `whatsapp:` prefix
-stripped from ids).
+Slack receivers cover the Events API, slash commands and interactive components; Twilio and
+Telnyx cover SMS (Twilio also WhatsApp — flagged in `metadata.transport`, with the `whatsapp:`
+prefix stripped from ids); Microsoft Teams covers outgoing-webhook message activities.
+
+### Not yet built in
+
+Some providers this package ships outbound do not have an inbound receiver yet, because their
+webhook signature schemes warrant a dedicated, separately-verified implementation:
+
+- **Plivo** — `X-Plivo-Signature-V3` (HMAC-SHA256 with nonce, multi-signature).
+- **MessageBird / Bird** — `MessageBird-Signature-JWT` (a full JWT with `url_hash` / `payload_hash` / timing claims).
+- **Vonage** — signed webhooks (JWT for the Messages API, `sig`/`nonce`/`timestamp` for the classic SMS API).
+- **AWS SNS** — RSA certificate-chain verification (the existing [`snsWebhook`](/docs/webhooks) verifier fails closed pending that work).
+
+Until they land, verify with the provider's own SDK helper, then normalise the body yourself —
+the `InboundMessage` shape and `context.reply()` mapping are the same for any channel.
 
 ## Routing several channels
 

--- a/packages/notification/notification/docs/inbound.mdx
+++ b/packages/notification/notification/docs/inbound.mdx
@@ -22,8 +22,13 @@ standard `Request`/`Response`.
 ```typescript
 import { createSlackReceiver } from "@visulima/notification/providers/slack";
 
+// Read the secret however your runtime exposes it: an `env` binding on
+// Cloudflare Workers, `Deno.env.get`, `process.env` on Node. Hard-coding
+// `process.env` here would break the edge runtimes listed below.
+declare const signingSecret: string;
+
 const slack = createSlackReceiver({
-    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    signingSecret,
     onMessage: async (message, context) => {
         // `message` is normalised across every channel.
         if (message.type === "message") {

--- a/packages/notification/notification/docs/meta.json
+++ b/packages/notification/notification/docs/meta.json
@@ -12,6 +12,7 @@
         "queue",
         "events",
         "webhooks",
+        "inbound",
         "templates",
         "workflow",
         "digest",

--- a/packages/notification/notification/docs/webhooks.mdx
+++ b/packages/notification/notification/docs/webhooks.mdx
@@ -21,11 +21,11 @@ if (ok) {
 
 ## Available verifiers
 
-| Verifier                  | Scheme                                                              |
-| ------------------------- | ------------------------------------------------------------------- |
-| `twilioVerifier`          | `X-Twilio-Signature` — base64 HMAC-SHA1 of URL + sorted params.     |
-| `slackVerifier`           | v0 signing — hex HMAC-SHA256 of `v0:{ts}:{body}` + replay window.   |
-| `standardWebhookVerifier` | [Standard Webhooks](https://www.standardwebhooks.com/) HMAC-SHA256. |
+| Verifier                  | Scheme                                                                       |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| `twilioVerifier`          | `X-Twilio-Signature` — base64 HMAC-SHA1 of URL + sorted params.              |
+| `slackVerifier`           | v0 signing — hex HMAC-SHA256 of `v0:{ts}:{body}` + replay window.            |
+| `standardWebhookVerifier` | [Standard Webhooks](https://www.standardwebhooks.com/) HMAC-SHA256.          |
 | `snsVerifier`             | SNS SignatureVersion 1 (RSA-SHA1) / 2 (RSA-SHA256) certificate verification. |
 
 Each exposes `verify(payload, headers, secret) => Promise<boolean>` and `parse(body) => NotificationEvent | undefined`.

--- a/packages/notification/notification/docs/webhooks.mdx
+++ b/packages/notification/notification/docs/webhooks.mdx
@@ -9,28 +9,28 @@ Verify the signature of inbound provider webhooks and normalise them to the `Not
 Web Crypto (`globalThis.crypto.subtle`), so they run on Cloudflare Workers and other edge runtimes.
 
 ```typescript
-import { twilioVerifier, slackVerifier, standardWebhookVerifier, snsVerifier } from "@visulima/notification/webhooks";
+import { twilioWebhook, slackWebhook, standardWebhook, snsWebhook } from "@visulima/notification/webhooks";
 
 // Slack (v0 signing): HMAC-SHA256 of `v0:{timestamp}:{body}` with a 5-minute replay window
-const ok = await slackVerifier.verify(rawBody, request.headers, signingSecret);
+const ok = await slackWebhook.verify(rawBody, request.headers, signingSecret);
 
 if (ok) {
-    const event = slackVerifier.parse(rawBody); // -> NotificationEvent | undefined
+    const event = slackWebhook.parse(rawBody); // -> NotificationEvent | undefined
 }
 ```
 
 ## Available verifiers
 
-| Verifier                  | Scheme                                                                       |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| `twilioVerifier`          | `X-Twilio-Signature` — base64 HMAC-SHA1 of URL + sorted params.              |
-| `slackVerifier`           | v0 signing — hex HMAC-SHA256 of `v0:{ts}:{body}` + replay window.            |
-| `standardWebhookVerifier` | [Standard Webhooks](https://www.standardwebhooks.com/) HMAC-SHA256.          |
-| `snsVerifier`             | SNS SignatureVersion 1 (RSA-SHA1) / 2 (RSA-SHA256) certificate verification. |
+| Verifier           | Scheme                                                                       |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `twilioWebhook`    | `X-Twilio-Signature` — base64 HMAC-SHA1 of URL + sorted params.               |
+| `slackWebhook`     | v0 signing — hex HMAC-SHA256 of `v0:{ts}:{body}` + replay window.             |
+| `standardWebhook`  | [Standard Webhooks](https://www.standardwebhooks.com/) HMAC-SHA256.           |
+| `snsWebhook`       | SNS SignatureVersion 1 (RSA-SHA1) / 2 (RSA-SHA256) certificate verification.  |
 
 Each exposes `verify(payload, headers, secret) => Promise<boolean>` and `parse(body) => NotificationEvent | undefined`.
 
-> `snsVerifier.verify` implements the full AWS scheme: it validates the `SigningCertURL` host (`sns.<region>.amazonaws.com`),
+> `snsWebhook.verify` implements the full AWS scheme: it validates the `SigningCertURL` host (`sns.<region>.amazonaws.com`),
 > rebuilds the canonical string-to-sign, fetches and caches the signing certificate, extracts its RSA public key and checks
 > the signature with Web Crypto. It performs a network `fetch` for the certificate (unlike the HMAC verifiers, which are
 > purely local), so allow outbound access to the SNS certificate host. `verifySnsMessage(parsedMessage)` is also exported for

--- a/packages/notification/notification/docs/webhooks.mdx
+++ b/packages/notification/notification/docs/webhooks.mdx
@@ -26,9 +26,12 @@ if (ok) {
 | `twilioVerifier`          | `X-Twilio-Signature` — base64 HMAC-SHA1 of URL + sorted params.     |
 | `slackVerifier`           | v0 signing — hex HMAC-SHA256 of `v0:{ts}:{body}` + replay window.   |
 | `standardWebhookVerifier` | [Standard Webhooks](https://www.standardwebhooks.com/) HMAC-SHA256. |
-| `snsVerifier`             | SNS envelope + subscription-confirmation handling.                  |
+| `snsVerifier`             | SNS SignatureVersion 1 (RSA-SHA1) / 2 (RSA-SHA256) certificate verification. |
 
 Each exposes `verify(payload, headers, secret) => Promise<boolean>` and `parse(body) => NotificationEvent | undefined`.
 
-> SNS full RSA certificate-chain verification is a documented TODO; the verifier handles envelope/type parsing and
-> subscription confirmation today.
+> `snsVerifier.verify` implements the full AWS scheme: it validates the `SigningCertURL` host (`sns.<region>.amazonaws.com`),
+> rebuilds the canonical string-to-sign, fetches and caches the signing certificate, extracts its RSA public key and checks
+> the signature with Web Crypto. It performs a network `fetch` for the certificate (unlike the HMAC verifiers, which are
+> purely local), so allow outbound access to the SNS certificate host. `verifySnsMessage(parsedMessage)` is also exported for
+> callers that have already parsed the body.

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -225,6 +225,14 @@
             "types": "./dist/inbound/channels/telnyx.d.ts",
             "default": "./dist/inbound/channels/telnyx.js"
         },
+        "./inbound/messagebird": {
+            "types": "./dist/inbound/channels/messagebird.d.ts",
+            "default": "./dist/inbound/channels/messagebird.js"
+        },
+        "./inbound/vonage": {
+            "types": "./dist/inbound/channels/vonage.d.ts",
+            "default": "./dist/inbound/channels/vonage.js"
+        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -201,38 +201,6 @@
             "types": "./dist/inbound/index.d.ts",
             "default": "./dist/inbound/index.js"
         },
-        "./inbound/slack": {
-            "types": "./dist/inbound/channels/slack.d.ts",
-            "default": "./dist/inbound/channels/slack.js"
-        },
-        "./inbound/discord": {
-            "types": "./dist/inbound/channels/discord.d.ts",
-            "default": "./dist/inbound/channels/discord.js"
-        },
-        "./inbound/telegram": {
-            "types": "./dist/inbound/channels/telegram.d.ts",
-            "default": "./dist/inbound/channels/telegram.js"
-        },
-        "./inbound/twilio": {
-            "types": "./dist/inbound/channels/twilio.d.ts",
-            "default": "./dist/inbound/channels/twilio.js"
-        },
-        "./inbound/msteams": {
-            "types": "./dist/inbound/channels/msteams.d.ts",
-            "default": "./dist/inbound/channels/msteams.js"
-        },
-        "./inbound/telnyx": {
-            "types": "./dist/inbound/channels/telnyx.d.ts",
-            "default": "./dist/inbound/channels/telnyx.js"
-        },
-        "./inbound/messagebird": {
-            "types": "./dist/inbound/channels/messagebird.d.ts",
-            "default": "./dist/inbound/channels/messagebird.js"
-        },
-        "./inbound/vonage": {
-            "types": "./dist/inbound/channels/vonage.d.ts",
-            "default": "./dist/inbound/channels/vonage.js"
-        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -3,8 +3,12 @@
     "version": "1.0.11",
     "description": "A reusable, ESM-only, edge-ready multi-channel notification library with SMS, push, chat, in-app and webhook providers",
     "keywords": [
+        "agent",
+        "ai",
         "apns",
         "aws-sns",
+        "chatbot",
+        "inbound",
         "chat",
         "discord",
         "expo",
@@ -192,6 +196,26 @@
         "./webhooks": {
             "types": "./dist/webhooks/index.d.ts",
             "default": "./dist/webhooks/index.js"
+        },
+        "./inbound": {
+            "types": "./dist/inbound/index.d.ts",
+            "default": "./dist/inbound/index.js"
+        },
+        "./inbound/slack": {
+            "types": "./dist/inbound/channels/slack.d.ts",
+            "default": "./dist/inbound/channels/slack.js"
+        },
+        "./inbound/discord": {
+            "types": "./dist/inbound/channels/discord.d.ts",
+            "default": "./dist/inbound/channels/discord.js"
+        },
+        "./inbound/telegram": {
+            "types": "./dist/inbound/channels/telegram.d.ts",
+            "default": "./dist/inbound/channels/telegram.js"
+        },
+        "./inbound/twilio": {
+            "types": "./dist/inbound/channels/twilio.d.ts",
+            "default": "./dist/inbound/channels/twilio.js"
         },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -217,6 +217,14 @@
             "types": "./dist/inbound/channels/twilio.d.ts",
             "default": "./dist/inbound/channels/twilio.js"
         },
+        "./inbound/msteams": {
+            "types": "./dist/inbound/channels/msteams.d.ts",
+            "default": "./dist/inbound/channels/msteams.js"
+        },
+        "./inbound/telnyx": {
+            "types": "./dist/inbound/channels/telnyx.d.ts",
+            "default": "./dist/inbound/channels/telnyx.js"
+        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -212,6 +212,14 @@
             "types": "./dist/inbound/channels/twilio.d.ts",
             "default": "./dist/inbound/channels/twilio.js"
         },
+        "./inbound/msteams": {
+            "types": "./dist/inbound/channels/msteams.d.ts",
+            "default": "./dist/inbound/channels/msteams.js"
+        },
+        "./inbound/telnyx": {
+            "types": "./dist/inbound/channels/telnyx.d.ts",
+            "default": "./dist/inbound/channels/telnyx.js"
+        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -220,6 +220,14 @@
             "types": "./dist/inbound/channels/telnyx.d.ts",
             "default": "./dist/inbound/channels/telnyx.js"
         },
+        "./inbound/messagebird": {
+            "types": "./dist/inbound/channels/messagebird.d.ts",
+            "default": "./dist/inbound/channels/messagebird.js"
+        },
+        "./inbound/vonage": {
+            "types": "./dist/inbound/channels/vonage.d.ts",
+            "default": "./dist/inbound/channels/vonage.js"
+        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -196,38 +196,6 @@
             "types": "./dist/inbound/index.d.ts",
             "default": "./dist/inbound/index.js"
         },
-        "./inbound/slack": {
-            "types": "./dist/inbound/channels/slack.d.ts",
-            "default": "./dist/inbound/channels/slack.js"
-        },
-        "./inbound/discord": {
-            "types": "./dist/inbound/channels/discord.d.ts",
-            "default": "./dist/inbound/channels/discord.js"
-        },
-        "./inbound/telegram": {
-            "types": "./dist/inbound/channels/telegram.d.ts",
-            "default": "./dist/inbound/channels/telegram.js"
-        },
-        "./inbound/twilio": {
-            "types": "./dist/inbound/channels/twilio.d.ts",
-            "default": "./dist/inbound/channels/twilio.js"
-        },
-        "./inbound/msteams": {
-            "types": "./dist/inbound/channels/msteams.d.ts",
-            "default": "./dist/inbound/channels/msteams.js"
-        },
-        "./inbound/telnyx": {
-            "types": "./dist/inbound/channels/telnyx.d.ts",
-            "default": "./dist/inbound/channels/telnyx.js"
-        },
-        "./inbound/messagebird": {
-            "types": "./dist/inbound/channels/messagebird.d.ts",
-            "default": "./dist/inbound/channels/messagebird.js"
-        },
-        "./inbound/vonage": {
-            "types": "./dist/inbound/channels/vonage.d.ts",
-            "default": "./dist/inbound/channels/vonage.js"
-        },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",
             "default": "./dist/template-engines/string.js"

--- a/packages/notification/notification/package.json
+++ b/packages/notification/notification/package.json
@@ -3,8 +3,12 @@
     "version": "1.0.17",
     "description": "A reusable, ESM-only, edge-ready multi-channel notification library with SMS, push, chat, in-app and webhook providers",
     "keywords": [
+        "agent",
+        "ai",
         "apns",
         "aws-sns",
+        "chatbot",
+        "inbound",
         "chat",
         "discord",
         "expo",
@@ -187,6 +191,26 @@
         "./webhooks": {
             "types": "./dist/webhooks/index.d.ts",
             "default": "./dist/webhooks/index.js"
+        },
+        "./inbound": {
+            "types": "./dist/inbound/index.d.ts",
+            "default": "./dist/inbound/index.js"
+        },
+        "./inbound/slack": {
+            "types": "./dist/inbound/channels/slack.d.ts",
+            "default": "./dist/inbound/channels/slack.js"
+        },
+        "./inbound/discord": {
+            "types": "./dist/inbound/channels/discord.d.ts",
+            "default": "./dist/inbound/channels/discord.js"
+        },
+        "./inbound/telegram": {
+            "types": "./dist/inbound/channels/telegram.d.ts",
+            "default": "./dist/inbound/channels/telegram.js"
+        },
+        "./inbound/twilio": {
+            "types": "./dist/inbound/channels/twilio.d.ts",
+            "default": "./dist/inbound/channels/twilio.js"
         },
         "./template/string": {
             "types": "./dist/template-engines/string.d.ts",

--- a/packages/notification/notification/src/channels/inapp/index.ts
+++ b/packages/notification/notification/src/channels/inapp/index.ts
@@ -1,5 +1,10 @@
+import { inAppProvider as inAppProviderImpl } from "./provider";
+
 export type { InAppProviderConfig } from "./provider";
-export { inAppProvider } from "./provider";
+export { inAppProvider as createInAppProvider } from "./provider";
 export type { InAppStore, ListOptions, StoredNotification } from "./store";
 export { MemoryInAppStore } from "./store";
 export { createUnstorageInAppStore, UnstorageInAppStore } from "./unstorage-store";
+
+/** @deprecated Renamed to `createInAppProvider`; removed in the next major. */
+export const inAppProvider: typeof inAppProviderImpl = inAppProviderImpl;

--- a/packages/notification/notification/src/inbound/channels/discord.ts
+++ b/packages/notification/notification/src/inbound/channels/discord.ts
@@ -1,0 +1,143 @@
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import { verifyEd25519 } from "../ed25519";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
+
+const SIGNATURE_HEADER = "X-Signature-Ed25519";
+const TIMESTAMP_HEADER = "X-Signature-Timestamp";
+
+/** Discord interaction types. */
+const PING = 1;
+const APPLICATION_COMMAND = 2;
+const MESSAGE_COMPONENT = 3;
+
+/** Discord interaction-response types. */
+const PONG = 1;
+const CHANNEL_MESSAGE_WITH_SOURCE = 4;
+const DEFERRED_CHANNEL_MESSAGE = 5;
+
+/**
+ * Extracts the invoking user from a Discord interaction, which lives under `member.user`
+ * inside a guild and `user` in a DM.
+ * @param payload The decoded Discord interaction request body.
+ * @returns The invoking user, or `undefined` when absent.
+ */
+const interactionUser = (payload: Record<string, unknown>): Record<string, unknown> | undefined => {
+    const member = payload.member as Record<string, unknown> | undefined;
+    const user = (member?.user ?? payload.user) as Record<string, unknown> | undefined;
+
+    return user;
+};
+
+/**
+ * Maps a verified Discord interaction to a normalised {@link InboundMessage}, or `undefined`
+ * for the `PING` handshake and unrecognised interaction types.
+ * @param payload The interaction payload.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseDiscord = (payload: Record<string, unknown>): InboundMessage | undefined => {
+    const { type } = payload;
+    const user = interactionUser(payload);
+    const from = {
+        id: asString(user?.id) ?? "",
+        isBot: user?.bot === true,
+        username: asString(user?.username),
+    };
+    const base = {
+        channel: "chat" as const,
+        conversationId: asString(payload.channel_id),
+        from,
+        id: asString(payload.id) ?? "",
+        metadata: { applicationId: payload.application_id, guildId: payload.guild_id, token: payload.token },
+        provider: "discord",
+        raw: payload,
+        timestamp: new Date(),
+    };
+
+    if (type === APPLICATION_COMMAND) {
+        const data = payload.data as Record<string, unknown> | undefined;
+
+        return { ...base, command: { name: asString(data?.name) ?? "" }, type: "command" };
+    }
+
+    if (type === MESSAGE_COMPONENT) {
+        const data = payload.data as Record<string, unknown> | undefined;
+
+        return { ...base, text: asString(data?.custom_id), type: "callback" };
+    }
+
+    return undefined;
+};
+
+/**
+ * Options for the Discord inbound receiver.
+ */
+export interface DiscordInboundOptions extends InboundChannelOptions {
+    /** The application's Ed25519 public key (hex), from the Discord developer dashboard. */
+    publicKey: string;
+}
+
+/**
+ * Creates a Discord inbound receiver for the interactions endpoint. Requests are verified
+ * with Ed25519 (`X-Signature-Ed25519` over `timestamp + body`) before dispatch, and the
+ * `PING` handshake is answered with a `PONG` automatically.
+ *
+ * A handler may return an {@link ../types.InboundReply} to respond with a channel message
+ * (`CHANNEL_MESSAGE_WITH_SOURCE`); returning nothing defers the interaction
+ * (`DEFERRED_CHANNEL_MESSAGE`), after which you follow up through the Discord API.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createDiscordInbound = (options: DiscordInboundOptions): InboundChannel => {
+    return {
+        channel: "chat",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+            const signature = getHeader(headers, SIGNATURE_HEADER);
+            const timestamp = getHeader(headers, TIMESTAMP_HEADER);
+
+            if (signature === undefined || timestamp === undefined) {
+                return rejectionResponse("missing_signature", request, options.onError);
+            }
+
+            if (!await verifyEd25519(options.publicKey, signature, timestamp, body)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            const payload = tryParseObject(body);
+
+            if (payload === undefined) {
+                return rejectionResponse("invalid_body", request, options.onError);
+            }
+
+            // Answer the interaction endpoint validation ping.
+            if (payload.type === PING) {
+                return jsonResponse({ type: PONG });
+            }
+
+            const message = parseDiscord(payload);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, request });
+            const raw = asRawResponse(result);
+
+            if (raw !== undefined) {
+                return raw;
+            }
+
+            const reply = asReply(result);
+
+            if (reply !== undefined) {
+                return jsonResponse({ data: { content: reply.text, ...reply.raw }, type: CHANNEL_MESSAGE_WITH_SOURCE });
+            }
+
+            // No synchronous reply: acknowledge and defer so the handler can follow up out-of-band.
+            return jsonResponse({ type: DEFERRED_CHANNEL_MESSAGE });
+        },
+        provider: "discord",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/discord.ts
+++ b/packages/notification/notification/src/inbound/channels/discord.ts
@@ -3,7 +3,7 @@ import type { ChatPayload } from "../../types";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { verifyEd25519 } from "../ed25519";
 import { chatReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "X-Signature-Ed25519";
@@ -75,7 +75,7 @@ const parseDiscord = (payload: Record<string, unknown>): InboundMessage | undefi
 /**
  * Options for the Discord inbound receiver.
  */
-export interface DiscordInboundOptions extends InboundChannelOptions {
+export interface DiscordReceiverOptions extends ReceiverOptions {
     /**
      * The outbound Discord chat provider used by `context.reply()`, which posts a message to
      * the originating channel (use this instead of the deferred HTTP response). Optional.
@@ -93,10 +93,10 @@ export interface DiscordInboundOptions extends InboundChannelOptions {
  * A handler may return an {@link ../types.InboundReply} to respond with a channel message
  * (`CHANNEL_MESSAGE_WITH_SOURCE`); returning nothing defers the interaction
  * (`DEFERRED_CHANNEL_MESSAGE`), after which you follow up through the Discord API.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createDiscordInbound = (options: DiscordInboundOptions): InboundChannel => {
+export const createDiscordReceiver = (options: DiscordReceiverOptions): Receiver => {
     return {
         channel: "chat",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/discord.ts
+++ b/packages/notification/notification/src/inbound/channels/discord.ts
@@ -1,5 +1,8 @@
+import type { Provider } from "../../providers/provider";
+import type { ChatPayload } from "../../types";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { verifyEd25519 } from "../ed25519";
+import { chatReply } from "../reply";
 import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
 import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
@@ -73,6 +76,11 @@ const parseDiscord = (payload: Record<string, unknown>): InboundMessage | undefi
  * Options for the Discord inbound receiver.
  */
 export interface DiscordInboundOptions extends InboundChannelOptions {
+    /**
+     * The outbound Discord chat provider used by `context.reply()`, which posts a message to
+     * the originating channel (use this instead of the deferred HTTP response). Optional.
+     */
+    provider?: Provider<unknown, ChatPayload>;
     /** The application's Ed25519 public key (hex), from the Discord developer dashboard. */
     publicKey: string;
 }
@@ -122,7 +130,7 @@ export const createDiscordInbound = (options: DiscordInboundOptions): InboundCha
                 return noContent();
             }
 
-            const result = await options.onMessage(message, { body, headers, request });
+            const result = await options.onMessage(message, { body, headers, reply: chatReply("discord", message, options.provider), request });
             const raw = asRawResponse(result);
 
             if (raw !== undefined) {

--- a/packages/notification/notification/src/inbound/channels/discord.ts
+++ b/packages/notification/notification/src/inbound/channels/discord.ts
@@ -19,6 +19,26 @@ const PONG = 1;
 const CHANNEL_MESSAGE_WITH_SOURCE = 4;
 const DEFERRED_CHANNEL_MESSAGE = 5;
 
+/** Comfortably inside Discord's three-second initial-response window. */
+const DEFAULT_DEFER_AFTER_MS = 2000;
+
+/** Sentinel resolved by {@link deferAfter}; a unique object cannot collide with a handler result. */
+const DEFER = Symbol("defer");
+
+/**
+ * Resolves to {@link DEFER} once the deadline passes.
+ * @param milliseconds How long to wait.
+ * @returns A promise resolving to the defer sentinel.
+ */
+const deferAfter = async (milliseconds: number): Promise<typeof DEFER> =>
+    new Promise((resolve) => {
+        const timer = setTimeout(() => resolve(DEFER), milliseconds);
+
+        // Node keeps the process alive for a pending timer; nothing waits on this one once the
+        // handler wins the race.
+        (timer as unknown as { unref?: () => void }).unref?.();
+    });
+
 /**
  * Extracts the invoking user from a Discord interaction, which lives under `member.user`
  * inside a guild and `user` in a DM.
@@ -77,6 +97,16 @@ const parseDiscord = (payload: Record<string, unknown>): InboundMessage | undefi
  */
 export interface DiscordReceiverOptions extends ReceiverOptions {
     /**
+     * How long the handler may run before the interaction is deferred, in milliseconds.
+     *
+     * Discord discards an interaction whose endpoint does not answer within three seconds, so a
+     * handler that outruns this deadline gets a `DEFERRED_CHANNEL_MESSAGE` sent on its behalf and
+     * keeps running; its eventual reply has to go out through the Discord API (or `provider`).
+     * @default 2000
+     */
+    deferAfterMs?: number;
+
+    /**
      * The outbound Discord chat provider used by `context.reply()`, which posts a message to
      * the originating channel (use this instead of the deferred HTTP response). Optional.
      */
@@ -130,7 +160,20 @@ export const createDiscordReceiver = (options: DiscordReceiverOptions): Receiver
                 return noContent();
             }
 
-            const result = await options.onMessage(message, { body, headers, reply: chatReply("discord", message, options.provider), request });
+            // Discord drops an interaction that is not answered within three seconds. Race the
+            // handler against a shorter deadline so slow work defers instead of timing out; the
+            // handler keeps running and follows up through the Discord API.
+            const handled = Promise.resolve(options.onMessage(message, { body, headers, reply: chatReply("discord", message, options.provider), request }));
+            const result = await Promise.race([handled, deferAfter(options.deferAfterMs ?? DEFAULT_DEFER_AFTER_MS)]);
+
+            if (result === DEFER) {
+                // Nothing awaits the handler now, so its rejection would surface as an unhandled
+                // one. The request itself is already answered.
+                handled.catch(() => undefined);
+
+                return jsonResponse({ type: DEFERRED_CHANNEL_MESSAGE });
+            }
+
             const raw = asRawResponse(result);
 
             if (raw !== undefined) {

--- a/packages/notification/notification/src/inbound/channels/discord.ts
+++ b/packages/notification/notification/src/inbound/channels/discord.ts
@@ -32,7 +32,7 @@ const DEFER = Symbol("defer");
  */
 const deferAfter = async (milliseconds: number): Promise<typeof DEFER> =>
     new Promise((resolve) => {
-        const timer = setTimeout(() => resolve(DEFER), milliseconds);
+        const timer = setTimeout(resolve, milliseconds, DEFER);
 
         // Node keeps the process alive for a pending timer; nothing waits on this one once the
         // handler wins the race.

--- a/packages/notification/notification/src/inbound/channels/messagebird.ts
+++ b/packages/notification/notification/src/inbound/channels/messagebird.ts
@@ -4,7 +4,7 @@ import { getHeader, tryParseObject } from "../../webhooks/types";
 import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
 import { smsReply } from "../reply";
 import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
-import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+import { asDate, asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "messagebird-signature-jwt";
 
@@ -18,8 +18,11 @@ const parseMessageBird = (body: string): InboundMessage | undefined => {
     const payload = tryParseObject(body);
     const originator = asString(payload?.originator);
     const text = asString(payload?.body);
+    const id = asString(payload?.id);
 
-    if (payload === undefined || originator === undefined) {
+    // A missing id used to become `""`, which collides with every other id-less message once a
+    // consumer deduplicates, persists or correlates on it. Reject the payload instead.
+    if (payload === undefined || originator === undefined || id === undefined) {
         return undefined;
     }
 
@@ -29,12 +32,12 @@ const parseMessageBird = (body: string): InboundMessage | undefined => {
         channel: "sms",
         conversationId: asString(payload.recipient),
         from: { id: originator },
-        id: asString(payload.id) ?? "",
+        id,
         metadata: { direction: payload.direction },
         provider: "messagebird",
         raw: payload,
         text,
-        timestamp: createdAt === undefined ? new Date() : new Date(createdAt),
+        timestamp: asDate(createdAt),
         type: "message",
     };
 };

--- a/packages/notification/notification/src/inbound/channels/messagebird.ts
+++ b/packages/notification/notification/src/inbound/channels/messagebird.ts
@@ -3,7 +3,7 @@ import type { SmsPayload } from "../../types";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
 import { smsReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "messagebird-signature-jwt";
@@ -42,7 +42,7 @@ const parseMessageBird = (body: string): InboundMessage | undefined => {
 /**
  * Options for the MessageBird inbound receiver.
  */
-export interface MessageBirdInboundOptions extends InboundChannelOptions {
+export interface MessageBirdReceiverOptions extends ReceiverOptions {
     /** The outbound MessageBird SMS provider used by `context.reply()`. Optional. */
     provider?: Provider<unknown, SmsPayload>;
 
@@ -64,10 +64,10 @@ export interface MessageBirdInboundOptions extends InboundChannelOptions {
  * and `payload_hash` (SHA-256 of the body) — each of which is checked before dispatch.
  *
  * MessageBird has no synchronous reply; acknowledge and answer via `context.reply()`.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createMessageBirdInbound = (options: MessageBirdInboundOptions): InboundChannel => {
+export const createMessageBirdReceiver = (options: MessageBirdReceiverOptions): Receiver => {
     return {
         channel: "sms",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/messagebird.ts
+++ b/packages/notification/notification/src/inbound/channels/messagebird.ts
@@ -1,0 +1,112 @@
+import type { Provider } from "../../providers/provider";
+import type { SmsPayload } from "../../types";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
+import { smsReply } from "../reply";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+
+const SIGNATURE_HEADER = "messagebird-signature-jwt";
+
+/**
+ * Maps a MessageBird inbound-message (MO) payload to a normalised {@link InboundMessage}, or
+ * `undefined` when the body is not a recognised inbound message.
+ * @param body The raw request body.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseMessageBird = (body: string): InboundMessage | undefined => {
+    const payload = tryParseObject(body);
+    const originator = asString(payload?.originator);
+    const text = asString(payload?.body);
+
+    if (payload === undefined || originator === undefined) {
+        return undefined;
+    }
+
+    const createdAt = asString(payload.createdDatetime);
+
+    return {
+        channel: "sms",
+        conversationId: asString(payload.recipient),
+        from: { id: originator },
+        id: asString(payload.id) ?? "",
+        metadata: { direction: payload.direction },
+        provider: "messagebird",
+        raw: payload,
+        text,
+        timestamp: createdAt === undefined ? new Date() : new Date(createdAt),
+        type: "message",
+    };
+};
+
+/**
+ * Options for the MessageBird inbound receiver.
+ */
+export interface MessageBirdInboundOptions extends InboundChannelOptions {
+    /** The outbound MessageBird SMS provider used by `context.reply()`. Optional. */
+    provider?: Provider<unknown, SmsPayload>;
+
+    /** The webhook signing key from the MessageBird dashboard (verifies the JWT signature). */
+    signingKey: string;
+
+    /**
+     * The public URL MessageBird signed (the `url_hash` claim covers the full URL). Set this
+     * when `request.url` differs from the configured webhook URL (proxy/rewrite). Defaults to
+     * `request.url`.
+     */
+    url?: string;
+}
+
+/**
+ * Creates a MessageBird inbound receiver. Requests are verified with MessageBird's
+ * `messagebird-signature-jwt` scheme: an HS256 JWT signed with the signing key whose claims
+ * bind the request — `iss` (`MessageBird`), `jti`, `exp`, `url_hash` (SHA-256 of the full URL)
+ * and `payload_hash` (SHA-256 of the body) — each of which is checked before dispatch.
+ *
+ * MessageBird has no synchronous reply; acknowledge and answer via `context.reply()`.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createMessageBirdInbound = (options: MessageBirdInboundOptions): InboundChannel => {
+    return {
+        channel: "sms",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+            const token = getHeader(headers, SIGNATURE_HEADER);
+
+            if (token === undefined) {
+                return rejectionResponse("missing_signature", request, options.onError);
+            }
+
+            const claims = await verifyHs256Jwt(token, options.signingKey);
+
+            if (claims === undefined) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (claims.iss !== "MessageBird" || typeof claims.jti !== "string" || !isJwtTimeValid(claims)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (claims.url_hash !== await sha256Hex(options.url ?? request.url)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (body.length > 0 && claims.payload_hash !== await sha256Hex(body)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            const message = parseMessageBird(body);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, reply: smsReply(message, options.provider), request });
+
+            return asRawResponse(result) ?? noContent();
+        },
+        provider: "messagebird",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/msteams.ts
+++ b/packages/notification/notification/src/inbound/channels/msteams.ts
@@ -4,7 +4,7 @@ import type { ChatPayload } from "../../types";
 import { hmacBase64, timingSafeEqual } from "../../webhooks/crypto";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { chatReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
 const AUTH_HEADER = "Authorization";
@@ -45,7 +45,7 @@ const parseTeams = (body: string): InboundMessage | undefined => {
 /**
  * Options for the Microsoft Teams inbound receiver (outgoing webhook).
  */
-export interface MsTeamsInboundOptions extends InboundChannelOptions {
+export interface MsTeamsReceiverOptions extends ReceiverOptions {
     /** The outbound Teams chat provider used by `context.reply()`. Optional. */
     provider?: Provider<unknown, ChatPayload>;
 
@@ -64,10 +64,10 @@ export interface MsTeamsInboundOptions extends InboundChannelOptions {
  *
  * A handler may return an {@link ../types.InboundReply}; its `text` is serialised into a Bot
  * Framework message activity in the HTTP response, which Teams renders as the reply.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createMsTeamsInbound = (options: MsTeamsInboundOptions): InboundChannel => {
+export const createMsTeamsReceiver = (options: MsTeamsReceiverOptions): Receiver => {
     return {
         channel: "chat",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/msteams.ts
+++ b/packages/notification/notification/src/inbound/channels/msteams.ts
@@ -1,0 +1,117 @@
+import type { Provider } from "../../providers/provider";
+import { fromBase64Url } from "../../providers/utils/webcrypto";
+import type { ChatPayload } from "../../types";
+import { hmacBase64, timingSafeEqual } from "../../webhooks/crypto";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import { chatReply } from "../reply";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
+
+const AUTH_HEADER = "Authorization";
+const HMAC_PREFIX = "HMAC ";
+
+/**
+ * Maps a Microsoft Teams Bot Framework activity to a normalised {@link InboundMessage}, or
+ * `undefined` for non-message activities the receiver does not dispatch.
+ * @param body The raw request body.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseTeams = (body: string): InboundMessage | undefined => {
+    const activity = tryParseObject(body);
+
+    if (activity?.type !== "message") {
+        return undefined;
+    }
+
+    const from = activity.from as Record<string, unknown> | undefined;
+    const conversation = activity.conversation as Record<string, unknown> | undefined;
+    const timestamp = asString(activity.timestamp);
+
+    return {
+        channel: "chat",
+        conversationId: asString(conversation?.id),
+        from: { id: asString(from?.id) ?? "", name: asString(from?.name) },
+        id: asString(activity.id) ?? "",
+        metadata: { channelId: activity.channelId, serviceUrl: activity.serviceUrl },
+        provider: "msteams",
+        raw: activity,
+        text: asString(activity.text),
+        threadId: asString(conversation?.id),
+        timestamp: timestamp === undefined ? new Date() : new Date(timestamp),
+        type: "message",
+    };
+};
+
+/**
+ * Options for the Microsoft Teams inbound receiver (outgoing webhook).
+ */
+export interface MsTeamsInboundOptions extends InboundChannelOptions {
+    /** The outbound Teams chat provider used by `context.reply()`. Optional. */
+    provider?: Provider<unknown, ChatPayload>;
+
+    /**
+     * The security token (HMAC key) Teams issued when the outgoing webhook was created. It is
+     * base64-decoded to key the HMAC that verifies the `Authorization` header.
+     */
+    securityToken: string;
+}
+
+/**
+ * Creates a Microsoft Teams inbound receiver for outgoing webhooks. Requests are verified with
+ * Teams' HMAC scheme — base64 HMAC-SHA256 over the raw request body, keyed by the
+ * base64-decoded security token, carried in the `Authorization` header as `HMAC` plus the
+ * signature.
+ *
+ * A handler may return an {@link ../types.InboundReply}; its `text` is serialised into a Bot
+ * Framework message activity in the HTTP response, which Teams renders as the reply.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createMsTeamsInbound = (options: MsTeamsInboundOptions): InboundChannel => {
+    return {
+        channel: "chat",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+            const auth = getHeader(headers, AUTH_HEADER);
+
+            if (auth?.startsWith(HMAC_PREFIX) !== true) {
+                return rejectionResponse("missing_signature", request, options.onError);
+            }
+
+            let expected: string;
+
+            try {
+                expected = await hmacBase64(fromBase64Url(options.securityToken), body, "SHA-256");
+            } catch {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (!timingSafeEqual(expected, auth.slice(HMAC_PREFIX.length))) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            const message = parseTeams(body);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, reply: chatReply("msteams", message, options.provider), request });
+            const raw = asRawResponse(result);
+
+            if (raw !== undefined) {
+                return raw;
+            }
+
+            const reply = asReply(result);
+
+            if (reply !== undefined) {
+                return jsonResponse({ text: reply.text, type: "message", ...reply.raw });
+            }
+
+            return new Response(undefined, { status: 200 });
+        },
+        provider: "msteams",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/msteams.ts
+++ b/packages/notification/notification/src/inbound/channels/msteams.ts
@@ -5,7 +5,7 @@ import { hmacBase64, timingSafeEqual } from "../../webhooks/crypto";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { chatReply } from "../reply";
 import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
-import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
+import { asDate, asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
 const AUTH_HEADER = "Authorization";
 const HMAC_PREFIX = "HMAC ";
@@ -37,7 +37,7 @@ const parseTeams = (body: string): InboundMessage | undefined => {
         raw: activity,
         text: asString(activity.text),
         threadId: asString(conversation?.id),
-        timestamp: timestamp === undefined ? new Date() : new Date(timestamp),
+        timestamp: asDate(timestamp),
         type: "message",
     };
 };

--- a/packages/notification/notification/src/inbound/channels/slack.ts
+++ b/packages/notification/notification/src/inbound/channels/slack.ts
@@ -3,7 +3,7 @@ import type { ChatPayload } from "../../types";
 import { slackWebhook } from "../../webhooks/slack";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { chatReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "X-Slack-Signature";
@@ -111,7 +111,7 @@ const parseSlack = (body: string, contentType: string): InboundMessage | undefin
 /**
  * Options for the Slack inbound receiver.
  */
-export interface SlackInboundOptions extends InboundChannelOptions {
+export interface SlackReceiverOptions extends ReceiverOptions {
     /**
      * The outbound Slack chat provider used by `context.reply()` (and for replying to Events
      * API deliveries, which cannot answer in the HTTP response). Optional.
@@ -129,10 +129,10 @@ export interface SlackInboundOptions extends InboundChannelOptions {
  * Slash-command and interaction handlers may return an {@link ../types.InboundReply} to post
  * a synchronous message in the HTTP response; Events API deliveries are acknowledged with
  * `200` and should be replied to through the outbound Slack provider.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createSlackInbound = (options: SlackInboundOptions): InboundChannel => {
+export const createSlackReceiver = (options: SlackReceiverOptions): Receiver => {
     return {
         channel: "chat",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/slack.ts
+++ b/packages/notification/notification/src/inbound/channels/slack.ts
@@ -1,5 +1,8 @@
+import type { Provider } from "../../providers/provider";
+import type { ChatPayload } from "../../types";
 import { slackWebhook } from "../../webhooks/slack";
 import { getHeader, tryParseObject } from "../../webhooks/types";
+import { chatReply } from "../reply";
 import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
 import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
@@ -109,6 +112,11 @@ const parseSlack = (body: string, contentType: string): InboundMessage | undefin
  * Options for the Slack inbound receiver.
  */
 export interface SlackInboundOptions extends InboundChannelOptions {
+    /**
+     * The outbound Slack chat provider used by `context.reply()` (and for replying to Events
+     * API deliveries, which cannot answer in the HTTP response). Optional.
+     */
+    provider?: Provider<unknown, ChatPayload>;
     /** The Slack app signing secret, used to verify `X-Slack-Signature`. */
     signingSecret: string;
 }
@@ -156,7 +164,7 @@ export const createSlackInbound = (options: SlackInboundOptions): InboundChannel
                 return noContent();
             }
 
-            const result = await options.onMessage(message, { body, headers, request });
+            const result = await options.onMessage(message, { body, headers, reply: chatReply("slack", message, options.provider), request });
             const raw = asRawResponse(result);
 
             if (raw !== undefined) {

--- a/packages/notification/notification/src/inbound/channels/slack.ts
+++ b/packages/notification/notification/src/inbound/channels/slack.ts
@@ -1,0 +1,177 @@
+import { slackWebhook } from "../../webhooks/slack";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
+
+const SIGNATURE_HEADER = "X-Slack-Signature";
+const LEADING_SLASH = /^\//u;
+
+/**
+ * Reads a value from a `URLSearchParams` as a string, or `undefined` when absent/empty.
+ * @param parameters The parsed form parameters.
+ * @param key The parameter name.
+ * @returns The value, or `undefined`.
+ */
+const formValue = (parameters: URLSearchParams, key: string): string | undefined => parameters.get(key) ?? undefined;
+
+/**
+ * Maps a verified Slack payload to a normalised {@link InboundMessage}, or `undefined` when
+ * the payload is not a message/command/interaction the receiver dispatches.
+ * @param body The raw request body.
+ * @param contentType The request content type.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseSlack = (body: string, contentType: string): InboundMessage | undefined => {
+    // Slash commands and interactions arrive form-encoded; Events API arrives as JSON.
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+        const parameters = new URLSearchParams(body);
+        const rawPayload = formValue(parameters, "payload");
+
+        if (rawPayload !== undefined) {
+            const payload = tryParseObject(rawPayload);
+
+            if (payload === undefined) {
+                return undefined;
+            }
+
+            const user = payload.user as Record<string, unknown> | undefined;
+            const container = payload.container as Record<string, unknown> | undefined;
+            const channel = payload.channel as Record<string, unknown> | undefined;
+
+            return {
+                channel: "chat",
+                conversationId: asString(channel?.id),
+                from: { id: asString(user?.id) ?? "", name: asString(user?.name) },
+                id: asString(payload.trigger_id) ?? "",
+                metadata: { apiAppId: payload.api_app_id, teamId: (payload.team as Record<string, unknown> | undefined)?.id },
+                provider: "slack",
+                raw: payload,
+                threadId: asString(container?.message_ts),
+                timestamp: new Date(),
+                type: "callback",
+            };
+        }
+
+        const command = formValue(parameters, "command");
+
+        if (command !== undefined) {
+            return {
+                channel: "chat",
+                command: { args: formValue(parameters, "text"), name: command.replace(LEADING_SLASH, "") },
+                conversationId: formValue(parameters, "channel_id"),
+                from: { id: formValue(parameters, "user_id") ?? "", username: formValue(parameters, "user_name") },
+                id: formValue(parameters, "trigger_id") ?? "",
+                metadata: { apiAppId: formValue(parameters, "api_app_id"), teamId: formValue(parameters, "team_id") },
+                provider: "slack",
+                raw: Object.fromEntries(parameters),
+                text: formValue(parameters, "text"),
+                timestamp: new Date(),
+                type: "command",
+            };
+        }
+
+        return undefined;
+    }
+
+    const parsed = tryParseObject(body);
+
+    if (parsed?.type !== "event_callback") {
+        return undefined;
+    }
+
+    const event = parsed.event as Record<string, unknown> | undefined;
+
+    if (event === undefined) {
+        return undefined;
+    }
+
+    const eventType = asString(event.type) ?? "";
+    const isMessage = eventType === "message" || eventType === "app_mention";
+    const ts = asString(event.ts);
+    const timestampSeconds = ts === undefined ? Number.NaN : Number.parseFloat(ts);
+
+    return {
+        channel: "chat",
+        conversationId: asString(event.channel),
+        from: { id: asString(event.user) ?? "", isBot: typeof event.bot_id === "string" },
+        id: asString(parsed.event_id) ?? ts ?? "",
+        metadata: { apiAppId: parsed.api_app_id, eventType, teamId: parsed.team_id },
+        provider: "slack",
+        raw: parsed,
+        text: asString(event.text),
+        threadId: asString(event.thread_ts) ?? ts,
+        timestamp: Number.isNaN(timestampSeconds) ? new Date() : new Date(timestampSeconds * 1000),
+        type: isMessage ? "message" : "event",
+    };
+};
+
+/**
+ * Options for the Slack inbound receiver.
+ */
+export interface SlackInboundOptions extends InboundChannelOptions {
+    /** The Slack app signing secret, used to verify `X-Slack-Signature`. */
+    signingSecret: string;
+}
+
+/**
+ * Creates a Slack inbound receiver covering the Events API, slash commands and interactive
+ * components. Requests are verified with Slack's v0 signing scheme (5-minute replay window)
+ * before dispatch, and the `url_verification` handshake is answered automatically.
+ *
+ * Slash-command and interaction handlers may return an {@link ../types.InboundReply} to post
+ * a synchronous message in the HTTP response; Events API deliveries are acknowledged with
+ * `200` and should be replied to through the outbound Slack provider.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createSlackInbound = (options: SlackInboundOptions): InboundChannel => {
+    return {
+        channel: "chat",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+
+            const verified = await slackWebhook.verify(body, headers, options.signingSecret);
+
+            if (!verified) {
+                const reason = getHeader(headers, SIGNATURE_HEADER) === undefined ? "missing_signature" : "invalid_signature";
+
+                return rejectionResponse(reason, request, options.onError);
+            }
+
+            const contentType = getHeader(headers, "content-type") ?? "";
+
+            // Answer the one-time URL verification handshake without invoking the handler.
+            if (contentType.includes("application/json")) {
+                const parsed = tryParseObject(body);
+
+                if (parsed?.type === "url_verification") {
+                    return jsonResponse({ challenge: parsed.challenge });
+                }
+            }
+
+            const message = parseSlack(body, contentType);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, request });
+            const raw = asRawResponse(result);
+
+            if (raw !== undefined) {
+                return raw;
+            }
+
+            const reply = asReply(result);
+
+            // Only slash commands / interactions can carry a synchronous reply in the response body.
+            if (reply !== undefined && (message.type === "command" || message.type === "callback")) {
+                return jsonResponse({ blocks: reply.blocks, text: reply.text, ...reply.raw });
+            }
+
+            return new Response(undefined, { status: 200 });
+        },
+        provider: "slack",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/telegram.ts
+++ b/packages/notification/notification/src/inbound/channels/telegram.ts
@@ -1,5 +1,8 @@
+import type { Provider } from "../../providers/provider";
+import type { ChatPayload } from "../../types";
 import { timingSafeEqual } from "../../webhooks/crypto";
 import { getHeader, tryParseObject } from "../../webhooks/types";
+import { chatReply } from "../reply";
 import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
 import { asId, asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
@@ -104,6 +107,9 @@ const parseTelegram = (update: Record<string, unknown>): InboundMessage | undefi
  * Options for the Telegram inbound receiver.
  */
 export interface TelegramInboundOptions extends InboundChannelOptions {
+    /** The outbound Telegram chat provider used by `context.reply()`. Optional. */
+    provider?: Provider<unknown, ChatPayload>;
+
     /**
      * The secret token configured via `setWebhook`'s `secret_token`. When set, the receiver
      * requires a matching `X-Telegram-Bot-Api-Secret-Token` header. Strongly recommended —
@@ -154,7 +160,7 @@ export const createTelegramInbound = (options: TelegramInboundOptions): InboundC
                 return noContent();
             }
 
-            const result = await options.onMessage(message, { body, headers, request });
+            const result = await options.onMessage(message, { body, headers, reply: chatReply("telegram", message, options.provider), request });
             const raw = asRawResponse(result);
 
             if (raw !== undefined) {

--- a/packages/notification/notification/src/inbound/channels/telegram.ts
+++ b/packages/notification/notification/src/inbound/channels/telegram.ts
@@ -9,6 +9,9 @@ import { asId, asRawResponse, asReply, asString, headersToRecord, jsonResponse, 
 const SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token";
 const WHITESPACE = /\s/u;
 
+/** A forum topic id, which Telegram always reports as a positive integer. */
+const TOPIC_ID = /^\d+$/u;
+
 /**
  * Parses a Telegram message body into a bot command, or `undefined` when the text is absent
  * or not a `/`-prefixed command. Splits on the first whitespace into `/name[@bot]` and the
@@ -170,10 +173,16 @@ export const createTelegramReceiver = (options: TelegramReceiverOptions): Receiv
             const reply = asReply(result);
 
             if (reply !== undefined && message.conversationId !== undefined) {
+                // `threadId` round-trips Telegram's `message_thread_id`, which identifies a forum
+                // topic — not a message. Sending it as `reply_parameters.message_id` quotes
+                // whichever message happens to carry that id, or fails outright. Non-integer
+                // values are not thread ids at all, so they are dropped.
+                const threadId = reply.threadId !== undefined && TOPIC_ID.test(reply.threadId) ? Number.parseInt(reply.threadId, 10) : undefined;
+
                 return jsonResponse({
                     chat_id: message.conversationId,
+                    message_thread_id: threadId,
                     method: "sendMessage",
-                    reply_parameters: reply.threadId === undefined ? undefined : { message_id: Number.parseInt(reply.threadId, 10) },
                     text: reply.text,
                     ...reply.raw,
                 });

--- a/packages/notification/notification/src/inbound/channels/telegram.ts
+++ b/packages/notification/notification/src/inbound/channels/telegram.ts
@@ -1,0 +1,180 @@
+import { timingSafeEqual } from "../../webhooks/crypto";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asId, asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
+
+const SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token";
+const WHITESPACE = /\s/u;
+
+/**
+ * Parses a Telegram message body into a bot command, or `undefined` when the text is absent
+ * or not a `/`-prefixed command. Splits on the first whitespace into `/name[@bot]` and the
+ * argument tail, scanning linearly to avoid regex backtracking.
+ * @param text The message text.
+ * @returns The parsed command, or `undefined`.
+ */
+const parseCommand = (text: string | undefined): InboundMessage["command"] => {
+    if (!text?.startsWith("/")) {
+        return undefined;
+    }
+
+    const rest = text.slice(1);
+    const splitAt = rest.search(WHITESPACE);
+    const head = splitAt === -1 ? rest : rest.slice(0, splitAt);
+    const name = head.split("@")[0] ?? "";
+
+    if (name.length === 0) {
+        return undefined;
+    }
+
+    const args = splitAt === -1 ? "" : rest.slice(splitAt + 1).trim();
+
+    return { args: args.length === 0 ? undefined : args, name };
+};
+
+/**
+ * Maps a Telegram participant record to a normalised {@link InboundMessage.from}.
+ * @param user The Telegram `from` record.
+ * @returns The normalised participant.
+ */
+const participant = (user: Record<string, unknown> | undefined): InboundMessage["from"] => {
+    return {
+        id: asId(user?.id) ?? "",
+        isBot: user?.is_bot === true,
+        name: asString(user?.first_name),
+        username: asString(user?.username),
+    };
+};
+
+/**
+ * Maps a Telegram update to a normalised {@link InboundMessage}, handling both plain messages
+ * and callback queries, or `undefined` for updates the receiver does not dispatch.
+ * @param update The Telegram update payload.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseTelegram = (update: Record<string, unknown>): InboundMessage | undefined => {
+    const updateId = asId(update.update_id) ?? "";
+    const callbackQuery = update.callback_query as Record<string, unknown> | undefined;
+
+    if (callbackQuery !== undefined) {
+        const message = callbackQuery.message as Record<string, unknown> | undefined;
+        const chat = message?.chat as Record<string, unknown> | undefined;
+
+        return {
+            channel: "chat",
+            conversationId: asId(chat?.id),
+            from: participant(callbackQuery.from as Record<string, unknown> | undefined),
+            id: asString(callbackQuery.id) ?? updateId,
+            provider: "telegram",
+            raw: update,
+            text: asString(callbackQuery.data),
+            timestamp: new Date(),
+            type: "callback",
+        };
+    }
+
+    const message = (update.message ?? update.edited_message) as Record<string, unknown> | undefined;
+
+    if (message === undefined) {
+        return undefined;
+    }
+
+    const chat = message.chat as Record<string, unknown> | undefined;
+    const dateSeconds = typeof message.date === "number" ? message.date : Number.NaN;
+    const text = asString(message.text);
+    const command = parseCommand(text);
+
+    return {
+        channel: "chat",
+        command,
+        conversationId: asId(chat?.id),
+        from: participant(message.from as Record<string, unknown> | undefined),
+        id: asId(message.message_id) ?? updateId,
+        metadata: { chatType: chat?.type },
+        provider: "telegram",
+        raw: update,
+        text,
+        threadId: asId(message.message_thread_id),
+        timestamp: Number.isNaN(dateSeconds) ? new Date() : new Date(dateSeconds * 1000),
+        type: command === undefined ? "message" : "command",
+    };
+};
+
+/**
+ * Options for the Telegram inbound receiver.
+ */
+export interface TelegramInboundOptions extends InboundChannelOptions {
+    /**
+     * The secret token configured via `setWebhook`'s `secret_token`. When set, the receiver
+     * requires a matching `X-Telegram-Bot-Api-Secret-Token` header. Strongly recommended —
+     * Telegram updates are otherwise unauthenticated.
+     */
+    secretToken?: string;
+}
+
+/**
+ * Creates a Telegram inbound receiver for bot webhook updates. When {@link
+ * TelegramInboundOptions.secretToken} is set, the `X-Telegram-Bot-Api-Secret-Token` header is
+ * verified before dispatch.
+ *
+ * A handler may return an {@link ../types.InboundReply}; it is serialised into a Telegram
+ * `sendMessage` method call in the response body (`chat_id` taken from the originating chat),
+ * which Telegram executes as the reply. Return `raw` to invoke a different method.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createTelegramInbound = (options: TelegramInboundOptions): InboundChannel => {
+    return {
+        channel: "chat",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+
+            if (options.secretToken !== undefined && options.secretToken !== "") {
+                const provided = getHeader(headers, SECRET_HEADER);
+
+                if (provided === undefined) {
+                    return rejectionResponse("missing_signature", request, options.onError);
+                }
+
+                if (!timingSafeEqual(provided, options.secretToken)) {
+                    return rejectionResponse("invalid_signature", request, options.onError);
+                }
+            }
+
+            const update = tryParseObject(body);
+
+            if (update === undefined) {
+                return rejectionResponse("invalid_body", request, options.onError);
+            }
+
+            const message = parseTelegram(update);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, request });
+            const raw = asRawResponse(result);
+
+            if (raw !== undefined) {
+                return raw;
+            }
+
+            const reply = asReply(result);
+
+            if (reply !== undefined && message.conversationId !== undefined) {
+                return jsonResponse({
+                    chat_id: message.conversationId,
+                    method: "sendMessage",
+                    reply_parameters: reply.threadId === undefined ? undefined : { message_id: Number.parseInt(reply.threadId, 10) },
+                    text: reply.text,
+                    ...reply.raw,
+                });
+            }
+
+            return noContent();
+        },
+        provider: "telegram",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/telegram.ts
+++ b/packages/notification/notification/src/inbound/channels/telegram.ts
@@ -3,7 +3,7 @@ import type { ChatPayload } from "../../types";
 import { timingSafeEqual } from "../../webhooks/crypto";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { chatReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asId, asRawResponse, asReply, asString, headersToRecord, jsonResponse, noContent, rejectionResponse } from "../utils";
 
 const SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token";
@@ -106,7 +106,7 @@ const parseTelegram = (update: Record<string, unknown>): InboundMessage | undefi
 /**
  * Options for the Telegram inbound receiver.
  */
-export interface TelegramInboundOptions extends InboundChannelOptions {
+export interface TelegramReceiverOptions extends ReceiverOptions {
     /** The outbound Telegram chat provider used by `context.reply()`. Optional. */
     provider?: Provider<unknown, ChatPayload>;
 
@@ -120,16 +120,16 @@ export interface TelegramInboundOptions extends InboundChannelOptions {
 
 /**
  * Creates a Telegram inbound receiver for bot webhook updates. When {@link
- * TelegramInboundOptions.secretToken} is set, the `X-Telegram-Bot-Api-Secret-Token` header is
+ * TelegramReceiverOptions.secretToken} is set, the `X-Telegram-Bot-Api-Secret-Token` header is
  * verified before dispatch.
  *
  * A handler may return an {@link ../types.InboundReply}; it is serialised into a Telegram
  * `sendMessage` method call in the response body (`chat_id` taken from the originating chat),
  * which Telegram executes as the reply. Return `raw` to invoke a different method.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createTelegramInbound = (options: TelegramInboundOptions): InboundChannel => {
+export const createTelegramReceiver = (options: TelegramReceiverOptions): Receiver => {
     return {
         channel: "chat",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/telnyx.ts
+++ b/packages/notification/notification/src/inbound/channels/telnyx.ts
@@ -4,7 +4,7 @@ import { isWithinReplayWindow, REPLAY_WINDOW_SECONDS } from "../../webhooks/cryp
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { verifyEd25519Base64 } from "../ed25519";
 import { smsReply } from "../reply";
-import type { InboundAttachment, InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundAttachment, InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "telnyx-signature-ed25519";
@@ -64,7 +64,7 @@ const parseTelnyx = (body: string): InboundMessage | undefined => {
 /**
  * Options for the Telnyx inbound receiver.
  */
-export interface TelnyxInboundOptions extends InboundChannelOptions {
+export interface TelnyxReceiverOptions extends ReceiverOptions {
     /** The outbound Telnyx SMS provider used by `context.reply()`. Optional. */
     provider?: Provider<unknown, SmsPayload>;
     /** The account's Ed25519 public key (base64), from the Telnyx Mission Control portal. */
@@ -79,10 +79,10 @@ export interface TelnyxInboundOptions extends InboundChannelOptions {
  *
  * Telnyx has no synchronous reply, so acknowledge and answer through `context.reply()` (or the
  * outbound Telnyx provider).
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createTelnyxInbound = (options: TelnyxInboundOptions): InboundChannel => {
+export const createTelnyxReceiver = (options: TelnyxReceiverOptions): Receiver => {
     return {
         channel: "sms",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/telnyx.ts
+++ b/packages/notification/notification/src/inbound/channels/telnyx.ts
@@ -5,7 +5,7 @@ import { getHeader, tryParseObject } from "../../webhooks/types";
 import { verifyEd25519Base64 } from "../ed25519";
 import { smsReply } from "../reply";
 import type { InboundAttachment, InboundMessage, Receiver, ReceiverOptions } from "../types";
-import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+import { asDate, asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "telnyx-signature-ed25519";
 const TIMESTAMP_HEADER = "telnyx-timestamp";
@@ -22,8 +22,10 @@ const parseMedia = (payload: Record<string, unknown>): InboundAttachment[] | und
         return undefined;
     }
 
-    return media.map((item: Record<string, unknown>) => {
-        return { contentType: asString(item.content_type), url: asString(item.url) };
+    return media.map((item) => {
+        const entry = item as Record<string, unknown>;
+
+        return { contentType: asString(entry.content_type), url: asString(entry.url) };
     });
 };
 
@@ -56,7 +58,7 @@ const parseTelnyx = (body: string): InboundMessage | undefined => {
         provider: "telnyx",
         raw: envelope,
         text: asString(payload.text),
-        timestamp: receivedAt === undefined ? new Date() : new Date(receivedAt),
+        timestamp: asDate(receivedAt),
         type: "message",
     };
 };

--- a/packages/notification/notification/src/inbound/channels/telnyx.ts
+++ b/packages/notification/notification/src/inbound/channels/telnyx.ts
@@ -1,0 +1,118 @@
+import type { Provider } from "../../providers/provider";
+import type { SmsPayload } from "../../types";
+import { isWithinReplayWindow, REPLAY_WINDOW_SECONDS } from "../../webhooks/crypto";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import { verifyEd25519Base64 } from "../ed25519";
+import { smsReply } from "../reply";
+import type { InboundAttachment, InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+
+const SIGNATURE_HEADER = "telnyx-signature-ed25519";
+const TIMESTAMP_HEADER = "telnyx-timestamp";
+
+/**
+ * Extracts media attachments from a Telnyx inbound message payload.
+ * @param payload The `data.payload` object.
+ * @returns The attachments, or `undefined` when none are present.
+ */
+const parseMedia = (payload: Record<string, unknown>): InboundAttachment[] | undefined => {
+    const { media } = payload;
+
+    if (!Array.isArray(media) || media.length === 0) {
+        return undefined;
+    }
+
+    return media.map((item: Record<string, unknown>) => {
+        return { contentType: asString(item.content_type), url: asString(item.url) };
+    });
+};
+
+/**
+ * Maps a verified Telnyx `message.received` webhook to a normalised {@link InboundMessage}, or
+ * `undefined` for other event types (e.g. outbound delivery receipts).
+ * @param body The raw request body.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseTelnyx = (body: string): InboundMessage | undefined => {
+    const envelope = tryParseObject(body);
+    const data = envelope?.data as Record<string, unknown> | undefined;
+    const payload = data?.payload as Record<string, unknown> | undefined;
+
+    if (payload === undefined || asString(data?.event_type) !== "message.received") {
+        return undefined;
+    }
+
+    const from = payload.from as Record<string, unknown> | undefined;
+    const to = payload.to as Record<string, unknown>[] | undefined;
+    const receivedAt = asString(payload.received_at);
+
+    return {
+        attachments: parseMedia(payload),
+        channel: "sms",
+        conversationId: asString(to?.[0]?.phone_number),
+        from: { id: asString(from?.phone_number) ?? "" },
+        id: asString(payload.id) ?? "",
+        metadata: { direction: payload.direction, messagingProfileId: payload.messaging_profile_id, transport: asString(payload.type) },
+        provider: "telnyx",
+        raw: envelope,
+        text: asString(payload.text),
+        timestamp: receivedAt === undefined ? new Date() : new Date(receivedAt),
+        type: "message",
+    };
+};
+
+/**
+ * Options for the Telnyx inbound receiver.
+ */
+export interface TelnyxInboundOptions extends InboundChannelOptions {
+    /** The outbound Telnyx SMS provider used by `context.reply()`. Optional. */
+    provider?: Provider<unknown, SmsPayload>;
+    /** The account's Ed25519 public key (base64), from the Telnyx Mission Control portal. */
+    publicKey: string;
+}
+
+/**
+ * Creates a Telnyx inbound receiver for incoming SMS/MMS. Requests are verified with Telnyx's
+ * Ed25519 scheme — the `telnyx-signature-ed25519` header (base64) over `{timestamp}|{body}`,
+ * checked against the account public key, with the `telnyx-timestamp` held to a 5-minute
+ * replay window.
+ *
+ * Telnyx has no synchronous reply, so acknowledge and answer through `context.reply()` (or the
+ * outbound Telnyx provider).
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createTelnyxInbound = (options: TelnyxInboundOptions): InboundChannel => {
+    return {
+        channel: "sms",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+            const signature = getHeader(headers, SIGNATURE_HEADER);
+            const timestamp = getHeader(headers, TIMESTAMP_HEADER);
+
+            if (signature === undefined || timestamp === undefined) {
+                return rejectionResponse("missing_signature", request, options.onError);
+            }
+
+            if (!isWithinReplayWindow(timestamp, REPLAY_WINDOW_SECONDS)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (!await verifyEd25519Base64(options.publicKey, signature, `${timestamp}|${body}`)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            const message = parseTelnyx(body);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, reply: smsReply(message, options.provider), request });
+
+            return asRawResponse(result) ?? noContent();
+        },
+        provider: "telnyx",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/twilio.ts
+++ b/packages/notification/notification/src/inbound/channels/twilio.ts
@@ -3,7 +3,7 @@ import type { SmsPayload } from "../../types";
 import { twilioWebhook } from "../../webhooks/twilio";
 import { getHeader } from "../../webhooks/types";
 import { smsReply } from "../reply";
-import type { InboundAttachment, InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundAttachment, InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asReply, headersToRecord, rejectionResponse } from "../utils";
 
 const SIGNATURE_HEADER = "X-Twilio-Signature";
@@ -75,7 +75,7 @@ const parseTwilio = (parameters: URLSearchParams): InboundMessage => {
 /**
  * Options for the Twilio inbound receiver (SMS and WhatsApp).
  */
-export interface TwilioInboundOptions extends InboundChannelOptions {
+export interface TwilioReceiverOptions extends ReceiverOptions {
     /** The Twilio auth token, used to verify `X-Twilio-Signature`. */
     authToken: string;
 
@@ -100,10 +100,10 @@ export interface TwilioInboundOptions extends InboundChannelOptions {
  *
  * A handler may return an {@link ../types.InboundReply}; its `text` is serialised into a TwiML
  * message element. Returning nothing acknowledges with an empty TwiML document.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createTwilioInbound = (options: TwilioInboundOptions): InboundChannel => {
+export const createTwilioReceiver = (options: TwilioReceiverOptions): Receiver => {
     return {
         channel: "sms",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/twilio.ts
+++ b/packages/notification/notification/src/inbound/channels/twilio.ts
@@ -1,5 +1,8 @@
+import type { Provider } from "../../providers/provider";
+import type { SmsPayload } from "../../types";
 import { twilioWebhook } from "../../webhooks/twilio";
 import { getHeader } from "../../webhooks/types";
+import { smsReply } from "../reply";
 import type { InboundAttachment, InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
 import { asRawResponse, asReply, headersToRecord, rejectionResponse } from "../utils";
 
@@ -77,6 +80,12 @@ export interface TwilioInboundOptions extends InboundChannelOptions {
     authToken: string;
 
     /**
+     * The outbound Twilio SMS provider used by `context.reply()`, which addresses the reply
+     * back to the sender (re-applying the `whatsapp:` prefix for WhatsApp). Optional.
+     */
+    provider?: Provider<unknown, SmsPayload>;
+
+    /**
      * The public URL Twilio signed the request against. Twilio's signature covers the exact
      * webhook URL it was configured with, so behind a proxy or rewrite (where `request.url`
      * differs) set this to the configured URL. Defaults to `request.url`.
@@ -113,7 +122,7 @@ export const createTwilioInbound = (options: TwilioInboundOptions): InboundChann
             }
 
             const message = parseTwilio(new URLSearchParams(body));
-            const result = await options.onMessage(message, { body, headers, request });
+            const result = await options.onMessage(message, { body, headers, reply: smsReply(message, options.provider), request });
             const raw = asRawResponse(result);
 
             if (raw !== undefined) {

--- a/packages/notification/notification/src/inbound/channels/twilio.ts
+++ b/packages/notification/notification/src/inbound/channels/twilio.ts
@@ -1,0 +1,127 @@
+import { twilioWebhook } from "../../webhooks/twilio";
+import { getHeader } from "../../webhooks/types";
+import type { InboundAttachment, InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asReply, headersToRecord, rejectionResponse } from "../utils";
+
+const SIGNATURE_HEADER = "X-Twilio-Signature";
+const WHATSAPP_PREFIX = "whatsapp:";
+
+/**
+ * Escapes the five XML predefined entities so message text is safe to embed in TwiML.
+ * @param value The text to escape.
+ * @returns The escaped text.
+ */
+const escapeXml = (value: string): string =>
+    value
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll("\"", "&quot;")
+        .replaceAll("'", "&apos;");
+
+/**
+ * Builds a TwiML response document, optionally carrying a single message element.
+ * @param text The reply text, or `undefined` for an empty acknowledgement.
+ * @returns The TwiML response.
+ */
+const twiml = (text: string | undefined): Response => {
+    const inner = text === undefined ? "" : `<Message>${escapeXml(text)}</Message>`;
+    // eslint-disable-next-line no-secrets/no-secrets -- static TwiML document scaffold, not a credential
+    const document = `<?xml version="1.0" encoding="UTF-8"?><Response>${inner}</Response>`;
+
+    return new Response(document, { headers: { "content-type": "text/xml; charset=utf-8" }, status: 200 });
+};
+
+/**
+ * Maps a verified Twilio inbound webhook to a normalised {@link InboundMessage}. The channel
+ * is reported as `"sms"`; WhatsApp is distinguished by the `whatsapp:` address prefix (kept
+ * in `metadata.transport`), with the prefix stripped from the participant ids.
+ * @param parameters The decoded form parameters.
+ * @returns The normalised message.
+ */
+const parseTwilio = (parameters: URLSearchParams): InboundMessage => {
+    const from = parameters.get("From") ?? "";
+    const to = parameters.get("To") ?? "";
+    const isWhatsApp = from.startsWith(WHATSAPP_PREFIX) || to.startsWith(WHATSAPP_PREFIX);
+    const mediaCount = Number.parseInt(parameters.get("NumMedia") ?? "0", 10);
+    const attachments: InboundAttachment[] = [];
+
+    for (let index = 0; index < mediaCount; index += 1) {
+        const url = parameters.get(`MediaUrl${String(index)}`);
+
+        if (url !== null) {
+            attachments.push({ contentType: parameters.get(`MediaContentType${String(index)}`) ?? undefined, url });
+        }
+    }
+
+    return {
+        attachments: attachments.length > 0 ? attachments : undefined,
+        channel: "sms",
+        conversationId: to.replace(WHATSAPP_PREFIX, ""),
+        from: { id: from.replace(WHATSAPP_PREFIX, ""), name: parameters.get("ProfileName") ?? undefined },
+        id: parameters.get("MessageSid") ?? parameters.get("SmsSid") ?? "",
+        metadata: { transport: isWhatsApp ? "whatsapp" : "sms" },
+        provider: "twilio",
+        raw: Object.fromEntries(parameters),
+        text: parameters.get("Body") ?? undefined,
+        timestamp: new Date(),
+        type: "message",
+    };
+};
+
+/**
+ * Options for the Twilio inbound receiver (SMS and WhatsApp).
+ */
+export interface TwilioInboundOptions extends InboundChannelOptions {
+    /** The Twilio auth token, used to verify `X-Twilio-Signature`. */
+    authToken: string;
+
+    /**
+     * The public URL Twilio signed the request against. Twilio's signature covers the exact
+     * webhook URL it was configured with, so behind a proxy or rewrite (where `request.url`
+     * differs) set this to the configured URL. Defaults to `request.url`.
+     */
+    url?: string;
+}
+
+/**
+ * Creates a Twilio inbound receiver for incoming SMS and WhatsApp messages. Requests are
+ * verified with Twilio's signature scheme (base64 HMAC-SHA1 over the request URL plus sorted
+ * form parameters) before dispatch.
+ *
+ * A handler may return an {@link ../types.InboundReply}; its `text` is serialised into a TwiML
+ * message element. Returning nothing acknowledges with an empty TwiML document.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createTwilioInbound = (options: TwilioInboundOptions): InboundChannel => {
+    return {
+        channel: "sms",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+
+            // twilioWebhook.verify reconstructs the signature base from the signed URL header.
+            headers["x-twilio-signature-url"] = options.url ?? request.url;
+
+            const verified = await twilioWebhook.verify(body, headers, options.authToken);
+
+            if (!verified) {
+                const reason = getHeader(headers, SIGNATURE_HEADER) === undefined ? "missing_signature" : "invalid_signature";
+
+                return rejectionResponse(reason, request, options.onError);
+            }
+
+            const message = parseTwilio(new URLSearchParams(body));
+            const result = await options.onMessage(message, { body, headers, request });
+            const raw = asRawResponse(result);
+
+            if (raw !== undefined) {
+                return raw;
+            }
+
+            return twiml(asReply(result)?.text);
+        },
+        provider: "twilio",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/twilio.ts
+++ b/packages/notification/notification/src/inbound/channels/twilio.ts
@@ -10,12 +10,25 @@ const SIGNATURE_HEADER = "X-Twilio-Signature";
 const WHATSAPP_PREFIX = "whatsapp:";
 
 /**
- * Escapes the five XML predefined entities so message text is safe to embed in TwiML.
+ * Control characters XML 1.0 forbids in character data: U+0000–U+0008, U+000B, U+000C and
+ * U+000E–U+001F. Tab, LF and CR are legal and are deliberately absent.
+ */
+// eslint-disable-next-line no-control-regex -- matching the control characters is the point
+const XML_ILLEGAL_CONTROLS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/gu;
+
+/**
+ * Escapes the five XML predefined entities and drops the control characters XML forbids, so
+ * message text is safe to embed in TwiML.
+ *
+ * Handler output routinely echoes the inbound `Body`, which is user-controlled. A single stray
+ * control character makes the document unparseable, and Twilio then reports a document-parse
+ * error instead of delivering the reply.
  * @param value The text to escape.
  * @returns The escaped text.
  */
 const escapeXml = (value: string): string =>
     value
+        .replaceAll(XML_ILLEGAL_CONTROLS, "")
         .replaceAll("&", "&amp;")
         .replaceAll("<", "&lt;")
         .replaceAll(">", "&gt;")

--- a/packages/notification/notification/src/inbound/channels/twilio.ts
+++ b/packages/notification/notification/src/inbound/channels/twilio.ts
@@ -14,7 +14,7 @@ const WHATSAPP_PREFIX = "whatsapp:";
  * U+000E–U+001F. Tab, LF and CR are legal and are deliberately absent.
  */
 // eslint-disable-next-line no-control-regex -- matching the control characters is the point
-const XML_ILLEGAL_CONTROLS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/gu;
+const XML_ILLEGAL_CONTROLS = /[\u0000-\u0008\v\f\u000E-\u001F]/gu;
 
 /**
  * Escapes the five XML predefined entities and drops the control characters XML forbids, so

--- a/packages/notification/notification/src/inbound/channels/vonage.ts
+++ b/packages/notification/notification/src/inbound/channels/vonage.ts
@@ -1,0 +1,110 @@
+import type { Provider } from "../../providers/provider";
+import type { SmsPayload } from "../../types";
+import { getHeader, tryParseObject } from "../../webhooks/types";
+import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
+import { smsReply } from "../reply";
+import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+
+const AUTH_HEADER = "Authorization";
+const BEARER_PREFIX = "Bearer ";
+
+/**
+ * Reads a Vonage party (`from` / `to`), which is a bare number string on the SMS channel and a
+ * `{ type, number }` object on newer channels.
+ * @param value The party field.
+ * @returns The phone number / address, or `undefined`.
+ */
+const partyNumber = (value: unknown): string | undefined => {
+    if (typeof value === "string") {
+        return value;
+    }
+
+    return asString((value as Record<string, unknown> | undefined)?.number);
+};
+
+/**
+ * Maps a Vonage Messages API inbound webhook to a normalised {@link InboundMessage}, or
+ * `undefined` when the body is not a recognised inbound message.
+ * @param body The raw request body.
+ * @returns The normalised message, or `undefined`.
+ */
+const parseVonage = (body: string): InboundMessage | undefined => {
+    const payload = tryParseObject(body);
+    const from = partyNumber(payload?.from);
+
+    if (payload === undefined || from === undefined) {
+        return undefined;
+    }
+
+    const timestamp = asString(payload.timestamp);
+
+    return {
+        channel: "sms",
+        conversationId: partyNumber(payload.to),
+        from: { id: from },
+        id: asString(payload.message_uuid) ?? "",
+        metadata: { channelType: payload.channel, messageType: payload.message_type },
+        provider: "vonage",
+        raw: payload,
+        text: asString(payload.text),
+        timestamp: timestamp === undefined ? new Date() : new Date(timestamp),
+        type: "message",
+    };
+};
+
+/**
+ * Options for the Vonage inbound receiver.
+ */
+export interface VonageInboundOptions extends InboundChannelOptions {
+    /** The outbound Vonage SMS provider used by `context.reply()`. Optional. */
+    provider?: Provider<unknown, SmsPayload>;
+    /** The account signature secret (verifies the `Authorization: Bearer` JWT). */
+    signatureSecret: string;
+}
+
+/**
+ * Creates a Vonage inbound receiver for the Messages API. Requests carry an HS256 JWT in the
+ * `Authorization: Bearer` header, signed with the account signature secret; the JWT's
+ * `payload_hash` claim (SHA-256 of the raw body) binds it to this request. Both the signature
+ * and `payload_hash` are checked, along with the token's validity window, before dispatch.
+ *
+ * Vonage has no synchronous reply; acknowledge and answer via `context.reply()`.
+ * @param options The receiver options.
+ * @returns The inbound channel.
+ */
+export const createVonageInbound = (options: VonageInboundOptions): InboundChannel => {
+    return {
+        channel: "sms",
+        handle: async (request: Request): Promise<Response> => {
+            const body = await request.text();
+            const headers = headersToRecord(request.headers);
+            const auth = getHeader(headers, AUTH_HEADER);
+
+            if (auth?.startsWith(BEARER_PREFIX) !== true) {
+                return rejectionResponse("missing_signature", request, options.onError);
+            }
+
+            const claims = await verifyHs256Jwt(auth.slice(BEARER_PREFIX.length), options.signatureSecret);
+
+            if (claims === undefined || !isJwtTimeValid(claims)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            if (body.length > 0 && claims.payload_hash !== await sha256Hex(body)) {
+                return rejectionResponse("invalid_signature", request, options.onError);
+            }
+
+            const message = parseVonage(body);
+
+            if (message === undefined) {
+                return noContent();
+            }
+
+            const result = await options.onMessage(message, { body, headers, reply: smsReply(message, options.provider), request });
+
+            return asRawResponse(result) ?? noContent();
+        },
+        provider: "vonage",
+    };
+};

--- a/packages/notification/notification/src/inbound/channels/vonage.ts
+++ b/packages/notification/notification/src/inbound/channels/vonage.ts
@@ -3,7 +3,7 @@ import type { SmsPayload } from "../../types";
 import { getHeader, tryParseObject } from "../../webhooks/types";
 import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
 import { smsReply } from "../reply";
-import type { InboundChannel, InboundChannelOptions, InboundMessage } from "../types";
+import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
 import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const AUTH_HEADER = "Authorization";
@@ -56,7 +56,7 @@ const parseVonage = (body: string): InboundMessage | undefined => {
 /**
  * Options for the Vonage inbound receiver.
  */
-export interface VonageInboundOptions extends InboundChannelOptions {
+export interface VonageReceiverOptions extends ReceiverOptions {
     /** The outbound Vonage SMS provider used by `context.reply()`. Optional. */
     provider?: Provider<unknown, SmsPayload>;
     /** The account signature secret (verifies the `Authorization: Bearer` JWT). */
@@ -70,10 +70,10 @@ export interface VonageInboundOptions extends InboundChannelOptions {
  * and `payload_hash` are checked, along with the token's validity window, before dispatch.
  *
  * Vonage has no synchronous reply; acknowledge and answer via `context.reply()`.
- * @param options The receiver options.
+ * @param options Verification config, the message handler and an optional reply provider.
  * @returns The inbound channel.
  */
-export const createVonageInbound = (options: VonageInboundOptions): InboundChannel => {
+export const createVonageReceiver = (options: VonageReceiverOptions): Receiver => {
     return {
         channel: "sms",
         handle: async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/channels/vonage.ts
+++ b/packages/notification/notification/src/inbound/channels/vonage.ts
@@ -4,7 +4,7 @@ import { getHeader, tryParseObject } from "../../webhooks/types";
 import { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "../jwt";
 import { smsReply } from "../reply";
 import type { InboundMessage, Receiver, ReceiverOptions } from "../types";
-import { asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
+import { asDate, asRawResponse, asString, headersToRecord, noContent, rejectionResponse } from "../utils";
 
 const AUTH_HEADER = "Authorization";
 const BEARER_PREFIX = "Bearer ";
@@ -32,8 +32,11 @@ const partyNumber = (value: unknown): string | undefined => {
 const parseVonage = (body: string): InboundMessage | undefined => {
     const payload = tryParseObject(body);
     const from = partyNumber(payload?.from);
+    const id = asString(payload?.message_uuid);
 
-    if (payload === undefined || from === undefined) {
+    // See the MessageBird parser: an id-less message normalised to `""` collides with every other
+    // one, so it is not a message this receiver can hand on.
+    if (payload === undefined || from === undefined || id === undefined) {
         return undefined;
     }
 
@@ -43,12 +46,12 @@ const parseVonage = (body: string): InboundMessage | undefined => {
         channel: "sms",
         conversationId: partyNumber(payload.to),
         from: { id: from },
-        id: asString(payload.message_uuid) ?? "",
+        id,
         metadata: { channelType: payload.channel, messageType: payload.message_type },
         provider: "vonage",
         raw: payload,
         text: asString(payload.text),
-        timestamp: timestamp === undefined ? new Date() : new Date(timestamp),
+        timestamp: asDate(timestamp),
         type: "message",
     };
 };

--- a/packages/notification/notification/src/inbound/ed25519.ts
+++ b/packages/notification/notification/src/inbound/ed25519.ts
@@ -1,5 +1,5 @@
 import type { Bytes } from "../providers/utils/webcrypto";
-import { subtle, utf8 } from "../providers/utils/webcrypto";
+import { fromBase64Url, subtle, utf8 } from "../providers/utils/webcrypto";
 
 const HEX_PATTERN = /^[0-9a-f]*$/iu;
 
@@ -47,6 +47,25 @@ export const verifyEd25519 = async (publicKeyHex: string, signatureHex: string, 
         const key = await subtle().importKey("raw", publicKey, { name: "Ed25519" }, false, ["verify"]);
 
         return await subtle().verify({ name: "Ed25519" }, key, signature, utf8(`${timestamp}${body}`));
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Verifies an Ed25519 signature over an arbitrary message, with the public key and signature
+ * supplied as base64 (Telnyx's webhook signing scheme, where the signed message is
+ * `{timestamp}|{body}`). Any malformed input resolves to `false` rather than throwing.
+ * @param publicKeyBase64 The Ed25519 public key (base64).
+ * @param signatureBase64 The header signature to check (base64).
+ * @param message The exact string that was signed (e.g. `{timestamp}|{body}` for Telnyx).
+ * @returns `true` when the signature is valid.
+ */
+export const verifyEd25519Base64 = async (publicKeyBase64: string, signatureBase64: string, message: string): Promise<boolean> => {
+    try {
+        const key = await subtle().importKey("raw", fromBase64Url(publicKeyBase64), { name: "Ed25519" }, false, ["verify"]);
+
+        return await subtle().verify({ name: "Ed25519" }, key, fromBase64Url(signatureBase64), utf8(message));
     } catch {
         return false;
     }

--- a/packages/notification/notification/src/inbound/ed25519.ts
+++ b/packages/notification/notification/src/inbound/ed25519.ts
@@ -1,0 +1,53 @@
+import type { Bytes } from "../providers/utils/webcrypto";
+import { subtle, utf8 } from "../providers/utils/webcrypto";
+
+const HEX_PATTERN = /^[0-9a-f]*$/iu;
+
+/**
+ * Decodes a lowercase/uppercase hex string into `ArrayBuffer`-backed bytes. Returns
+ * `undefined` for odd-length or non-hex input rather than throwing, so a malformed
+ * signature header fails verification cleanly.
+ * @param value The hex string.
+ * @returns The decoded bytes, or `undefined` when the input is not valid hex.
+ */
+export const hexToBytes = (value: string): Bytes | undefined => {
+    if (value.length % 2 !== 0 || !HEX_PATTERN.test(value)) {
+        return undefined;
+    }
+
+    const bytes = new Uint8Array(new ArrayBuffer(value.length / 2));
+
+    for (let index = 0; index < bytes.length; index += 1) {
+        bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+    }
+
+    return bytes;
+};
+
+/**
+ * Verifies an Ed25519 signature over `timestamp + body`, Discord's interaction signing
+ * scheme. Edge-safe — uses Web Crypto's Ed25519 primitive only (available on Node 22+ and
+ * Cloudflare Workers). Any malformed input or unsupported-algorithm error resolves to
+ * `false` rather than throwing.
+ * @param publicKeyHex The application's Ed25519 public key (hex), from the Discord dashboard.
+ * @param signatureHex The `X-Signature-Ed25519` header value (hex).
+ * @param timestamp The `X-Signature-Timestamp` header value.
+ * @param body The raw request body.
+ * @returns `true` when the signature is valid.
+ */
+export const verifyEd25519 = async (publicKeyHex: string, signatureHex: string, timestamp: string, body: string): Promise<boolean> => {
+    const publicKey = hexToBytes(publicKeyHex);
+    const signature = hexToBytes(signatureHex);
+
+    if (publicKey === undefined || signature === undefined) {
+        return false;
+    }
+
+    try {
+        const key = await subtle().importKey("raw", publicKey, { name: "Ed25519" }, false, ["verify"]);
+
+        return await subtle().verify({ name: "Ed25519" }, key, signature, utf8(`${timestamp}${body}`));
+    } catch {
+        return false;
+    }
+};

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -1,12 +1,16 @@
 export type { DiscordInboundOptions } from "./channels/discord";
 export { createDiscordInbound } from "./channels/discord";
+export type { MsTeamsInboundOptions } from "./channels/msteams";
+export { createMsTeamsInbound } from "./channels/msteams";
 export type { SlackInboundOptions } from "./channels/slack";
 export { createSlackInbound } from "./channels/slack";
 export type { TelegramInboundOptions } from "./channels/telegram";
 export { createTelegramInbound } from "./channels/telegram";
+export type { TelnyxInboundOptions } from "./channels/telnyx";
+export { createTelnyxInbound } from "./channels/telnyx";
 export type { TwilioInboundOptions } from "./channels/twilio";
 export { createTwilioInbound } from "./channels/twilio";
-export { verifyEd25519 } from "./ed25519";
+export { verifyEd25519, verifyEd25519Base64 } from "./ed25519";
 export { chatReply, normaliseReply, smsReply } from "./reply";
 export type { FetchHandler } from "./router";
 export { createInboundRouter } from "./router";

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -7,6 +7,7 @@ export { createTelegramInbound } from "./channels/telegram";
 export type { TwilioInboundOptions } from "./channels/twilio";
 export { createTwilioInbound } from "./channels/twilio";
 export { verifyEd25519 } from "./ed25519";
+export { chatReply, normaliseReply, smsReply } from "./reply";
 export type { FetchHandler } from "./router";
 export { createInboundRouter } from "./router";
 export type {
@@ -20,5 +21,7 @@ export type {
     InboundMessageType,
     InboundParticipant,
     InboundReply,
+    InboundReplyFunction,
+    InboundReplyInput,
     InboundResponse,
 } from "./types";

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -1,0 +1,24 @@
+export type { DiscordInboundOptions } from "./channels/discord";
+export { createDiscordInbound } from "./channels/discord";
+export type { SlackInboundOptions } from "./channels/slack";
+export { createSlackInbound } from "./channels/slack";
+export type { TelegramInboundOptions } from "./channels/telegram";
+export { createTelegramInbound } from "./channels/telegram";
+export type { TwilioInboundOptions } from "./channels/twilio";
+export { createTwilioInbound } from "./channels/twilio";
+export { verifyEd25519 } from "./ed25519";
+export type { FetchHandler } from "./router";
+export { createInboundRouter } from "./router";
+export type {
+    InboundAttachment,
+    InboundChannel,
+    InboundChannelOptions,
+    InboundContext,
+    InboundErrorReason,
+    InboundHandler,
+    InboundMessage,
+    InboundMessageType,
+    InboundParticipant,
+    InboundReply,
+    InboundResponse,
+} from "./types";

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -1,6 +1,6 @@
-// Channel receivers are intentionally NOT re-exported here — import each from its own subpath
-// (e.g. `@visulima/notification/inbound/slack`) so bundles only pull in the channels they use.
-// This barrel exposes the shared types, router and verification/reply helpers.
+// Channel receivers are intentionally NOT re-exported here — import each from its channel subpath
+// (e.g. `@visulima/notification/providers/slack`, alongside the outbound provider). This barrel
+// exposes the shared types, router and verification/reply helpers.
 export { verifyEd25519, verifyEd25519Base64 } from "./ed25519";
 export { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "./jwt";
 export { chatReply, normaliseReply, smsReply } from "./reply";
@@ -9,7 +9,6 @@ export { createInboundRouter } from "./router";
 export type {
     InboundAttachment,
     InboundChannel,
-    InboundChannelOptions,
     InboundContext,
     InboundErrorReason,
     InboundHandler,
@@ -20,4 +19,6 @@ export type {
     InboundReplyFunction,
     InboundReplyInput,
     InboundResponse,
+    Receiver,
+    ReceiverOptions,
 } from "./types";

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -1,19 +1,6 @@
-export type { DiscordInboundOptions } from "./channels/discord";
-export { createDiscordInbound } from "./channels/discord";
-export type { MessageBirdInboundOptions } from "./channels/messagebird";
-export { createMessageBirdInbound } from "./channels/messagebird";
-export type { MsTeamsInboundOptions } from "./channels/msteams";
-export { createMsTeamsInbound } from "./channels/msteams";
-export type { SlackInboundOptions } from "./channels/slack";
-export { createSlackInbound } from "./channels/slack";
-export type { TelegramInboundOptions } from "./channels/telegram";
-export { createTelegramInbound } from "./channels/telegram";
-export type { TelnyxInboundOptions } from "./channels/telnyx";
-export { createTelnyxInbound } from "./channels/telnyx";
-export type { TwilioInboundOptions } from "./channels/twilio";
-export { createTwilioInbound } from "./channels/twilio";
-export type { VonageInboundOptions } from "./channels/vonage";
-export { createVonageInbound } from "./channels/vonage";
+// Channel receivers are intentionally NOT re-exported here — import each from its own subpath
+// (e.g. `@visulima/notification/inbound/slack`) so bundles only pull in the channels they use.
+// This barrel exposes the shared types, router and verification/reply helpers.
 export { verifyEd25519, verifyEd25519Base64 } from "./ed25519";
 export { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "./jwt";
 export { chatReply, normaliseReply, smsReply } from "./reply";

--- a/packages/notification/notification/src/inbound/index.ts
+++ b/packages/notification/notification/src/inbound/index.ts
@@ -1,5 +1,7 @@
 export type { DiscordInboundOptions } from "./channels/discord";
 export { createDiscordInbound } from "./channels/discord";
+export type { MessageBirdInboundOptions } from "./channels/messagebird";
+export { createMessageBirdInbound } from "./channels/messagebird";
 export type { MsTeamsInboundOptions } from "./channels/msteams";
 export { createMsTeamsInbound } from "./channels/msteams";
 export type { SlackInboundOptions } from "./channels/slack";
@@ -10,7 +12,10 @@ export type { TelnyxInboundOptions } from "./channels/telnyx";
 export { createTelnyxInbound } from "./channels/telnyx";
 export type { TwilioInboundOptions } from "./channels/twilio";
 export { createTwilioInbound } from "./channels/twilio";
+export type { VonageInboundOptions } from "./channels/vonage";
+export { createVonageInbound } from "./channels/vonage";
 export { verifyEd25519, verifyEd25519Base64 } from "./ed25519";
+export { isJwtTimeValid, sha256Hex, verifyHs256Jwt } from "./jwt";
 export { chatReply, normaliseReply, smsReply } from "./reply";
 export type { FetchHandler } from "./router";
 export { createInboundRouter } from "./router";

--- a/packages/notification/notification/src/inbound/jwt.ts
+++ b/packages/notification/notification/src/inbound/jwt.ts
@@ -1,0 +1,82 @@
+import { fromBase64Url, hmac, sha256, toBase64Url, toHex, utf8 } from "../providers/utils/webcrypto";
+import { timingSafeEqual } from "../webhooks/crypto";
+
+/**
+ * Decodes a base64url JWT segment into a JSON object, or `undefined` when it is not valid
+ * base64url JSON.
+ * @param segment The base64url-encoded segment.
+ * @returns The decoded object, or `undefined`.
+ */
+const decodeSegment = (segment: string): Record<string, unknown> | undefined => {
+    try {
+        const parsed: unknown = JSON.parse(new TextDecoder().decode(fromBase64Url(segment)));
+
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+
+        return undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Computes the lowercase hex SHA-256 digest of a UTF-8 string — the encoding used by the
+ * `payload_hash` / `url_hash` claims in MessageBird and Vonage signed webhooks.
+ * @param value The string to hash.
+ * @returns The hex digest.
+ */
+export const sha256Hex = async (value: string): Promise<string> => toHex(await sha256(utf8(value)));
+
+/**
+ * Verifies a compact HS256 JWT against `secret` and returns its decoded payload claims, or
+ * `undefined` when the token is malformed, uses a different algorithm, or the signature does
+ * not match. Signature comparison is constant-time. Edge-safe — Web Crypto only.
+ * @param token The compact JWT (`header.payload.signature`).
+ * @param secret The shared signing secret.
+ * @returns The verified payload claims, or `undefined`.
+ */
+export const verifyHs256Jwt = async (token: string, secret: string): Promise<Record<string, unknown> | undefined> => {
+    const parts = token.split(".");
+
+    if (parts.length !== 3) {
+        return undefined;
+    }
+
+    const [headerSegment, payloadSegment, signatureSegment] = parts as [string, string, string];
+    const header = decodeSegment(headerSegment);
+
+    if (header?.alg !== "HS256") {
+        return undefined;
+    }
+
+    const expected = toBase64Url(await hmac(secret, `${headerSegment}.${payloadSegment}`, "SHA-256"));
+
+    if (!timingSafeEqual(expected, signatureSegment)) {
+        return undefined;
+    }
+
+    return decodeSegment(payloadSegment);
+};
+
+/**
+ * Checks that a JWT's `exp` (and optional `nbf`) claims place `now` within the token's validity
+ * window, allowing a small clock-skew tolerance. Missing claims are treated as unbounded.
+ * @param payload The decoded claims.
+ * @param toleranceSeconds The allowed clock skew (default 5 seconds).
+ * @returns `true` when the token is temporally valid.
+ */
+export const isJwtTimeValid = (payload: Record<string, unknown>, toleranceSeconds = 5): boolean => {
+    const now = Math.floor(Date.now() / 1000);
+
+    if (typeof payload.exp === "number" && now > payload.exp + toleranceSeconds) {
+        return false;
+    }
+
+    if (typeof payload.nbf === "number" && now + toleranceSeconds < payload.nbf) {
+        return false;
+    }
+
+    return true;
+};

--- a/packages/notification/notification/src/inbound/reply.ts
+++ b/packages/notification/notification/src/inbound/reply.ts
@@ -39,10 +39,10 @@ export const chatReply = (provider: string, message: InboundMessage, outbound: P
     };
 
 /**
- * Creates the reply sender for the Twilio channel, mapping the inbound message and reply into
- * an {@link SmsPayload} sent through `outbound`. The reply is addressed back to the sender from
- * the receiving number, re-applying the `whatsapp:` prefix for WhatsApp. The returned function
- * rejects when `outbound` is absent.
+ * Creates the reply sender for an SMS channel (Twilio, Telnyx, Vonage, MessageBird), mapping the
+ * inbound message and reply into an {@link SmsPayload} sent through `outbound`. The reply is
+ * addressed back to the sender from the receiving number, re-applying the `whatsapp:` prefix for
+ * WhatsApp. The returned function rejects when `outbound` is absent.
  * @param message The inbound message being replied to.
  * @param outbound The matching outbound SMS provider, or `undefined`.
  * @returns A reply sender bound to `message`.
@@ -50,8 +50,10 @@ export const chatReply = (provider: string, message: InboundMessage, outbound: P
 export const smsReply = (message: InboundMessage, outbound: Provider<unknown, SmsPayload> | undefined): InboundReplyFunction =>
     async (input: InboundReplyInput): Promise<Result<NotificationResult>> => {
         if (outbound === undefined) {
-            throw new NotificationError("twilio-inbound", "No `provider` configured to send replies", {
-                hint: "Pass `provider` to the twilio inbound receiver to enable context.reply()",
+            // Named from the message rather than a hardcoded "twilio": four receivers share this
+            // sender, and a Telnyx handler pointed at the Twilio docs is a wrong answer.
+            throw new NotificationError(`${message.provider}-inbound`, "No `provider` configured to send replies", {
+                hint: `Pass \`provider\` to the ${message.provider} inbound receiver to enable context.reply()`,
             });
         }
 

--- a/packages/notification/notification/src/inbound/reply.ts
+++ b/packages/notification/notification/src/inbound/reply.ts
@@ -1,0 +1,66 @@
+import NotificationError from "../errors/notification-error";
+import type { Provider } from "../providers/provider";
+import type { ChatPayload, NotificationResult, Result, SmsPayload } from "../types";
+import type { InboundMessage, InboundReply, InboundReplyFunction, InboundReplyInput } from "./types";
+
+/**
+ * Normalises the shorthand string form of a reply into an {@link InboundReply}.
+ * @param input The reply content, as an object or a plain string.
+ * @returns The reply as an object, wrapping a bare string as `{ text }`.
+ */
+export const normaliseReply = (input: InboundReplyInput): InboundReply => {
+    if (typeof input === "string") {
+        return { text: input };
+    }
+
+    return input;
+};
+
+/**
+ * Creates the reply sender for a chat channel (Slack, Discord, Telegram), mapping the inbound
+ * message and reply into a {@link ChatPayload} sent through `outbound`. The reply targets the
+ * originating conversation and thread. The returned function rejects when `outbound` is absent.
+ * @param provider The provider id, used in the not-configured error.
+ * @param message The inbound message being replied to.
+ * @param outbound The matching outbound chat provider, or `undefined`.
+ * @returns A reply sender bound to `message`.
+ */
+export const chatReply = (provider: string, message: InboundMessage, outbound: Provider<unknown, ChatPayload> | undefined): InboundReplyFunction =>
+    async (input: InboundReplyInput): Promise<Result<NotificationResult>> => {
+        if (outbound === undefined) {
+            throw new NotificationError(`${provider}-inbound`, "No `provider` configured to send replies", {
+                hint: `Pass \`provider\` to the ${provider} inbound receiver to enable context.reply()`,
+            });
+        }
+
+        const reply = normaliseReply(input);
+
+        return outbound.send({ blocks: reply.blocks, text: reply.text ?? "", threadId: reply.threadId ?? message.threadId, to: message.conversationId });
+    };
+
+/**
+ * Creates the reply sender for the Twilio channel, mapping the inbound message and reply into
+ * an {@link SmsPayload} sent through `outbound`. The reply is addressed back to the sender from
+ * the receiving number, re-applying the `whatsapp:` prefix for WhatsApp. The returned function
+ * rejects when `outbound` is absent.
+ * @param message The inbound message being replied to.
+ * @param outbound The matching outbound SMS provider, or `undefined`.
+ * @returns A reply sender bound to `message`.
+ */
+export const smsReply = (message: InboundMessage, outbound: Provider<unknown, SmsPayload> | undefined): InboundReplyFunction =>
+    async (input: InboundReplyInput): Promise<Result<NotificationResult>> => {
+        if (outbound === undefined) {
+            throw new NotificationError("twilio-inbound", "No `provider` configured to send replies", {
+                hint: "Pass `provider` to the twilio inbound receiver to enable context.reply()",
+            });
+        }
+
+        const reply = normaliseReply(input);
+        const prefix = message.metadata?.transport === "whatsapp" ? "whatsapp:" : "";
+
+        return outbound.send({
+            from: message.conversationId === undefined ? undefined : `${prefix}${message.conversationId}`,
+            text: reply.text ?? "",
+            to: `${prefix}${message.from.id}`,
+        });
+    };

--- a/packages/notification/notification/src/inbound/router.ts
+++ b/packages/notification/notification/src/inbound/router.ts
@@ -11,8 +11,9 @@ export type FetchHandler = (request: Request) => Promise<Response>;
 
 /**
  * Mounts several {@link Receiver}s behind a single fetch handler, dispatching by URL
- * path. Each key is matched against the request's path (by exact match or suffix, so a
- * mount base path does not need to be known ahead of time); unmatched paths get a `404`.
+ * path. Each key is matched against the request's path — exactly, or as a suffix beginning at a
+ * path-segment boundary, so a mount base path does not need to be known ahead of time. The most
+ * specific route wins; unmatched paths get a `404`.
  *
  * The result is directly usable as a Cloudflare Workers / Deno / Bun `fetch` export, or via a
  * Node/Express/Hono web-request adapter.
@@ -20,7 +21,14 @@ export type FetchHandler = (request: Request) => Promise<Response>;
  * @returns A fetch handler dispatching to the matching channel.
  */
 export const createInboundRouter = (routes: Record<string, Receiver>): FetchHandler => {
-    const entries = Object.entries(routes);
+    // Give every route a leading slash so the suffix test below can only match at a path-segment
+    // boundary: without it a `slack` route also answers for `/webhooks/evil-slack`. Longest first,
+    // because an unordered `find` lets a short `/telnyx` route swallow requests meant for a
+    // longer `/inbound/telnyx` one purely by declaration order — and a receiver configured
+    // without a signature secret would accept them.
+    const entries = Object.entries(routes)
+        .map(([path, receiver]): [string, Receiver] => [path.startsWith("/") ? path : `/${path}`, receiver])
+        .sort(([a], [b]) => b.length - a.length);
 
     return async (request: Request): Promise<Response> => {
         const { pathname } = new URL(request.url);

--- a/packages/notification/notification/src/inbound/router.ts
+++ b/packages/notification/notification/src/inbound/router.ts
@@ -1,4 +1,4 @@
-import type { InboundChannel } from "./types";
+import type { Receiver } from "./types";
 import { jsonResponse } from "./utils";
 
 /**
@@ -10,7 +10,7 @@ import { jsonResponse } from "./utils";
 export type FetchHandler = (request: Request) => Promise<Response>;
 
 /**
- * Mounts several {@link InboundChannel}s behind a single fetch handler, dispatching by URL
+ * Mounts several {@link Receiver}s behind a single fetch handler, dispatching by URL
  * path. Each key is matched against the request's path (by exact match or suffix, so a
  * mount base path does not need to be known ahead of time); unmatched paths get a `404`.
  *
@@ -19,7 +19,7 @@ export type FetchHandler = (request: Request) => Promise<Response>;
  * @param routes A map of path (e.g. `"/webhooks/slack"`) to channel receiver.
  * @returns A fetch handler dispatching to the matching channel.
  */
-export const createInboundRouter = (routes: Record<string, InboundChannel>): FetchHandler => {
+export const createInboundRouter = (routes: Record<string, Receiver>): FetchHandler => {
     const entries = Object.entries(routes);
 
     return async (request: Request): Promise<Response> => {

--- a/packages/notification/notification/src/inbound/router.ts
+++ b/packages/notification/notification/src/inbound/router.ts
@@ -1,0 +1,35 @@
+import type { InboundChannel } from "./types";
+import { jsonResponse } from "./utils";
+
+/**
+ * A web-standard request handler: the shape returned by {@link createInboundRouter} and the
+ * signature platforms like Cloudflare Workers, Deno, Bun and Node's `fetch` server expect.
+ * @param request The inbound request.
+ * @returns The response.
+ */
+export type FetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * Mounts several {@link InboundChannel}s behind a single fetch handler, dispatching by URL
+ * path. Each key is matched against the request's path (by exact match or suffix, so a
+ * mount base path does not need to be known ahead of time); unmatched paths get a `404`.
+ *
+ * The result is directly usable as a Cloudflare Workers / Deno / Bun `fetch` export, or via a
+ * Node/Express/Hono web-request adapter.
+ * @param routes A map of path (e.g. `"/webhooks/slack"`) to channel receiver.
+ * @returns A fetch handler dispatching to the matching channel.
+ */
+export const createInboundRouter = (routes: Record<string, InboundChannel>): FetchHandler => {
+    const entries = Object.entries(routes);
+
+    return async (request: Request): Promise<Response> => {
+        const { pathname } = new URL(request.url);
+        const match = entries.find(([path]) => pathname === path || pathname.endsWith(path));
+
+        if (match === undefined) {
+            return jsonResponse({ error: "not_found" }, 404);
+        }
+
+        return match[1].handle(request);
+    };
+};

--- a/packages/notification/notification/src/inbound/router.ts
+++ b/packages/notification/notification/src/inbound/router.ts
@@ -28,7 +28,8 @@ export const createInboundRouter = (routes: Record<string, Receiver>): FetchHand
     // without a signature secret would accept them.
     const entries = Object.entries(routes)
         .map(([path, receiver]): [string, Receiver] => [path.startsWith("/") ? path : `/${path}`, receiver])
-        .sort(([a], [b]) => b.length - a.length);
+        // Longest path first, so `/inbound/telegram` is matched before `/inbound`.
+        .toSorted(([a], [b]) => b.length - a.length);
 
     return async (request: Request): Promise<Response> => {
         const { pathname } = new URL(request.url);

--- a/packages/notification/notification/src/inbound/types.ts
+++ b/packages/notification/notification/src/inbound/types.ts
@@ -1,4 +1,4 @@
-import type { ChannelType, MaybePromise } from "../types";
+import type { ChannelType, MaybePromise, NotificationResult, Result } from "../types";
 import type { WebhookHeaders } from "../webhooks/types";
 
 /**
@@ -99,14 +99,37 @@ export interface InboundReply {
 }
 
 /**
- * Context passed to an {@link InboundHandler} alongside the parsed message, exposing the
- * verified raw request for handlers that need provider-native fields.
+ * What {@link InboundContext.reply} accepts: a normalised {@link InboundReply} or, as a
+ * shorthand, a plain string treated as `{ text }`.
+ */
+export type InboundReplyInput = InboundReply | string;
+
+/**
+ * Sends a reply back to the originating conversation through the outbound provider configured
+ * on the receiver — the out-of-band counterpart to returning an {@link InboundReply} from the
+ * handler. Resolves to the provider's send {@link Result}; rejects when no provider was
+ * configured. The reply target (recipient, thread) is derived from the inbound message.
+ * @param reply The reply content.
+ * @returns The provider's send result.
+ */
+export type InboundReplyFunction = (reply: InboundReplyInput) => Promise<Result<NotificationResult>>;
+
+/**
+ * Context passed to an {@link InboundHandler} alongside the parsed message: the verified raw
+ * request for handlers that need provider-native fields, plus {@link InboundContext.reply} to
+ * answer in a single call.
  */
 export interface InboundContext {
     /** The raw request body text, already read and signature-verified. */
     body: string;
     /** Case-insensitive request headers. */
     headers: WebhookHeaders;
+
+    /**
+     * Sends a reply to the originating conversation through the receiver's outbound provider.
+     * Rejects if no `provider` was passed to the receiver factory.
+     */
+    reply: InboundReplyFunction;
     /** The originating web-standard {@link Request}. */
     request: Request;
 }

--- a/packages/notification/notification/src/inbound/types.ts
+++ b/packages/notification/notification/src/inbound/types.ts
@@ -1,0 +1,172 @@
+import type { ChannelType, MaybePromise } from "../types";
+import type { WebhookHeaders } from "../webhooks/types";
+
+/**
+ * The normalised kind of an inbound payload, abstracting over each provider's own taxonomy:
+ *
+ * - `"message"` — a user-authored message (chat message, SMS, WhatsApp).
+ * - `"command"` — a slash / bot command (Slack slash command, Discord application command).
+ * - `"callback"` — a UI interaction (Slack block action, Discord component, Telegram callback query).
+ * - `"event"` — a provider lifecycle event that is not a direct user message (Slack Events API envelope).
+ * - `"unknown"` — a recognised payload that does not map to a more specific kind.
+ */
+export type InboundMessageType = "callback" | "command" | "event" | "message" | "unknown";
+
+/**
+ * A participant in an inbound conversation (the sender, or the bot/recipient).
+ */
+export interface InboundParticipant {
+    /** Provider-native id (Slack user id, Discord user id, phone number, ...). */
+    id: string;
+    /** Whether the participant is a bot / automated account, when the provider reports it. */
+    isBot?: boolean;
+    /** Human-readable display name, when available. */
+    name?: string;
+    /** Handle / username, when available. */
+    username?: string;
+}
+
+/**
+ * A file or media attachment carried by an inbound message.
+ */
+export interface InboundAttachment {
+    /** MIME type, when reported. */
+    contentType?: string;
+    /** Original filename, when reported. */
+    filename?: string;
+    /** Provider-native attachment id, when reported. */
+    id?: string;
+    /** Size in bytes, when reported. */
+    size?: number;
+    /** URL to fetch the attachment (may require provider auth). */
+    url?: string;
+}
+
+/**
+ * A normalised inbound message. Every channel receiver maps its provider-native payload
+ * into this shape so a single handler can process messages from any channel — the
+ * counterpart to the outbound {@link ../types.NotificationPayload NotificationPayload}.
+ */
+export interface InboundMessage {
+    /** File / media attachments carried by the message. */
+    attachments?: InboundAttachment[];
+    /** The logical channel the message arrived on, mirroring {@link ChannelType}. */
+    channel: ChannelType;
+    /** Parsed command detail when {@link InboundMessage.type} is `"command"`. */
+    command?: {
+        /** Positional / free-text arguments following the command name. */
+        args?: string;
+        /** The command name, without any leading `/`. */
+        name: string;
+    };
+    /** Conversation / channel / room / chat id the message belongs to. */
+    conversationId?: string;
+    /** The sender. */
+    from: InboundParticipant;
+    /** Provider message / event id. */
+    id: string;
+    /** Provider extras not covered by a normalised field (team id, guild id, app id, ...). */
+    metadata?: Record<string, unknown>;
+    /** The provider id: `"slack"`, `"discord"`, `"telegram"`, `"twilio"`. */
+    provider: string;
+    /** The original, unmodified provider payload. */
+    raw: unknown;
+    /** Plain-text content, when the payload carries text. */
+    text?: string;
+    /** Thread / reply anchor, so replies can be threaded where the channel supports it. */
+    threadId?: string;
+    /** Provider event timestamp (falls back to receive time when the payload omits one). */
+    timestamp: Date;
+    /** The kind of inbound payload. */
+    type: InboundMessageType;
+}
+
+/**
+ * A normalised reply a handler can return to be delivered in the webhook's HTTP response,
+ * where the channel supports synchronous replies (Slack slash commands, Discord
+ * interactions, Telegram webhook method calls, Twilio TwiML). For channels that require an
+ * out-of-band reply (Slack Events API), send through the matching outbound provider instead.
+ */
+export interface InboundReply {
+    /** Provider-native rich content (Slack blocks, Discord embeds, ...). */
+    blocks?: unknown;
+    /** Provider-specific fields merged into the serialised response (escape hatch). */
+    raw?: Record<string, unknown>;
+    /** Plain-text reply body. */
+    text?: string;
+    /** Reply within the given thread, when the channel supports threading. */
+    threadId?: string;
+}
+
+/**
+ * Context passed to an {@link InboundHandler} alongside the parsed message, exposing the
+ * verified raw request for handlers that need provider-native fields.
+ */
+export interface InboundContext {
+    /** The raw request body text, already read and signature-verified. */
+    body: string;
+    /** Case-insensitive request headers. */
+    headers: WebhookHeaders;
+    /** The originating web-standard {@link Request}. */
+    request: Request;
+}
+
+/**
+ * What an {@link InboundHandler} may return: a normalised {@link InboundReply} (serialised
+ * by the channel), a raw web-standard {@link Response} (passed through unchanged), or
+ * nothing (the channel acknowledges the delivery with an empty success response).
+ */
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- `void` keeps a handler that returns nothing (`() => {}`) assignable
+export type InboundResponse = InboundReply | Response | void;
+
+/**
+ * Handles a verified, parsed inbound message. This is the seam an AI agent plugs into:
+ * receive a normalised message, optionally return a reply.
+ * @param message The normalised inbound message.
+ * @param context The request context.
+ * @returns The reply to deliver, a raw response, or nothing.
+ */
+export type InboundHandler = (message: InboundMessage, context: InboundContext) => MaybePromise<InboundResponse>;
+
+/**
+ * The reason an inbound request was rejected before it reached the handler.
+ */
+export type InboundErrorReason = "invalid_body" | "invalid_signature" | "missing_signature";
+
+/**
+ * Options shared by every channel receiver factory.
+ */
+export interface InboundChannelOptions {
+    /**
+     * Called when a request fails verification or cannot be parsed, before the handler runs.
+     * Return a {@link Response} to override the default (`401` for signature failures,
+     * `400` for malformed bodies); return nothing to keep the default.
+     * @param reason Why the request was rejected.
+     * @param request The originating request.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- allow an error hook that returns nothing to fall through to the default
+    onError?: (reason: InboundErrorReason, request: Request) => MaybePromise<Response | void>;
+
+    /** Called for every verified, parsed inbound message. */
+    onMessage: InboundHandler;
+}
+
+/**
+ * A channel receiver: the inbound counterpart to an outbound
+ * {@link ../providers/provider.Provider Provider}. It verifies, parses and dispatches
+ * inbound webhook requests through a single web-standard entry point.
+ */
+export interface InboundChannel {
+    /** The logical channel this receiver handles. */
+    readonly channel: ChannelType;
+
+    /**
+     * Verify, parse and dispatch an inbound webhook request, returning the HTTP response to
+     * send back to the provider. Framework-agnostic: pass any web-standard {@link Request}.
+     * @param request The inbound webhook request.
+     * @returns The response to return to the provider.
+     */
+    handle: (request: Request) => Promise<Response>;
+    /** The provider id this receiver handles. */
+    readonly provider: string;
+}

--- a/packages/notification/notification/src/inbound/types.ts
+++ b/packages/notification/notification/src/inbound/types.ts
@@ -159,7 +159,7 @@ export type InboundErrorReason = "invalid_body" | "invalid_signature" | "missing
 /**
  * Options shared by every channel receiver factory.
  */
-export interface InboundChannelOptions {
+export interface ReceiverOptions {
     /**
      * Called when a request fails verification or cannot be parsed, before the handler runs.
      * Return a {@link Response} to override the default (`401` for signature failures,
@@ -179,7 +179,7 @@ export interface InboundChannelOptions {
  * {@link ../providers/provider.Provider Provider}. It verifies, parses and dispatches
  * inbound webhook requests through a single web-standard entry point.
  */
-export interface InboundChannel {
+export interface Receiver {
     /** The logical channel this receiver handles. */
     readonly channel: ChannelType;
 
@@ -193,3 +193,8 @@ export interface InboundChannel {
     /** The provider id this receiver handles. */
     readonly provider: string;
 }
+
+/**
+ * @deprecated Renamed to {@link Receiver}. Kept as an alias for one major; removed in the next.
+ */
+export type InboundChannel = Receiver;

--- a/packages/notification/notification/src/inbound/utils.ts
+++ b/packages/notification/notification/src/inbound/utils.ts
@@ -1,0 +1,116 @@
+import type { WebhookHeaders } from "../webhooks/types";
+import type { InboundChannelOptions, InboundErrorReason, InboundReply, InboundResponse } from "./types";
+
+/**
+ * Returns `value` when it is a string, otherwise `undefined`. Narrows the untyped fields of
+ * a parsed provider payload without repeating `typeof` guards or nesting ternaries.
+ * @param value The candidate value.
+ * @returns The string, or `undefined`.
+ */
+export const asString = (value: unknown): string | undefined => {
+    if (typeof value === "string") {
+        return value;
+    }
+
+    return undefined;
+};
+
+/**
+ * Coerces a provider id that may arrive as a string or a number (Telegram sends numeric ids)
+ * into a string, or `undefined` when it is neither.
+ * @param value The candidate id.
+ * @returns The stringified id, or `undefined`.
+ */
+export const asId = (value: unknown): string | undefined => {
+    if (typeof value === "string") {
+        return value;
+    }
+
+    if (typeof value === "number") {
+        return String(value);
+    }
+
+    return undefined;
+};
+
+/**
+ * Reads a web-standard {@link Headers} object into a plain, case-insensitive
+ * {@link WebhookHeaders} map so the existing webhook verifiers can consume it.
+ * @param headers The request headers.
+ * @returns A plain header map.
+ */
+export const headersToRecord = (headers: Headers): WebhookHeaders => {
+    const record: Record<string, string> = {};
+
+    headers.forEach((value, key) => {
+        record[key] = value;
+    });
+
+    return record;
+};
+
+/**
+ * Builds a JSON {@link Response} with the given status.
+ * @param body The JSON-serialisable body.
+ * @param status The HTTP status (defaults to `200`).
+ * @returns A response with the JSON body and `content-type` header set.
+ */
+export const jsonResponse = (body: unknown, status = 200): Response =>
+    Response.json(body, { headers: { "content-type": "application/json" }, status });
+
+/**
+ * An empty `204 No Content` acknowledgement — the default success response when a handler
+ * returns nothing.
+ * @returns The response.
+ */
+export const noContent = (): Response => new Response(undefined, { status: 204 });
+
+/**
+ * Resolves the default rejection response for a given reason, giving {@link
+ * InboundChannelOptions.onError} the chance to override it first.
+ * @param reason Why the request was rejected.
+ * @param request The originating request.
+ * @param onError The optional consumer error hook.
+ * @returns The response to send back to the provider.
+ */
+export const rejectionResponse = async (
+    reason: InboundErrorReason,
+    request: Request,
+    onError: InboundChannelOptions["onError"],
+): Promise<Response> => {
+    const override = await onError?.(reason, request);
+
+    if (override instanceof Response) {
+        return override;
+    }
+
+    const status = reason === "invalid_body" ? 400 : 401;
+
+    return jsonResponse({ error: reason }, status);
+};
+
+/**
+ * Narrows a handler's {@link InboundResponse} to a raw {@link Response} when it returned one.
+ * @param response The handler result.
+ * @returns The response, or `undefined` when the handler returned a reply or nothing.
+ */
+export const asRawResponse = (response: InboundResponse): Response | undefined => {
+    if (response instanceof Response) {
+        return response;
+    }
+
+    return undefined;
+};
+
+/**
+ * Narrows a handler's {@link InboundResponse} to a normalised {@link InboundReply}.
+ * @param response The handler result.
+ * @returns The reply, or `undefined` when the handler returned a raw response or nothing.
+ */
+export const asReply = (response: InboundResponse): InboundReply | undefined => {
+    if (response === undefined || response instanceof Response) {
+        return undefined;
+    }
+
+    return response;
+};

--- a/packages/notification/notification/src/inbound/utils.ts
+++ b/packages/notification/notification/src/inbound/utils.ts
@@ -34,6 +34,20 @@ export const asId = (value: unknown): string | undefined => {
 };
 
 /**
+ * Parses a provider-supplied timestamp, falling back to now when it is missing or malformed.
+ *
+ * `new Date("not a date")` produces an `Invalid Date` that passes silently through assignment and
+ * only throws once a consumer calls `toISOString()` on it — far from the payload that caused it.
+ * @param value The timestamp string, if the payload carried one.
+ * @returns A valid {@link Date}.
+ */
+export const asDate = (value: string | undefined): Date => {
+    const parsed = value === undefined ? Number.NaN : Date.parse(value);
+
+    return Number.isNaN(parsed) ? new Date() : new Date(parsed);
+};
+
+/**
  * Reads a web-standard {@link Headers} object into a plain, case-insensitive
  * {@link WebhookHeaders} map so the existing webhook verifiers can consume it.
  * @param headers The request headers.

--- a/packages/notification/notification/src/inbound/utils.ts
+++ b/packages/notification/notification/src/inbound/utils.ts
@@ -1,5 +1,5 @@
 import type { WebhookHeaders } from "../webhooks/types";
-import type { InboundChannelOptions, InboundErrorReason, InboundReply, InboundResponse } from "./types";
+import type { InboundErrorReason, InboundReply, InboundResponse, ReceiverOptions } from "./types";
 
 /**
  * Returns `value` when it is a string, otherwise `undefined`. Narrows the untyped fields of
@@ -67,7 +67,7 @@ export const noContent = (): Response => new Response(undefined, { status: 204 }
 
 /**
  * Resolves the default rejection response for a given reason, giving {@link
- * InboundChannelOptions.onError} the chance to override it first.
+ * ReceiverOptions.onError} the chance to override it first.
  * @param reason Why the request was rejected.
  * @param request The originating request.
  * @param onError The optional consumer error hook.
@@ -76,7 +76,7 @@ export const noContent = (): Response => new Response(undefined, { status: 204 }
 export const rejectionResponse = async (
     reason: InboundErrorReason,
     request: Request,
-    onError: InboundChannelOptions["onError"],
+    onError: ReceiverOptions["onError"],
 ): Promise<Response> => {
     const override = await onError?.(reason, request);
 

--- a/packages/notification/notification/src/providers/chat/discord/index.ts
+++ b/packages/notification/notification/src/providers/chat/discord/index.ts
@@ -1,4 +1,9 @@
-export type { DiscordInboundOptions } from "../../../inbound/channels/discord";
-export { createDiscordInbound } from "../../../inbound/channels/discord";
-export { default as discordProvider } from "./provider";
+import discordProviderFactory from "./provider";
+
+export type { DiscordReceiverOptions } from "../../../inbound/channels/discord";
+export { createDiscordReceiver } from "../../../inbound/channels/discord";
+export { default as createDiscordProvider } from "./provider";
 export type { DiscordConfig } from "./types";
+
+/** @deprecated Renamed to `createDiscordProvider`; removed in the next major. */
+export const discordProvider: typeof discordProviderFactory = discordProviderFactory;

--- a/packages/notification/notification/src/providers/chat/discord/index.ts
+++ b/packages/notification/notification/src/providers/chat/discord/index.ts
@@ -1,2 +1,4 @@
+export type { DiscordInboundOptions } from "../../../inbound/channels/discord";
+export { createDiscordInbound } from "../../../inbound/channels/discord";
 export { default as discordProvider } from "./provider";
 export type { DiscordConfig } from "./types";

--- a/packages/notification/notification/src/providers/chat/msteams/index.ts
+++ b/packages/notification/notification/src/providers/chat/msteams/index.ts
@@ -1,4 +1,9 @@
-export type { MsTeamsInboundOptions } from "../../../inbound/channels/msteams";
-export { createMsTeamsInbound } from "../../../inbound/channels/msteams";
-export { default as msTeamsProvider } from "./provider";
+import msTeamsProviderFactory from "./provider";
+
+export type { MsTeamsReceiverOptions } from "../../../inbound/channels/msteams";
+export { createMsTeamsReceiver } from "../../../inbound/channels/msteams";
+export { default as createMsTeamsProvider } from "./provider";
 export type { MsTeamsConfig } from "./types";
+
+/** @deprecated Renamed to `createMsTeamsProvider`; removed in the next major. */
+export const msTeamsProvider: typeof msTeamsProviderFactory = msTeamsProviderFactory;

--- a/packages/notification/notification/src/providers/chat/msteams/index.ts
+++ b/packages/notification/notification/src/providers/chat/msteams/index.ts
@@ -1,2 +1,4 @@
+export type { MsTeamsInboundOptions } from "../../../inbound/channels/msteams";
+export { createMsTeamsInbound } from "../../../inbound/channels/msteams";
 export { default as msTeamsProvider } from "./provider";
 export type { MsTeamsConfig } from "./types";

--- a/packages/notification/notification/src/providers/chat/slack/index.ts
+++ b/packages/notification/notification/src/providers/chat/slack/index.ts
@@ -1,2 +1,4 @@
+export type { SlackInboundOptions } from "../../../inbound/channels/slack";
+export { createSlackInbound } from "../../../inbound/channels/slack";
 export { default as slackProvider } from "./provider";
 export type { SlackConfig } from "./types";

--- a/packages/notification/notification/src/providers/chat/slack/index.ts
+++ b/packages/notification/notification/src/providers/chat/slack/index.ts
@@ -1,4 +1,9 @@
-export type { SlackInboundOptions } from "../../../inbound/channels/slack";
-export { createSlackInbound } from "../../../inbound/channels/slack";
-export { default as slackProvider } from "./provider";
+import slackProviderFactory from "./provider";
+
+export type { SlackReceiverOptions } from "../../../inbound/channels/slack";
+export { createSlackReceiver } from "../../../inbound/channels/slack";
+export { default as createSlackProvider } from "./provider";
 export type { SlackConfig } from "./types";
+
+/** @deprecated Renamed to `createSlackProvider`; removed in the next major. */
+export const slackProvider: typeof slackProviderFactory = slackProviderFactory;

--- a/packages/notification/notification/src/providers/chat/telegram/index.ts
+++ b/packages/notification/notification/src/providers/chat/telegram/index.ts
@@ -1,2 +1,4 @@
+export type { TelegramInboundOptions } from "../../../inbound/channels/telegram";
+export { createTelegramInbound } from "../../../inbound/channels/telegram";
 export { default as telegramProvider } from "./provider";
 export type { TelegramConfig } from "./types";

--- a/packages/notification/notification/src/providers/chat/telegram/index.ts
+++ b/packages/notification/notification/src/providers/chat/telegram/index.ts
@@ -1,4 +1,9 @@
-export type { TelegramInboundOptions } from "../../../inbound/channels/telegram";
-export { createTelegramInbound } from "../../../inbound/channels/telegram";
-export { default as telegramProvider } from "./provider";
+import telegramProviderFactory from "./provider";
+
+export type { TelegramReceiverOptions } from "../../../inbound/channels/telegram";
+export { createTelegramReceiver } from "../../../inbound/channels/telegram";
+export { default as createTelegramProvider } from "./provider";
 export type { TelegramConfig } from "./types";
+
+/** @deprecated Renamed to `createTelegramProvider`; removed in the next major. */
+export const telegramProvider: typeof telegramProviderFactory = telegramProviderFactory;

--- a/packages/notification/notification/src/providers/failover/index.ts
+++ b/packages/notification/notification/src/providers/failover/index.ts
@@ -1,2 +1,7 @@
+import { failoverProvider as failoverProviderImpl } from "./provider";
+
 export type { FailoverConfig } from "./provider";
-export { failoverProvider } from "./provider";
+export { failoverProvider as createFailoverProvider } from "./provider";
+
+/** @deprecated Renamed to `createFailoverProvider`; removed in the next major. */
+export const failoverProvider: typeof failoverProviderImpl = failoverProviderImpl;

--- a/packages/notification/notification/src/providers/mock/index.ts
+++ b/packages/notification/notification/src/providers/mock/index.ts
@@ -1,2 +1,7 @@
+import { mockProvider as mockProviderImpl } from "./provider";
+
 export type { MockProviderConfig, MockProviderInstance, MockSentMessage } from "./provider";
-export { mockProvider } from "./provider";
+export { mockProvider as createMockProvider } from "./provider";
+
+/** @deprecated Renamed to `createMockProvider`; removed in the next major. */
+export const mockProvider: typeof mockProviderImpl = mockProviderImpl;

--- a/packages/notification/notification/src/providers/opentelemetry/index.ts
+++ b/packages/notification/notification/src/providers/opentelemetry/index.ts
@@ -1,2 +1,7 @@
+import { otelProvider as otelProviderImpl } from "./provider";
+
 export type { OtelProviderConfig } from "./provider";
-export { otelProvider } from "./provider";
+export { otelProvider as createOtelProvider } from "./provider";
+
+/** @deprecated Renamed to `createOtelProvider`; removed in the next major. */
+export const otelProvider: typeof otelProviderImpl = otelProviderImpl;

--- a/packages/notification/notification/src/providers/push/apns/index.ts
+++ b/packages/notification/notification/src/providers/push/apns/index.ts
@@ -1,2 +1,7 @@
-export { default as apnsProvider } from "./provider";
+import apnsProviderFactory from "./provider";
+
+export { default as createApnsProvider } from "./provider";
 export type { ApnsConfig } from "./types";
+
+/** @deprecated Renamed to `createApnsProvider`; removed in the next major. */
+export const apnsProvider: typeof apnsProviderFactory = apnsProviderFactory;

--- a/packages/notification/notification/src/providers/push/expo/index.ts
+++ b/packages/notification/notification/src/providers/push/expo/index.ts
@@ -1,2 +1,7 @@
-export { default as expoProvider } from "./provider";
+import expoProviderFactory from "./provider";
+
+export { default as createExpoProvider } from "./provider";
 export type { ExpoConfig } from "./types";
+
+/** @deprecated Renamed to `createExpoProvider`; removed in the next major. */
+export const expoProvider: typeof expoProviderFactory = expoProviderFactory;

--- a/packages/notification/notification/src/providers/push/fcm/index.ts
+++ b/packages/notification/notification/src/providers/push/fcm/index.ts
@@ -1,2 +1,7 @@
-export { default as fcmProvider } from "./provider";
+import fcmProviderFactory from "./provider";
+
+export { default as createFcmProvider } from "./provider";
 export type { FcmConfig } from "./types";
+
+/** @deprecated Renamed to `createFcmProvider`; removed in the next major. */
+export const fcmProvider: typeof fcmProviderFactory = fcmProviderFactory;

--- a/packages/notification/notification/src/providers/push/web-push/index.ts
+++ b/packages/notification/notification/src/providers/push/web-push/index.ts
@@ -1,2 +1,7 @@
-export { default as webPushProvider } from "./provider";
+import webPushProviderFactory from "./provider";
+
+export { default as createWebPushProvider } from "./provider";
 export type { PushSubscriptionLike, WebPushConfig } from "./types";
+
+/** @deprecated Renamed to `createWebPushProvider`; removed in the next major. */
+export const webPushProvider: typeof webPushProviderFactory = webPushProviderFactory;

--- a/packages/notification/notification/src/providers/roundrobin/index.ts
+++ b/packages/notification/notification/src/providers/roundrobin/index.ts
@@ -1,2 +1,7 @@
+import { roundRobinProvider as roundRobinProviderImpl } from "./provider";
+
 export type { RoundRobinConfig } from "./provider";
-export { roundRobinProvider } from "./provider";
+export { roundRobinProvider as createRoundRobinProvider } from "./provider";
+
+/** @deprecated Renamed to `createRoundRobinProvider`; removed in the next major. */
+export const roundRobinProvider: typeof roundRobinProviderImpl = roundRobinProviderImpl;

--- a/packages/notification/notification/src/providers/sms/messagebird/index.ts
+++ b/packages/notification/notification/src/providers/sms/messagebird/index.ts
@@ -1,4 +1,9 @@
-export type { MessageBirdInboundOptions } from "../../../inbound/channels/messagebird";
-export { createMessageBirdInbound } from "../../../inbound/channels/messagebird";
-export { default as messageBirdProvider } from "./provider";
+import messageBirdProviderFactory from "./provider";
+
+export type { MessageBirdReceiverOptions } from "../../../inbound/channels/messagebird";
+export { createMessageBirdReceiver } from "../../../inbound/channels/messagebird";
+export { default as createMessageBirdProvider } from "./provider";
 export type { MessageBirdConfig } from "./types";
+
+/** @deprecated Renamed to `createMessageBirdProvider`; removed in the next major. */
+export const messageBirdProvider: typeof messageBirdProviderFactory = messageBirdProviderFactory;

--- a/packages/notification/notification/src/providers/sms/messagebird/index.ts
+++ b/packages/notification/notification/src/providers/sms/messagebird/index.ts
@@ -1,2 +1,4 @@
+export type { MessageBirdInboundOptions } from "../../../inbound/channels/messagebird";
+export { createMessageBirdInbound } from "../../../inbound/channels/messagebird";
 export { default as messageBirdProvider } from "./provider";
 export type { MessageBirdConfig } from "./types";

--- a/packages/notification/notification/src/providers/sms/plivo/index.ts
+++ b/packages/notification/notification/src/providers/sms/plivo/index.ts
@@ -1,2 +1,7 @@
-export { default as plivoProvider } from "./provider";
+import plivoProviderFactory from "./provider";
+
+export { default as createPlivoProvider } from "./provider";
 export type { PlivoConfig } from "./types";
+
+/** @deprecated Renamed to `createPlivoProvider`; removed in the next major. */
+export const plivoProvider: typeof plivoProviderFactory = plivoProviderFactory;

--- a/packages/notification/notification/src/providers/sms/sns/index.ts
+++ b/packages/notification/notification/src/providers/sms/sns/index.ts
@@ -1,2 +1,7 @@
-export { default as snsProvider } from "./provider";
+import snsProviderFactory from "./provider";
+
+export { default as createSnsProvider } from "./provider";
 export type { SnsConfig } from "./types";
+
+/** @deprecated Renamed to `createSnsProvider`; removed in the next major. */
+export const snsProvider: typeof snsProviderFactory = snsProviderFactory;

--- a/packages/notification/notification/src/providers/sms/telnyx/index.ts
+++ b/packages/notification/notification/src/providers/sms/telnyx/index.ts
@@ -1,4 +1,9 @@
-export type { TelnyxInboundOptions } from "../../../inbound/channels/telnyx";
-export { createTelnyxInbound } from "../../../inbound/channels/telnyx";
-export { default as telnyxProvider } from "./provider";
+import telnyxProviderFactory from "./provider";
+
+export type { TelnyxReceiverOptions } from "../../../inbound/channels/telnyx";
+export { createTelnyxReceiver } from "../../../inbound/channels/telnyx";
+export { default as createTelnyxProvider } from "./provider";
 export type { TelnyxConfig } from "./types";
+
+/** @deprecated Renamed to `createTelnyxProvider`; removed in the next major. */
+export const telnyxProvider: typeof telnyxProviderFactory = telnyxProviderFactory;

--- a/packages/notification/notification/src/providers/sms/telnyx/index.ts
+++ b/packages/notification/notification/src/providers/sms/telnyx/index.ts
@@ -1,2 +1,4 @@
+export type { TelnyxInboundOptions } from "../../../inbound/channels/telnyx";
+export { createTelnyxInbound } from "../../../inbound/channels/telnyx";
 export { default as telnyxProvider } from "./provider";
 export type { TelnyxConfig } from "./types";

--- a/packages/notification/notification/src/providers/sms/twilio/index.ts
+++ b/packages/notification/notification/src/providers/sms/twilio/index.ts
@@ -1,2 +1,4 @@
+export type { TwilioInboundOptions } from "../../../inbound/channels/twilio";
+export { createTwilioInbound } from "../../../inbound/channels/twilio";
 export { default as twilioProvider } from "./provider";
 export type { TwilioConfig } from "./types";

--- a/packages/notification/notification/src/providers/sms/twilio/index.ts
+++ b/packages/notification/notification/src/providers/sms/twilio/index.ts
@@ -1,4 +1,9 @@
-export type { TwilioInboundOptions } from "../../../inbound/channels/twilio";
-export { createTwilioInbound } from "../../../inbound/channels/twilio";
-export { default as twilioProvider } from "./provider";
+import twilioProviderFactory from "./provider";
+
+export type { TwilioReceiverOptions } from "../../../inbound/channels/twilio";
+export { createTwilioReceiver } from "../../../inbound/channels/twilio";
+export { default as createTwilioProvider } from "./provider";
 export type { TwilioConfig } from "./types";
+
+/** @deprecated Renamed to `createTwilioProvider`; removed in the next major. */
+export const twilioProvider: typeof twilioProviderFactory = twilioProviderFactory;

--- a/packages/notification/notification/src/providers/sms/vonage/index.ts
+++ b/packages/notification/notification/src/providers/sms/vonage/index.ts
@@ -1,2 +1,4 @@
+export type { VonageInboundOptions } from "../../../inbound/channels/vonage";
+export { createVonageInbound } from "../../../inbound/channels/vonage";
 export { default as vonageProvider } from "./provider";
 export type { VonageConfig } from "./types";

--- a/packages/notification/notification/src/providers/sms/vonage/index.ts
+++ b/packages/notification/notification/src/providers/sms/vonage/index.ts
@@ -1,4 +1,9 @@
-export type { VonageInboundOptions } from "../../../inbound/channels/vonage";
-export { createVonageInbound } from "../../../inbound/channels/vonage";
-export { default as vonageProvider } from "./provider";
+import vonageProviderFactory from "./provider";
+
+export type { VonageReceiverOptions } from "../../../inbound/channels/vonage";
+export { createVonageReceiver } from "../../../inbound/channels/vonage";
+export { default as createVonageProvider } from "./provider";
 export type { VonageConfig } from "./types";
+
+/** @deprecated Renamed to `createVonageProvider`; removed in the next major. */
+export const vonageProvider: typeof vonageProviderFactory = vonageProviderFactory;

--- a/packages/notification/notification/src/providers/webhook/index.ts
+++ b/packages/notification/notification/src/providers/webhook/index.ts
@@ -1,2 +1,7 @@
+import { webhookProvider as webhookProviderImpl } from "./provider";
+
 export type { WebhookConfig } from "./provider";
-export { webhookProvider } from "./provider";
+export { webhookProvider as createWebhookProvider } from "./provider";
+
+/** @deprecated Renamed to `createWebhookProvider`; removed in the next major. */
+export const webhookProvider: typeof webhookProviderImpl = webhookProviderImpl;

--- a/packages/notification/notification/src/webhooks/index.ts
+++ b/packages/notification/notification/src/webhooks/index.ts
@@ -1,6 +1,6 @@
 export { hmacBase64, hmacHex, timingSafeEqual } from "./crypto";
 export { slackWebhook } from "./slack";
-export { snsWebhook } from "./sns";
+export { snsWebhook, verifySnsMessage } from "./sns";
 export { standardWebhook } from "./standard";
 export { twilioWebhook } from "./twilio";
 export type { WebhookHeaders, WebhookVerifier } from "./types";

--- a/packages/notification/notification/src/webhooks/sns.ts
+++ b/packages/notification/notification/src/webhooks/sns.ts
@@ -41,8 +41,29 @@ const SIGNABLE_SUBSCRIPTION = ["Message", "MessageId", "SubscribeURL", "Timestam
 /**
  * Per-URL cache of extracted signing public keys, so repeated deliveries from the same topic do
  * not re-fetch and re-parse the certificate.
+ *
+ * Bounded: {@link isValidCertUrl} pins the host, but the path is whatever the caller sent, so an
+ * unbounded map would grow one entry per distinct `.pem` path a forged delivery names. Real
+ * deployments see a handful of signing certificates.
  */
 const spkiCache = new Map<string, Bytes>();
+
+/** Maximum number of cached signing keys before the oldest is evicted. */
+const SPKI_CACHE_LIMIT = 64;
+
+/** How long the certificate fetch may block the webhook request path. */
+const CERT_FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * How stale a `Timestamp` may be before the message is rejected.
+ *
+ * Deliberately far wider than the shared five-minute window the Slack and Telnyx verifiers use:
+ * an SNS `Timestamp` records when the message was *published* and does not change across
+ * redeliveries, so a tight window would drop legitimate retries. An hour still ends the
+ * indefinite replay that an unchecked timestamp allows — the signature itself stays valid for
+ * the lifetime of the signing certificate.
+ */
+const MAX_TIMESTAMP_AGE_MS = 60 * 60 * 1000;
 
 /**
  * Safely parses an SNS message envelope.
@@ -109,7 +130,9 @@ const loadSpki = async (url: string): Promise<Bytes | undefined> => {
         return cached;
     }
 
-    const response = await globalThis.fetch(url);
+    // This runs on the webhook request path; without a timeout an unreachable certificate host
+    // holds the handler open until the platform's own (much longer) default fires.
+    const response = await globalThis.fetch(url, { signal: AbortSignal.timeout(CERT_FETCH_TIMEOUT_MS) });
 
     if (!response.ok) {
         return undefined;
@@ -118,6 +141,15 @@ const loadSpki = async (url: string): Promise<Bytes | undefined> => {
     const spki = pemCertificateToSpki(await response.text());
 
     if (spki !== undefined) {
+        if (spkiCache.size >= SPKI_CACHE_LIMIT) {
+            // A Map iterates in insertion order, so the first key is the oldest entry.
+            const oldest = spkiCache.keys().next().value;
+
+            if (oldest !== undefined) {
+                spkiCache.delete(oldest);
+            }
+        }
+
         spkiCache.set(url, spki);
     }
 
@@ -128,8 +160,8 @@ const loadSpki = async (url: string): Promise<Bytes | undefined> => {
  * Verifies an AWS SNS message signature (SignatureVersion 1 = RSA-SHA1, 2 = RSA-SHA256) against
  * the certificate at its `SigningCertURL`. Validates the certificate host, rebuilds the
  * canonical string-to-sign, fetches (and caches) the signing certificate, and checks the RSA
- * signature with Web Crypto. Returns `false` on any malformed input, disallowed host, fetch
- * failure or signature mismatch. Edge-safe — `fetch` + Web Crypto only.
+ * signature with Web Crypto. Returns `false` on any malformed input, disallowed host, stale
+ * `Timestamp`, fetch failure or signature mismatch. Edge-safe — `fetch` + Web Crypto only.
  * @param message The parsed SNS envelope.
  * @returns `true` when the signature is valid.
  */
@@ -142,6 +174,14 @@ export const verifySnsMessage = async (message: SnsMessage): Promise<boolean> =>
     }
 
     if (!isValidCertUrl(url)) {
+        return false;
+    }
+
+    // `Timestamp` is one of the signed fields, so an attacker cannot move it. Without this check a
+    // captured delivery replays successfully for as long as the signing certificate lives.
+    const timestampMs = Date.parse(message.Timestamp ?? "");
+
+    if (Number.isNaN(timestampMs) || Math.abs(Date.now() - timestampMs) > MAX_TIMESTAMP_AGE_MS) {
         return false;
     }
 

--- a/packages/notification/notification/src/webhooks/sns.ts
+++ b/packages/notification/notification/src/webhooks/sns.ts
@@ -1,11 +1,15 @@
+import type { Bytes } from "../providers/utils/webcrypto";
+import { fromBase64Url, subtle, utf8 } from "../providers/utils/webcrypto";
 import type { NotificationEvent } from "../types";
 import type { WebhookVerifier } from "./types";
 import { tryParseObject } from "./types";
+import { pemCertificateToSpki } from "./x509";
 
 /**
- * SNS message envelope (the relevant subset).
+ * SNS message envelope (the relevant subset). SNS delivers every field as a string.
  */
 interface SnsMessage {
+    [key: string]: unknown;
     Message?: string;
     MessageId?: string;
     Signature?: string;
@@ -18,6 +22,29 @@ interface SnsMessage {
 }
 
 /**
+ * Host allow-list for the `SigningCertURL`: an `sns.REGION.amazonaws.com` host (optionally the
+ * China partition). Matches the AWS SDK's validation, preventing an attacker from pointing the
+ * verifier at a certificate they control.
+ */
+const CERT_HOST = /^sns\.[a-z0-9-]{3,}\.amazonaws\.com(?:\.cn)?$/iu;
+
+/**
+ * Fields signed for a `Notification`, in canonical order.
+ */
+const SIGNABLE_NOTIFICATION = ["Message", "MessageId", "Subject", "SubscribeURL", "Timestamp", "TopicArn", "Type"] as const;
+
+/**
+ * Fields signed for a `SubscriptionConfirmation` / `UnsubscribeConfirmation`, in canonical order.
+ */
+const SIGNABLE_SUBSCRIPTION = ["Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type"] as const;
+
+/**
+ * Per-URL cache of extracted signing public keys, so repeated deliveries from the same topic do
+ * not re-fetch and re-parse the certificate.
+ */
+const spkiCache = new Map<string, Bytes>();
+
+/**
  * Safely parses an SNS message envelope.
  * @param body The request body.
  * @returns The parsed envelope, or `undefined`.
@@ -25,23 +52,127 @@ interface SnsMessage {
 const parseEnvelope = (body: string): SnsMessage | undefined => tryParseObject(body);
 
 /**
+ * Reads the `SigningCertURL` field, tolerating the legacy `SigningCertUrl` spelling.
+ * @param message The SNS envelope.
+ * @returns The certificate URL, or `undefined`.
+ */
+const certUrlOf = (message: SnsMessage): string | undefined => {
+    const url = message.SigningCertURL ?? message.SigningCertUrl;
+
+    return typeof url === "string" ? url : undefined;
+};
+
+/**
+ * Validates that a `SigningCertURL` is an HTTPS `.pem` on an AWS SNS host.
+ * @param url The certificate URL.
+ * @returns `true` when the URL is a trusted SNS certificate location.
+ */
+const isValidCertUrl = (url: string): boolean => {
+    try {
+        const parsed = new URL(url);
+
+        return parsed.protocol === "https:" && parsed.pathname.endsWith(".pem") && CERT_HOST.test(parsed.hostname);
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Builds the canonical string-to-sign: each present signable key as `key\nvalue\n`, in order.
+ * @param message The SNS envelope.
+ * @param keys The ordered signable keys for the message type.
+ * @returns The string AWS signed.
+ */
+const buildStringToSign = (message: SnsMessage, keys: ReadonlyArray<string>): string => {
+    let result = "";
+
+    for (const key of keys) {
+        const value = message[key];
+
+        if (typeof value === "string") {
+            result += `${key}\n${value}\n`;
+        }
+    }
+
+    return result;
+};
+
+/**
+ * Fetches and caches the signing certificate's public key (SPKI).
+ * @param url The validated `SigningCertURL`.
+ * @returns The SPKI bytes, or `undefined` when the certificate cannot be fetched or parsed.
+ */
+const loadSpki = async (url: string): Promise<Bytes | undefined> => {
+    const cached = spkiCache.get(url);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const response = await globalThis.fetch(url);
+
+    if (!response.ok) {
+        return undefined;
+    }
+
+    const spki = pemCertificateToSpki(await response.text());
+
+    if (spki !== undefined) {
+        spkiCache.set(url, spki);
+    }
+
+    return spki;
+};
+
+/**
+ * Verifies an AWS SNS message signature (SignatureVersion 1 = RSA-SHA1, 2 = RSA-SHA256) against
+ * the certificate at its `SigningCertURL`. Validates the certificate host, rebuilds the
+ * canonical string-to-sign, fetches (and caches) the signing certificate, and checks the RSA
+ * signature with Web Crypto. Returns `false` on any malformed input, disallowed host, fetch
+ * failure or signature mismatch. Edge-safe — `fetch` + Web Crypto only.
+ * @param message The parsed SNS envelope.
+ * @returns `true` when the signature is valid.
+ */
+export const verifySnsMessage = async (message: SnsMessage): Promise<boolean> => {
+    const url = certUrlOf(message);
+    const version = message.SignatureVersion;
+
+    if (url === undefined || typeof message.Signature !== "string" || typeof message.Type !== "string" || (version !== "1" && version !== "2")) {
+        return false;
+    }
+
+    if (!isValidCertUrl(url)) {
+        return false;
+    }
+
+    const keys = message.Type === "Notification" ? SIGNABLE_NOTIFICATION : SIGNABLE_SUBSCRIPTION;
+    const stringToSign = buildStringToSign(message, keys);
+
+    try {
+        const spki = await loadSpki(url);
+
+        if (spki === undefined) {
+            return false;
+        }
+
+        const key = await subtle().importKey("spki", spki, { hash: version === "1" ? "SHA-1" : "SHA-256", name: "RSASSA-PKCS1-v1_5" }, false, ["verify"]);
+
+        return await subtle().verify("RSASSA-PKCS1-v1_5", key, fromBase64Url(message.Signature), utf8(stringToSign));
+    } catch {
+        return false;
+    }
+};
+
+/**
  * Verifier + parser for AWS SNS HTTP/S subscription deliveries.
  *
- * NOTE: signature verification is NOT yet implemented. Real verification requires
- * fetching the X.509 certificate at `SigningCertURL`, validating its cert chain back to
- * an Amazon root, and checking the RSA-SHA1/RSA-SHA256 signature over the canonical
- * string-to-sign (SignatureVersion 1 and 2). Until that lands, {@link snsWebhook.verify}
- * fails closed and always returns `false` — accepting a payload purely on its structure
- * (a `Signature` field plus an `sns.*.amazonaws.com` `SigningCertURL`) is an auth bypass,
- * since both are attacker-controllable. `parse` remains available for callers that have
- * verified the message out-of-band. Callers handling `SubscriptionConfirmation` should
- * confirm the subscription by requesting the `SubscribeURL` from the parsed metadata.
- * Edge-safe — performs no `node:*` work.
- *
- * TODO: implement RSA-SHA1/RSA-SHA256 verification of the canonical string-to-sign
- * against the fetched signing certificate (SignatureVersion 1 and 2).
+ * `verify` implements SNS SignatureVersion 1 (RSA-SHA1) and 2 (RSA-SHA256): it validates the
+ * `SigningCertURL` host, rebuilds the canonical string-to-sign, fetches and caches the signing
+ * certificate, extracts its RSA public key and checks the signature — all with `fetch` + Web
+ * Crypto, so it runs on edge runtimes. `headers` and `secret` are unused (SNS is asymmetric).
+ * Callers handling `SubscriptionConfirmation` should confirm by requesting the `SubscribeURL`
+ * from the parsed metadata.
  */
-// eslint-disable-next-line import/prefer-default-export -- named export is re-exported by the ./webhooks barrel
 export const snsWebhook: WebhookVerifier = {
     parse: (body: string): NotificationEvent | undefined => {
         const envelope = parseEnvelope(body);
@@ -66,9 +197,13 @@ export const snsWebhook: WebhookVerifier = {
             type: "delivered",
         };
     },
-    verify: (): Promise<boolean> =>
-        // Fail closed: cert-chain + RSA signature verification is not implemented (see the
-        // verifier-level NOTE/TODO). Returning anything other than `false` would be an auth
-        // bypass, so always reject.
-        Promise.resolve(false),
+    verify: async (payload: string): Promise<boolean> => {
+        const message = parseEnvelope(payload);
+
+        if (message === undefined) {
+            return false;
+        }
+
+        return verifySnsMessage(message);
+    },
 };

--- a/packages/notification/notification/src/webhooks/x509.ts
+++ b/packages/notification/notification/src/webhooks/x509.ts
@@ -1,0 +1,151 @@
+/* eslint-disable no-secrets/no-secrets -- "SubjectPublicKeyInfo" is a standard X.509 term, not a credential */
+
+/**
+ * Minimal, dependency-free X.509 helpers for extracting an RSA public key from a PEM
+ * certificate. Web Crypto's `importKey` accepts a `SubjectPublicKeyInfo` (`"spki"`) but not a
+ * full X.509 certificate, so this walks the certificate's DER (TLV) structure to locate the
+ * `SubjectPublicKeyInfo` and returns it for import. Edge-safe — no `node:*`, only `Uint8Array`
+ * and the shared Web Crypto base64 helper.
+ */
+
+import type { Bytes } from "../providers/utils/webcrypto";
+import { fromBase64Url } from "../providers/utils/webcrypto";
+
+const PEM_HEADER = /-----BEGIN CERTIFICATE-----/u;
+const PEM_FOOTER = /-----END CERTIFICATE-----/u;
+const WHITESPACE = /\s+/gu;
+
+/** DER tag for a SEQUENCE. */
+const SEQUENCE = 0x30;
+
+/** DER tag for the EXPLICIT `[0]` context class wrapping the optional `version` field. */
+const CONTEXT_0 = 0xa0;
+
+interface Tlv {
+    /** Offset one past the end of this element (value end). */
+    end: number;
+    /** Length of the value in bytes. */
+    length: number;
+    /** DER tag byte. */
+    tag: number;
+    /** Offset of the first value byte. */
+    valueOffset: number;
+}
+
+/**
+ * Reads a single DER type-length-value triple starting at `offset`, supporting short- and
+ * long-form lengths. Throws {@link RangeError} on a truncated element.
+ * @param bytes The DER bytes.
+ * @param offset The offset of the tag byte.
+ * @returns The parsed TLV envelope.
+ */
+const readTlv = (bytes: Uint8Array, offset: number): Tlv => {
+    if (offset + 2 > bytes.length) {
+        throw new RangeError("truncated DER");
+    }
+
+    const tag = bytes[offset] ?? 0;
+    const lengthByte = bytes[offset + 1] ?? 0;
+
+    if (lengthByte < 0x80) {
+        const valueOffset = offset + 2;
+
+        return { end: valueOffset + lengthByte, length: lengthByte, tag, valueOffset };
+    }
+
+    // eslint-disable-next-line no-bitwise -- DER long-form length is defined bitwise
+    const byteCount = lengthByte & 0x7f;
+    let length = 0;
+
+    for (let index = 0; index < byteCount; index += 1) {
+        // eslint-disable-next-line no-bitwise -- assembling a big-endian length
+        length = (length << 8) | (bytes[offset + 2 + index] ?? 0);
+    }
+
+    const valueOffset = offset + 2 + byteCount;
+
+    if (valueOffset + length > bytes.length) {
+        throw new RangeError("truncated DER");
+    }
+
+    return { end: valueOffset + length, length, tag, valueOffset };
+};
+
+/**
+ * Decodes a PEM certificate into its DER bytes.
+ * @param pem The PEM-encoded certificate.
+ * @returns The DER bytes, or `undefined` when the input is not a base64 certificate body.
+ */
+const pemToDer = (pem: string): Bytes | undefined => {
+    const base64 = pem.replace(PEM_HEADER, "").replace(PEM_FOOTER, "").replaceAll(WHITESPACE, "");
+
+    if (base64.length === 0) {
+        return undefined;
+    }
+
+    try {
+        return fromBase64Url(base64);
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Extracts the `SubjectPublicKeyInfo` (SPKI) from a PEM X.509 certificate, ready to hand to
+ * Web Crypto's `importKey("spki", …)`. Walks `Certificate → tbsCertificate` and skips the
+ * fixed leading fields (optional `version`, `serialNumber`, `signature`, `issuer`, `validity`,
+ * `subject`) to reach the public key. Returns `undefined` for malformed input rather than
+ * throwing.
+ * @param pem The PEM-encoded certificate.
+ * @returns The SPKI DER bytes, or `undefined`.
+ */
+// eslint-disable-next-line import/prefer-default-export -- named export mirrors the rest of the webhooks module
+export const pemCertificateToSpki = (pem: string): Bytes | undefined => {
+    const der = pemToDer(pem);
+
+    if (der === undefined) {
+        return undefined;
+    }
+
+    try {
+        const certificate = readTlv(der, 0);
+
+        if (certificate.tag !== SEQUENCE) {
+            return undefined;
+        }
+
+        const tbs = readTlv(der, certificate.valueOffset);
+
+        if (tbs.tag !== SEQUENCE) {
+            return undefined;
+        }
+
+        let offset = tbs.valueOffset;
+        const first = readTlv(der, offset);
+
+        // The `version` field is `[0] EXPLICIT` and optional; skip it when present.
+        if (first.tag === CONTEXT_0) {
+            offset = first.end;
+        }
+
+        // Skip serialNumber, signature, issuer, validity, subject in order.
+        for (let field = 0; field < 5; field += 1) {
+            offset = readTlv(der, offset).end;
+        }
+
+        const spki = readTlv(der, offset);
+
+        if (spki.tag !== SEQUENCE) {
+            return undefined;
+        }
+
+        // Return a fresh ArrayBuffer-backed copy of the full SPKI element (tag + length + value).
+        const copy = new Uint8Array(new ArrayBuffer(spki.end - offset));
+
+        copy.set(der.subarray(offset, spki.end));
+
+        return copy;
+    } catch {
+        return undefined;
+    }
+};

--- a/packages/notification/notification/src/webhooks/x509.ts
+++ b/packages/notification/notification/src/webhooks/x509.ts
@@ -50,16 +50,32 @@ const readTlv = (bytes: Uint8Array, offset: number): Tlv => {
     if (lengthByte < 0x80) {
         const valueOffset = offset + 2;
 
+        // Same bounds check as the long form below. Without it a truncated element returns an `end`
+        // past the buffer, and the clamped `subarray` copy in `pemCertificateToSpki` silently pads
+        // the SPKI with trailing zero bytes instead of failing.
+        if (valueOffset + lengthByte > bytes.length) {
+            throw new RangeError("truncated DER");
+        }
+
         return { end: valueOffset + lengthByte, length: lengthByte, tag, valueOffset };
     }
 
     // eslint-disable-next-line no-bitwise -- DER long-form length is defined bitwise
     const byteCount = lengthByte & 0x7f;
+
+    // `byteCount === 0` is BER's indefinite-length form, which DER forbids. Beyond four bytes the
+    // length exceeds anything a certificate can hold, and accumulating it would only risk losing
+    // precision on a value that must fail the bounds check anyway.
+    if (byteCount === 0 || byteCount > 4) {
+        throw new RangeError("unsupported DER length");
+    }
+
     let length = 0;
 
     for (let index = 0; index < byteCount; index += 1) {
-        // eslint-disable-next-line no-bitwise -- assembling a big-endian length
-        length = (length << 8) | (bytes[offset + 2 + index] ?? 0);
+        // Arithmetic rather than `<<`: a 32-bit shift turns a large length negative, which would
+        // pass the bounds check below and yield `end < valueOffset`.
+        length = length * 256 + (bytes[offset + 2 + index] ?? 0);
     }
 
     const valueOffset = offset + 2 + byteCount;


### PR DESCRIPTION
## Summary

A channel is two-way, so this pairs the outbound providers in `@visulima/notification` with an **inbound** half under `@visulima/notification/inbound`. Each receiver verifies the signature, answers the platform handshake, and normalises the payload into a single `InboundMessage` — the seam a bot or AI agent plugs into — and can reply in one call. It also fixes the outstanding SNS signature-verification TODO.

Inbound is the counterpart to the existing `Provider` abstraction, reusing the package's `webhooks/` crypto. The implementation stays self-contained under `src/inbound/`, so it could be split out later with no rewrite, but each receiver ships from its channel's existing `@visulima/notification/providers/<name>` subpath alongside the outbound provider — a channel is one import, both directions. The `@visulima/notification/inbound` barrel holds only the shared types, `createInboundRouter` and the verification/reply helpers.

## Receivers

Framework-agnostic `handle(request: Request) => Promise<Response>`, edge-safe (Web Crypto only). Every signature scheme is verified in full, ported from the provider's own SDK/spec:

| Import — factory | Verification | Reply |
| --- | --- | --- |
| `.../providers/slack` — `createSlackReceiver` | v0 HMAC-SHA256 + 5-min replay | `url_verification`; slash/interaction |
| `.../providers/discord` — `createDiscordReceiver` | Ed25519 (hex) over `timestamp+body` | `PING → PONG`; interaction response |
| `.../providers/telegram` — `createTelegramReceiver` | `X-Telegram-Bot-Api-Secret-Token` | `sendMessage` method |
| `.../providers/twilio` — `createTwilioReceiver` | `X-Twilio-Signature` HMAC-SHA1 | TwiML (SMS + WhatsApp) |
| `.../providers/msteams` — `createMsTeamsReceiver` | `Authorization: HMAC` base64 HMAC-SHA256 of raw body | Bot Framework activity |
| `.../providers/telnyx` — `createTelnyxReceiver` | Ed25519 (base64) over `{timestamp}\|{body}` + replay | `context.reply()` |
| `.../providers/messagebird` — `createMessageBirdReceiver` | `messagebird-signature-jwt` HS256 JWT + `url_hash`/`payload_hash` | `context.reply()` |
| `.../providers/vonage` — `createVonageReceiver` | `Authorization: Bearer` HS256 JWT + `payload_hash` | `context.reply()` |

## Core pieces

- **Normalised `InboundMessage`** — `channel`/`provider`/`type`/`text`/`from`/`conversationId`/`threadId`/`command`/`attachments`/`raw`/`metadata`.
- **`context.reply()`** — the one-call receive → reply loop. Pass the matching outbound `provider` to the receiver and call `context.reply(text | InboundReply)`; it derives the target (recipient, thread, `whatsapp:` prefix) from the inbound message and sends through the provider. This is the out-of-band path for channels that can't answer in the HTTP response.
- **`createInboundRouter`** — mounts several receivers behind one fetch handler.
- Reusable edge-safe crypto: `verifyEd25519` / `verifyEd25519Base64` (Ed25519), `verifyHs256Jwt` / `sha256Hex` / `isJwtTimeValid` (signed-JWT), `pemCertificateToSpki` (X.509).

## Fixes the SNS TODO

`snsWebhook.verify` previously failed closed with an unimplemented RSA cert-chain TODO. Now it implements the full AWS scheme (ported from `aws-js-sns-message-validator`), edge-safe on Web Crypto:

- validates the `SigningCertURL` host (`sns.<region>.amazonaws.com`, incl. `.cn`),
- rebuilds the canonical string-to-sign for Notification vs Subscription messages,
- fetches + caches the signing certificate and extracts its RSA public key by walking the X.509 DER to the `SubjectPublicKeyInfo` (new `webhooks/x509.ts`, since Web Crypto `importKey` takes `spki`, not a full cert),
- verifies SignatureVersion 1 (RSA-SHA1) and 2 (RSA-SHA256). Exports `verifySnsMessage`.

## Still deferred

- **Plivo** — `X-Plivo-Signature-V3` (HMAC-SHA256 with a nonce and multiple comma-separated signatures). The exact canonicalisation could not be confirmed from a verifiable SDK source, so it's left out rather than guessed (documented, with the "verify via the Plivo SDK then normalise" path). Push channels (APNs/FCM/Expo/web-push) are outbound-only by nature.

## Testing

33 tests across `__tests__/inbound.test.ts` (24) and `__tests__/webhooks.test.ts` (9): per-channel signature verify pass/fail (real Ed25519 keypairs for Discord/Telnyx, HMAC for Slack/Twilio/Teams, signed JWTs for MessageBird/Vonage, a generated RSA key + hand-built certificate for SNS), handshakes, `InboundMessage` normalisation, sync + `context.reply()` replies (incl. WhatsApp prefix, payload_hash tamper rejection), and router dispatch. ESLint + `tsc` clean for the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tgPT7Hoxzkf4wxp3LQEs4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound webhook receivers for Slack, Discord, Telegram, Microsoft Teams, Twilio, Telnyx, MessageBird, and Vonage.
  * Added normalized inbound messages, signature verification, routing, and synchronous or asynchronous replies.
  * Added support for AI-agent receive–think–reply workflows.
  * Added verified SNS webhook signature handling.

* **Documentation**
  * Added comprehensive inbound webhook documentation and updated provider examples.

* **Compatibility**
  * Introduced consistent `create…Provider` factory names while retaining deprecated aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
