### PR TITLE
ci(lint): retry the actionlint release download

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -284,8 +284,19 @@ jobs:
                   tarball="actionlint_${version}_linux_amd64.tar.gz"
                   checksums="actionlint_${version}_checksums.txt"
 
-                  curl --fail --silent --show-error --location --output "$tarball" "${base}/${tarball}"
-                  curl --fail --silent --show-error --location --output "$checksums" "${base}/${checksums}"
+                  # A single-shot fetch makes this job fail whenever the release CDN
+                  # hiccups; it has died on both `curl: (56)` and 503. --retry alone
+                  # skips transport-level errors, so --retry-all-errors is needed to
+                  # cover the connection-died case.
+                  fetch() {
+                      curl --fail --silent --show-error --location \
+                          --retry 5 --retry-delay 2 --retry-all-errors \
+                          --connect-timeout 10 --max-time 120 \
+                          --output "$1" "$2"
+                  }
+
+                  fetch "$tarball" "${base}/${tarball}"
+                  fetch "$checksums" "${base}/${checksums}"
 
                   grep " ${tarball}\$" "$checksums" | sha256sum --check --status
 

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -150,6 +150,15 @@ jobs:
               if: "${{ steps.native-artifacts.outcome == 'success' }}"
               shell: "bash"
               run: |
+                  # `if_no_artifact_found: ignore` makes the download step succeed while
+                  # creating nothing, so outcome == 'success' is not evidence that any
+                  # prebuild arrived — a PR that touches no native code reaches here with
+                  # no artifacts directory at all, and `find` then kills the job.
+                  if [ ! -d artifacts ]; then
+                      echo "No native prebuilds for this PR; nothing to distribute."
+                      exit 0
+                  fi
+
                   # task-runner: move matching .node files and distribute to npm packages
                   find artifacts -name "task-runner-native.*.node" -exec mv {} packages/tooling/task-runner/ \;
                   cd packages/tooling/task-runner && pnpm exec napi artifacts --output-dir . --npm-dir npm && rm -f *.node && cd ../../..


### PR DESCRIPTION
The workflow-lint job fetched the actionlint tarball and its checksum with a single-shot `curl`, so any hiccup on the release CDN turned into a red check with nothing wrong in the repo. Observed failures: `curl: (56) Connection died, tried 5 times before giving up`, and a 503.

Plain `--retry` only covers transient HTTP statuses and timeouts; `--retry-all-errors` is what actually covers the connection-died case. `--connect-timeout` / `--max-time` bound each attempt so a hung connection cannot eat the job's 30-minute budget.

Checksum verification is unchanged — the tarball is still checked against the published `sha256` before it is executed.

### Not fixed here

The same class of failure exists in the Windows native build, where lz4 is fetched with a single-shot `Invoke-WebRequest` (it returned 503 on the run that prompted this). That step lives in `anolilab/workflows/step/node`, not in this repo, so it needs the same treatment upstream. It matters more than it looks: every `Test (…)` job gates on `Check Native Build`, so one flaky lz4 download turns the whole board red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when downloading workflow validation files by adding retries, timeouts, and transport-error handling.
  * Preview releases now complete successfully when no native build artifacts are available.
  * Native artifacts continue to be distributed normally when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->