### PR TITLE
feat(yaml): add document layer with error recovery and comment-preserving edits

### DIFF
--- a/packages/api/jsdoc-open-api/package.json
+++ b/packages/api/jsdoc-open-api/package.json
@@ -111,9 +111,9 @@
     "dependencies": {
         "@apidevtools/swagger-parser": "catalog:prod",
         "@visulima/fs": "5.1.0",
+        "@visulima/yaml": "workspace:*",
         "comment-parser": "catalog:prod",
-        "es-toolkit": "catalog:prod",
-        "yaml": "catalog:prod"
+        "es-toolkit": "catalog:prod"
     },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
@@ -140,6 +140,7 @@
         "semantic-release": "catalog:cli",
         "typescript": "catalog:tsc",
         "vitest": "catalog:test",
+        "yaml": "catalog:prod",
         "webpack": "catalog:build"
     },
     "optionalDependencies": {

--- a/packages/api/jsdoc-open-api/src/cli/command/generate-command.ts
+++ b/packages/api/jsdoc-open-api/src/cli/command/generate-command.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { collect } from "@visulima/fs";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { MultiBar, Presets } from "cli-progress";
-import yaml from "yaml";
+import * as yaml from "@visulima/yaml";
 
 import { DEFAULT_EXCLUDE } from "../../constants";
 import type { BaseDefinition } from "../../exported";

--- a/packages/api/jsdoc-open-api/src/parse-file.ts
+++ b/packages/api/jsdoc-open-api/src/parse-file.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import type { Block } from "comment-parser";
 import { parse as parseComments } from "comment-parser";
-import yaml from "yaml";
+import * as yaml from "@visulima/yaml";
 
 import type { OpenApiObject } from "./exported";
 import yamlLoc from "./util/yaml-loc";
@@ -25,7 +25,8 @@ export type CommentsToOpenApi = (fileContent: string, verbose?: boolean, comment
 const YAML_EXTENSIONS = new Set([".yaml", ".yml"]);
 
 const parseYamlFile = (file: string, fileContent: string): { loc: number; spec: OpenApiObject }[] => {
-    const spec = yaml.parse(fileContent);
+    // `@visulima/yaml` returns `unknown`, so narrow before use.
+    const spec = yaml.parse(fileContent) as OpenApiObject | null;
 
     if (spec === null || typeof spec !== "object") {
         return [];

--- a/packages/api/jsdoc-open-api/src/swagger-jsdoc/comments-to-open-api.ts
+++ b/packages/api/jsdoc-open-api/src/swagger-jsdoc/comments-to-open-api.ts
@@ -1,8 +1,8 @@
 import type { Block, Spec } from "comment-parser";
 import { parse as parseComments } from "comment-parser";
 import { mergeWith } from "es-toolkit";
-import type { YAMLError } from "yaml";
-import yaml from "yaml";
+import type { YAMLError } from "@visulima/yaml";
+import * as yaml from "@visulima/yaml";
 
 import type { OpenApiObject } from "../exported";
 import customizer from "../util/customizer";
@@ -50,7 +50,7 @@ const tagsToObjects = (specs: Spec[], verbose?: boolean) =>
                 throw new Error(errorString);
             }
 
-            const parsedDocument = parsed.toJSON();
+            const parsedDocument = parsed.toJSON() as Record<string, any>;
             const specification: Record<string, any> = {
                 tags: [],
             };

--- a/packages/api/jsdoc-open-api/src/util/load-definition.ts
+++ b/packages/api/jsdoc-open-api/src/util/load-definition.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import yaml from "yaml";
+import * as yaml from "@visulima/yaml";
 
 import type { BaseDefinition } from "../exported";
 

--- a/packages/data-manipulation/yaml/AGENTS.md
+++ b/packages/data-manipulation/yaml/AGENTS.md
@@ -18,6 +18,8 @@ The pipeline lives entirely in `src/`:
 - `src/schema/resolve-scalar.ts` — YAML 1.2 **core schema** scalar resolution (`null`, `bool`, `int` in dec/hex/oct, `float`, `.inf`/`.nan`) plus explicit-tag (`!!int`, `!!str`, …) application.
 - `src/errors.ts` — `YAMLError`, `YAMLParseError`, `YAMLStringifyError`, `YAMLWarning` carrying a `{ line, column, position }` mark and a source snippet.
 - `src/types.ts` — `ParseOptions` / `StringifyOptions`.
+- `src/document.ts` — the document layer. `parseDocument` / `parseAllDocuments` report diagnostics instead of throwing, and `setIn` edits by **splicing the original source** rather than re-serializing, so comments, blank lines and key order survive. Edits need source spans, which `loader.ts` records into `State.mappingRanges` **only when that field is set** — the plain `parse` path never pays for it.
+- `src/parser/ranges.ts` — the span types, in their own module so `document.ts` can use them without dragging the `State` class into the published `.d.ts` (it is not isolated-declarations clean).
 - `src/index.ts` — public barrel (`parse`, `parseAll`, `stringify`, plus the `js-yaml` aliases `load`, `loadAll`, `dump`).
 
 ## Conventions
@@ -50,6 +52,12 @@ The parser always rejects the unambiguous spec violations (tabs as indentation, 
 Both property cases route through one helper, `speculateBlockMapping`: it tries a block mapping either from the _first_ property (rewinding to the `propertyStart` snapshot, for `&anchor key: value`) or from the current position (for `!!map\n&a !!str key: value`). On failure it rolls back the cursor, the anchor map and the alias budget together (`beginSpeculation` / `rollbackSpeculation`) — anchors are restored by swapping in a copy of the map rather than by journalling each write, so `state.anchorMap.set` on the hot path stays branch-free. The helper only swallows `YAMLParseError`; anything else (a bug, a `RangeError`) propagates rather than being disguised as a failed guess.
 
 `strict: false` relaxes exactly these checks (closer to `js-yaml`) and nothing else — it never changes the value of an accepted document, only whether these malformed inputs throw. See `__tests__/strict.test.ts`.
+
+## Document layer
+
+Error recovery is **per document, not within one**: `loadDocuments` catches a document's `YAMLParseError`, records it, resyncs to the next `---`/`...` marker and carries on. Inside a single document the first error still ends it, because the parser has no resync points — so `parseDocument` reports at most one error while `parseAllDocuments` reports one per document.
+
+`setIn` only edits block mappings. A path through a flow collection or a sequence throws, because there is no unambiguous place to splice. When splicing, spans are trimmed back over trailing whitespace (`trimTrailingSpace`) — a node's recorded end runs past the spaces before a trailing comment and past the file's final newline, and splicing at the raw end would eat both.
 
 ## Hardening invariants (do not regress)
 

--- a/packages/data-manipulation/yaml/README.md
+++ b/packages/data-manipulation/yaml/README.md
@@ -172,6 +172,45 @@ parse("--- a: b", { strict: false }); // => { a: "b" }
 `load` / `loadAll` aliases default to `strict: false` so they stay drop-in
 replacements for `js-yaml`. Pass `{ strict: true }` to opt in.
 
+### `parseDocument(source, options?)` / `parseAllDocuments(source, options?)`
+
+Parse **without throwing**. Each returns a `YAMLDocument` carrying its own
+`errors` and `warnings`, so a caller can report problems in its own words —
+and `parseAllDocuments` keeps going after a malformed document instead of
+losing the whole stream.
+
+Documents also support **comment-preserving edits**: `setIn` splices the
+original source rather than re-serializing it, so comments, blank lines and key
+order elsewhere in the file are untouched.
+
+```ts
+import { parseDocument } from "@visulima/yaml";
+
+const document = parseDocument("packages:\n  - 'a/*'\n\n# keep me\n");
+
+document.setIn(["overrides", "some-pkg"], "npm:other@1.2.3");
+document.toString();
+// packages:
+//   - 'a/*'
+//
+// # keep me
+// overrides:
+//   some-pkg: npm:other@1.2.3
+```
+
+| Member                           | Description                                   |
+| -------------------------------- | --------------------------------------------- |
+| `errors` / `warnings`            | Diagnostics from reading the document.        |
+| `toJS()` / `toJSON()`            | The parsed value.                             |
+| `get(key)` / `getIn(path)`       | Read a value by key or path.                  |
+| `has(key)` / `hasIn(path)`       | Whether a key or path is present.             |
+| `set(key, v)` / `setIn(path, v)` | Edit, creating missing intermediate mappings. |
+| `toString()`                     | The source with every pending edit applied.   |
+
+Error recovery is per document — within one document the first error ends it.
+`setIn` edits block mappings only; a path through a flow collection or a
+sequence throws.
+
 ### `parseAll(source, options?)` / `loadAll(source, iterator?, options?)`
 
 Parse every document of a multi-document stream. `parseAll` returns an array; the

--- a/packages/data-manipulation/yaml/__tests__/document.test.ts
+++ b/packages/data-manipulation/yaml/__tests__/document.test.ts
@@ -161,6 +161,23 @@ describe("document › comment-preserving edits", () => {
         expect(edit).toThrow(ROOT_NOT_MAPPING);
     });
 
+    it("builds a document from empty or comment-only source", () => {
+        expect.assertions(3);
+
+        const fromEmpty = parseDocument("");
+
+        fromEmpty.setIn(["overrides", "pkg"], "npm:x@1");
+
+        expect(fromEmpty.toString()).toBe("overrides:\n  pkg: npm:x@1\n");
+
+        const fromComment = parseDocument("# keep\n");
+
+        fromComment.setIn(["a"], 1);
+
+        expect(fromComment.toString()).toBe("# keep\na: 1\n");
+        expect(parseDocument(fromEmpty.toString()).toJS()).toStrictEqual({ overrides: { pkg: "npm:x@1" } });
+    });
+
     it("returns the source unchanged when nothing was edited", () => {
         expect.assertions(1);
 

--- a/packages/data-manipulation/yaml/__tests__/document.test.ts
+++ b/packages/data-manipulation/yaml/__tests__/document.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { parseAllDocuments, parseDocument, YAMLParseError } from "../src";
+
+const ROOT_NOT_MAPPING = /root is not a mapping/;
+
+describe("parseDocument › diagnostics", () => {
+    it("reports errors instead of throwing", () => {
+        expect.assertions(3);
+
+        const document = parseDocument("a:\n\tb: 1\n");
+
+        expect(document.errors).toHaveLength(1);
+        expect(document.errors[0]).toBeInstanceOf(YAMLParseError);
+        expect(document.contents).toBeNull();
+    });
+
+    it("reports no errors for a valid document", () => {
+        expect.assertions(2);
+
+        const document = parseDocument("a: 1\nb: [2, 3]\n");
+
+        expect(document.errors).toHaveLength(0);
+        expect(document.toJS()).toStrictEqual({ a: 1, b: [2, 3] });
+    });
+
+    it("collects warnings without failing", () => {
+        expect.assertions(2);
+
+        const document = parseDocument("%FOO bar\n---\na: 1\n");
+
+        expect(document.errors).toHaveLength(0);
+        expect(document.warnings.length).toBeGreaterThan(0);
+    });
+});
+
+describe("parseAllDocuments › recovery", () => {
+    it("keeps parsing after a malformed document", () => {
+        expect.assertions(4);
+
+        const documents = parseAllDocuments("a: 1\n---\nb:\n\tc: 2\n---\nd: 3\n");
+
+        expect(documents).toHaveLength(3);
+        expect(documents[0]!.toJS()).toStrictEqual({ a: 1 });
+        expect(documents[1]!.errors).toHaveLength(1);
+        expect(documents[2]!.toJS()).toStrictEqual({ d: 3 });
+    });
+
+    it("returns one document per stream entry when all are valid", () => {
+        expect.assertions(2);
+
+        const documents = parseAllDocuments("---\na: 1\n---\nb: 2\n");
+
+        expect(documents).toHaveLength(2);
+        expect(documents.map((document) => document.toJS())).toStrictEqual([{ a: 1 }, { b: 2 }]);
+    });
+});
+
+describe("document › reading", () => {
+    it("reads nested values by path", () => {
+        expect.assertions(5);
+
+        const document = parseDocument("a:\n  b:\n    c: 1\nlist:\n  - x\n");
+
+        expect(document.get("a")).toStrictEqual({ b: { c: 1 } });
+        expect(document.getIn(["a", "b", "c"])).toBe(1);
+        expect(document.getIn(["list", 0])).toBe("x");
+        expect(document.hasIn(["a", "b"])).toBe(true);
+        expect(document.hasIn(["a", "nope"])).toBe(false);
+    });
+});
+
+describe("document › comment-preserving edits", () => {
+    it("replaces an existing value without disturbing its comment", () => {
+        expect.assertions(1);
+
+        const document = parseDocument("a: 1\nb: 2 # note\n");
+
+        document.setIn(["b"], 99);
+
+        expect(document.toString()).toBe("a: 1\nb: 99 # note\n");
+    });
+
+    it("adds a key to an existing nested mapping", () => {
+        expect.assertions(1);
+
+        const source = "packages:\n  - 'packages/*'\n\n# keep this comment\noverrides:\n  foo: '1.0.0'\n";
+        const document = parseDocument(source);
+
+        document.setIn(["overrides", "vite-client"], "npm:pkg@1.2.3");
+
+        expect(document.toString()).toBe("packages:\n  - 'packages/*'\n\n# keep this comment\noverrides:\n  foo: '1.0.0'\n  vite-client: npm:pkg@1.2.3\n");
+    });
+
+    it("creates the intermediate mapping when it is absent", () => {
+        expect.assertions(1);
+
+        const document = parseDocument("packages:\n  - 'a/*'\n\n# trailing comment\n");
+
+        document.setIn(["overrides", "vite-client"], "npm:x@1");
+
+        expect(document.toString()).toBe("packages:\n  - 'a/*'\n\n# trailing comment\noverrides:\n  vite-client: npm:x@1\n");
+    });
+
+    it("keeps every other byte of the file identical", () => {
+        expect.assertions(2);
+
+        const source = ["# header", "", "first: 1   # spaced comment", "", "nested:", "  deep:", "    value: keep", "", "last: true", ""].join("\n");
+        const document = parseDocument(source);
+
+        document.setIn(["nested", "deep", "value"], "changed");
+
+        const output = document.toString();
+
+        expect(output).toBe(source.replace("value: keep", "value: changed"));
+        expect(parseDocument(output).toJS()).toStrictEqual({ first: 1, last: true, nested: { deep: { value: "changed" } } });
+    });
+
+    it("writes a collection value as an indented block", () => {
+        expect.assertions(1);
+
+        const document = parseDocument("root:\n  a: 1\n");
+
+        document.setIn(["root", "list"], [1, 2]);
+
+        expect(parseDocument(document.toString()).toJS()).toStrictEqual({ root: { a: 1, list: [1, 2] } });
+    });
+
+    it("reflects edits in the parsed view", () => {
+        expect.assertions(2);
+
+        const document = parseDocument("a: 1\n");
+
+        document.setIn(["b", "c"], 2);
+
+        expect(document.getIn(["b", "c"])).toBe(2);
+        expect(parseDocument(document.toString()).toJS()).toStrictEqual({ a: 1, b: { c: 2 } });
+    });
+
+    it("applies several edits in one pass", () => {
+        expect.assertions(1);
+
+        const document = parseDocument("a: 1\nb: 2\nc: 3\n");
+
+        document.setIn(["a"], "x");
+        document.setIn(["c"], "z");
+
+        expect(document.toString()).toBe("a: x\nb: 2\nc: z\n");
+    });
+
+    it("refuses to edit a document whose root is not a mapping", () => {
+        expect.assertions(1);
+
+        const document = parseDocument("- 1\n- 2\n");
+
+        const edit = () => {
+            document.setIn(["a"], 1);
+        };
+
+        expect(edit).toThrow(ROOT_NOT_MAPPING);
+    });
+
+    it("returns the source unchanged when nothing was edited", () => {
+        expect.assertions(1);
+
+        const source = "a: 1 # untouched\n";
+
+        expect(parseDocument(source).toString()).toBe(source);
+    });
+});

--- a/packages/data-manipulation/yaml/docs/api.mdx
+++ b/packages/data-manipulation/yaml/docs/api.mdx
@@ -115,6 +115,74 @@ parse("--- a: b"); // throws YAMLParseError
 parse("--- a: b", { strict: false }); // => { a: "b" }
 ```
 
+### parseDocument
+
+Parse the first document **without throwing**, returning a {@link YAMLDocument}
+that carries its own diagnostics and supports comment-preserving edits.
+
+**Signature:**
+
+```typescript
+function parseDocument(source: string, options?: ParseOptions): YAMLDocument;
+```
+
+**Example:**
+
+```typescript
+import { parseDocument } from "@visulima/yaml";
+
+const document = parseDocument("a:\n\tb: 1\n");
+
+document.errors.length; // 1 — reported, not thrown
+document.contents; // null
+```
+
+### parseAllDocuments
+
+Parse every document of a stream without throwing. A malformed document reports
+its error and does not stop the ones after it.
+
+```typescript
+function parseAllDocuments(source: string, options?: ParseOptions): YAMLDocument[];
+```
+
+### YAMLDocument
+
+| Member                                   | Description                                             |
+| ---------------------------------------- | ------------------------------------------------------- |
+| `errors` / `warnings`                    | Diagnostics collected while reading the document.       |
+| `contents`                               | The parsed value, or `null` when `errors` is non-empty. |
+| `toJS()` / `toJSON()`                    | The parsed value.                                       |
+| `get(key)` / `getIn(path)`               | Read a value by key or path.                            |
+| `has(key)` / `hasIn(path)`               | Whether a key or path is present.                       |
+| `set(key, value)` / `setIn(path, value)` | Edit, creating missing intermediate mappings.           |
+| `toString()`                             | The source with every pending edit applied.             |
+
+**Comment-preserving edits.** `setIn` splices the original source instead of
+re-serializing it, so comments, blank lines and key order elsewhere in the file
+are left byte-identical:
+
+```typescript
+import { parseDocument } from "@visulima/yaml";
+
+const document = parseDocument("packages:\n  - 'a/*'\n\n# keep me\n");
+
+document.setIn(["overrides", "some-pkg"], "npm:other@1.2.3");
+document.toString();
+// packages:
+//   - 'a/*'
+//
+// # keep me
+// overrides:
+//   some-pkg: npm:other@1.2.3
+```
+
+**Limits.** Error recovery is per document — within one document the first error
+ends it, so `parseDocument` reports at most one error while `parseAllDocuments`
+reports one per document. `setIn` edits block mappings only; a path running
+through a flow collection (`{a: 1}`) or a sequence throws, because there is no
+unambiguous place to splice.
+
 ## Serializing
 
 ### stringify

--- a/packages/data-manipulation/yaml/docs/index.mdx
+++ b/packages/data-manipulation/yaml/docs/index.mdx
@@ -27,6 +27,12 @@ A fast, zero-runtime-dependency **YAML 1.2** parser and serializer written from 
 - `<<` merge keys, enabled by default
 - Multi-document streams with `---` / `...` markers and `%YAML` / `%TAG` directives
 
+**Document layer**
+
+- `parseDocument` / `parseAllDocuments` report diagnostics instead of throwing
+- Edits splice the source, preserving comments, blank lines and key order
+- A malformed document does not stop the rest of the stream
+
 **Two compatible APIs**
 
 - `yaml`-style `parse` / `parseAll` / `stringify`

--- a/packages/data-manipulation/yaml/docs/usage.mdx
+++ b/packages/data-manipulation/yaml/docs/usage.mdx
@@ -125,6 +125,48 @@ parse("--- [1, 2]"); // => [1, 2]
 parse("--- scalar"); // => "scalar"
 ```
 
+## Editing a file without losing its comments
+
+`parse` + `stringify` round-trips lose every comment and blank line, which makes
+them unsafe for a hand-maintained config file. `parseDocument` edits by splicing
+the original source instead, so only the bytes you change are touched:
+
+```typescript
+import { parseDocument } from "@visulima/yaml";
+
+const document = parseDocument("packages:\n  - 'a/*'\n\n# keep me\noverrides:\n  foo: '1.0.0'\n");
+
+document.setIn(["overrides", "bar"], "2.0.0");
+document.toString();
+// packages:
+//   - 'a/*'
+//
+// # keep me
+// overrides:
+//   foo: '1.0.0'
+//   bar: 2.0.0
+```
+
+Missing intermediate mappings are created, so the path does not have to exist
+yet — `setIn(["overrides", "bar"], …)` works on a file with no `overrides:` key.
+
+## Reporting errors instead of throwing
+
+A document reports its diagnostics rather than throwing, and one malformed
+document does not stop the rest of a stream:
+
+```typescript
+import { parseAllDocuments, parseDocument } from "@visulima/yaml";
+
+const document = parseDocument("a:\n\tb: 1\n");
+
+document.errors[0]?.message; // "tab characters must not be used in indentation …"
+
+const stream = parseAllDocuments("a: 1\n---\nb:\n\tc: 2\n---\nd: 3\n");
+
+stream.map((entry) => entry.errors.length); // [0, 1, 0] — the third still parsed
+```
+
 ## Handling duplicate keys
 
 By default a repeated key inside one mapping throws. Choose a different policy

--- a/packages/data-manipulation/yaml/src/document.ts
+++ b/packages/data-manipulation/yaml/src/document.ts
@@ -1,0 +1,291 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+/**
+ * The document layer: parsing that reports diagnostics instead of throwing, and
+ * edits that splice the original source rather than re-serializing it.
+ *
+ * Not re-serializing is the whole point. A round-trip through `parse` +
+ * `stringify` loses every comment, blank line and key-order choice in the file;
+ * splicing only the bytes an edit touches leaves the rest byte-identical, which
+ * is what makes this safe to run over a hand-maintained config file.
+ */
+
+import type { YAMLParseError, YAMLWarning } from "./errors";
+import { YAMLStringifyError } from "./errors";
+import { dump } from "./parser/dumper";
+import type { MappingEntryRange, MappingRanges } from "./parser/ranges";
+import type { StringifyOptions } from "./types";
+
+/** A pending source edit, applied by `toString`. */
+interface Edit {
+    end: number;
+    start: number;
+    text: string;
+}
+
+/**
+ * Walk `end` back over trailing whitespace.
+ *
+ * A node's recorded end runs to wherever the scanner stopped, which is past the
+ * spaces before a trailing comment and past the blank lines at end of file.
+ * Splicing at the raw end would eat the space in front of `# comment` and drop
+ * the file's final newline; splicing at the trimmed end leaves both in place.
+ */
+const WHITESPACE = /\s/;
+
+const trimTrailingSpace = (source: string, end: number): number => {
+    let index = end;
+
+    while (index > 0 && WHITESPACE.test(source[index - 1]!)) {
+        index -= 1;
+    }
+
+    return index;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Render a value as the right-hand side of a `key:` entry.
+ *
+ * A scalar stays inline (`key: value`); a collection moves onto following lines
+ * indented under the key, which is the shape a block mapping expects.
+ */
+const renderValue = (value: unknown, indent: number, options: StringifyOptions): string => {
+    const serialized = dump(value, options).trimEnd();
+
+    if (!serialized.includes("\n") && !isRecord(value) && !Array.isArray(value)) {
+        return ` ${serialized}`;
+    }
+
+    const pad = " ".repeat(indent + (options.indent ?? 2));
+
+    const indented = serialized.split("\n").map((line) => {
+        if (line === "") {
+            return line;
+        }
+
+        return pad + line;
+    });
+
+    return `\n${indented.join("\n")}`;
+};
+
+/**
+ * A parsed YAML document plus the diagnostics from reading it.
+ *
+ * Unlike `parse`, constructing a document never throws for malformed input —
+ * the failure is reported in {@link YAMLDocument.errors} and `contents` is
+ * `null`. That lets a caller report the problem in its own words, and lets
+ * `parseAllDocuments` keep going after one bad document.
+ */
+class YAMLDocument {
+    /** Parse errors. Empty when the document read cleanly. */
+    public readonly errors: YAMLParseError[];
+
+    /** Non-fatal notices raised while reading. */
+    public readonly warnings: YAMLWarning[];
+
+    /** The parsed value, or `null` when `errors` is non-empty. */
+    public contents: unknown;
+
+    readonly #ranges: MappingRanges;
+
+    readonly #edits: Edit[] = [];
+
+    readonly #stringifyOptions: StringifyOptions;
+
+    #source: string;
+
+    public constructor(
+        source: string,
+        result: { contents: unknown; errors: YAMLParseError[]; warnings: YAMLWarning[] },
+        ranges: MappingRanges,
+        stringifyOptions: StringifyOptions = {},
+    ) {
+        this.#source = source;
+        this.#ranges = ranges;
+        this.#stringifyOptions = stringifyOptions;
+        this.contents = result.contents;
+        this.errors = result.errors;
+        this.warnings = result.warnings;
+    }
+
+    /** The document's value as plain JavaScript. */
+    public toJS(): unknown {
+        return this.contents;
+    }
+
+    /** Alias of {@link YAMLDocument.toJS}, so `JSON.stringify` works directly. */
+    public toJSON(): unknown {
+        return this.contents;
+    }
+
+    /** Value at `path`, or `undefined` if any segment is missing. */
+    public getIn(path: ReadonlyArray<number | string>): unknown {
+        let current: unknown = this.contents;
+
+        for (const segment of path) {
+            if (Array.isArray(current) && typeof segment === "number") {
+                current = current[segment];
+            } else if (isRecord(current)) {
+                current = current[String(segment)];
+            } else {
+                return undefined;
+            }
+        }
+
+        return current;
+    }
+
+    /** Value of a top-level key. */
+    public get(key: number | string): unknown {
+        return this.getIn([key]);
+    }
+
+    /** Whether `path` resolves to something present in the document. */
+    public hasIn(path: ReadonlyArray<number | string>): boolean {
+        return this.getIn(path) !== undefined;
+    }
+
+    /** Whether a top-level key is present. */
+    public has(key: number | string): boolean {
+        return this.hasIn([key]);
+    }
+
+    /**
+     * Set the value at `path`, creating any missing intermediate mappings.
+     *
+     * The edit is a source splice, so comments, blank lines and key order
+     * elsewhere in the file survive untouched. Only block mappings can be
+     * edited: a path that runs through a flow collection (`{a: 1}`) or a
+     * sequence throws, because there is no unambiguous place to splice.
+     */
+    public setIn(path: ReadonlyArray<number | string>, value: unknown): void {
+        if (path.length === 0) {
+            throw new YAMLStringifyError("setIn requires a non-empty path");
+        }
+
+        const keys = path.map(String);
+
+        // Walk as far down the existing structure as the path allows.
+        let container: Record<string, unknown> = this.#rootMapping();
+        let depth = 0;
+
+        while (depth < keys.length - 1) {
+            const next = container[keys[depth]!];
+
+            if (!isRecord(next)) {
+                break;
+            }
+
+            container = next;
+            depth += 1;
+        }
+
+        const entries = this.#ranges.get(container);
+
+        if (entries === undefined || entries.length === 0) {
+            throw new YAMLStringifyError(`cannot edit ${JSON.stringify(path)}: the target is not a block mapping`);
+        }
+
+        const remaining = keys.slice(depth);
+        const existing = remaining.length === 1 ? entries.find((entry) => entry.key === remaining[0]) : undefined;
+
+        if (existing) {
+            this.#replaceValue(existing, value);
+        } else {
+            this.#insertEntry(entries, remaining, value);
+        }
+
+        // Keep the parsed view consistent with the text we just edited.
+        let cursor: Record<string, unknown> = container;
+
+        for (const key of remaining.slice(0, -1)) {
+            const created: Record<string, unknown> = {};
+
+            cursor[key] = created;
+            cursor = created;
+        }
+
+        cursor[remaining.at(-1)!] = value;
+    }
+
+    /** Set a top-level key. */
+    public set(key: number | string, value: unknown): void {
+        this.setIn([key], value);
+    }
+
+    /** The document source with every pending edit applied. */
+    public toString(): string {
+        if (this.#edits.length === 0) {
+            return this.#source;
+        }
+
+        // Apply back-to-front so earlier offsets stay valid.
+        const ordered = this.#edits.toSorted((a, b) => b.start - a.start);
+
+        let output = this.#source;
+
+        for (const edit of ordered) {
+            output = output.slice(0, edit.start) + edit.text + output.slice(edit.end);
+        }
+
+        this.#source = output;
+        this.#edits.length = 0;
+
+        return output;
+    }
+
+    #rootMapping(): Record<string, unknown> {
+        if (!isRecord(this.contents)) {
+            throw new YAMLStringifyError("cannot edit a document whose root is not a mapping");
+        }
+
+        return this.contents;
+    }
+
+    #replaceValue(entry: MappingEntryRange, value: unknown): void {
+        const rendered = renderValue(value, entry.column, this.#stringifyOptions);
+        // `valueStart - 1` is the colon; replacing from there covers the
+        // separating space, so an inline value and a block value both land
+        // correctly.
+        const start = entry.valueStart > 0 ? entry.valueStart - 1 : entry.end;
+        const end = Math.max(start, trimTrailingSpace(this.#source, entry.end));
+
+        this.#edits.push({ end, start, text: rendered });
+    }
+
+    #insertEntry(entries: MappingEntryRange[], keys: string[], value: unknown): void {
+        let anchor = entries[0]!;
+
+        for (const entry of entries) {
+            if (entry.end > anchor.end) {
+                anchor = entry;
+            }
+        }
+
+        const indent = anchor.column;
+
+        // Nest the remaining path segments under one another.
+        let text = "";
+
+        for (const [index, key] of keys.entries()) {
+            const pad = " ".repeat(indent + index * (this.#stringifyOptions.indent ?? 2));
+
+            text += `\n${pad}${key}:`;
+
+            if (index === keys.length - 1) {
+                text += renderValue(value, indent + index * (this.#stringifyOptions.indent ?? 2), this.#stringifyOptions);
+            }
+        }
+
+        const at = trimTrailingSpace(this.#source, anchor.end);
+
+        this.#edits.push({ end: at, start: at, text });
+    }
+}
+
+export { YAMLDocument };
+
+export { type ParseOptions } from "./types";

--- a/packages/data-manipulation/yaml/src/document.ts
+++ b/packages/data-manipulation/yaml/src/document.ts
@@ -183,13 +183,16 @@ class YAMLDocument {
             depth += 1;
         }
 
-        const entries = this.#ranges.get(container);
+        const entries = this.#ranges.get(container) ?? [];
+        const remaining = keys.slice(depth);
 
-        if (entries === undefined || entries.length === 0) {
+        // An empty or comment-only document has a root mapping with no entries
+        // and therefore nothing to anchor an insert to; append at the end of the
+        // source instead so a config file can be created from nothing.
+        if (entries.length === 0 && container !== this.contents) {
             throw new YAMLStringifyError(`cannot edit ${JSON.stringify(path)}: the target is not a block mapping`);
         }
 
-        const remaining = keys.slice(depth);
         const existing = remaining.length === 1 ? entries.find((entry) => entry.key === remaining[0]) : undefined;
 
         if (existing) {
@@ -238,6 +241,14 @@ class YAMLDocument {
     }
 
     #rootMapping(): Record<string, unknown> {
+        // An empty or comment-only document has no contents yet; treat it as an
+        // empty mapping so the first `setIn` can create one.
+        if (this.contents === null || this.contents === undefined) {
+            this.contents = {};
+
+            return this.contents as Record<string, unknown>;
+        }
+
         if (!isRecord(this.contents)) {
             throw new YAMLStringifyError("cannot edit a document whose root is not a mapping");
         }
@@ -257,15 +268,15 @@ class YAMLDocument {
     }
 
     #insertEntry(entries: MappingEntryRange[], keys: string[], value: unknown): void {
-        let anchor = entries[0]!;
+        let anchor: MappingEntryRange | undefined;
 
         for (const entry of entries) {
-            if (entry.end > anchor.end) {
+            if (anchor === undefined || entry.end > anchor.end) {
                 anchor = entry;
             }
         }
 
-        const indent = anchor.column;
+        const indent = anchor?.column ?? 0;
 
         // Nest the remaining path segments under one another.
         let text = "";
@@ -280,9 +291,19 @@ class YAMLDocument {
             }
         }
 
-        const at = trimTrailingSpace(this.#source, anchor.end);
+        const at = trimTrailingSpace(this.#source, anchor?.end ?? this.#source.length);
 
-        this.#edits.push({ end: at, start: at, text });
+        // With no anchor there is no preceding entry, so the leading newline the
+        // loop added would open the file with a blank line.
+        let body = at === 0 ? text.slice(1) : text;
+
+        // Nothing follows the insert point in a file that never ended in a
+        // newline, so add the one a YAML file is expected to end with.
+        if (!this.#source.slice(at).includes("\n")) {
+            body += "\n";
+        }
+
+        this.#edits.push({ end: at, start: at, text: body });
     }
 }
 

--- a/packages/data-manipulation/yaml/src/index.ts
+++ b/packages/data-manipulation/yaml/src/index.ts
@@ -1,5 +1,6 @@
+import { YAMLDocument } from "./document";
 import { dump as dumpValue } from "./parser/dumper";
-import { loadAll as loadAllDocuments, loadOne } from "./parser/loader";
+import { loadAll as loadAllDocuments, loadDocuments, loadOne } from "./parser/loader";
 import type { ParseOptions, StringifyOptions } from "./types";
 
 // The `js-yaml`-style aliases default to `strict: false` so they stay
@@ -8,9 +9,13 @@ import type { ParseOptions, StringifyOptions } from "./types";
 // strict on by default. An explicit `strict` in the caller's options wins.
 const LENIENT_DEFAULTS: ParseOptions = { strict: false };
 
+/** Stand-in for `parseDocument` on empty input: no contents, no diagnostics. */
+// eslint-disable-next-line unicorn/no-null
+const EMPTY_DOCUMENT = { contents: null, errors: [], warnings: [] };
+
+export { YAMLDocument } from "./document";
 export type { Mark } from "./errors";
 export { YAMLError, YAMLParseError, YAMLStringifyError, YAMLWarning } from "./errors";
-export type { DuplicateKeyBehavior, ParseOptions, StringifyOptions } from "./types";
 
 /**
  * Parse the first document of a YAML string into a native JavaScript value.
@@ -83,3 +88,32 @@ export function loadAll(source: string, iteratorOrOptions?: ((document: unknown)
  * `js-yaml`-compatible alias of {@link stringify}.
  */
 export const dump = (value: unknown, options?: StringifyOptions): string => dumpValue(value, options);
+
+/**
+ * Parse the first document without throwing, returning a {@link YAMLDocument}
+ * that carries its own diagnostics and supports comment-preserving edits.
+ * @example
+ * ```ts
+ * const document = parseDocument("a: 1 # keep me");
+ *
+ * document.setIn(["b", "c"], 2);
+ * document.toString(); // "a: 1 # keep me\nb:\n  c: 2\n"
+ * ```
+ */
+export const parseDocument = (source: string, options?: ParseOptions): YAMLDocument => {
+    const { documents, ranges } = loadDocuments(source, options);
+
+    return new YAMLDocument(source, documents[0] ?? EMPTY_DOCUMENT, ranges);
+};
+
+/**
+ * Parse every document of a stream without throwing. A malformed document
+ * reports its error and does not stop the ones after it.
+ */
+export const parseAllDocuments = (source: string, options?: ParseOptions): YAMLDocument[] => {
+    const { documents, ranges } = loadDocuments(source, options);
+
+    return documents.map((document) => new YAMLDocument(source, document, ranges));
+};
+
+export type { DuplicateKeyBehavior, ParseOptions, StringifyOptions } from "./types";

--- a/packages/data-manipulation/yaml/src/parser/loader.ts
+++ b/packages/data-manipulation/yaml/src/parser/loader.ts
@@ -30,9 +30,11 @@
  * no intermediate concrete syntax tree on the default path).
  */
 
+import type { YAMLWarning } from "../errors";
 import { YAMLParseError } from "../errors";
 import { resolveExplicitTag, resolveScalarValue } from "../schema/resolve-scalar";
 import type { ParseOptions } from "../types";
+import type { MappingRanges } from "./ranges";
 import { readBlockScalar, readDoubleQuotedScalar, readPlainScalar, readSingleQuotedScalar } from "./scalars";
 import { isEol, isFlowIndicator, isWhiteSpace, isWsOrEol, readLineBreak, skipSeparationSpace, testDocumentSeparator } from "./scanner";
 import type { Snapshot } from "./state";
@@ -115,6 +117,34 @@ const stringifyComplexKey = (node: unknown): string => {
     return String(node);
 };
 
+/** The string a mapping key is stored under. */
+const mappingKeyOf = (keyNode: unknown): string => {
+    if (typeof keyNode === "object" && keyNode !== null) {
+        return stringifyComplexKey(keyNode);
+    }
+
+    return String(keyNode);
+};
+
+/**
+ * Record where one block-mapping entry sits in the source. No-op unless
+ * `parseDocument` asked for ranges.
+ */
+const recordMappingEntry = (state: State, mapping: object, keyNode: unknown, start: number, valueStart: number, end: number): void => {
+    if (state.mappingRanges === null || start < 0) {
+        return;
+    }
+
+    let entries = state.mappingRanges.get(mapping);
+
+    if (entries === undefined) {
+        entries = [];
+        state.mappingRanges.set(mapping, entries);
+    }
+
+    entries.push({ column: start - (state.input.lastIndexOf("\n", start - 1) + 1), end, key: mappingKeyOf(keyNode), start, valueStart });
+};
+
 const storeMappingPair = (
     state: State,
     result: Record<string, unknown>,
@@ -126,7 +156,7 @@ const storeMappingPair = (
     const keyNode = keyNodeInput;
     let keys = overridableKeys;
 
-    const key = typeof keyNode === "object" && keyNode !== null ? stringifyComplexKey(keyNode) : String(keyNode);
+    const key = mappingKeyOf(keyNode);
 
     const isMerge = keyTag === MERGE_TAG || (keyTag === "?" && keyNode === "<<");
 
@@ -251,6 +281,8 @@ const readBlockMapping = (state: State, nodeIndent: number, flowIndent: number):
     let atExplicitKey = false;
     let detected = false;
     let allowCompact = false;
+    let entryKeyStart = -1;
+    let entryValueStart = -1;
 
     // A tab in this line's indentation cannot introduce a block mapping.
     if (state.firstTabInLine !== -1) {
@@ -308,6 +340,8 @@ const readBlockMapping = (state: State, nodeIndent: number, flowIndent: number):
             state.position += 1;
             ch = following;
         } else {
+            entryKeyStart = state.position;
+
             if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
                 break;
             }
@@ -338,6 +372,7 @@ const readBlockMapping = (state: State, nodeIndent: number, flowIndent: number):
                     allowCompact = false;
                     keyTag = state.tag;
                     keyNode = state.result;
+                    entryValueStart = state.position + 1;
                 } else if (detected) {
                     throwError(state, "can not read an implicit mapping pair; a colon is missed");
                 } else {
@@ -366,10 +401,13 @@ const readBlockMapping = (state: State, nodeIndent: number, flowIndent: number):
             }
 
             if (!atExplicitKey) {
+                recordMappingEntry(state, result, keyNode, entryKeyStart, entryValueStart, state.position);
                 overridableKeys = storeMappingPair(state, result, overridableKeys, keyTag, keyNode, valueNode);
                 keyTag = null;
                 keyNode = null;
                 valueNode = null;
+                entryKeyStart = -1;
+                entryValueStart = -1;
             }
 
             skipSeparationSpace(state, true, -1);
@@ -1117,11 +1155,14 @@ const normalizeInput = (input: string): string => {
     return source;
 };
 
-/** Parse every document in a YAML stream, returning them in order. */
-export const loadAll = (input: string, options: ParseOptions = {}): unknown[] => {
-    // This is a trust boundary, so a non-string must fail as a YAMLParseError
-    // rather than as whichever TypeError the first string method happens to
-    // raise — callers catch the former.
+/**
+ * Validate the input and build a cursor over it. Shared by every entry point so
+ * the trust-boundary checks cannot be bypassed by one of them.
+ */
+const prepareState = (input: string, options: ParseOptions): State => {
+    // A non-string must fail as a YAMLParseError rather than as whichever
+    // TypeError the first string method happens to raise — callers catch the
+    // former.
     if (typeof input !== "string") {
         throw new YAMLParseError(`expected a string to parse, received ${input === null ? "null" : typeof input}`);
     }
@@ -1139,6 +1180,13 @@ export const loadAll = (input: string, options: ParseOptions = {}): unknown[] =>
     state.position = 0;
     state.lineIndent = 0;
 
+    return state;
+};
+
+/** Parse every document in a YAML stream, returning them in order. */
+const loadAll = (input: string, options: ParseOptions = {}): unknown[] => {
+    const state = prepareState(input, options);
+
     while (state.position < state.length - 1) {
         readDocument(state);
     }
@@ -1146,8 +1194,99 @@ export const loadAll = (input: string, options: ParseOptions = {}): unknown[] =>
     return state.documents;
 };
 
+/**
+ * Move the cursor to the next document marker after a failed document, so one
+ * malformed document does not hide the rest of the stream. Returns false when
+ * there is nothing left to parse.
+ */
+const skipToNextDocument = (state: State): boolean => {
+    const { input } = state;
+    let index = input.indexOf("\n", state.position);
+
+    while (index !== -1) {
+        const lineStart = index + 1;
+        const marker = input.slice(lineStart, lineStart + 3);
+
+        if (marker === "---" || marker === "...") {
+            state.position = lineStart;
+            state.lineStart = lineStart;
+            state.line += 1;
+            state.lineIndent = 0;
+            state.firstTabInLine = -1;
+
+            return state.position < state.length - 1;
+        }
+
+        index = input.indexOf("\n", lineStart);
+    }
+
+    return false;
+};
+
+/** One document of a stream, with the diagnostics raised while reading it. */
+interface DocumentResult {
+    contents: unknown;
+    errors: YAMLParseError[];
+    warnings: YAMLWarning[];
+}
+
+/**
+ * Parse a stream without throwing: each document's diagnostics are collected
+ * and a malformed document does not prevent the following ones from parsing.
+ *
+ * Recovery is per document — within one document the first error still ends it,
+ * because the parser has no resync points inside a document.
+ */
+const loadDocuments = (input: string, options: ParseOptions = {}): { documents: DocumentResult[]; ranges: MappingRanges } => {
+    const warnings: YAMLWarning[] = [];
+    const state = prepareState(input, {
+        ...options,
+        onWarning: (warning) => {
+            warnings.push(warning);
+            options.onWarning?.(warning);
+        },
+    });
+
+    state.mappingRanges = new WeakMap();
+
+    const documents: DocumentResult[] = [];
+
+    while (state.position < state.length - 1) {
+        const producedBefore = state.documents.length;
+        const warningsBefore = warnings.length;
+        const positionBefore = state.position;
+
+        try {
+            readDocument(state);
+        } catch (error) {
+            if (!(error instanceof YAMLParseError)) {
+                throw error;
+            }
+
+            documents.push({ contents: null, errors: [error], warnings: warnings.slice(warningsBefore) });
+
+            if (!skipToNextDocument(state)) {
+                break;
+            }
+
+            continue;
+        }
+
+        for (const contents of state.documents.slice(producedBefore)) {
+            documents.push({ contents, errors: [], warnings: warnings.slice(warningsBefore) });
+        }
+
+        // A document that consumed nothing would loop forever.
+        if (state.position === positionBefore) {
+            break;
+        }
+    }
+
+    return { documents, ranges: state.mappingRanges };
+};
+
 /** Parse the first document in a YAML stream. */
-export const loadOne = (input: string, options: ParseOptions = {}): unknown => {
+const loadOne = (input: string, options: ParseOptions = {}): unknown => {
     const documents = loadAll(input, options);
 
     if (documents.length === 0) {
@@ -1160,3 +1299,6 @@ export const loadOne = (input: string, options: ParseOptions = {}): unknown => {
 
     throw new YAMLParseError("expected a single document in the stream, but found more");
 };
+
+export type { DocumentResult };
+export { loadAll, loadDocuments, loadOne };

--- a/packages/data-manipulation/yaml/src/parser/ranges.ts
+++ b/packages/data-manipulation/yaml/src/parser/ranges.ts
@@ -1,0 +1,33 @@
+/**
+ * Source spans for block-mapping entries.
+ *
+ * Kept in its own module so the document layer can depend on these types
+ * without pulling the `State` class into the public declaration graph.
+ */
+
+/**
+ * Source span of one `key: value` entry inside a block mapping, recorded only
+ * when `State.mappingRanges` is set (i.e. by `parseDocument`). The document
+ * layer uses these to splice edits into the original text instead of
+ * re-serializing, which is what preserves comments and formatting.
+ */
+interface MappingEntryRange {
+    /** Column the key starts at — the indent a sibling entry must match. */
+    column: number;
+
+    /** Offset just past the entry's value. */
+    end: number;
+
+    key: string;
+
+    /** Offset of the first character of the key. */
+    start: number;
+
+    /** Offset of the first character of the value, or -1 when it is empty. */
+    valueStart: number;
+}
+
+/** Block mappings in a parse, keyed by the object each one produced. */
+type MappingRanges = WeakMap<object, MappingEntryRange[]>;
+
+export type { MappingEntryRange, MappingRanges };

--- a/packages/data-manipulation/yaml/src/parser/state.ts
+++ b/packages/data-manipulation/yaml/src/parser/state.ts
@@ -15,6 +15,7 @@
 
 import { YAMLParseError, YAMLWarning } from "../errors";
 import type { ParseOptions } from "../types";
+import type { MappingRanges } from "./ranges";
 
 /** The three node shapes the composer distinguishes. */
 type NodeKind = "mapping" | "scalar" | "sequence";
@@ -61,6 +62,12 @@ class State {
 
     /** Current `composeNode` recursion depth; bounded by `options.maxDepth`. */
     public depth = 0;
+
+    /**
+     * Block-mapping source spans, or `null` to skip recording them. Only
+     * `parseDocument` turns this on — the plain `parse` path never pays for it.
+     */
+    public mappingRanges: MappingRanges | null = null;
 
     public readonly options: ParseOptions & Required<Pick<ParseOptions, "duplicateKeys" | "maxAliasCount" | "maxDepth" | "preventProtoPollution" | "strict">>;
 

--- a/packages/tooling/vis/package.json
+++ b/packages/tooling/vis/package.json
@@ -208,6 +208,7 @@
         "@visulima/spinner": "1.0.1",
         "@visulima/string": "3.1.0",
         "@visulima/tsconfig": "3.2.6",
+        "@visulima/yaml": "workspace:*",
         "@vitest/coverage-v8": "catalog:test",
         "@vitest/ui": "catalog:test",
         "@yarnpkg/parsers": "^3.0.3",

--- a/packages/tooling/vis/src/commands/hook/prek.ts
+++ b/packages/tooling/vis/src/commands/hook/prek.ts
@@ -4,7 +4,7 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { ensureDirSync, isAccessibleSync, readFileSync } from "@visulima/fs";
 import { readTomlSync } from "@visulima/fs/toml";
 import { join } from "@visulima/path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import { resolveIndentForFile } from "../../util/editorconfig";
 import { isKnownTag } from "../../util/identify";

--- a/packages/tooling/vis/src/commands/update/ecosystems/dependabot.ts
+++ b/packages/tooling/vis/src/commands/update/ecosystems/dependabot.ts
@@ -1,6 +1,6 @@
 import { isAccessibleSync, readFileSync } from "@visulima/fs";
 import { join } from "@visulima/path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import type { EcosystemId } from "./types";
 

--- a/packages/tooling/vis/src/config/workspace.ts
+++ b/packages/tooling/vis/src/config/workspace.ts
@@ -11,7 +11,7 @@ import type {
     WorkspaceConfiguration,
 } from "@visulima/task-runner";
 import { looksLikeInputUri, parseInputUri } from "@visulima/task-runner";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import { VisUserError } from "../errors/vis-user-error";
 import { BUILT_IN_DETECTORS, inferProjectTargets } from "../inference";

--- a/packages/tooling/vis/src/generate/moon-adapter/index.ts
+++ b/packages/tooling/vis/src/generate/moon-adapter/index.ts
@@ -13,7 +13,7 @@
 import { readFileSync, walkSync } from "@visulima/fs";
 import { readYamlSync } from "@visulima/fs/yaml";
 import { join, relative } from "@visulima/path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import { pail } from "../../io/logger";
 import type { Creation, CreationDirectory, CreationFile, FileMeta, Template, TemplateContext, Variable, VariableMap } from "../types";

--- a/packages/tooling/vis/src/preflight/vite-client-override.ts
+++ b/packages/tooling/vis/src/preflight/vite-client-override.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 import { dirname, join } from "@visulima/path";
-import { parseDocument } from "yaml";
+import { parseDocument } from "@visulima/yaml";
 
 import type { LockfilePackageManager } from "./lockfile";
 import { detectPackageManager } from "./lockfile";

--- a/packages/tooling/vis/src/release/core/catalog.ts
+++ b/packages/tooling/vis/src/release/core/catalog.ts
@@ -11,7 +11,7 @@
  * already-parsed YAML content.
  */
 
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import { VisReleaseError } from "../errors";
 import type { DependencyKind, PackageManifest } from "../types";
@@ -38,7 +38,7 @@ export const parseCatalogs = (yamlContent: string | undefined): Catalogs => {
     let raw: unknown;
 
     try {
-        raw = parseYaml(yamlContent, { schema: "core", strict: true });
+        raw = parseYaml(yamlContent, { strict: true } /* @visulima/yaml is always YAML 1.2 core */);
     } catch (error) {
         throw new VisReleaseError({
             cause: error,

--- a/packages/tooling/vis/src/release/core/change-file.ts
+++ b/packages/tooling/vis/src/release/core/change-file.ts
@@ -41,7 +41,7 @@
  * the null entries take the inferred level.
  */
 
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 import { VisReleaseError } from "../errors";
 import type { BumpLevel, ChangeFile, ChangeFileNested, ChangeFileSimple } from "../types";
@@ -322,7 +322,7 @@ export const parseChangeFile = (content: string, file: string): ChangeFile => {
     let raw: unknown;
 
     try {
-        raw = parseYaml(split.frontmatter, { schema: "core", strict: true });
+        raw = parseYaml(split.frontmatter, { strict: true } /* @visulima/yaml is always YAML 1.2 core */);
     } catch (error) {
         throw new VisReleaseError({
             cause: error,

--- a/packages/tooling/vis/src/util/aube-config.ts
+++ b/packages/tooling/vis/src/util/aube-config.ts
@@ -1,6 +1,6 @@
 import { isAccessibleSync, readFileSync } from "@visulima/fs";
 import { join } from "@visulima/path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml } from "@visulima/yaml";
 
 /**
  * Subset of `aube-workspace.yaml` / `pnpm-workspace.yaml` that aube

--- a/packages/tooling/vis/src/util/docker-lockfile/pnpm.ts
+++ b/packages/tooling/vis/src/util/docker-lockfile/pnpm.ts
@@ -1,4 +1,4 @@
-import { parseAllDocuments, stringify as stringifyYaml } from "yaml";
+import { parseAllDocuments, stringify as stringifyYaml } from "@visulima/yaml";
 
 import type { PruneInput, PruneResult } from "./types";
 import { LockfilePruneError } from "./types";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2451,15 +2451,15 @@ importers:
       '@visulima/fs':
         specifier: 5.1.0
         version: link:../../filesystem/fs
+      '@visulima/yaml':
+        specifier: workspace:*
+        version: link:../../data-manipulation/yaml
       comment-parser:
         specifier: catalog:prod
         version: 1.4.7
       es-toolkit:
         specifier: catalog:prod
         version: 1.49.0
-      yaml:
-        specifier: catalog:prod
-        version: 2.9.0
     devDependencies:
       '@anolilab/eslint-config':
         specifier: catalog:lint
@@ -2527,6 +2527,9 @@ importers:
       vitest:
         specifier: catalog:test
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      yaml:
+        specifier: catalog:prod
+        version: 2.9.0
     optionalDependencies:
       cli-progress:
         specifier: catalog:optional
@@ -10376,6 +10379,9 @@ importers:
       '@visulima/tsconfig':
         specifier: 3.2.6
         version: link:../tsconfig
+      '@visulima/yaml':
+        specifier: workspace:*
+        version: link:../../data-manipulation/yaml
       '@vitest/coverage-v8':
         specifier: catalog:test
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -11920,7 +11926,7 @@ packages:
     resolution: {integrity: sha512-5ThLXS2ZXPoCa9xpRqDi9BebpkkbYbAhUU1lMomD+UXEp2SeB4/pVxeFF0j/9nbBlUhDOm5aariI31h8ZcXrBg==}
     hasBin: true
     peerDependencies:
-      vite: ^7.3.5
+      vite: '>=6.4.2'
       wrangler: ^4.107.0
 
   '@cloudflare/vitest-pool-workers@0.19.0':


### PR DESCRIPTION
Stacked on #825 — targets `claude/yaml-package-implementation-sqcciv`, not `main`.

## What

Adds `parseDocument` / `parseAllDocuments`, returning a `YAMLDocument` that reports diagnostics instead of throwing and can edit a file without reformatting it.

These were the two capabilities blocking the rest of the monorepo from using `@visulima/yaml`. Three consumers still needed `yaml` purely for them.

## Error recovery

Per document: a malformed document records its error, the cursor resyncs to the next `---`/`...`, and the rest of the stream still parses.

Within a single document the first error still ends it — the parser has no resync points inside a document — so `parseDocument` reports at most one error while `parseAllDocuments` reports one per document. Scoped honestly rather than faked.

## Comment-preserving edits

`setIn` splices the original source instead of re-serializing. A `parse` → `stringify` round-trip destroys every comment and blank line, which makes it unusable on hand-maintained config; splicing only the changed bytes leaves everything else byte-identical (there is a test asserting exactly that).

```ts
const document = parseDocument("packages:\n  - 'a/*'\n\n# keep me\n");

document.setIn(["overrides", "some-pkg"], "npm:other@1.2.3");
document.toString();
// packages:
//   - 'a/*'
//
// # keep me
// overrides:
//   some-pkg: npm:other@1.2.3
```

Missing intermediate mappings are created, and an empty or comment-only file can be built from nothing.

Spans are recorded **only when `State.mappingRanges` is set**, so the plain `parse` path pays nothing.

## Migration

| package | change |
| --- | --- |
| `vis` | `parseDocument`+`setIn`+`toString` for pnpm-workspace overrides, `parseAllDocuments` for lockfile pruning, plus 7 plain `parse` sites |
| `jsdoc-open-api` | `parseDocument().errors` for `@openapi` diagnostics; `yaml` moves out of `dependencies` |

Both keep `yaml` as a **dev-only** dependency so their tests still cross-check against an independent implementation.

`fs` is deliberately **not** migrated: its public `ReadYamlOptions`/`WriteYamlOptions` *are* `yaml`'s option types, so that needs a major.

## Verification

- 133 tests, 402/402 official yaml-test-suite conformance, lint + types + publint + attw clean
- `vis`: 47/47 on the YAML paths · `jsdoc-open-api`: 130/130

## Worth a second opinion

Two `vis` call sites passed `{ schema: "core" }`, which this parser does not accept. I dropped the option because core is its only mode — that is me asserting equivalence.