### PR TITLE
build(deps): drop inert audit suppressions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,26 +60,11 @@ allowBuilds:
   yarn: true
 
 auditConfig:
-  ignoreCves:
-    - CVE-2022-37620
-    - CVE-2020-8203
-    - CVE-2025-67898
-    - CVE-2025-13465
-    - CVE-2025-69874
-    - CVE-2026-0540
   ignoreGhsas:
-    - GHSA-chqc-8p9q-pq6q
     # lodash.set prototype pollution — dev-only path
     # (redact/__bench__ > @qiwi/masker); no patched release of the
     # frozen per-method package exists. Re-check if @qiwi/masker updates.
     - GHSA-p6mc-m468-83gw
-    # js-yaml merge-key quadratic DoS — only via @yarnpkg/parsers@3.x, which
-    # calls the v3-only safeLoad API (removed in v4), so we cannot move to 4.x.
-    # We pin its nested js-yaml to ^3.14.2, the patched v3 backport that fixes
-    # this CVE. The advisory's vulnerable range (<=4.1.1) is overly broad and
-    # still flags 3.14.2 even though the fix is present. Re-check if
-    # @yarnpkg/parsers adopts js-yaml v4.
-    - GHSA-h67p-54hq-rp68
     # image-size ICNS / JXL / HEIF parser DoS. No patched release exists for
     # either advisory (2.0.2 is latest and still affected), and it reaches us
     # only through @netlify/dev-utils, a dev-time dependency that never parses


### PR DESCRIPTION
## What

Removes eight entries from `auditConfig` in `pnpm-workspace.yaml` that match nothing in the current lockfile.

- All six `ignoreCves` entries — the registry audit response returns no CVE ids for any current advisory, so these never suppressed anything.
- `GHSA-chqc-8p9q-pq6q` — no longer reported.
- `GHSA-h67p-54hq-rp68` (js-yaml merge-key DoS) — the `js-yaml@3: '>=3.15.1 <4'` override in `pnpm.overrides` resolves it. The ignore was dead and its comment (claiming a `^3.14.2` pin) was stale.

Dead suppressions aren't harmless: they silently hide a finding if one of those packages reappears on a vulnerable version.

## Why nothing else changed

With `auditConfig` disabled entirely, `pnpm audit` reports exactly four advisories — the ones the remaining `ignoreGhsas` entries cover. Each was re-checked against npm and has no patched release:

| Advisory | Package | Patched range | Latest published |
|---|---|---|---|
| GHSA-p6mc-m468-83gw | lodash.set | >=4.3.3 | 4.3.2 |
| GHSA-w3rx-r6r6-pgpr | image-size | >=2.0.3 | 2.0.2 |
| GHSA-5p2g-fcmc-qvqq | image-size | >=2.0.3 | 2.0.2 |
| GHSA-jmr9-qjv8-65gv | extract-zip | >=2.0.2 | 2.0.1 |

Since the fixed version does not exist on the registry, neither an upgrade nor an override can resolve them. All four reach us only through dev-time transitive paths, as the retained comments describe.

## Verification

`pnpm audit` before and after: `4 vulnerabilities found / Severity: 4 high (4 ignored)`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8xLbMxoS2aewPatJ2HxWW