### PR TITLE
fix(tui): batch the palette probe, serialize terminal probes, widen colour parsing

### DIFF
--- a/packages/terminal/tui/__tests__/ink/probe-terminal.test.ts
+++ b/packages/terminal/tui/__tests__/ink/probe-terminal.test.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it } from "vitest";
+
+import runExclusiveProbe from "../../src/ink/probe-terminal";
+
+const flush = async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+describe(runExclusiveProbe, () => {
+    it("runs a lone probe synchronously, so its listener is attached before the next statement", () => {
+        expect.assertions(1);
+
+        const stdin = new EventEmitter() as unknown as NodeJS.ReadableStream;
+        let isStarted = false;
+
+        void runExclusiveProbe(stdin, async () => {
+            isStarted = true;
+
+            return undefined;
+        });
+
+        // Deferring by even a microtask would let bytes arrive before the probe is listening.
+        expect(isStarted).toBe(true);
+    });
+
+    it("holds a second probe until the first finishes", async () => {
+        expect.assertions(2);
+
+        const stdin = new EventEmitter() as unknown as NodeJS.ReadableStream;
+        const order: string[] = [];
+        const held = Promise.withResolvers<undefined>();
+
+        const first = runExclusiveProbe(stdin, async () => {
+            order.push("first:start");
+
+            await held.promise;
+
+            order.push("first:end");
+        });
+
+        const second = runExclusiveProbe(stdin, async () => {
+            order.push("second:start");
+        });
+
+        await flush();
+
+        // The kitty query and the palette query both read this stdin; overlapping them makes each
+        // treat the other's answer as user input.
+        expect(order).toStrictEqual(["first:start"]);
+
+        held.resolve(undefined);
+        await Promise.all([first, second]);
+
+        expect(order).toStrictEqual(["first:start", "first:end", "second:start"]);
+    });
+
+    it("lets the next probe run after one rejects", async () => {
+        expect.assertions(2);
+
+        const stdin = new EventEmitter() as unknown as NodeJS.ReadableStream;
+
+        const failing = runExclusiveProbe(stdin, async () => {
+            throw new Error("terminal went away");
+        });
+
+        await expect(failing).rejects.toThrow("terminal went away");
+
+        // A probe that blew up must not wedge the queue for every later feature.
+        await expect(runExclusiveProbe(stdin, async () => "ok")).resolves.toBe("ok");
+    });
+
+    it("keeps separate streams independent", async () => {
+        expect.assertions(1);
+
+        const first = new EventEmitter() as unknown as NodeJS.ReadableStream;
+        const second = new EventEmitter() as unknown as NodeJS.ReadableStream;
+        const started: string[] = [];
+
+        void runExclusiveProbe(first, async () => {
+            started.push("first");
+
+            await new Promise(() => undefined);
+        });
+        void runExclusiveProbe(second, async () => {
+            started.push("second");
+        });
+
+        await flush();
+
+        expect(started).toStrictEqual(["first", "second"]);
+    });
+
+    it("runs synchronously again once the queue has drained", async () => {
+        expect.assertions(1);
+
+        const stdin = new EventEmitter() as unknown as NodeJS.ReadableStream;
+
+        await runExclusiveProbe(stdin, async () => undefined);
+        await flush();
+
+        let isStarted = false;
+
+        void runExclusiveProbe(stdin, async () => {
+            isStarted = true;
+
+            return undefined;
+        });
+
+        // A probe that finished long ago must not leave a permanent microtask hop behind.
+        expect(isStarted).toBe(true);
+    });
+});

--- a/packages/terminal/tui/__tests__/ink/terminal-palette.test.ts
+++ b/packages/terminal/tui/__tests__/ink/terminal-palette.test.ts
@@ -1,6 +1,86 @@
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Writable } from "node:stream";
 
-import { isTerminalPaletteQuerySupported } from "../../src/ink/terminal-palette";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { clearTerminalPaletteCache, isTerminalPaletteQuerySupported, queryTerminalPalette, takeOscAnswers } from "../../src/ink/terminal-palette";
+
+const BEL = "\u{7}";
+const ESCAPE = "\u{1B}";
+const OSC = `${ESCAPE}]`;
+
+/**
+ * A stdin stand-in that models the parts of stream flow the probe depends on.
+ *
+ * Recording the `unshift` call alone is not enough: a real stream keeps flowing after its last
+ * `data` listener is removed, and an unshift into a flowing stream is re-emitted to nobody. This
+ * tracks `flowing` so a test can assert the bytes are actually recoverable.
+ */
+class FakeStdin extends EventEmitter {
+    public readonly unshifted: string[] = [];
+
+    public flowing = false;
+
+    public override on(event: string, listener: (...arguments_: unknown[]) => void): this {
+        if (event === "data") {
+            this.flowing = true;
+        }
+
+        return super.on(event, listener);
+    }
+
+    public pause(): this {
+        this.flowing = false;
+
+        return this;
+    }
+
+    public unshift(chunk: string): void {
+        this.unshifted.push(chunk);
+    }
+
+    /** What a listener attaching after the probe would read. */
+    public get recoverable(): string {
+        return this.flowing ? "" : this.unshifted.join("");
+    }
+
+    public send(data: string): void {
+        this.emit("data", data);
+    }
+}
+
+/** A stdout stand-in that records what was written. */
+const createStdout = (): Writable & { writes: string[] } => {
+    const writes: string[] = [];
+
+    return {
+        write: (chunk: string) => {
+            writes.push(chunk);
+
+            return true;
+        },
+        writes,
+    } as unknown as Writable & { writes: string[] };
+};
+
+/** What every indexed slot answers with in these fixtures. */
+const SIXTEEN_GREYS = Array.from({ length: 16 }).fill("#102030");
+
+const colorResponse = (ps: string, hex: string): string => {
+    const channel = (offset: number) => hex.slice(offset, offset + 2).repeat(2);
+
+    return `${OSC}${ps};rgb:${channel(1)}/${channel(3)}/${channel(5)}${BEL}`;
+};
+
+const fullPaletteResponse = (): string => {
+    let response = colorResponse("10", "#ffffff") + colorResponse("11", "#000000") + colorResponse("12", "#ff0000");
+
+    for (let index = 0; index < 16; index += 1) {
+        response += colorResponse(`4;${String(index)}`, "#102030");
+    }
+
+    return response;
+};
 
 describe("terminal-palette", () => {
     it("isTerminalPaletteQuerySupported should detect supported terminals", () => {
@@ -14,9 +94,9 @@ describe("terminal-palette", () => {
 
         process.env["TERM_PROGRAM"] = "unknown-terminal";
         // May return true if TERM is xterm or WT_SESSION is set
-        const result = isTerminalPaletteQuerySupported();
+        const isResult = isTerminalPaletteQuerySupported();
 
-        expectTypeOf(result).toBeBoolean();
+        expectTypeOf(isResult).toBeBoolean();
 
         if (original === undefined) {
             delete process.env["TERM_PROGRAM"];
@@ -63,5 +143,360 @@ describe("terminal-palette", () => {
         } else {
             process.env["TERM"] = originalTerm;
         }
+    });
+
+    describe(takeOscAnswers, () => {
+        it("separates answers from application bytes", () => {
+            expect.assertions(3);
+
+            const result = takeOscAnswers(`q${colorResponse("11", "#112233")}uit`);
+
+            expect(result.answers).toStrictEqual(["11;rgb:1111/2222/3333"]);
+            expect(result.foreign).toBe("quit");
+            expect(result.rest).toBe("");
+        });
+
+        it("carries an incomplete answer forward instead of emitting it", () => {
+            expect.assertions(2);
+
+            const response = colorResponse("10", "#445566");
+            const first = takeOscAnswers(response.slice(0, 6));
+
+            expect(first.answers).toStrictEqual([]);
+
+            const second = takeOscAnswers(first.rest + response.slice(6));
+
+            expect(second.answers).toStrictEqual(["10;rgb:4444/5555/6666"]);
+        });
+
+        it("holds back a trailing lone escape, which may begin the next answer", () => {
+            expect.assertions(2);
+
+            const result = takeOscAnswers(`ab${ESCAPE}`);
+
+            expect(result.foreign).toBe("ab");
+            expect(result.rest).toBe(ESCAPE);
+        });
+
+        it("accepts a string-terminated answer as well as a bell-terminated one", () => {
+            expect.assertions(1);
+
+            expect(takeOscAnswers(`${OSC}11;rgb:0000/0000/0000${ESCAPE}\\`).answers).toStrictEqual(["11;rgb:0000/0000/0000"]);
+        });
+
+        it("treats a stray bell as application input, not as an answer", () => {
+            expect.assertions(2);
+
+            const result = takeOscAnswers(BEL);
+
+            expect(result.answers).toStrictEqual([]);
+            expect(result.foreign).toBe(BEL);
+        });
+
+        it("pulls several answers out of one chunk", () => {
+            expect.assertions(1);
+
+            const chunk = colorResponse("10", "#010203") + colorResponse("11", "#040506") + colorResponse("4;7", "#070809");
+
+            expect(takeOscAnswers(chunk).answers).toHaveLength(3);
+        });
+    });
+
+    describe(queryTerminalPalette, () => {
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("sends all 19 queries in a single write", async () => {
+            expect.assertions(3);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            expect(stdout.writes).toHaveLength(1);
+            // Nineteen queries, one round trip: previously each waited for the last to time out.
+            expect(stdout.writes[0]?.split(BEL).filter(Boolean)).toHaveLength(19);
+
+            stdin.send(fullPaletteResponse());
+
+            await expect(query).resolves.toStrictEqual({
+                background: "#000000",
+                colors: SIXTEEN_GREYS,
+                cursor: "#ff0000",
+                foreground: "#ffffff",
+            });
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("resolves as soon as the last answer arrives, without waiting out the timeout", async () => {
+            expect.assertions(1);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 10_000);
+
+            stdin.send(fullPaletteResponse());
+
+            const result = await query;
+
+            expect(result.foreground).toBe("#ffffff");
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("detaches its stdin listener once finished", async () => {
+            expect.assertions(2);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            expect(stdin.listenerCount("data")).toBe(1);
+
+            stdin.send(fullPaletteResponse());
+            await query;
+
+            expect(stdin.listenerCount("data")).toBe(0);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("hands keystrokes typed during the query back to the stream", async () => {
+            expect.assertions(2);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            // The user types while the terminal is answering. Those bytes are not ours to eat.
+            stdin.send(colorResponse("10", "#ffffff"));
+            stdin.send("q");
+            stdin.send(colorResponse("11", "#000000"));
+            stdin.send("uit");
+
+            await query;
+
+            // Not just "unshift was called" — the stream must be out of flowing mode, or the
+            // bytes are re-emitted to nobody and the keystrokes are lost anyway.
+            expect(stdin.recoverable).toBe("quit");
+            // One unshift call: successive unshifts would deliver the input back to front.
+            expect(stdin.unshifted).toHaveLength(1);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("does not hand bytes back when the app is already listening", async () => {
+            expect.assertions(1);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            // The app's own input handler is attached, so it already received these chunks.
+            // Unshifting would deliver every keystroke a second time.
+            stdin.on("data", () => undefined);
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            stdin.send("q");
+
+            await query;
+
+            expect(stdin.unshifted).toHaveLength(0);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("keeps a response split across chunks intact", async () => {
+            expect.assertions(2);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+            const controller = new AbortController();
+
+            const query = queryTerminalPalette(stdin, stdout, 50, controller.signal);
+            const response = colorResponse("11", "#123456");
+
+            stdin.send(response.slice(0, 5));
+            stdin.send(response.slice(5));
+            // Only the background answered, so the batch runs to its timeout; stop waiting for it.
+            controller.abort();
+            await query;
+
+            const cached = await queryTerminalPalette(stdin, stdout, 50);
+
+            expect(cached.background).toBe("#123456");
+            expect(stdin.unshifted.join("")).toBe("");
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("ignores a stray BEL from user input instead of treating it as an answer", async () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            // A lone BEL used to satisfy the "response arrived" check and resolve with garbage.
+            stdin.send(BEL);
+
+            await vi.advanceTimersByTimeAsync(60);
+
+            const result = await query;
+
+            expect(result).toStrictEqual({});
+            expect(stdin.unshifted.join("")).toBe(BEL);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("gives up after one timeout for the whole batch", async () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 200);
+
+            // A single 200ms budget covers all 19 queries; the old code spent 200ms per query.
+            await vi.advanceTimersByTimeAsync(250);
+
+            await expect(query).resolves.toStrictEqual({});
+            expect(stdin.listenerCount("data")).toBe(0);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("stops waiting when aborted", async () => {
+            expect.assertions(1);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+            const controller = new AbortController();
+
+            const query = queryTerminalPalette(stdin, stdout, 10_000, controller.signal);
+
+            controller.abort();
+
+            await expect(query).resolves.toStrictEqual({});
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("returns an empty palette without probing when the signal is already aborted", async () => {
+            expect.assertions(2);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            await expect(queryTerminalPalette(stdin, stdout, 50, AbortSignal.abort())).resolves.toStrictEqual({});
+            expect(stdout.writes).toHaveLength(0);
+        });
+
+        it("keeps the shared probe alive when one caller aborts", async () => {
+            expect.assertions(3);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+            const controller = new AbortController();
+
+            // Two components want the palette; the first unmounts mid-flight. Cancelling the round
+            // trip there would throw away the answer the second one is still waiting for.
+            const aborted = queryTerminalPalette(stdin, stdout, 10_000, controller.signal);
+            const survivor = queryTerminalPalette(stdin, stdout, 10_000);
+
+            controller.abort();
+
+            await expect(aborted).resolves.toStrictEqual({});
+
+            expect(stdin.listenerCount("data")).toBe(1);
+
+            stdin.send(fullPaletteResponse());
+
+            await expect(survivor).resolves.toMatchObject({ foreground: "#ffffff" });
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("does not poison the cache when the first caller aborts (StrictMode double-mount)", async () => {
+            expect.assertions(2);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+            const first = new AbortController();
+
+            // React 19 StrictMode mounts, unmounts, remounts. The remount must not be handed the
+            // empty promise the unmount resolved.
+            const mountOne = queryTerminalPalette(stdin, stdout, 10_000, first.signal);
+
+            first.abort();
+            await mountOne;
+
+            const mountTwo = queryTerminalPalette(stdin, stdout, 10_000);
+
+            stdin.send(fullPaletteResponse());
+
+            await expect(mountTwo).resolves.toMatchObject({ foreground: "#ffffff" });
+            expect(stdout.writes).toHaveLength(1);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("caches the result per stdout so a second caller does not re-query", async () => {
+            expect.assertions(3);
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const first = queryTerminalPalette(stdin, stdout, 50);
+
+            stdin.send(fullPaletteResponse());
+            await first;
+
+            const second = await queryTerminalPalette(stdin, stdout, 50);
+
+            expect(stdout.writes).toHaveLength(1);
+            expect(second.foreground).toBe("#ffffff");
+
+            clearTerminalPaletteCache(stdout);
+
+            void queryTerminalPalette(stdin, stdout, 50);
+
+            expect(stdout.writes).toHaveLength(2);
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("does not cache an empty result, so a later attempt can still succeed", async () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const first = queryTerminalPalette(stdin, stdout, 50);
+
+            await vi.advanceTimersByTimeAsync(60);
+
+            await expect(first).resolves.toStrictEqual({});
+
+            void queryTerminalPalette(stdin, stdout, 50);
+
+            expect(stdout.writes).toHaveLength(2);
+
+            clearTerminalPaletteCache(stdout);
+        });
     });
 });

--- a/packages/terminal/tui/__tests__/ink/terminal-palette.test.ts
+++ b/packages/terminal/tui/__tests__/ink/terminal-palette.test.ts
@@ -378,6 +378,53 @@ describe("terminal-palette", () => {
             clearTerminalPaletteCache(stdout);
         });
 
+        it.each([
+            ["an rgb: device specification", "rgb:ffff/0000/0000"],
+            ["a short rgb: specification", "rgb:f/0/0"],
+            ["a hex triplet", "#ff0000"],
+            ["a long hex triplet", "#ffff00000000"],
+            ["an X11 colour name", "red"],
+        ])("accepts %s as a foreground reply", async (_name, spec) => {
+            expect.assertions(1);
+
+            // Only `rgb:` used to be understood; every other form a terminal answers with was
+            // silently dropped and the palette came back missing that entry.
+            vi.useFakeTimers();
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            stdin.send(`${OSC}10;${spec}${BEL}`);
+            // Only one of the nineteen answers arrived, so the batch runs to its timeout.
+            await vi.advanceTimersByTimeAsync(60);
+
+            await expect(query).resolves.toMatchObject({ foreground: "#ff0000" });
+
+            clearTerminalPaletteCache(stdout);
+        });
+
+        it("reads the colour from an indexed reply, which carries two fields before it", async () => {
+            expect.assertions(1);
+
+            vi.useFakeTimers();
+
+            const stdin = new FakeStdin();
+            const stdout = createStdout();
+
+            const query = queryTerminalPalette(stdin, stdout, 50);
+
+            stdin.send(`${OSC}4;7;cornflowerblue${BEL}`);
+            await vi.advanceTimersByTimeAsync(60);
+
+            const result = await query;
+
+            expect(result.colors?.[7]).toBe("#6495ed");
+
+            clearTerminalPaletteCache(stdout);
+        });
+
         it("stops waiting when aborted", async () => {
             expect.assertions(1);
 

--- a/packages/terminal/tui/src/ink/hooks/use-terminal-palette.ts
+++ b/packages/terminal/tui/src/ink/hooks/use-terminal-palette.ts
@@ -41,26 +41,29 @@ const useTerminalPalette = (): UseTerminalPaletteResult => {
             return;
         }
 
-        let cancelled = false;
+        // Stops this component waiting on unmount. The probe itself is shared per stdout and is
+        // deliberately not cancelled: another mounted component may still be waiting on the same
+        // round trip. Its listener and timer therefore outlive us by at most `timeout`.
+        const controller = new AbortController();
 
         void (async () => {
             try {
-                const result = await queryTerminalPalette(stdin, stdout, 200);
+                const result = await queryTerminalPalette(stdin, stdout, 200, controller.signal);
 
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setPalette(result);
                 }
             } catch {
                 // Query failed — leave palette as null
             } finally {
-                if (!cancelled) {
+                if (!controller.signal.aborted) {
                     setIsLoading(false);
                 }
             }
         })();
 
         return () => {
-            cancelled = true;
+            controller.abort();
         };
     }, [isSupported, stdin, stdout]);
 

--- a/packages/terminal/tui/src/ink/ink.tsx
+++ b/packages/terminal/tui/src/ink/ink.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @stylistic/no-tabs, @stylistic/no-trailing-spaces, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unnecessary-type-conversion, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-use-before-define, @typescript-eslint/unbound-method, class-methods-use-this, e18e/prefer-static-regex, import/no-namespace, jsdoc/no-undefined-types, jsdoc/require-asterisk-prefix, jsdoc/tag-lines, no-empty, no-void, react-x/no-context-provider, sonarjs/different-types-comparison, sonarjs/no-async-constructor, sonarjs/no-tab */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-use-before-define, @typescript-eslint/unbound-method, class-methods-use-this, e18e/prefer-static-regex, import/no-namespace, jsdoc/no-undefined-types, jsdoc/tag-lines, no-empty, no-void, react-x/no-context-provider, sonarjs/different-types-comparison, sonarjs/no-async-constructor */
 import { Buffer } from "node:buffer";
 import { Console as NodeConsole } from "node:console";
 import process from "node:process";
@@ -26,6 +26,7 @@ import logUpdate from "./log-update";
 import type { NativeLogUpdate } from "./log-update-native";
 import { createNative } from "./log-update-native";
 import { clearStyledLineCache } from "./measure-text";
+import runExclusiveProbe from "./probe-terminal";
 import reconciler from "./reconciler";
 import { renderToStatic } from "./render-node-to-output";
 import render from "./renderer";
@@ -154,7 +155,7 @@ const shouldClearTerminalForFrame = ({
         return false;
     }
 
-    const hadPreviousFrame = previousOutputHeight > 0;
+    const isHadPreviousFrame = previousOutputHeight > 0;
     const wasFullscreen = previousOutputHeight >= viewportRows;
     const isFullscreen = nextOutputHeight >= viewportRows;
     const wasOverflowing = previousOutputHeight > viewportRows;
@@ -167,18 +168,18 @@ const shouldClearTerminalForFrame = ({
     // so on Windows the cursor arithmetic drifts one row per frame and stale
     // fullscreen frames leak through. Force a full clear for any fullscreen
     // frame on Windows. See vadimdemedes/ink#971.
-    const windowsFullscreenRedraw = isWindows && (isFullscreen || wasFullscreen);
+    const isWindowsFullscreenRedraw = isWindows && (isFullscreen || wasFullscreen);
 
     return (
         // Overflowing frames still need full clear fallback.
         wasOverflowing
-        || (isOverflowing && hadPreviousFrame)
+        || (isOverflowing && isHadPreviousFrame)
         // Clear when shrinking from fullscreen to non-fullscreen output.
         || isLeavingFullscreen
         // Preserve legacy unmount behavior for fullscreen frames: final teardown
         // render should clear once to avoid leaving a scrolled viewport state.
         || shouldClearOnUnmount
-        || windowsFullscreenRedraw
+        || isWindowsFullscreenRedraw
     );
 };
 
@@ -237,13 +238,13 @@ export type Options = {
      *
      * Note: Ink intentionally treats alternate-screen teardown output as disposable. It does not preserve or replay teardown-time frames, hook writes, or `console.*` output after restoring the primary screen.
      *
-	Only works in interactive mode. Ignored when `interactive` is `false` or in a non-interactive environment (CI, piped stdout).
-     
-	Note: Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change this option or create a fresh instance.
-     
-	@default false
-     
-	@see {@link RenderOptions.alternateScreen}
+     * Only works in interactive mode. Ignored when `interactive` is `false` or in a non-interactive environment (CI, piped stdout).
+     *
+     * Note: Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change this option or create a fresh instance.
+     *
+     * @default false
+     *
+     * @see {@link RenderOptions.alternateScreen}
      */
     alternateScreen?: boolean;
 
@@ -253,12 +254,12 @@ export type Options = {
      * When enabled:
      * - Suspense boundaries work correctly with async data
      * - `useTransition` and `useDeferredValue` are fully functional
-	- Updates can be interrupted for higher priority work
-     
-	Note: Concurrent mode changes the timing of renders. Some tests may need to use `act()` to properly await updates. Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change the rendering mode or create a fresh instance.
-     
-	@default false
-	@experimental
+     * - Updates can be interrupted for higher priority work
+     *
+     * Note: Concurrent mode changes the timing of renders. Some tests may need to use `act()` to properly await updates. Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change the rendering mode or create a fresh instance.
+     *
+     * @default false
+     * @experimental
      */
     concurrent?: boolean;
     debug: boolean;
@@ -272,13 +273,13 @@ export type Options = {
      *
      * When non-interactive, Ink disables ANSI erase sequences, cursor manipulation, synchronized output, resize handling, and kitty keyboard auto-detection, writing only the final frame at unmount.
      *
-	Set to `false` to force non-interactive mode or `true` to force interactive mode when the automatic detection doesn't suit your use case.
-     
-	Note: Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change this option or create a fresh instance.
-     
-	@default true (false if in CI or `stdout.isTTY` is falsy)
-     
-	@see {@link RenderOptions.interactive}
+     * Set to `false` to force non-interactive mode or `true` to force interactive mode when the automatic detection doesn't suit your use case.
+     *
+     * Note: Reusing the same stdout across multiple `render()` calls without unmounting is unsupported. Call `unmount()` first if you need to change this option or create a fresh instance.
+     *
+     * @default true (false if in CI or `stdout.isTTY` is falsy)
+     *
+     * @see {@link RenderOptions.interactive}
      */
     interactive?: boolean;
     isScreenReaderEnabled?: boolean;
@@ -423,13 +424,13 @@ export default class Ink {
 
         this.alternateScreen = false;
 
-        const unthrottled = options.debug || this.isScreenReaderEnabled;
+        const isUnthrottled = options.debug || this.isScreenReaderEnabled;
         const maxFps = options.maxFps ?? 30;
         const renderThrottleMs = maxFps > 0 ? Math.max(1, Math.ceil(1000 / maxFps)) : 0;
 
-        this.renderThrottleMs = unthrottled ? 0 : renderThrottleMs;
+        this.renderThrottleMs = isUnthrottled ? 0 : renderThrottleMs;
 
-        const baseOnRender = unthrottled
+        const baseOnRender = isUnthrottled
             ? this.onRender
             : (() => {
                 const throttled = throttle(this.onRender, renderThrottleMs, {
@@ -445,7 +446,7 @@ export default class Ink {
                 };
             })();
 
-        if (unthrottled) {
+        if (isUnthrottled) {
             this.throttledOnRender = undefined;
         } else {
             // throttledOnRender already set above
@@ -497,20 +498,20 @@ export default class Ink {
         this.manualCursorPosition = undefined;
         this.renderedCursorPosition = undefined;
         this.renderedCursorRequested = false;
-        this.throttledLog = unthrottled
+        this.throttledLog = isUnthrottled
             ? this.log
             : throttle(
                 (output: string) => {
                     const shouldWrite = this.log.willRender(output);
-                    const sync = this.shouldSync();
+                    const isSync = this.shouldSync();
 
-                    if (sync && shouldWrite) {
+                    if (isSync && shouldWrite) {
                         this.options.stdout.write(bsu);
                     }
 
                     this.log(output);
 
-                    if (sync && shouldWrite) {
+                    if (isSync && shouldWrite) {
                         this.options.stdout.write(esu);
                     }
                 },
@@ -997,9 +998,9 @@ export default class Ink {
         }
 
         if (this.isScreenReaderEnabled) {
-            const sync = this.shouldSync();
+            const isSync = this.shouldSync();
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(bsu);
             }
 
@@ -1013,7 +1014,7 @@ export default class Ink {
             }
 
             if (output === this.lastOutput && !hasStaticOutput) {
-                if (sync) {
+                if (isSync) {
                     this.options.stdout.write(esu);
                 }
 
@@ -1041,7 +1042,7 @@ export default class Ink {
             this.lastOutputToRender = wrappedOutput;
             this.lastOutputHeight = wrappedOutput === "" ? 0 : wrappedOutput.split("\n").length;
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(esu);
             }
 
@@ -1109,9 +1110,9 @@ export default class Ink {
             return;
         }
 
-        const sync = this.shouldSync();
+        const isSync = this.shouldSync();
 
-        if (sync) {
+        if (isSync) {
             this.options.stdout.write(bsu);
         }
 
@@ -1119,7 +1120,7 @@ export default class Ink {
         this.options.stdout.write(data);
         this.restoreLastOutput();
 
-        if (sync) {
+        if (isSync) {
             this.options.stdout.write(esu);
         }
     };
@@ -1142,9 +1143,9 @@ export default class Ink {
             return;
         }
 
-        const sync = this.shouldSync();
+        const isSync = this.shouldSync();
 
-        if (sync) {
+        if (isSync) {
             this.options.stdout.write(bsu);
         }
 
@@ -1152,7 +1153,7 @@ export default class Ink {
         this.options.stderr.write(data);
         this.restoreLastOutput();
 
-        if (sync) {
+        if (isSync) {
             this.options.stdout.write(esu);
         }
     };
@@ -1223,7 +1224,7 @@ export default class Ink {
 
             if (canWriteToStdout) {
                 if (this.kittyProtocolEnabled) {
-                    this.writeBestEffort(this.options.stdout, "\u001B[<u");
+                    this.writeBestEffort(this.options.stdout, "\u{1B}[<u");
                 }
 
                 // Alternate-screen content is disposable by design. We intentionally
@@ -1379,12 +1380,14 @@ export default class Ink {
     }
 
     clear(): void {
-        if (this.interactive && !this.options.debug) {
-            this.log.clear();
-            // Sync lastOutput so that unmount's final onRender
-            // sees it as unchanged and log-update skips it
-            this.log.sync(this.lastOutputToRender || `${this.lastOutput}\n`);
+        if (!this.interactive || this.options.debug) {
+            return;
         }
+
+        this.log.clear();
+        // Sync lastOutput so that unmount's final onRender
+        // sees it as unchanged and log-update skips it
+        this.log.sync(this.lastOutputToRender || `${this.lastOutput}\n`);
     }
 
     patchConsole(): void {
@@ -1417,11 +1420,11 @@ export default class Ink {
     }
 
     private resolveInteractiveOption(interactive: boolean | undefined): boolean {
-        return interactive ?? (!isInCi && Boolean(this.options.stdout.isTTY));
+        return interactive ?? (!isInCi && this.options.stdout.isTTY);
     }
 
     private resolveAlternateScreenOption(alternateScreen: boolean | undefined, interactive: boolean): boolean {
-        return Boolean(alternateScreen) && interactive && Boolean(this.options.stdout.isTTY);
+        return Boolean(alternateScreen) && interactive && this.options.stdout.isTTY;
     }
 
     private shouldSync(): boolean {
@@ -1487,7 +1490,7 @@ export default class Ink {
         // On Windows, fullscreen incremental redraws are broken (immediate scroll
         // drifts the cursor arithmetic), so the clear cannot be skipped even in
         // incremental mode. See vadimdemedes/ink#971.
-        const windowsFullscreenRedraw = isTty && isWindows && (isFullscreen || this.lastOutputHeight >= viewportRows);
+        const isWindowsFullscreenRedraw = isTty && isWindows && (isFullscreen || this.lastOutputHeight >= viewportRows);
 
         const shouldClearTerminal = shouldClearTerminalForFrame({
             isTty,
@@ -1504,7 +1507,7 @@ export default class Ink {
             // static output is still handled and the log-update diffing takes care of it.
             // Exception: Windows fullscreen redraws must perform a real clear because
             // the incremental eraseLines path is broken there (see ink#971).
-            if (this.options.incrementalRendering && !windowsFullscreenRedraw) {
+            if (this.options.incrementalRendering && !isWindowsFullscreenRedraw) {
                 if (hasPrepend) {
                     this.log.clear();
                     this.options.stdout.write(prepend);
@@ -1521,9 +1524,9 @@ export default class Ink {
                 return;
             }
 
-            const sync = this.shouldSync();
+            const isSync = this.shouldSync();
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(bsu);
             }
 
@@ -1547,7 +1550,7 @@ export default class Ink {
             this.lastOutputHeight = outputHeight;
             this.log.sync(outputToRender);
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(esu);
             }
 
@@ -1557,9 +1560,9 @@ export default class Ink {
         // To ensure prepended output (static + backbuffer) is cleanly rendered
         // before main output, clear main output first
         if (hasPrepend) {
-            const sync = this.shouldSync();
+            const isSync = this.shouldSync();
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(bsu);
             }
 
@@ -1567,7 +1570,7 @@ export default class Ink {
             this.options.stdout.write(prepend);
             this.log(outputToRender);
 
-            if (sync) {
+            if (isSync) {
                 this.options.stdout.write(esu);
             }
         } else if (output !== this.lastOutput || this.log.isCursorDirty()) {
@@ -1635,13 +1638,27 @@ export default class Ink {
     }
 
     private confirmKittySupport(flags: KittyFlagName[]): void {
+        // Serialized against the OSC palette query, which reads the same stdin. Concurrent probes
+        // mistake each other's answers for user input: this one's stripper does not know about OSC
+        // replies, so it would unshift the palette's answer into the input pipeline.
+        void runExclusiveProbe(this.options.stdin, async () => this.runKittySupportQuery(flags));
+    }
+
+    private async runKittySupportQuery(flags: KittyFlagName[]): Promise<void> {
         const { stdin, stdout } = this.options;
 
         let responseBuffer: number[] = [];
 
+        let timer: NodeJS.Timeout | undefined;
+        let settle: (() => void) | undefined;
+
         const cleanup = (): void => {
             this.cancelKittyDetection = undefined;
-            clearTimeout(timer);
+
+            if (timer) {
+                clearTimeout(timer);
+            }
+
             stdin.removeListener("data", onData);
 
             // Re-emit any buffered data that wasn't the protocol response,
@@ -1669,17 +1686,31 @@ export default class Ink {
                 if (!this.isUnmounted) {
                     this.enableKittyProtocol(flags);
                 }
+
+                settle?.();
             }
         };
 
         // Attach listener before writing the query so that synchronous
         // or immediate responses are not missed.
         stdin.on("data", onData);
-        const timer = setTimeout(cleanup, 200);
 
-        this.cancelKittyDetection = cleanup;
+        stdout.write("\u{1B}[?u");
 
-        stdout.write("\u001B[?u");
+        // Resolve when the answer lands or the window closes, so the next probe in the queue does
+        // not start while this listener is still attached.
+        return new Promise<void>((resolve) => {
+            settle = resolve;
+            timer = setTimeout(() => {
+                cleanup();
+                resolve();
+            }, 200);
+
+            this.cancelKittyDetection = () => {
+                cleanup();
+                resolve();
+            };
+        });
     }
 
     // Called by the App component to register how input is paused/resumed. Kept
@@ -1779,7 +1810,7 @@ export default class Ink {
         }
 
         if (this.kittyProtocolEnabled && this.kittyFlags) {
-            this.writeBestEffort(this.options.stdout, `\u001B[>${resolveFlags(this.kittyFlags)}u`);
+            this.writeBestEffort(this.options.stdout, `\u{1B}[>${resolveFlags(this.kittyFlags)}u`);
         }
 
         // Force a full redraw instead of diffing against the stale pre-suspension
@@ -1800,7 +1831,7 @@ export default class Ink {
 
     private enableKittyProtocol(flags: KittyFlagName[]): void {
         this.kittyFlags = flags;
-        this.options.stdout.write(`\u001B[>${resolveFlags(flags)}u`);
+        this.options.stdout.write(`\u{1B}[>${resolveFlags(flags)}u`);
         this.kittyProtocolEnabled = true;
     }
 }

--- a/packages/terminal/tui/src/ink/log-update.ts
+++ b/packages/terminal/tui/src/ink/log-update.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @stylistic/no-extra-parens, @typescript-eslint/restrict-plus-operands, sonarjs/no-identical-functions */
+/* eslint-disable @stylistic/no-extra-parens, @typescript-eslint/restrict-plus-operands */
 import type { Writable } from "node:stream";
 
 import { cursorHide, cursorNextLine, cursorShow, cursorTo, cursorUp, eraseLineEnd, eraseLines } from "@visulima/ansi";
@@ -55,12 +55,12 @@ const createCursorShapeTracker = (): CursorShapeTracker => {
             return buildCursorShapeSequence(next);
         },
         consumeRestoreOnDone: () => {
-            const needsRestore = normalizeShape(currentShape) !== "default";
+            const isNeedsRestore = normalizeShape(currentShape) !== "default";
 
             currentShape = undefined;
             pendingShape = undefined;
 
-            return needsRestore ? buildCursorShapeSequence("default") : "";
+            return isNeedsRestore ? buildCursorShapeSequence("default") : "";
         },
         isDirty: () => normalizeShape(pendingShape) !== normalizeShape(currentShape),
         setPending: (shape) => {
@@ -82,21 +82,156 @@ const getViewportRows = (stream: Writable): number => (stream as NodeJS.WriteStr
 // scrolled into terminal scrollback and cannot be erased.
 const clampToViewport = (lineCount: number, stream: Writable): number => Math.min(lineCount, getViewportRows(stream));
 
-const createStandard = (stream: Writable, { showCursor = false } = {}): LogUpdate => {
-    let previousLineCount = 0;
+/**
+ * Everything a frame writer needs to emit one changed frame.
+ *
+ * The renderer resolves all of this before choosing a writer, and owns the state updates that
+ * follow — a writer only produces bytes.
+ */
+type Frame = {
+    /** Cursor position to restore after the frame, or undefined when no &lt;Cursor> is mounted. */
+    activeCursor: CursorPosition | undefined;
+
+    content: string;
+
+    /** `content` and `previous` split on newlines — the renderer has already split both. */
+    contentLines: string[];
+
+    previous: string;
+
+    previousLines: string[];
+
+    /** Cursor motion back to the bottom of the previous frame. Goes first. */
+    returnPrefix: string;
+
+    /** Pending DECSCUSR change. Goes before any cursor motion or erase. */
+    shapeDelta: string;
+};
+
+/** Emits one changed frame to the stream. */
+type WriteFrame = (frame: Frame, stream: Writable) => void;
+
+/**
+ * Erases the previous frame and writes the new one whole.
+ *
+ * Also the fallback inside the incremental writer, for the cases a line diff cannot express: the
+ * first frame, and a bare newline.
+ * @param frame The frame to write.
+ * @param stream The stream to write it to.
+ */
+const writeFullFrame: WriteFrame = (frame, stream) => {
+    const { activeCursor, content, contentLines, previousLines, returnPrefix, shapeDelta } = frame;
+    const cursorSuffix = buildCursorSuffix(visibleLineCount(contentLines, content), activeCursor);
+
+    stream.write(shapeDelta + returnPrefix + eraseLines(clampToViewport(previousLines.length, stream)) + content + cursorSuffix);
+};
+
+/**
+ * Rewrites only the lines that changed since the previous frame.
+ *
+ * Skipping untouched lines is what stops the display flickering on every render.
+ * @param frame The frame to write.
+ * @param stream The stream to write it to.
+ */
+
+const writeIncrementalFrame: WriteFrame = (frame, stream) => {
+    const { activeCursor, content, contentLines, previous, previousLines, returnPrefix, shapeDelta } = frame;
+    const visibleCount = visibleLineCount(contentLines, content);
+
+    // Nothing to diff against, or a bare newline: fall back to a full redraw.
+    if (content === "\n" || previous.length === 0) {
+        writeFullFrame(frame, stream);
+
+        return;
+    }
+
+    const previousVisible = visibleLineCount(previousLines, previous);
+    const hasTrailingNewline = content.endsWith("\n");
+
+    // We aggregate all chunks for incremental rendering into a buffer, and then write them to stdout at the end.
+    // Shape delta is prepended so DECSCUSR lands before any cursor motion/erase from this frame.
+    const buffer: string[] = [shapeDelta, returnPrefix];
+
+    // Clear extra lines if the current content's line count is lower than the previous.
+    const viewportRows = getViewportRows(stream);
+
+    if (visibleCount < previousVisible) {
+        const isPreviousHadTrailingNewline = previous.endsWith("\n");
+        const extraSlot = isPreviousHadTrailingNewline ? 1 : 0;
+
+        buffer.push(eraseLines(Math.min(previousVisible - visibleCount + extraSlot, viewportRows)), cursorUp(Math.min(visibleCount, viewportRows - 1)));
+    } else {
+        buffer.push(cursorUp(Math.min(previousVisible - 1, viewportRows - 1)));
+    }
+
+    for (let index = 0; index < visibleCount; index += 1) {
+        const isLastLine = index === visibleCount - 1;
+
+        // We do not write lines if the contents are the same. This prevents flickering during renders.
+        if (contentLines[index] === previousLines[index]) {
+            // Don't move past the last line when there's no trailing newline,
+            // otherwise the cursor overshoots the rendered block.
+            if (!isLastLine || hasTrailingNewline) {
+                buffer.push(cursorNextLine());
+            }
+
+            continue;
+        }
+
+        buffer.push(
+            cursorTo(0)
+            + contentLines[index]
+            + eraseLineEnd
+            // Don't append newline after the last line when the input
+            // has no trailing newline (fullscreen mode).
+            + (isLastLine && !hasTrailingNewline ? "" : "\n"),
+        );
+    }
+
+    buffer.push(buildCursorSuffix(visibleCount, activeCursor));
+
+    stream.write(buffer.join(""));
+};
+
+/**
+ * Builds a log updater around a frame-writing strategy.
+ *
+ * Frame bookkeeping — hidden cursor, previous output and lines, cursor position and shape — is
+ * identical whichever way frames reach the terminal, so it lives here once. The strategy is only
+ * consulted for the one case the two modes disagree on: emitting a frame whose content changed.
+ * @param stream The stream to render to.
+ * @param options Renderer options.
+ * @param options.showCursor Leave the terminal cursor visible while rendering.
+ * @param writeFrame How to emit a changed frame.
+ * @returns The log updater.
+ */
+const createLogUpdate = (stream: Writable, { showCursor = false }: { showCursor?: boolean }, writeFrame: WriteFrame): LogUpdate => {
+    let previousLines: string[] = [];
     let previousOutput = "";
     let hasHiddenCursor = false;
     let cursorPosition: CursorPosition | undefined;
-    let cursorDirty = false;
+    let isCursorDirty = false;
     let previousCursorPosition: CursorPosition | undefined;
-    let cursorWasShown = false;
+    let isCursorWasShown = false;
     const shapeTracker = createCursorShapeTracker();
 
-    const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
+    const getActiveCursor = () => (isCursorDirty ? cursorPosition : undefined);
     const hasChanges = (string_: string, activeCursor: CursorPosition | undefined): boolean => {
-        const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+        const isCursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
 
-        return string_ !== previousOutput || cursorChanged || shapeTracker.isDirty();
+        return string_ !== previousOutput || isCursorChanged || shapeTracker.isDirty();
+    };
+
+    const commitCursor = (activeCursor: CursorPosition | undefined) => {
+        previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+        isCursorWasShown = activeCursor !== undefined;
+    };
+
+    const forgetFrame = () => {
+        previousOutput = "";
+        previousLines = [];
+        previousCursorPosition = undefined;
+        isCursorWasShown = false;
     };
 
     const render = (string_: string) => {
@@ -109,8 +244,8 @@ const createStandard = (stream: Writable, { showCursor = false } = {}): LogUpdat
         // This ensures stale positions don't persist after component unmount.
         const activeCursor = getActiveCursor();
 
-        cursorDirty = false;
-        const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+        isCursorDirty = false;
+        const isCursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
 
         if (!hasChanges(string_, activeCursor)) {
             return false;
@@ -118,54 +253,63 @@ const createStandard = (stream: Writable, { showCursor = false } = {}): LogUpdat
 
         const shapeDelta = shapeTracker.consumeDelta();
 
-        const lines = string_.split("\n");
-        const visibleCount = visibleLineCount(lines, string_);
-        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
+        const nextLines = string_.split("\n");
+        const visibleCount = visibleLineCount(nextLines, string_);
 
-        if (string_ === previousOutput && cursorChanged) {
+        if (string_ === previousOutput && isCursorChanged) {
             stream.write(
                 shapeDelta
                 + buildCursorOnlySequence({
                     cursorPosition: activeCursor,
-                    cursorWasShown,
+                    cursorWasShown: isCursorWasShown,
                     previousCursorPosition,
-                    previousLineCount,
+                    previousLineCount: previousLines.length,
                     visibleLineCount: visibleCount,
                 }),
             );
-        } else if (string_ === previousOutput && shapeDelta !== "") {
+            commitCursor(activeCursor);
+
+            return true;
+        }
+
+        if (string_ === previousOutput && shapeDelta !== "") {
             // Output and cursor position unchanged, but shape did — emit the
             // bare DECSCUSR delta without redrawing the frame.
             stream.write(shapeDelta);
-        } else {
-            previousOutput = string_;
-            const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
+            commitCursor(activeCursor);
 
-            stream.write(shapeDelta + returnPrefix + eraseLines(clampToViewport(previousLineCount, stream)) + string_ + cursorSuffix);
-            previousLineCount = lines.length;
+            return true;
         }
 
-        previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-        cursorWasShown = activeCursor !== undefined;
+        writeFrame(
+            {
+                activeCursor,
+                content: string_,
+                contentLines: nextLines,
+                previous: previousOutput,
+                previousLines,
+                returnPrefix: buildReturnToBottomPrefix(isCursorWasShown, previousLines.length, previousCursorPosition),
+                shapeDelta,
+            },
+            stream,
+        );
+
+        previousOutput = string_;
+        previousLines = nextLines;
+        commitCursor(activeCursor);
 
         return true;
     };
 
     render.clear = () => {
-        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
+        const prefix = buildReturnToBottomPrefix(isCursorWasShown, previousLines.length, previousCursorPosition);
 
-        stream.write(prefix + eraseLines(clampToViewport(previousLineCount, stream)));
-        previousOutput = "";
-        previousLineCount = 0;
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
+        stream.write(prefix + eraseLines(clampToViewport(previousLines.length, stream)));
+        forgetFrame();
     };
 
     render.done = () => {
-        previousOutput = "";
-        previousLineCount = 0;
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
+        forgetFrame();
 
         // Restore the terminal's user-configured shape before handing the
         // cursor back. We only emit the sequence when we actually changed the
@@ -183,229 +327,12 @@ const createStandard = (stream: Writable, { showCursor = false } = {}): LogUpdat
         }
     };
 
-    render.reset = () => {
-        previousOutput = "";
-        previousLineCount = 0;
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
-    };
+    render.reset = forgetFrame;
 
     render.sync = (string_: string) => {
-        const activeCursor = cursorDirty ? cursorPosition : undefined;
-
-        cursorDirty = false;
-
-        const lines = string_.split("\n");
-
-        previousOutput = string_;
-        previousLineCount = lines.length;
-
-        const shapeDelta = shapeTracker.consumeDelta();
-
-        if (shapeDelta !== "") {
-            stream.write(shapeDelta);
-        }
-
-        if (!activeCursor && cursorWasShown) {
-            stream.write(cursorHide);
-        }
-
-        if (activeCursor) {
-            stream.write(buildCursorSuffix(visibleLineCount(lines, string_), activeCursor));
-        }
-
-        previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-        cursorWasShown = activeCursor !== undefined;
-    };
-
-    render.setCursorPosition = (position: CursorPosition | undefined) => {
-        cursorPosition = position;
-        cursorDirty = true;
-    };
-
-    render.setCursorShape = shapeTracker.setPending;
-
-    // isCursorDirty signals "re-flush needed even if output bytes are
-    // identical" — covers cursor position changes *and* shape changes.
-    render.isCursorDirty = () => cursorDirty || shapeTracker.isDirty();
-    render.willRender = (string_: string) => hasChanges(string_, getActiveCursor());
-
-    return render;
-};
-
-const createIncremental = (stream: Writable, { showCursor = false } = {}): LogUpdate => {
-    let previousLines: string[] = [];
-    let previousOutput = "";
-    let hasHiddenCursor = false;
-    let cursorPosition: CursorPosition | undefined;
-    let cursorDirty = false;
-    let previousCursorPosition: CursorPosition | undefined;
-    let cursorWasShown = false;
-    const shapeTracker = createCursorShapeTracker();
-
-    const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
-    const hasChanges = (string_: string, activeCursor: CursorPosition | undefined): boolean => {
-        const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
-
-        return string_ !== previousOutput || cursorChanged || shapeTracker.isDirty();
-    };
-
-    const render = (string_: string) => {
-        if (!showCursor && !hasHiddenCursor) {
-            stream.write(cursorHide);
-            hasHiddenCursor = true;
-        }
-
-        // Only use cursor if setCursorPosition was called since last render.
-        // This ensures stale positions don't persist after component unmount.
         const activeCursor = getActiveCursor();
 
-        cursorDirty = false;
-        const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
-
-        if (!hasChanges(string_, activeCursor)) {
-            return false;
-        }
-
-        const shapeDelta = shapeTracker.consumeDelta();
-
-        const nextLines = string_.split("\n");
-        const visibleCount = visibleLineCount(nextLines, string_);
-        const previousVisible = visibleLineCount(previousLines, previousOutput);
-
-        if (string_ === previousOutput && cursorChanged) {
-            stream.write(
-                shapeDelta
-                + buildCursorOnlySequence({
-                    cursorPosition: activeCursor,
-                    cursorWasShown,
-                    previousCursorPosition,
-                    previousLineCount: previousLines.length,
-                    visibleLineCount: visibleCount,
-                }),
-            );
-            previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-            cursorWasShown = activeCursor !== undefined;
-
-            return true;
-        }
-
-        if (string_ === previousOutput && shapeDelta !== "") {
-            // Output and position unchanged, only shape moved.
-            stream.write(shapeDelta);
-
-            return true;
-        }
-
-        const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
-
-        if (string_ === "\n" || previousOutput.length === 0) {
-            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
-
-            stream.write(shapeDelta + returnPrefix + eraseLines(clampToViewport(previousLines.length, stream)) + string_ + cursorSuffix);
-            cursorWasShown = activeCursor !== undefined;
-            previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-            previousOutput = string_;
-            previousLines = nextLines;
-
-            return true;
-        }
-
-        const hasTrailingNewline = string_.endsWith("\n");
-
-        // We aggregate all chunks for incremental rendering into a buffer, and then write them to stdout at the end.
-        // Shape delta is prepended so DECSCUSR lands before any cursor motion/erase from this frame.
-        const buffer: string[] = [shapeDelta, returnPrefix];
-
-        // Clear extra lines if the current content's line count is lower than the previous.
-        const viewportRows = getViewportRows(stream);
-
-        if (visibleCount < previousVisible) {
-            const previousHadTrailingNewline = previousOutput.endsWith("\n");
-            const extraSlot = previousHadTrailingNewline ? 1 : 0;
-
-            buffer.push(eraseLines(Math.min(previousVisible - visibleCount + extraSlot, viewportRows)), cursorUp(Math.min(visibleCount, viewportRows - 1)));
-        } else {
-            buffer.push(cursorUp(Math.min(previousVisible - 1, viewportRows - 1)));
-        }
-
-        for (let i = 0; i < visibleCount; i++) {
-            const isLastLine = i === visibleCount - 1;
-
-            // We do not write lines if the contents are the same. This prevents flickering during renders.
-            if (nextLines[i] === previousLines[i]) {
-                // Don't move past the last line when there's no trailing newline,
-                // otherwise the cursor overshoots the rendered block.
-                if (!isLastLine || hasTrailingNewline) {
-                    buffer.push(cursorNextLine());
-                }
-
-                continue;
-            }
-
-            buffer.push(
-                cursorTo(0)
-                + nextLines[i]
-                + eraseLineEnd
-                // Don't append newline after the last line when the input
-                // has no trailing newline (fullscreen mode).
-                + (isLastLine && !hasTrailingNewline ? "" : "\n"),
-            );
-        }
-
-        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
-
-        buffer.push(cursorSuffix);
-
-        stream.write(buffer.join(""));
-
-        cursorWasShown = activeCursor !== undefined;
-        previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-        previousOutput = string_;
-        previousLines = nextLines;
-
-        return true;
-    };
-
-    render.clear = () => {
-        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
-
-        stream.write(prefix + eraseLines(clampToViewport(previousLines.length, stream)));
-        previousOutput = "";
-        previousLines = [];
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
-    };
-
-    render.done = () => {
-        previousOutput = "";
-        previousLines = [];
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
-
-        const restore = shapeTracker.consumeRestoreOnDone();
-
-        if (restore !== "") {
-            stream.write(restore);
-        }
-
-        if (!showCursor) {
-            stream.write(cursorShow);
-            hasHiddenCursor = false;
-        }
-    };
-
-    render.reset = () => {
-        previousOutput = "";
-        previousLines = [];
-        previousCursorPosition = undefined;
-        cursorWasShown = false;
-    };
-
-    render.sync = (string_: string) => {
-        const activeCursor = cursorDirty ? cursorPosition : undefined;
-
-        cursorDirty = false;
+        isCursorDirty = false;
 
         const lines = string_.split("\n");
 
@@ -418,7 +345,7 @@ const createIncremental = (stream: Writable, { showCursor = false } = {}): LogUp
             stream.write(shapeDelta);
         }
 
-        if (!activeCursor && cursorWasShown) {
+        if (!activeCursor && isCursorWasShown) {
             stream.write(cursorHide);
         }
 
@@ -426,32 +353,26 @@ const createIncremental = (stream: Writable, { showCursor = false } = {}): LogUp
             stream.write(buildCursorSuffix(visibleLineCount(lines, string_), activeCursor));
         }
 
-        previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
-        cursorWasShown = activeCursor !== undefined;
+        commitCursor(activeCursor);
     };
 
     render.setCursorPosition = (position: CursorPosition | undefined) => {
         cursorPosition = position;
-        cursorDirty = true;
+        isCursorDirty = true;
     };
 
     render.setCursorShape = shapeTracker.setPending;
 
     // isCursorDirty signals "re-flush needed even if output bytes are
     // identical" — covers cursor position changes *and* shape changes.
-    render.isCursorDirty = () => cursorDirty || shapeTracker.isDirty();
+    render.isCursorDirty = () => isCursorDirty || shapeTracker.isDirty();
     render.willRender = (string_: string) => hasChanges(string_, getActiveCursor());
 
     return render;
 };
 
-const create = (stream: Writable, { incremental = false, showCursor = false }: { incremental?: boolean; showCursor?: boolean } = {}): LogUpdate => {
-    if (incremental) {
-        return createIncremental(stream, { showCursor });
-    }
-
-    return createStandard(stream, { showCursor });
-};
+const create = (stream: Writable, { incremental = false, showCursor = false }: { incremental?: boolean; showCursor?: boolean } = {}): LogUpdate =>
+    createLogUpdate(stream, { showCursor }, incremental ? writeIncrementalFrame : writeFullFrame);
 
 const logUpdate: { create: typeof create } = { create };
 

--- a/packages/terminal/tui/src/ink/probe-terminal.ts
+++ b/packages/terminal/tui/src/ink/probe-terminal.ts
@@ -1,0 +1,69 @@
+/**
+ * Serializes terminal capability probes that read from the same stdin.
+ *
+ * Several features ask the terminal a question and wait for it to answer: the kitty keyboard query
+ * (`CSI ? u`), the OSC palette query, and anything added later. Each attaches its own `data`
+ * listener, buffers what arrives, keeps the bytes it recognises and hands the rest back.
+ *
+ * Run two of those at once and they corrupt each other — one probe's answer looks like foreign
+ * input to the other, which pushes it back into the stream as if the user had typed it, while the
+ * probe that was waiting for it times out. The kitty query fires on first render and the palette
+ * query from a mount effect, so the overlap is ordinary, not exotic.
+ *
+ * Rather than teach every probe about every other probe's wire format, they take turns.
+ */
+
+/** The tail of the probe chain for each stdin, so the next probe can await it. */
+const chains = new WeakMap<object, Promise<void>>();
+
+/**
+ * Runs `probe` after `previous`, whichever way `previous` ended.
+ *
+ * A probe that threw must not cancel the next one; its own caller already sees the error.
+ * @param previous The predecessor's completion.
+ * @param probe The probe to run next.
+ * @returns The probe's result.
+ */
+const runAfter = async <T>(previous: Promise<void>, probe: () => Promise<T>): Promise<T> => {
+    await previous;
+
+    return probe();
+};
+
+/**
+ * Runs `probe` once every earlier probe on this stdin has finished.
+ * @param stdin The stream the probe will listen on. Only its identity is used, as a queue key.
+ * @param probe The probe to run. It gets exclusive use of `stdin` for its duration.
+ * @returns Whatever `probe` resolves to.
+ */
+const runExclusiveProbe = <T>(stdin: object, probe: () => Promise<T>): Promise<T> => {
+    const previous = chains.get(stdin);
+
+    // With an empty queue the probe starts synchronously, so its listener is attached before the
+    // caller's next statement — deferring by a microtask would let bytes arrive unobserved.
+    const result = previous === undefined ? probe() : runAfter(previous, probe);
+
+    let link: Promise<void> | undefined;
+
+    const track = async (): Promise<void> => {
+        try {
+            await result;
+        } catch {
+            // Swallowed here only so the queue keeps moving; the caller still sees the rejection.
+        }
+
+        // Drop the link once the queue drains, so a later probe is synchronous again rather than
+        // inheriting a microtask hop from a probe that finished long ago.
+        if (chains.get(stdin) === link) {
+            chains.delete(stdin);
+        }
+    };
+
+    // `track` awaits before reading `link`, so the assignment below always lands first.
+    link = track();
+    chains.set(stdin, link);
+
+    return result;
+};
+
+export default runExclusiveProbe;

--- a/packages/terminal/tui/src/ink/terminal-palette.ts
+++ b/packages/terminal/tui/src/ink/terminal-palette.ts
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/no-use-before-define, e18e/prefer-static-regex, jsdoc/lines-before-block, no-await-in-loop, unicorn/no-null */
+/* eslint-disable unicorn/no-null */
+
 /**
  * Terminal palette auto-detection via OSC escape sequences.
  *
@@ -8,8 +9,28 @@
  */
 import type { Writable } from "node:stream";
 
-const BEL = "\u0007";
-const OSC = "\u001B]";
+import runExclusiveProbe from "./probe-terminal";
+
+const BEL = "\u{7}";
+const ESCAPE = "\u{1B}";
+const OSC = `${ESCAPE}]`;
+const ST = `${ESCAPE}\\`;
+
+/** Number of indexed palette entries queried via OSC 4. */
+const PALETTE_SIZE = 16;
+
+/** Foreground, background and cursor, plus every indexed colour. */
+const EXPECTED_RESPONSES = 3 + PALETTE_SIZE;
+
+/**
+ * Give up once the buffer grows past anything a real exchange could need.
+ *
+ * Nineteen answers run to roughly 600 bytes; the rest of the budget is headroom for the user
+ * typing while we wait, since those bytes are held here until they can be handed back.
+ */
+const MAX_RESPONSE_BYTES = 8192;
+
+const RE_OSC_COLOR = /rgb:([\da-f]{2,4})\/([\da-f]{2,4})\/([\da-f]{2,4})/i;
 
 export type TerminalPalette = {
     readonly background: string;
@@ -21,9 +42,11 @@ export type TerminalPalette = {
 /**
  * Parse an OSC color response like `rgb:RRRR/GGGG/BBBB` to a hex string.
  * Terminal color responses use 16-bit values per channel; we extract the top 8 bits.
+ * @param response The response payload to parse.
+ * @returns The colour as `#rrggbb`, or null when the payload is not a colour.
  */
 const parseOscColorResponse = (response: string): string | null => {
-    const match = /rgb:([\da-f]{2,4})\/([\da-f]{2,4})\/([\da-f]{2,4})/i.exec(response);
+    const match = RE_OSC_COLOR.exec(response);
 
     if (!match) {
         return null;
@@ -42,6 +65,7 @@ const parseOscColorResponse = (response: string): string | null => {
 
 /**
  * Check if the terminal likely supports OSC palette queries.
+ * @returns Whether a palette query is worth attempting.
  */
 export const isTerminalPaletteQuerySupported = (): boolean => {
     const termProgram = process.env["TERM_PROGRAM"] ?? "";
@@ -56,106 +80,361 @@ export const isTerminalPaletteQuerySupported = (): boolean => {
     return term.startsWith("xterm") || Boolean(process.env["WT_SESSION"]);
 };
 
-/**
- * Send an OSC query and wait for the terminal's response.
- */
-const MAX_RESPONSE_BYTES = 256;
+/** A palette under construction, filled in as responses arrive. */
+type PaletteDraft = {
+    background?: string;
+    colors: (string | undefined)[];
+    cursor?: string;
+    foreground?: string;
+};
 
-const queryOsc = (stdin: NodeJS.ReadableStream, stdout: Writable, sequence: string, timeout = 500): Promise<string | null> =>
+/**
+ * Routes one OSC payload into the draft palette.
+ * @param payload The text between `OSC` and the string terminator, e.g. `11;rgb:0000/0000/0000`.
+ * @param draft The palette being assembled.
+ * @returns Whether the payload was a recognised colour response.
+ */
+const didApplyOscPayload = (payload: string, draft: PaletteDraft): boolean => {
+    const color = parseOscColorResponse(payload);
+
+    if (color === null) {
+        return false;
+    }
+
+    if (payload.startsWith("10;")) {
+        draft.foreground = color;
+
+        return true;
+    }
+
+    if (payload.startsWith("11;")) {
+        draft.background = color;
+
+        return true;
+    }
+
+    if (payload.startsWith("12;")) {
+        draft.cursor = color;
+
+        return true;
+    }
+
+    if (payload.startsWith("4;")) {
+        // `4;<index>;rgb:…` — take the index field, not everything after the "4;".
+        const separator = payload.indexOf(";", 2);
+        const index = Number(payload.slice(2, separator === -1 ? payload.length : separator));
+
+        if (Number.isSafeInteger(index) && index >= 0 && index < PALETTE_SIZE) {
+            draft.colors[index] = color;
+
+            return true;
+        }
+    }
+
+    return false;
+};
+
+/** Every query, concatenated so the terminal receives them in a single write. */
+const buildQuery = (): string => {
+    const queries = [`${OSC}10;?${BEL}`, `${OSC}11;?${BEL}`, `${OSC}12;?${BEL}`];
+
+    for (let index = 0; index < PALETTE_SIZE; index += 1) {
+        queries.push(`${OSC}4;${String(index)};?${BEL}`);
+    }
+
+    return queries.join("");
+};
+
+/**
+ * Caches the in-flight or completed query per output stream.
+ *
+ * A terminal's palette does not change while the process runs, and every query blocks a slice of
+ * stdin for up to `timeout`. Keying on the stream also collapses concurrent callers (several
+ * mounted components asking at once) onto a single round trip.
+ */
+const paletteCache = new WeakMap<Writable, Promise<Partial<TerminalPalette>>>();
+
+/**
+ * Drops the cached palette for a stream.
+ *
+ * Not re-exported from the package barrel: a terminal's palette does not change under a running
+ * program, so this exists for tests and for the rare caller that knows the theme was switched.
+ */
+export const clearTerminalPaletteCache = (stdout: Writable): void => {
+    paletteCache.delete(stdout);
+};
+
+/**
+ * The slice of a readable stream a probe needs.
+ *
+ * Narrower than `NodeJS.ReadableStream` so a caller can hand in any object with these four members
+ * — a test double included — without asserting it is a full stream.
+ */
+export interface ProbeStdin {
+    listenerCount: (event: string) => number;
+    on: (event: "data", listener: (chunk: Buffer | string) => void) => unknown;
+    pause: () => unknown;
+    removeListener: (event: "data", listener: (chunk: Buffer | string) => void) => unknown;
+    unshift: (chunk: string) => void;
+}
+
+/** What one pass of the incremental parser pulled out of the buffer. */
+type ParseResult = {
+    /** Complete OSC payloads, without the introducer or terminator. */
+    answers: string[];
+
+    /** Bytes that belong to the application, not to us. */
+    foreign: string;
+
+    /** A partial answer (or lone introducer) to prepend to the next chunk. */
+    rest: string;
+};
+
+/**
+ * Splits a stdin chunk into OSC answers and everything else.
+ *
+ * Pure and exported for tests: this is where the buffer-boundary reasoning lives, and testing it
+ * through a fake stream would only obscure it.
+ * @param buffer Unparsed bytes, oldest first.
+ * @returns The answers found, the application's bytes, and any incomplete tail to carry forward.
+ */
+export const takeOscAnswers = (buffer: string): ParseResult => {
+    const answers: string[] = [];
+
+    let foreign = "";
+    let rest = buffer;
+
+    for (;;) {
+        const start = rest.indexOf(OSC);
+
+        if (start === -1) {
+            // No answer is starting. A trailing lone ESC may be the first byte of one, so hold it
+            // back; everything before it belongs to the app.
+            const trailingEscape = rest.endsWith(ESCAPE) ? 1 : 0;
+
+            foreign += rest.slice(0, rest.length - trailingEscape);
+
+            return { answers, foreign, rest: rest.slice(rest.length - trailingEscape) };
+        }
+
+        foreign += rest.slice(0, start);
+        rest = rest.slice(start);
+
+        const bell = rest.indexOf(BEL);
+        const stringTerminator = rest.indexOf(ST);
+        const hasBell = bell !== -1;
+        const hasStringTerminator = stringTerminator !== -1;
+
+        if (!hasBell && !hasStringTerminator) {
+            // Incomplete answer: wait for the rest.
+            return { answers, foreign, rest };
+        }
+
+        const end = hasBell && (!hasStringTerminator || bell < stringTerminator) ? bell : stringTerminator;
+
+        answers.push(rest.slice(OSC.length, end));
+        rest = rest.slice(end + (end === bell ? BEL.length : ST.length));
+    }
+};
+
+/**
+ * Issues every OSC query in one write and collects the answers with a single listener.
+ *
+ * Deliberately takes no `AbortSignal`: the probe is shared between every caller for a given stream
+ * (see {@link paletteCache}), so one subscriber going away must not cancel the round trip for the
+ * rest. Callers opt out of *waiting* instead — see {@link queryTerminalPalette}.
+ * @param stdin Readable stream (typically process.stdin in raw mode)
+ * @param stdout Writable stream (typically process.stdout)
+ * @param timeout Milliseconds to wait for the whole batch
+ * @returns Whatever the terminal answered before the batch finished or timed out.
+ */
+const runQuery = async (stdin: ProbeStdin, stdout: Writable, timeout: number): Promise<Partial<TerminalPalette>> =>
     new Promise((resolve) => {
-        let buffer = "";
+        const draft: PaletteDraft = { colors: Array.from({ length: PALETTE_SIZE }) };
+
+        // Bytes that are not part of an OSC answer — the user typing while we wait. They are
+        // handed back to the stream on cleanup rather than dropped.
+        let foreign = "";
+        let pending = "";
+        let received = 0;
+        let isSettled = false;
+
+        // Only put bytes back if nothing else is listening. When the app's own input handler is
+        // already attached it received the same chunks, so unshifting would deliver them twice.
+        const isSoleConsumerAtStart = stdin.listenerCount("data") === 0;
+
         let timer: ReturnType<typeof setTimeout> | undefined;
 
-        const cleanup = () => {
+        const onData = (data: Buffer | string): void => {
+            const parsed = takeOscAnswers(pending + data.toString());
+
+            foreign += parsed.foreign;
+            pending = parsed.rest;
+
+            for (const answer of parsed.answers) {
+                if (didApplyOscPayload(answer, draft)) {
+                    received += 1;
+                }
+            }
+
+            if (received >= EXPECTED_RESPONSES || pending.length + foreign.length > MAX_RESPONSE_BYTES) {
+                finish();
+            }
+        };
+
+        function finish(): void {
+            if (isSettled) {
+                return;
+            }
+
+            isSettled = true;
+
             if (timer) {
                 clearTimeout(timer);
             }
 
+            const isSoleConsumerAtEnd = stdin.listenerCount("data") === 1;
+
             stdin.removeListener("data", onData);
-        };
 
-        const onData = (data: Buffer | string) => {
-            buffer += data.toString();
+            const leftover = foreign + pending;
 
-            // Guard against unbounded accumulation from misbehaving terminals
-            if (buffer.length > MAX_RESPONSE_BYTES) {
-                cleanup();
-                resolve(null);
-
-                return;
+            if (isSoleConsumerAtStart && isSoleConsumerAtEnd && leftover.length > 0) {
+                try {
+                    // Attaching the listener put the stream into flowing mode, and removing the
+                    // last listener does not take it back out. Unshifting while it still flows
+                    // re-emits the bytes to nobody, so pause first — and leave it paused, which is
+                    // the state the stream was in before the probe attached. Whoever reads next
+                    // gets the keystrokes at the front of the buffer.
+                    stdin.pause();
+                    // One unshift, in arrival order: successive unshifts would reverse the input.
+                    stdin.unshift(leftover);
+                } catch {
+                    // The stream ended underneath us; the bytes have nowhere to go.
+                }
             }
 
-            if (buffer.includes(BEL) || buffer.includes("\u001B\\")) {
-                cleanup();
-                resolve(buffer);
+            // Built mutably, then handed out through the readonly public shape.
+            const result: Partial<{ background: string; colors: string[]; cursor: string; foreground: string }> = {};
+
+            if (draft.foreground) {
+                result.foreground = draft.foreground;
             }
-        };
 
-        timer = setTimeout(() => {
-            cleanup();
-            resolve(null);
-        }, timeout);
+            if (draft.background) {
+                result.background = draft.background;
+            }
 
+            if (draft.cursor) {
+                result.cursor = draft.cursor;
+            }
+
+            if (draft.colors.some(Boolean)) {
+                result.colors = draft.colors.map((color) => color ?? "");
+            }
+
+            resolve(result);
+        }
+
+        // Attach before writing so an immediate reply is not missed.
         stdin.on("data", onData);
-        stdout.write(sequence);
+
+        // One timer for the whole batch. Previously each of the 19 queries had its own, so an
+        // unresponsive terminal held stdin for nineteen timeouts back to back.
+        timer = setTimeout(finish, timeout);
+
+        stdout.write(buildQuery());
     });
 
 /**
- * Query the terminal for its current color palette.
- * @param stdin Readable stream (typically process.stdin in raw mode)
- * @param stdout Writable stream (typically process.stdout)
- * @param timeout Per-query timeout in milliseconds (default: 500)
+ * Waits for `query`, giving up early if `signal` aborts.
+ *
+ * The listener is removed however the race ends, so a caller reusing one long-lived signal does
+ * not accumulate one listener per call.
+ * @param query The shared probe.
+ * @param signal The caller's abort signal.
+ * @returns The probe's answer, or an empty palette if the caller aborted first.
  */
-export const queryTerminalPalette = async (stdin: NodeJS.ReadableStream, stdout: Writable, timeout = 500): Promise<Partial<TerminalPalette>> => {
-    const result: Partial<{ background: string; colors: string[]; cursor: string; foreground: string }> = {};
+const raceAbort = async (query: Promise<Partial<TerminalPalette>>, signal: AbortSignal): Promise<Partial<TerminalPalette>> => {
+    const aborted = Promise.withResolvers<Partial<TerminalPalette>>();
 
-    const fgResponse = await queryOsc(stdin, stdout, `${OSC}10;?${BEL}`, timeout);
+    const onAbort = (): void => {
+        aborted.resolve({});
+    };
 
-    if (fgResponse) {
-        const fg = parseOscColorResponse(fgResponse);
+    signal.addEventListener("abort", onAbort, { once: true });
 
-        if (fg) {
-            result.foreground = fg;
-        }
+    try {
+        return await Promise.race([query, aborted.promise]);
+    } finally {
+        signal.removeEventListener("abort", onAbort);
+    }
+};
+
+/**
+ * Runs the shared probe and drops it from the cache if the terminal said nothing.
+ *
+ * The eviction lives inside the cached promise rather than in a `.then()` on it: an aborted caller
+ * resumes late, and a second caller arriving in that window would otherwise be handed a promise
+ * that has already resolved empty.
+ * @param stdin Readable stream to listen on.
+ * @param stdout Writable stream, and the cache key.
+ * @param timeout Milliseconds to wait for the whole batch.
+ * @returns The colours the terminal reported.
+ */
+const runCachedQuery = async (stdin: ProbeStdin, stdout: Writable, timeout: number): Promise<Partial<TerminalPalette>> => {
+    let result: Partial<TerminalPalette>;
+
+    try {
+        // Serialized against the kitty-keyboard query, which reads the same stdin: concurrent
+        // probes swallow each other's answers and re-inject them as user input.
+        result = await runExclusiveProbe(stdin, async () => runQuery(stdin, stdout, timeout));
+    } catch (error) {
+        paletteCache.delete(stdout);
+
+        throw error;
     }
 
-    const bgResponse = await queryOsc(stdin, stdout, `${OSC}11;?${BEL}`, timeout);
-
-    if (bgResponse) {
-        const bg = parseOscColorResponse(bgResponse);
-
-        if (bg) {
-            result.background = bg;
-        }
-    }
-
-    const cursorResponse = await queryOsc(stdin, stdout, `${OSC}12;?${BEL}`, timeout);
-
-    if (cursorResponse) {
-        const cursor = parseOscColorResponse(cursorResponse);
-
-        if (cursor) {
-            result.cursor = cursor;
-        }
-    }
-
-    const colors: string[] = [];
-
-    for (let index = 0; index < 16; index++) {
-        const colorResponse = await queryOsc(stdin, stdout, `${OSC}4;${index};?${BEL}`, timeout);
-
-        if (colorResponse) {
-            const color = parseOscColorResponse(colorResponse);
-
-            colors.push(color ?? "");
-        } else {
-            colors.push("");
-        }
-    }
-
-    if (colors.some((c) => c.length > 0)) {
-        result.colors = colors;
+    if (Object.keys(result).length === 0) {
+        paletteCache.delete(stdout);
     }
 
     return result;
+};
+
+/**
+ * Query the terminal for its current color palette.
+ *
+ * All queries go out in a single write and are answered against one listener, so an unresponsive
+ * terminal costs one `timeout` rather than one per query. The probe is shared per output stream:
+ * concurrent callers collapse onto one round trip, and the answer is reused for the process
+ * lifetime because a terminal's palette does not change underneath a running program.
+ *
+ * `signal` unsubscribes *this* caller; it does not cancel the shared probe, so a component
+ * unmounting mid-flight cannot discard the answer every other component is waiting for.
+ * @param stdin Readable stream (typically process.stdin in raw mode)
+ * @param stdout Writable stream (typically process.stdout)
+ * @param timeout Timeout in milliseconds for the whole batch (default: 500). Ignored when a probe
+ * for this stream is already in flight.
+ * @param signal Stops waiting; resolves with an empty palette
+ * @returns The colours the terminal reported. Missing entries mean it did not answer.
+ */
+export const queryTerminalPalette = async (
+    stdin: ProbeStdin,
+    stdout: Writable,
+    timeout = 500,
+    signal?: AbortSignal,
+): Promise<Partial<TerminalPalette>> => {
+    if (signal?.aborted) {
+        return {};
+    }
+
+    let query = paletteCache.get(stdout);
+
+    if (!query) {
+        query = runCachedQuery(stdin, stdout, timeout);
+        paletteCache.set(stdout, query);
+    }
+
+    return signal ? raceAbort(query, signal) : query;
 };

--- a/packages/terminal/tui/src/ink/terminal-palette.ts
+++ b/packages/terminal/tui/src/ink/terminal-palette.ts
@@ -9,6 +9,8 @@
  */
 import type { Writable } from "node:stream";
 
+import { parseColor } from "@visulima/ansi";
+
 import runExclusiveProbe from "./probe-terminal";
 
 const BEL = "\u{7}";
@@ -30,8 +32,6 @@ const EXPECTED_RESPONSES = 3 + PALETTE_SIZE;
  */
 const MAX_RESPONSE_BYTES = 8192;
 
-const RE_OSC_COLOR = /rgb:([\da-f]{2,4})\/([\da-f]{2,4})\/([\da-f]{2,4})/i;
-
 export type TerminalPalette = {
     readonly background: string;
     readonly colors: ReadonlyArray<string>;
@@ -40,27 +40,28 @@ export type TerminalPalette = {
 };
 
 /**
- * Parse an OSC color response like `rgb:RRRR/GGGG/BBBB` to a hex string.
- * Terminal color responses use 16-bit values per channel; we extract the top 8 bits.
- * @param response The response payload to parse.
- * @returns The colour as `#rrggbb`, or null when the payload is not a colour.
+ * Reads the colour out of an OSC 10/11/12 reply payload.
+ *
+ * Terminals disagree about the form they answer in: `rgb:` device specifications are the documented
+ * one, but `#rrggbb` and bare X11 colour names both occur. Delegating to the shared parser means
+ * this does not have to guess which terminal it is talking to — it previously understood `rgb:`
+ * only, and silently dropped every other reply.
+ * @param payload The reply payload, `&lt;ps>;&lt;colour>`.
+ * @returns The colour as `#rrggbb`, or null when the payload names no colour.
  */
-const parseOscColorResponse = (response: string): string | null => {
-    const match = RE_OSC_COLOR.exec(response);
+const parseOscColorResponse = (payload: string): string | null => {
+    // The last field is the colour: OSC 10/11/12 answer `<ps>;<colour>`, but OSC 4 answers
+    // `4;<index>;<colour>`. No colour form contains a semicolon, so the last one always precedes it.
+    const separator = payload.lastIndexOf(";");
+    const color = parseColor(separator === -1 ? payload : payload.slice(separator + 1));
 
-    if (!match) {
+    if (color === undefined) {
         return null;
     }
 
-    const toHex = (value: string): string => {
-        if (value.length <= 2) {
-            return value.padStart(2, "0");
-        }
+    const channel = (value: number): string => value.toString(16).padStart(2, "0");
 
-        return value.slice(0, 2);
-    };
-
-    return `#${toHex(match[1]!)}${toHex(match[2]!)}${toHex(match[3]!)}`;
+    return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
 };
 
 /**


### PR DESCRIPTION
Depends on #836 — merge that first. The branch contains it so the wiring compiles and tests on its own; once ansi lands, this diff collapses to `terminal/tui`.

## The palette probe held stdin for nineteen timeouts

It sent nineteen OSC queries back to back, each with its own timeout and its own stdin listener, and resolved on any stray `BEL` — so an unresponsive terminal held input for nineteen timeouts and a keystroke could be mistaken for an answer.

It is now a single write answered by one listener with one timeout and an incremental parser that only accepts real OSC replies.

## Keystrokes typed during the probe

Bytes that are not ours are handed back to the stream, but only when nothing else is listening: a Node `data` listener does not consume exclusively, so unshifting while the app is attached would deliver every keystroke **twice**. The stream is paused first, because removing the last listener does not stop the flow and an unshift into a flowing stream is re-emitted to nobody.

## The probe is shared, not per-caller

The result is cached per stdout. `signal` unsubscribes the caller without cancelling the round trip, so a component unmounting mid-flight no longer discards the answer another component is waiting for, and a React StrictMode double-mount is not handed a dead promise.

## Two probes were fighting over stdin

The kitty-keyboard query reads the same stdin and could run concurrently — its stripper knows nothing about OSC replies, so it would push the palette’s answer back into the input pipeline as if the user had typed it. Both now take turns through one per-stdin queue, which runs synchronously when nothing is pending so no probe misses bytes.

## Colour replies other than `rgb:` were dropped

The parser understood `rgb:` device specifications and nothing else, so a terminal replying with `#rrggbb` or a bare X11 name had its answer silently discarded and that entry came back missing. It now delegates to the shared parser.

Indexed replies carry two fields before the colour (`4;<index>;<colour>`) where the others carry one, so the colour is taken from the last field; no colour form contains a semicolon.

`@visulima/ansi` moves to `workspace:*` — the release tooling rewrites it to the published range.

## Also

`createStandard` and `createIncremental` in `log-update` folded into one factory plus a frame-writing strategy; they duplicated ~120 lines of frame state behind a `sonarjs/no-identical-functions` suppression, now removed (458 → 383 lines). The unification is behaviour-preserving.

Whitespace-only cleanup in `ink.tsx` (tabs and trailing spaces in JSDoc blocks) so the file passes the newer lint config.

1426 tests pass. `native-binding.test.ts` fails locally only because the Rust artifact is not built in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD8GfiGLkMa3D6hfcaWcTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal color detection across supported response formats and terminators.
  * Prevented stale terminal updates during shutdown and cleanup.
  * Improved Kitty keyboard detection reliability during timeouts and exit.
  * Preserved unrelated terminal input while probing capabilities.
* **Performance**
  * Batched terminal palette detection and reused cached results.
  * Improved incremental terminal rendering and output synchronization.
* **Compatibility**
  * Improved fullscreen redraw behavior on Windows.
  * Ensured terminal probes run safely without interfering with one another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->