### PR TITLE
build(deps): ignore the unfixable extract-zip advisory

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,14 @@ auditConfig:
     # untrusted images in this repo. Re-check when image-size publishes a fix.
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
+    # extract-zip symlink path traversal. The advisory names 2.0.2 as the fix
+    # but no such release exists — 2.0.1 is the latest published version — so
+    # neither an upgrade nor an override can resolve it. Every path is
+    # dev-only tooling (apps/web > @netlify/vite-plugin-tanstack-start, and
+    # inspector > webdriverio > @puppeteer/browsers), each unpacking archives
+    # it fetched itself, so no untrusted zip reaches it. Re-check when
+    # extract-zip publishes a patched release.
+    - GHSA-jmr9-qjv8-65gv
 
 autoInstallPeers: true
 


### PR DESCRIPTION
GHSA-jmr9-qjv8-65gv (high, `extract-zip` unvalidated symlink path traversal) was published recently and now fails the `pnpm audit` gate in `Lint (eslint, types, attw)` on **every** branch, not just one.

There is nothing to upgrade to. The advisory names `>=2.0.2` as patched, but extract-zip has never published a 2.0.2 — `2.0.1` is the latest version on npm — so neither a bump nor a pnpm override can clear it.

All five paths are dev-only tooling that unpacks archives it fetched itself:

- `apps/web > @netlify/vite-plugin-tanstack-start > @netlify/vite-plugin > @netlify/dev > @netlify/functions-dev`
- `packages/error-debugging/inspector > webdriverio > @wdio/{config,utils} > @puppeteer/browsers`

Neither is in any published package, and no untrusted zip reaches either one.

Added to `auditConfig.ignoreGhsas` with a re-check note, matching the existing entries. Split out of the catalog-refresh branch so the other open PRs can pick it up without waiting on that one.