### PR TITLE
ci: build @visulima/yaml before @visulima/fs in Build Native

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -557,10 +557,17 @@ jobs:
               run: "pnpm vitest run __tests__/native/native-binding.test.ts"
               working-directory: "packages/tooling/vis"
 
-            # @visulima/path and @visulima/error have no @visulima inter-deps, so
-            # they build concurrently. @visulima/fs depends on @visulima/path, so it
-            # stays sequential AFTER the group (the implicit wait-all guarantees path
-            # is built before fs starts).
+            # @visulima/path, @visulima/error and @visulima/yaml have no @visulima
+            # inter-deps, so they build concurrently. @visulima/fs depends on all
+            # three, so it stays sequential AFTER the group (the implicit wait-all
+            # guarantees they are built before fs starts).
+            #
+            # These steps run `pnpm run build` inside each package rather than
+            # through nx, so nothing resolves the dependency graph for us: a new
+            # workspace dependency of fs has to be added here by hand. Missing
+            # @visulima/yaml is what broke this job — fs's `src/types.ts` imports
+            # its option types, so generating fs's declarations needs yaml's
+            # `dist/index.d.ts` to exist.
             - parallel:
                   - name: "Build @visulima/path (secret-scanner dep)"
                     if: "matrix.settings.testable && (github.event_name != 'pull_request' || needs.files-changed.outputs.secret-scanner == 'true')"
@@ -571,6 +578,11 @@ jobs:
                     if: "matrix.settings.testable && (github.event_name != 'pull_request' || needs.files-changed.outputs.secret-scanner == 'true')"
                     run: "pnpm --config.verify-deps-before-run=false run build"
                     working-directory: "packages/error-debugging/error"
+
+                  - name: "Build @visulima/yaml (fs dep)"
+                    if: "matrix.settings.testable && (github.event_name != 'pull_request' || needs.files-changed.outputs.secret-scanner == 'true')"
+                    run: "pnpm --config.verify-deps-before-run=false run build"
+                    working-directory: "packages/data-manipulation/yaml"
 
             - name: "Build @visulima/fs (secret-scanner dep)"
               if: "matrix.settings.testable && (github.event_name != 'pull_request' || needs.files-changed.outputs.secret-scanner == 'true')"


### PR DESCRIPTION
The secret-scanner native test needs @visulima/fs built, and this job builds
fs's workspace dependencies by hand — `pnpm run build` inside each package,
not through nx — so nothing resolves the dependency graph for it.

fs gained a dependency on @visulima/yaml when its YAML reader moved over:
`src/types.ts` imports the option types, so generating fs's declarations
needs yaml's `dist/index.d.ts`. Without that step the job failed with

    Could not load .../yaml/dist/index.d.ts (imported by src/types.d.ts)

yaml has no workspace dependencies of its own, so it joins @visulima/path
and @visulima/error in the concurrent group; fs still runs after them.

The comment there now says a new workspace dependency of fs has to be added
by hand, since the failure mode gives no hint that this list is the cause.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CT3GAfPNZD2oGG519ifgbX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the native build workflow by optimizing the order in which supporting packages are built.
  * Documented build dependencies and parallelization to make the process clearer and more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->