### PR TITLE
refactor(vis): declare commands with defineCommand

### DIFF
--- a/packages/terminal/cerebro/src/define-command.ts
+++ b/packages/terminal/cerebro/src/define-command.ts
@@ -33,8 +33,12 @@ type DefinedCommand<
 > = Omit<CommandInput<OptionDefinition<unknown>, TLogger>, "arguments" | "env" | "execute" | "loader" | "options"> & {
     arguments?: TArguments;
     env?: TEnv;
-    execute?: CommandExecute<InferredToolbox<TOptions, TEnv, TArguments, TLogger>>;
-    loader?: () => Promise<LazyCommandModule<InferredToolbox<TOptions, TEnv, TArguments, TLogger>>>;
+    // `NoInfer` keeps the handler out of inference: the toolbox shape is decided
+    // by `options` / `env` / `arguments` alone. Without it a `loader` pointing at
+    // a separately-typed handler module becomes a competing inference site and
+    // collapses `TEnv` / `TArguments` / `TLogger` to `never`.
+    execute?: CommandExecute<NoInfer<InferredToolbox<TOptions, TEnv, TArguments, TLogger>>>;
+    loader?: () => Promise<LazyCommandModule<NoInfer<InferredToolbox<TOptions, TEnv, TArguments, TLogger>>>>;
     options?: TOptions;
 };
 

--- a/packages/terminal/cerebro/src/index.ts
+++ b/packages/terminal/cerebro/src/index.ts
@@ -94,6 +94,7 @@ export { default as MissingArgumentError } from "./errors/missing-argument-error
 export { default as SurplusArgumentError } from "./errors/surplus-argument-error";
 export type { Cli, CliRunOptions, OutputType, RunCommandOptions, VERBOSITY_LEVEL } from "./types/cli";
 export type {
+    AnyCommandInput,
     ArgumentDefinition,
     Command,
     CommandExecute,

--- a/packages/terminal/cerebro/src/types/cli.ts
+++ b/packages/terminal/cerebro/src/types/cli.ts
@@ -1,6 +1,7 @@
 import type PluginManager from "../plugin-manager";
-import type { Command as ICommand, OptionDefinition } from "./command";
+import type { Command as ICommand, CommandInput as ICommandInput, OptionDefinition } from "./command";
 import type { Plugin } from "./plugin";
+import type { Toolbox as IToolbox } from "./toolbox";
 
 export type CommandSection = { footer?: string; header?: string };
 
@@ -39,7 +40,9 @@ export interface Cli<T extends Console> {
      * @param command The command to add.
      * @returns self
      */
-    addCommand: <OD extends OptionDefinition<unknown> = OptionDefinition<unknown>>(command: ICommand<OD, T>) => this;
+    addCommand: <OD extends OptionDefinition<unknown> = OptionDefinition<unknown>, TContext extends IToolbox<T> = IToolbox<T>>(
+        command: ICommandInput<OD, T, TContext>,
+    ) => this;
 
     /**
      * Add a global option available to all commands.

--- a/packages/terminal/cerebro/src/types/command.ts
+++ b/packages/terminal/cerebro/src/types/command.ts
@@ -362,3 +362,21 @@ export type CommandInput<
     /** Options supported by this command, as an array or keyed by option name. */
     options?: Command<O, TLogger, TContext>["options"] | OptionDefinitionRecord;
 };
+
+/**
+ * A command of any shape, for collections.
+ *
+ * Handlers are contravariant in their toolbox, so a `CommandInput[]` annotated
+ * with the default toolbox rejects every command whose handler was typed against
+ * the narrower toolbox `defineCommand` infers — which is all of them. Pinning
+ * `TContext` to `never` accepts any handler, because `never` is assignable to
+ * whatever toolbox that handler asked for.
+ *
+ * Use it for arrays and registries that carry commands from different sources.
+ * It says nothing about the toolbox, so it is not useful for declaring one.
+ * @example
+ * ```typescript
+ * const releaseCommands: AnyCommandInput[] = [addCommand, generateCommand, doctorCommand];
+ * ```
+ */
+export type AnyCommandInput<TLogger extends Console = Console> = CommandInput<OptionDefinition<unknown>, TLogger, never>;

--- a/packages/terminal/cerebro/src/util/lazy-named.ts
+++ b/packages/terminal/cerebro/src/util/lazy-named.ts
@@ -1,4 +1,5 @@
 import type { CommandExecute, LazyCommandModule } from "../types/command";
+import type { Toolbox as IToolbox } from "../types/toolbox";
 
 /**
  * Builds a `loader` for commands whose handler lives as a named export in a
@@ -19,10 +20,15 @@ import type { CommandExecute, LazyCommandModule } from "../types/command";
  */
 // eslint-disable-next-line import/prefer-default-export -- re-exported by name from src/index.ts as public API
 export const lazyNamed
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- K constrains `key` to be a valid key of M, used by the caller
-    = <M extends Record<string, unknown>, K extends keyof M, TContext>(load: () => Promise<M>, key: K): () => Promise<LazyCommandModule<TContext>> =>
+    // No `TContext` parameter on purpose. It appeared only in the return type, so
+    // TypeScript resolved it from whatever context the loader was assigned into —
+    // and inside `defineCommand`, that context is `NoInfer`-wrapped and still has
+    // unresolved type parameters, which collapsed it to `never`. Pinning the wide
+    // toolbox instead is always assignable to a narrower one, because the handler
+    // parameter is contravariant.
+    = <M extends Record<string, unknown>>(load: () => Promise<M>, key: keyof M): () => Promise<LazyCommandModule<IToolbox>> =>
         async () => {
             const loaded = await load();
 
-            return { default: loaded[key] as CommandExecute<TContext> };
+            return { default: loaded[key] as CommandExecute<IToolbox> };
         };

--- a/packages/tooling/vis/__tests__/commands/ci/ci-command.test.ts
+++ b/packages/tooling/vis/__tests__/commands/ci/ci-command.test.ts
@@ -113,7 +113,7 @@ describe("vis ci", () => {
         await ciExecute({
             argument: ["lint,test"],
             logger,
-            options: { skipToolchain: true },
+            options: { install: true, skipToolchain: true },
             runtime,
             visConfig: undefined,
             workspaceRoot,

--- a/packages/tooling/vis/__tests__/commands/secrets/secrets-command.test.ts
+++ b/packages/tooling/vis/__tests__/commands/secrets/secrets-command.test.ts
@@ -22,7 +22,8 @@ describe("secrets command", () => {
     it("exposes the expected flags", () => {
         expect.assertions(1);
 
-        const names = (secretsCommand.options ?? []).map((option) => option.name);
+        // Options are declared as a record keyed by name.
+        const names = Object.keys(secretsCommand.options ?? {});
 
         expect(names).toStrictEqual(
             expect.arrayContaining(["config", "format", "baseline", "redact", "include-hidden", "no-gitignore", "max-size", "update-baseline"]),

--- a/packages/tooling/vis/__tests__/generate/command-surface.test.ts
+++ b/packages/tooling/vis/__tests__/generate/command-surface.test.ts
@@ -72,67 +72,57 @@ describe("vis generate — CLI surface", () => {
             ],
             "group": "Scaffold & Config",
             "name": "generate",
-            "options": [
-              {
-                "defaultValue": false,
-                "description": "List discovered templates",
-                "name": "list",
-                "type": [Function],
-              },
-              {
-                "defaultValue": false,
-                "description": "Print template metadata (about, destination, variables) without running produce",
-                "name": "describe",
-                "type": [Function],
-              },
-              {
-                "defaultValue": false,
-                "description": "Emit JSON output (with --list or --describe)",
-                "name": "json",
-                "type": [Function],
-              },
-              {
-                "description": "Destination directory",
-                "name": "to",
-                "type": [Function],
-              },
-              {
-                "defaultValue": false,
-                "description": "Print planned writes without touching disk",
-                "name": "dry-run",
-                "type": [Function],
-              },
-              {
-                "defaultValue": false,
-                "description": "Overwrite existing files without prompting",
-                "name": "force",
-                "type": [Function],
-              },
-              {
+            "options": {
+              "defaults": {
                 "defaultValue": false,
                 "description": "Skip prompts; use template defaults",
-                "name": "defaults",
                 "type": [Function],
               },
-              {
+              "describe": {
                 "defaultValue": false,
-                "description": "Skip running post-generation scripts",
-                "name": "skip-scripts",
+                "description": "Print template metadata (about, destination, variables) without running produce",
                 "type": [Function],
               },
-              {
+              "dry-run": {
+                "defaultValue": false,
+                "description": "Print planned writes without touching disk",
+                "type": [Function],
+              },
+              "force": {
+                "defaultValue": false,
+                "description": "Overwrite existing files without prompting",
+                "type": [Function],
+              },
+              "json": {
+                "defaultValue": false,
+                "description": "Emit JSON output (with --list or --describe)",
+                "type": [Function],
+              },
+              "list": {
+                "defaultValue": false,
+                "description": "List discovered templates",
+                "type": [Function],
+              },
+              "no-interactive": {
                 "defaultValue": false,
                 "description": "Skip interactive prompts (errors on missing required values)",
-                "name": "no-interactive",
                 "type": [Function],
               },
-              {
+              "prefer-offline": {
                 "defaultValue": false,
                 "description": "Prefer locally cached remote templates over re-downloading",
-                "name": "prefer-offline",
                 "type": [Function],
               },
-            ],
+              "skip-scripts": {
+                "defaultValue": false,
+                "description": "Skip running post-generation scripts",
+                "type": [Function],
+              },
+              "to": {
+                "description": "Destination directory",
+                "type": [Function],
+              },
+            },
           }
         `);
     });
@@ -140,7 +130,9 @@ describe("vis generate — CLI surface", () => {
     it("keeps each option name kebab-cased", () => {
         expect.hasAssertions();
 
-        const optionNames = (generateCommand as unknown as { options?: { name: string }[] }).options?.map((o) => o.name) ?? [];
+        // Options are declared as a record keyed by name, so the keys are the
+        // option names.
+        const optionNames = Object.keys((generateCommand as unknown as { options?: Record<string, unknown> }).options ?? {});
 
         for (const name of optionNames) {
             expect(name).toMatch(/^[a-z][a-z0-9-]*$/);

--- a/packages/tooling/vis/__tests__/util/negatable-option.test.ts
+++ b/packages/tooling/vis/__tests__/util/negatable-option.test.ts
@@ -3,28 +3,30 @@ import { describe, expect, it } from "vitest";
 import { negatable } from "../../src/util/negatable-option";
 
 describe(negatable, () => {
-    it("should return the option followed by its negated twin", () => {
+    it("should key the option and its negated twin by name", () => {
         expect.assertions(3);
 
-        const [positive, negated] = negatable({ defaultValue: true, description: "Enable caching", name: "cache", type: Boolean });
+        const pair = negatable({ defaultValue: true, description: "Enable caching", name: "cache", type: Boolean });
 
-        expect(positive?.name).toBe("cache");
-        expect(negated?.name).toBe("no-cache");
-        expect(negated?.type).toBe(Boolean);
+        expect(Object.keys(pair).sort()).toStrictEqual(["cache", "no-cache"]);
+        expect(pair.cache).toStrictEqual({ defaultValue: true, description: "Enable caching", type: Boolean });
+        expect(pair["no-cache"].type).toBe(Boolean);
     });
 
-    it("should pass the positive option through untouched", () => {
-        expect.assertions(1);
+    it("should carry the positive option through without its name", () => {
+        expect.assertions(2);
 
-        const option = { defaultValue: true, description: "Enable caching", name: "cache", type: Boolean };
+        // The record key is the name, so it must not also sit inside the value.
+        const pair = negatable({ defaultValue: true, description: "Enable caching", name: "cache", type: Boolean });
 
-        expect(negatable(option)[0]).toBe(option);
+        expect(pair.cache).not.toHaveProperty("name");
+        expect(pair.cache.description).toBe("Enable caching");
     });
 
     it("should hide the twin so help output is unchanged", () => {
         expect.assertions(1);
 
-        expect(negatable({ description: "x", name: "flaky", type: Boolean })[1]?.hidden).toBe(true);
+        expect(negatable({ description: "x", name: "flaky", type: Boolean })["no-flaky"].hidden).toBe(true);
     });
 
     it("should give the twin no defaultValue so a tri-state option stays tri-state", () => {
@@ -32,6 +34,6 @@ describe(negatable, () => {
 
         // With a default on the twin, "neither flag passed" would resolve to
         // a boolean and clobber the "fall back to config" case.
-        expect(negatable({ description: "x", name: "strict-env", type: Boolean })[1]).not.toHaveProperty("defaultValue");
+        expect(negatable({ description: "x", name: "strict-env", type: Boolean })["no-strict-env"]).not.toHaveProperty("defaultValue");
     });
 });

--- a/packages/tooling/vis/src/commands/action-graph/index.ts
+++ b/packages/tooling/vis/src/commands/action-graph/index.ts
@@ -1,11 +1,34 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis action-graph &lt;selector>` — shows the execution plan that would
  * be produced by `vis run &lt;selector>` without running anything. Matches
  * moon's `moon action-graph`.
  */
-const actionGraph: Command = {
+const actionGraphOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit JSON instead of ASCII",
+        type: Boolean,
+    },
+    projects: {
+        alias: "p",
+        description: "Comma-separated list of projects to plan (same semantics as `vis run --projects`)",
+        type: String,
+    },
+    query: {
+        description: "Filter matched projects by a query",
+        type: String,
+    },
+    tag: {
+        description: "Only plan projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\".",
+        multiple: true,
+        type: String,
+    },
+} as const;
+
+const actionGraph = defineCommand({
     argument: {
         description: "Target selector (same syntax as `vis run`): `build`, `:build`, `~:test`, `#tag:lint`, …",
         name: "selector",
@@ -22,38 +45,9 @@ const actionGraph: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "action-graph",
-    options: [
-        {
-            defaultValue: false,
-            description: "Emit JSON instead of ASCII",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            alias: "p",
-            description: "Comma-separated list of projects to plan (same semantics as `vis run --projects`)",
-            name: "projects",
-            type: String,
-        },
-        {
-            description: "Filter matched projects by a query",
-            name: "query",
-            type: String,
-        },
-        {
-            description: "Only plan projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\".",
-            multiple: true,
-            name: "tag",
-            type: String,
-        },
-    ],
-};
+    options: actionGraphOptionDefinitions,
+});
 
 export default actionGraph;
 
-export type ActionGraphOptions = CreateOptions<{
-    json: boolean | undefined;
-    projects: string | undefined;
-    query: string | undefined;
-    tag: string[] | undefined;
-}>;
+export type ActionGraphOptions = InferOptions<typeof actionGraphOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/add/index.ts
+++ b/packages/tooling/vis/src/commands/add/index.ts
@@ -1,6 +1,88 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const add: Command = {
+const addOptionDefinitions = {
+    "auto-install-peers": {
+        defaultValue: false,
+        description:
+                "After adding, recursively install non-optional peer dependencies that aren't already in the workspace (matches nypm's installPeerDependencies)",
+        type: Boolean,
+    },
+    exact: {
+        alias: "E",
+        defaultValue: false,
+        description: "Save exact version",
+        type: Boolean,
+    },
+    filter: {
+        alias: "F",
+        description: "Filter by workspace package name",
+        multiple: true,
+        type: String,
+    },
+    global: {
+        alias: "g",
+        defaultValue: false,
+        description: "Install globally (uses npm)",
+        type: Boolean,
+    },
+    "no-marshall-check": {
+        defaultValue: false,
+        description: "Skip the offline marshall pipeline (author, provenance, metadata, downloads, expired-domains, new-bin, signatures, archived-repo)",
+        type: Boolean,
+    },
+    "no-socket-check": {
+        defaultValue: false,
+        description: "Skip Socket.dev security check before adding",
+        type: Boolean,
+    },
+    "no-typosquat-check": {
+        defaultValue: false,
+        description: "Skip typosquat name check before adding",
+        type: Boolean,
+    },
+    "run-scripts": {
+        defaultValue: false,
+        description:
+                "Run lifecycle scripts during add (opts out of vis's default block-by-default policy; allowlisted packages run via security.policies.installScripts.allow)",
+        type: Boolean,
+    },
+    "save-dev": {
+        alias: "D",
+        defaultValue: false,
+        description: "Add as dev dependency",
+        type: Boolean,
+    },
+    "save-optional": {
+        alias: "O",
+        defaultValue: false,
+        description: "Add as optional dependency",
+        type: Boolean,
+    },
+    "save-peer": {
+        alias: "P",
+        defaultValue: false,
+        description: "Add as peer dependency",
+        type: Boolean,
+    },
+    to: {
+        description: "Target a single workspace package and auto-conform the version to existing catalogs / sibling deps (syncpack#285)",
+        type: String,
+    },
+    workspace: {
+        defaultValue: false,
+        description: "Use workspace protocol (pnpm)",
+        type: Boolean,
+    },
+    "workspace-root": {
+        alias: "w",
+        defaultValue: false,
+        description: "Add to workspace root",
+        type: Boolean,
+    },
+} as const;
+
+const add = defineCommand({
     argument: {
         description: "Packages to add (e.g., react react-dom)",
         name: "packages",
@@ -22,60 +104,9 @@ const add: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "add",
-    options: [
-        { alias: "D", defaultValue: false, description: "Add as dev dependency", name: "save-dev", type: Boolean },
-        { alias: "E", defaultValue: false, description: "Save exact version", name: "exact", type: Boolean },
-        { alias: "P", defaultValue: false, description: "Add as peer dependency", name: "save-peer", type: Boolean },
-        { alias: "O", defaultValue: false, description: "Add as optional dependency", name: "save-optional", type: Boolean },
-        { alias: "g", defaultValue: false, description: "Install globally (uses npm)", name: "global", type: Boolean },
-        { alias: "w", defaultValue: false, description: "Add to workspace root", name: "workspace-root", type: Boolean },
-        { defaultValue: false, description: "Use workspace protocol (pnpm)", name: "workspace", type: Boolean },
-        { alias: "F", description: "Filter by workspace package name", multiple: true, name: "filter", type: String },
-        {
-            description: "Target a single workspace package and auto-conform the version to existing catalogs / sibling deps (syncpack#285)",
-            name: "to",
-            type: String,
-        },
-        { defaultValue: false, description: "Skip typosquat name check before adding", name: "no-typosquat-check", type: Boolean },
-        { defaultValue: false, description: "Skip Socket.dev security check before adding", name: "no-socket-check", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Skip the offline marshall pipeline (author, provenance, metadata, downloads, expired-domains, new-bin, signatures, archived-repo)",
-            name: "no-marshall-check",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Run lifecycle scripts during add (opts out of vis's default block-by-default policy; allowlisted packages run via security.policies.installScripts.allow)",
-            name: "run-scripts",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "After adding, recursively install non-optional peer dependencies that aren't already in the workspace (matches nypm's installPeerDependencies)",
-            name: "auto-install-peers",
-            type: Boolean,
-        },
-    ],
-};
+    options: addOptionDefinitions,
+});
 
 export default add;
 
-export type AddOptions = CreateOptions<{
-    "auto-install-peers": boolean | undefined;
-    exact: boolean | undefined;
-    filter: string[] | undefined;
-    global: boolean | undefined;
-    "no-marshall-check": boolean | undefined;
-    "no-socket-check": boolean | undefined;
-    "no-typosquat-check": boolean | undefined;
-    "run-scripts": boolean | undefined;
-    "save-dev": boolean | undefined;
-    "save-optional": boolean | undefined;
-    "save-peer": boolean | undefined;
-    to: string | undefined;
-    workspace: boolean | undefined;
-    "workspace-root": boolean | undefined;
-}>;
+export type AddOptions = InferOptions<typeof addOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/advisories/index.ts
+++ b/packages/tooling/vis/src/commands/advisories/index.ts
@@ -14,7 +14,7 @@
  * into the native crate.
  */
 
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions } from "@visulima/cerebro";
 import { lazyNamed } from "@visulima/cerebro";
 
 const dbPathOption = {
@@ -146,7 +146,7 @@ const advisoriesBloomStatus: Command = {
     options: [bloomCacheDirOption, formatOption],
 };
 
-const advisoriesCommands = [advisoriesSync, advisoriesStatus, advisoriesPrune, advisoriesBloomSync, advisoriesBloomStatus];
+const advisoriesCommands: AnyCommandInput[] = [advisoriesSync, advisoriesStatus, advisoriesPrune, advisoriesBloomSync, advisoriesBloomStatus];
 
 export default advisoriesCommands;
 

--- a/packages/tooling/vis/src/commands/advisories/index.ts
+++ b/packages/tooling/vis/src/commands/advisories/index.ts
@@ -146,7 +146,7 @@ const advisoriesBloomStatus: Command = {
     options: [bloomCacheDirOption, formatOption],
 };
 
-const advisoriesCommands: Command[] = [advisoriesSync, advisoriesStatus, advisoriesPrune, advisoriesBloomSync, advisoriesBloomStatus];
+const advisoriesCommands = [advisoriesSync, advisoriesStatus, advisoriesPrune, advisoriesBloomSync, advisoriesBloomStatus];
 
 export default advisoriesCommands;
 

--- a/packages/tooling/vis/src/commands/affected/index.ts
+++ b/packages/tooling/vis/src/commands/affected/index.ts
@@ -1,8 +1,87 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 import { negatable } from "../../util/negatable-option";
 
-const affected: Command = {
+const affectedOptionDefinitions = {
+    base: {
+        description:
+                "Git base ref for comparison. When omitted, vis auto-resolves it from the active CI provider (GitHub/GitLab/Buildkite/CircleCI) or falls back to `git merge-base HEAD origin/<defaultBase>` locally. Default base branch comes from `vis.config.ts#defaultBase` (or `main`).",
+        type: String,
+    },
+    head: {
+        description: "Git head ref for comparison. When omitted, auto-resolves from CI env (e.g. `$GITHUB_SHA`) or defaults to `HEAD`.",
+        type: String,
+    },
+    ...negatable({
+        // No `defaultValue` — `undefined` means "auto": include the
+        // working tree for local runs, ignore it in CI where the
+        // checkout is the whole truth.
+        description:
+                "Include uncommitted working-tree changes (tracked edits and untracked files) in the changed-file set. Defaults to on for local runs and off in CI; use --no-uncommitted to force off.",
+        name: "uncommitted",
+        type: Boolean,
+    }),
+    downstream: {
+        defaultValue: "deep",
+        description: "Downstream scope: \"none\", \"direct\", or \"deep\" — controls how far to include dependents of changed projects",
+        type: String,
+    },
+    parallel: {
+        defaultValue: 3,
+        description: "Maximum number of parallel tasks",
+        type: Number,
+    },
+    upstream: {
+        defaultValue: "none",
+        description: "Upstream scope: \"none\", \"direct\", or \"deep\" — controls how far to include dependencies of changed projects",
+        type: String,
+    },
+    ...negatable({
+        defaultValue: true,
+        description: "Enable caching (use --no-cache to disable)",
+        name: "cache",
+        type: Boolean,
+    }),
+    "dry-run": {
+        defaultValue: false,
+        description: "Show what would run without executing",
+        type: Boolean,
+    },
+    partition: {
+        description: "Partition tasks for distributed CI (e.g., \"1/4\" for first of four runners). Falls back to VIS_PARTITION env var.",
+        type: String,
+    },
+    query: {
+        description: "Filter affected projects by a query (e.g. 'language=typescript && tag=lib')",
+        type: String,
+    },
+    reverse: {
+        defaultValue: false,
+        description:
+                "Run the dependency graph in reverse (leaves first, then their dependents). Useful for teardown targets like `destroy`/`undeploy` where dependents must run before the things they depend on.",
+        type: Boolean,
+    },
+    "runner-tags": {
+        description:
+                "Comma-separated tags this runner advertises (e.g. 'gpu,slow'). Forwarded verbatim to the downstream `vis run` so capability-gated tasks resolve identically. Falls back to VIS_RUNNER_TAGS env var.",
+        type: String,
+    },
+    "sparse-checkout": {
+        defaultValue: false,
+        description:
+                "Instead of running, print the affected project roots as a git sparse-checkout cone set (one path per line) and exit. Pipe into `git sparse-checkout set --stdin` to shrink huge-monorepo CI checkouts.",
+        type: Boolean,
+    },
+    tag: {
+        description:
+                "Only run affected projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\"; combines with --query as AND.",
+        multiple: true,
+        type: String,
+    },
+} as const;
+
+const affected = defineCommand({
     argument: {
         description: "The target to run (e.g., build, test, lint)",
         name: "target",
@@ -18,96 +97,8 @@ const affected: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "affected",
-    options: [
-        {
-            description:
-                "Git base ref for comparison. When omitted, vis auto-resolves it from the active CI provider (GitHub/GitLab/Buildkite/CircleCI) or falls back to `git merge-base HEAD origin/<defaultBase>` locally. Default base branch comes from `vis.config.ts#defaultBase` (or `main`).",
-            name: "base",
-            type: String,
-        },
-        {
-            description: "Git head ref for comparison. When omitted, auto-resolves from CI env (e.g. `$GITHUB_SHA`) or defaults to `HEAD`.",
-            name: "head",
-            type: String,
-        },
-        ...negatable({
-            // No `defaultValue` — `undefined` means "auto": include the
-            // working tree for local runs, ignore it in CI where the
-            // checkout is the whole truth.
-            description:
-                "Include uncommitted working-tree changes (tracked edits and untracked files) in the changed-file set. Defaults to on for local runs and off in CI; use --no-uncommitted to force off.",
-            name: "uncommitted",
-            type: Boolean,
-        }),
-        {
-            defaultValue: "deep",
-            description: "Downstream scope: \"none\", \"direct\", or \"deep\" — controls how far to include dependents of changed projects",
-            name: "downstream",
-            type: String,
-        },
-        {
-            defaultValue: "none",
-            description: "Upstream scope: \"none\", \"direct\", or \"deep\" — controls how far to include dependencies of changed projects",
-            name: "upstream",
-            type: String,
-        },
-        {
-            defaultValue: 3,
-            description: "Maximum number of parallel tasks",
-            name: "parallel",
-            type: Number,
-        },
-        ...negatable({
-            defaultValue: true,
-            description: "Enable caching (use --no-cache to disable)",
-            name: "cache",
-            type: Boolean,
-        }),
-        {
-            defaultValue: false,
-            description: "Show what would run without executing",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Instead of running, print the affected project roots as a git sparse-checkout cone set (one path per line) and exit. Pipe into `git sparse-checkout set --stdin` to shrink huge-monorepo CI checkouts.",
-            name: "sparse-checkout",
-            type: Boolean,
-        },
-        {
-            description: "Partition tasks for distributed CI (e.g., \"1/4\" for first of four runners). Falls back to VIS_PARTITION env var.",
-            name: "partition",
-            type: String,
-        },
-        {
-            description: "Filter affected projects by a query (e.g. 'language=typescript && tag=lib')",
-            name: "query",
-            type: String,
-        },
-        {
-            description:
-                "Only run affected projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\"; combines with --query as AND.",
-            multiple: true,
-            name: "tag",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Run the dependency graph in reverse (leaves first, then their dependents). Useful for teardown targets like `destroy`/`undeploy` where dependents must run before the things they depend on.",
-            name: "reverse",
-            type: Boolean,
-        },
-        {
-            description:
-                "Comma-separated tags this runner advertises (e.g. 'gpu,slow'). Forwarded verbatim to the downstream `vis run` so capability-gated tasks resolve identically. Falls back to VIS_RUNNER_TAGS env var.",
-            name: "runner-tags",
-            type: String,
-        },
-    ],
-};
+    options: affectedOptionDefinitions,
+});
 
 export default affected;
 

--- a/packages/tooling/vis/src/commands/ai/discovery.ts
+++ b/packages/tooling/vis/src/commands/ai/discovery.ts
@@ -1,4 +1,4 @@
-import type { Command } from "@visulima/cerebro";
+import type { AnyCommandInput } from "@visulima/cerebro";
 import { bold, cyan, dim, green, yellow } from "@visulima/colorize";
 
 export interface DiscoveryOption {
@@ -35,6 +35,8 @@ const AI_DISCOVERY_META: DiscoveryMeta = {
     description: "AI-assisted commands: provider detection, cache management, and failure-fix proposals.",
 };
 
+type DiscoveryOptionSource = { defaultValue?: unknown; description?: string; type?: unknown };
+
 const typeName = (type: unknown): string => {
     if (typeof type !== "function") {
         return String(type);
@@ -57,7 +59,28 @@ const typeName = (type: unknown): string => {
     return name ?? "unknown";
 };
 
-const buildSubcommand = (command: Command): DiscoverySubcommand => {
+/**
+ * Flattens either shape of `options` into `[name, definition]` pairs.
+ *
+ * Commands may declare options as an array carrying `name`, or as a record keyed
+ * by name. Discovery output must not depend on which one a command happened to
+ * use.
+ * @param options The command's options, in either form.
+ * @returns One entry per option, name first.
+ */
+const toOptionEntries = (options: AnyCommandInput["options"]): [string, DiscoveryOptionSource][] => {
+    if (options === undefined) {
+        return [];
+    }
+
+    if (Array.isArray(options)) {
+        return options.map((option) => [option.name, option as DiscoveryOptionSource]);
+    }
+
+    return Object.entries(options);
+};
+
+const buildSubcommand = (command: AnyCommandInput): DiscoverySubcommand => {
     const path = [...(command.commandPath ?? []), command.name].join(" ");
     const examples = (command.examples ?? []).map(([cmd, description]) => {
         return {
@@ -65,11 +88,11 @@ const buildSubcommand = (command: Command): DiscoverySubcommand => {
             description: description ?? "",
         };
     });
-    const options = (command.options ?? []).map((option): DiscoveryOption => {
+    const options = toOptionEntries(command.options).map(([name, option]): DiscoveryOption => {
         return {
             defaultValue: option.defaultValue,
             description: option.description,
-            name: option.name,
+            name,
             type: typeName(option.type),
         };
     });
@@ -84,7 +107,7 @@ const buildSubcommand = (command: Command): DiscoverySubcommand => {
     };
 };
 
-export const buildDiscoveryPayload = (subcommands: Command[], meta: DiscoveryMeta = AI_DISCOVERY_META): DiscoveryPayload => {
+export const buildDiscoveryPayload = (subcommands: AnyCommandInput[], meta: DiscoveryMeta = AI_DISCOVERY_META): DiscoveryPayload => {
     return {
         command: meta.command,
         description: meta.description,
@@ -92,10 +115,10 @@ export const buildDiscoveryPayload = (subcommands: Command[], meta: DiscoveryMet
     };
 };
 
-export const renderDiscoveryJson = (subcommands: Command[], meta: DiscoveryMeta = AI_DISCOVERY_META): string =>
+export const renderDiscoveryJson = (subcommands: AnyCommandInput[], meta: DiscoveryMeta = AI_DISCOVERY_META): string =>
     `${JSON.stringify(buildDiscoveryPayload(subcommands, meta), undefined, 2)}\n`;
 
-export const renderDiscoveryText = (subcommands: Command[], meta: DiscoveryMeta = AI_DISCOVERY_META): string => {
+export const renderDiscoveryText = (subcommands: AnyCommandInput[], meta: DiscoveryMeta = AI_DISCOVERY_META): string => {
     const payload = buildDiscoveryPayload(subcommands, meta);
     const lines: string[] = [bold(`vis ${payload.command} — ${payload.description}`), "", dim("Subcommands:")];
 

--- a/packages/tooling/vis/src/commands/ai/index.ts
+++ b/packages/tooling/vis/src/commands/ai/index.ts
@@ -158,7 +158,7 @@ const aiHealAccept: Command = {
     ],
 };
 
-const aiCommands: Command[] = [aiRoot, aiDiscoverHelp, aiProviders, aiTest, aiFix, aiHeal, aiHealAccept];
+const aiCommands = [aiRoot, aiDiscoverHelp, aiProviders, aiTest, aiFix, aiHeal, aiHealAccept];
 
 export default aiCommands;
 

--- a/packages/tooling/vis/src/commands/ai/index.ts
+++ b/packages/tooling/vis/src/commands/ai/index.ts
@@ -1,5 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions, InferOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
 const formatOption = {
     description: "Output format: table or json (default: table)",
@@ -20,15 +20,19 @@ const aiProviders: Command = {
     options: [formatOption],
 };
 
-const aiTest: Command = {
+const aiTestOptionDefinitions = {
+
+} as const;
+
+const aiTest = defineCommand({
     commandPath: ["ai"],
     description: "Test the best available AI provider with a quick prompt",
     examples: [["vis ai test", "Test the selected provider"]],
     group: "System",
     loader: lazyNamed(() => import("./handler"), "aiTestExecute"),
     name: "test",
-    options: [],
-};
+    options: aiTestOptionDefinitions,
+});
 
 const aiFix: Command = {
     argument: {
@@ -75,7 +79,11 @@ const aiFix: Command = {
     ],
 };
 
-const aiRoot: Command = {
+const aiRootOptionDefinitions = {
+
+} as const;
+
+const aiRoot = defineCommand({
     description: "AI-assisted commands: provider detection and failure-fix proposals (cache management lives under `vis cache`)",
     examples: [
         ["vis ai", "List all AI subcommands"],
@@ -84,10 +92,14 @@ const aiRoot: Command = {
     group: "System",
     loader: lazyNamed(() => import("./handler"), "aiRootExecute"),
     name: "ai",
-    options: [],
-};
+    options: aiRootOptionDefinitions,
+});
 
-const aiDiscoverHelp: Command = {
+const aiDiscoverHelpOptionDefinitions = {
+
+} as const;
+
+const aiDiscoverHelp = defineCommand({
     commandPath: ["ai"],
     description: "Print the machine-readable AI subcommand catalogue (JSON to stdout, designed for AI agents)",
     examples: [
@@ -97,10 +109,31 @@ const aiDiscoverHelp: Command = {
     group: "System",
     loader: lazyNamed(() => import("./handler"), "aiDiscoverHelpExecute"),
     name: "discover-help",
-    options: [],
-};
+    options: aiDiscoverHelpOptionDefinitions,
+});
 
-const aiHeal: Command = {
+const aiHealOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Show the proposal and exit without applying or posting it",
+        type: Boolean,
+    },
+    "no-cache": {
+        defaultValue: false,
+        description: "Bypass the AI response cache",
+        type: Boolean,
+    },
+    run: {
+        description: "Use a specific run ID from .vis/runs/ instead of the latest run",
+        type: String,
+    },
+    "validation-timeout": {
+        description: "Per-task validation timeout in seconds (default: 1800)",
+        type: Number,
+    },
+} as const;
+
+const aiHeal = defineCommand({
     commandPath: ["ai"],
     description: "Diagnose the most recent failed task and post a structured patch as a PR/MR comment (or Buildkite annotation)",
     examples: [
@@ -111,66 +144,43 @@ const aiHeal: Command = {
     group: "System",
     loader: lazyNamed(() => import("./heal"), "aiHeal"),
     name: "heal",
-    options: [
-        {
-            defaultValue: false,
-            description: "Show the proposal and exit without applying or posting it",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Bypass the AI response cache",
-            name: "no-cache",
-            type: Boolean,
-        },
-        {
-            description: "Use a specific run ID from .vis/runs/ instead of the latest run",
-            name: "run",
-            type: String,
-        },
-        {
-            description: "Per-task validation timeout in seconds (default: 1800)",
-            name: "validation-timeout",
-            type: Number,
-        },
-    ],
-};
+    options: aiHealOptionDefinitions,
+});
 
-const aiHealAccept: Command = {
+const aiHealAcceptOptionDefinitions = {
+    run: {
+        description: "Use a specific run ID from .vis/runs/ instead of the latest run",
+        type: String,
+    },
+    "validation-timeout": {
+        description: "Per-task validation timeout in seconds (default: 1800)",
+        type: Number,
+    },
+} as const;
+
+const aiHealAccept = defineCommand({
     commandPath: ["ai", "heal"],
     description: "Re-run the proposed fix and commit it to the PR/MR branch when validation passes",
     examples: [["vis ai heal accept", "Triggered automatically by a `/vis heal accept` PR comment (GitHub/GitLab) or a Buildkite block-step unblock"]],
     group: "System",
     loader: lazyNamed(() => import("./heal-accept"), "aiHealAccept"),
     name: "accept",
-    options: [
-        {
-            description: "Use a specific run ID from .vis/runs/ instead of the latest run",
-            name: "run",
-            type: String,
-        },
-        {
-            description: "Per-task validation timeout in seconds (default: 1800)",
-            name: "validation-timeout",
-            type: Number,
-        },
-    ],
-};
+    options: aiHealAcceptOptionDefinitions,
+});
 
-const aiCommands = [aiRoot, aiDiscoverHelp, aiProviders, aiTest, aiFix, aiHeal, aiHealAccept];
+const aiCommands: AnyCommandInput[] = [aiRoot, aiDiscoverHelp, aiProviders, aiTest, aiFix, aiHeal, aiHealAccept];
 
 export default aiCommands;
 
-export type AiRootOptions = CreateOptions<Record<string, never>>;
+export type AiRootOptions = InferOptions<typeof aiRootOptionDefinitions>;
 
-export type AiDiscoverHelpOptions = CreateOptions<Record<string, never>>;
+export type AiDiscoverHelpOptions = InferOptions<typeof aiDiscoverHelpOptionDefinitions>;
 
 export type AiProvidersOptions = CreateOptions<{
     format: string | undefined;
 }>;
 
-export type AiTestOptions = CreateOptions<Record<string, never>>;
+export type AiTestOptions = InferOptions<typeof aiTestOptionDefinitions>;
 
 export type AiFixOptions = CreateOptions<{
     apply: boolean | undefined;
@@ -180,14 +190,6 @@ export type AiFixOptions = CreateOptions<{
     yes: boolean | undefined;
 }>;
 
-export type AiHealOptions = CreateOptions<{
-    "dry-run": boolean | undefined;
-    "no-cache": boolean | undefined;
-    run: string | undefined;
-    "validation-timeout": number | undefined;
-}>;
+export type AiHealOptions = InferOptions<typeof aiHealOptionDefinitions>;
 
-export type AiHealAcceptOptions = CreateOptions<{
-    run: string | undefined;
-    "validation-timeout": number | undefined;
-}>;
+export type AiHealAcceptOptions = InferOptions<typeof aiHealAcceptOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/analyze/index.ts
+++ b/packages/tooling/vis/src/commands/analyze/index.ts
@@ -1,6 +1,23 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const analyze: Command = {
+const analyzeOptionDefinitions = {
+    "ai-type": {
+        description: "AI analysis type: impact, security, compatibility, or recommend (default: impact)",
+        type: String,
+    },
+    format: {
+        description: "Output format: table or json (default: table)",
+        type: String,
+    },
+    security: {
+        defaultValue: false,
+        description: "Check for known security vulnerabilities",
+        type: Boolean,
+    },
+} as const;
+
+const analyze = defineCommand({
     argument: {
         description: "Package name to analyze (e.g., react)",
         name: "package",
@@ -17,30 +34,9 @@ const analyze: Command = {
     group: "System",
     loader: () => import("./handler"),
     name: "analyze",
-    options: [
-        {
-            description: "AI analysis type: impact, security, compatibility, or recommend (default: impact)",
-            name: "ai-type",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Check for known security vulnerabilities",
-            name: "security",
-            type: Boolean,
-        },
-        {
-            description: "Output format: table or json (default: table)",
-            name: "format",
-            type: String,
-        },
-    ],
-};
+    options: analyzeOptionDefinitions,
+});
 
 export default analyze;
 
-export type AnalyzeOptions = CreateOptions<{
-    "ai-type": string | undefined;
-    format: string | undefined;
-    security: boolean | undefined;
-}>;
+export type AnalyzeOptions = InferOptions<typeof analyzeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/approve-builds/index.ts
+++ b/packages/tooling/vis/src/commands/approve-builds/index.ts
@@ -1,6 +1,30 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const approveBuilds: Command = {
+const approveBuildsOptionDefinitions = {
+    all: {
+        defaultValue: false,
+        description: "Approve all pending builds without prompting (pnpm only)",
+        type: Boolean,
+    },
+    scan: {
+        defaultValue: false,
+        description: "Force vis scanning even for pnpm (instead of delegating)",
+        type: Boolean,
+    },
+    "sync-native": {
+        defaultValue: false,
+        description: "Sync allowBuilds to native PM config (bun: trustedDependencies, npm: .npmrc, yarn: .yarnrc.yml)",
+        type: Boolean,
+    },
+    write: {
+        defaultValue: false,
+        description: "Write unapproved entries directly into vis.config.ts security.policies.installScripts.allow (LavaMoat 'auto' parity)",
+        type: Boolean,
+    },
+} as const;
+
+const approveBuilds = defineCommand({
     description: "Review and approve dependencies with build scripts",
     examples: [
         ["vis approve-builds", "Scan and list unapproved build scripts"],
@@ -11,29 +35,9 @@ const approveBuilds: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "approve-builds",
-    options: [
-        { defaultValue: false, description: "Approve all pending builds without prompting (pnpm only)", name: "all", type: Boolean },
-        { defaultValue: false, description: "Force vis scanning even for pnpm (instead of delegating)", name: "scan", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Sync allowBuilds to native PM config (bun: trustedDependencies, npm: .npmrc, yarn: .yarnrc.yml)",
-            name: "sync-native",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Write unapproved entries directly into vis.config.ts security.policies.installScripts.allow (LavaMoat 'auto' parity)",
-            name: "write",
-            type: Boolean,
-        },
-    ],
-};
+    options: approveBuildsOptionDefinitions,
+});
 
 export default approveBuilds;
 
-export type ApproveBuildsOptions = CreateOptions<{
-    all: boolean | undefined;
-    scan: boolean | undefined;
-    "sync-native": boolean | undefined;
-    write: boolean | undefined;
-}>;
+export type ApproveBuildsOptions = InferOptions<typeof approveBuildsOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/attest/index.ts
+++ b/packages/tooling/vis/src/commands/attest/index.ts
@@ -1,4 +1,4 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions } from "@visulima/cerebro";
 import { lazyNamed } from "@visulima/cerebro";
 
 /**
@@ -93,7 +93,7 @@ const attestEmit: Command = {
     ],
 };
 
-const attestCommands = [attestEmit, attestVerify];
+const attestCommands: AnyCommandInput[] = [attestEmit, attestVerify];
 
 export default attestCommands;
 

--- a/packages/tooling/vis/src/commands/attest/index.ts
+++ b/packages/tooling/vis/src/commands/attest/index.ts
@@ -93,7 +93,7 @@ const attestEmit: Command = {
     ],
 };
 
-const attestCommands: Command[] = [attestEmit, attestVerify];
+const attestCommands = [attestEmit, attestVerify];
 
 export default attestCommands;
 

--- a/packages/tooling/vis/src/commands/audit/index.ts
+++ b/packages/tooling/vis/src/commands/audit/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis audit` — vulnerability and supply-chain scan over installed packages.
@@ -8,7 +9,110 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * and renders the result in one of the supported formats. Also drives the
  * `--fix` / `--fix-transitive` apply loops and the HTML report writer.
  */
-const audit: Command = {
+const auditOptionDefinitions = {
+    "allow-major": {
+        defaultValue: false,
+        description: "Allow --fix to bump a direct dep across a major version when the lowest fix is outside the existing range",
+        type: Boolean,
+    },
+    backend: {
+        description:
+                "Audit backend: 'auto' (default, delegates to 'aube audit' when aube is the installer), 'aube' (force delegate), or 'vis' (always use vis's OSV/Socket scanner).",
+        type: String,
+    },
+    db: {
+        description: "Override the offline advisory DB path (default: <cache>/vis/advisories/db.sqlite).",
+        type: String,
+    },
+    ecosystem: {
+        description:
+                "Comma-separated list of OSV ecosystems to scan (default: npm). Supported: npm, pypi, crates.io (or 'cargo'), maven, go, rubygems. Non-npm ecosystems require --offline (online OSV path is npm-only).",
+        type: String,
+    },
+    "exit-code": {
+        defaultValue: false,
+        description: "Exit with code 1 if any issues found (for CI)",
+        type: Boolean,
+    },
+    explain: {
+        description:
+                "Add a plain-English AI explanation to findings. Bare flag explains all findings at/above --severity; pass a finding index (e.g. 2) or a CVE/GHSA id to explain just one. Auto-detects an installed AI CLI; mutually exclusive with --offline.",
+        type: String,
+    },
+    "fail-on": {
+        description: "Exit non-zero when any finding is at this severity or higher. One of: low, medium, high, critical.",
+        type: String,
+    },
+    fix: {
+        defaultValue: false,
+        description: "Apply direct-dep fixes for vulnerable packages by running the active PM update command, then rescan",
+        type: Boolean,
+    },
+    "fix-transitive": {
+        defaultValue: false,
+        description: "Apply transitive fixes by writing PM-specific overrides (pnpm-workspace.yaml / package.json overrides / resolutions)",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table, json, sarif, csaf, cyclonedx-vex, gitlab, or junit (default: table)",
+        type: String,
+    },
+    "no-usage": {
+        defaultValue: false,
+        description: "Disable the reachability filter even if enabled in config.",
+        type: Boolean,
+    },
+    offline: {
+        defaultValue: false,
+        description: "Query the local OSV advisory cache only — no network calls. Errors if the cache is missing.",
+        type: Boolean,
+    },
+    policies: {
+        description:
+                "Comma-separated list of supply-chain policies to evaluate (default: every configured policy). Use 'none' to skip the engine entirely, 'all' to force the full set. Known: malware, firstSeen, unexpectedDeps, publisherChange, installScripts, score, vulnerability, license.",
+        type: String,
+    },
+    "prod-only": {
+        defaultValue: false,
+        description: "Skip devDependencies — scan production graph only.",
+        type: Boolean,
+    },
+    report: {
+        description: "Write a self-contained HTML report to this path. Auto-opens in a TTY when not in CI.",
+        type: String,
+    },
+    severity: {
+        description: "Minimum severity to report: low, medium, high, critical (default: low)",
+        type: String,
+    },
+    "show-accepted": {
+        defaultValue: false,
+        description: "Include acknowledged (accepted risk) issues in output",
+        type: Boolean,
+    },
+    "show-fixes": {
+        defaultValue: false,
+        description: "Print fix-suggestion lines for each finding (no apply, no rescan)",
+        type: Boolean,
+    },
+    sync: {
+        defaultValue: false,
+        description: "Sync vis accepted risks to native PM config (pnpm-workspace.yaml / .yarnrc.yml)",
+        type: Boolean,
+    },
+    usage: {
+        defaultValue: false,
+        description: "Only report vulnerabilities in statically-imported packages (reachability filter).",
+        type: Boolean,
+    },
+    yes: {
+        defaultValue: false,
+        description: "Skip confirmation prompt for --fix / --fix-transitive (required in CI)",
+        type: Boolean,
+    },
+} as const;
+
+const audit = defineCommand({
     description: "Audit installed packages for vulnerabilities and supply chain risks",
     examples: [
         ["vis audit", "Full audit of all installed packages"],
@@ -43,154 +147,10 @@ const audit: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "audit",
-    options: [
-        {
-            description: "Minimum severity to report: low, medium, high, critical (default: low)",
-            name: "severity",
-            type: String,
-        },
-        {
-            description: "Output format: table, json, sarif, csaf, cyclonedx-vex, gitlab, or junit (default: table)",
-            name: "format",
-            type: String,
-        },
-        {
-            description: "Write a self-contained HTML report to this path. Auto-opens in a TTY when not in CI.",
-            name: "report",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Only report vulnerabilities in statically-imported packages (reachability filter).",
-            name: "usage",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Disable the reachability filter even if enabled in config.",
-            name: "no-usage",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Query the local OSV advisory cache only — no network calls. Errors if the cache is missing.",
-            name: "offline",
-            type: Boolean,
-        },
-        {
-            description: "Override the offline advisory DB path (default: <cache>/vis/advisories/db.sqlite).",
-            name: "db",
-            type: String,
-        },
-        {
-            description:
-                "Comma-separated list of OSV ecosystems to scan (default: npm). Supported: npm, pypi, crates.io (or 'cargo'), maven, go, rubygems. Non-npm ecosystems require --offline (online OSV path is npm-only).",
-            name: "ecosystem",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Skip devDependencies — scan production graph only.",
-            name: "prod-only",
-            type: Boolean,
-        },
-        {
-            description: "Exit non-zero when any finding is at this severity or higher. One of: low, medium, high, critical.",
-            name: "fail-on",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Print fix-suggestion lines for each finding (no apply, no rescan)",
-            name: "show-fixes",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Apply direct-dep fixes for vulnerable packages by running the active PM update command, then rescan",
-            name: "fix",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Apply transitive fixes by writing PM-specific overrides (pnpm-workspace.yaml / package.json overrides / resolutions)",
-            name: "fix-transitive",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip confirmation prompt for --fix / --fix-transitive (required in CI)",
-            name: "yes",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Allow --fix to bump a direct dep across a major version when the lowest fix is outside the existing range",
-            name: "allow-major",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Exit with code 1 if any issues found (for CI)",
-            name: "exit-code",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Include acknowledged (accepted risk) issues in output",
-            name: "show-accepted",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Sync vis accepted risks to native PM config (pnpm-workspace.yaml / .yarnrc.yml)",
-            name: "sync",
-            type: Boolean,
-        },
-        {
-            description:
-                "Comma-separated list of supply-chain policies to evaluate (default: every configured policy). Use 'none' to skip the engine entirely, 'all' to force the full set. Known: malware, firstSeen, unexpectedDeps, publisherChange, installScripts, score, vulnerability, license.",
-            name: "policies",
-            type: String,
-        },
-        {
-            description:
-                "Audit backend: 'auto' (default, delegates to 'aube audit' when aube is the installer), 'aube' (force delegate), or 'vis' (always use vis's OSV/Socket scanner).",
-            name: "backend",
-            type: String,
-        },
-        {
-            description:
-                "Add a plain-English AI explanation to findings. Bare flag explains all findings at/above --severity; pass a finding index (e.g. 2) or a CVE/GHSA id to explain just one. Auto-detects an installed AI CLI; mutually exclusive with --offline.",
-            name: "explain",
-            type: String,
-        },
-    ],
-};
+    options: auditOptionDefinitions,
+});
 
 export default audit;
 
 /** Typed options object for the `vis audit` command handler, derived from {@link audit.options}. */
-export type AuditOptions = CreateOptions<{
-    "allow-major": boolean | undefined;
-    backend: string | undefined;
-    db: string | undefined;
-    ecosystem: string | undefined;
-    "exit-code": boolean | undefined;
-    explain: boolean | string | undefined;
-    "fail-on": string | undefined;
-    fix: boolean | undefined;
-    "fix-transitive": boolean | undefined;
-    format: string | undefined;
-    "no-usage": boolean | undefined;
-    offline: boolean | undefined;
-    policies: string | undefined;
-    "prod-only": boolean | undefined;
-    report: string | undefined;
-    severity: string | undefined;
-    "show-accepted": boolean | undefined;
-    "show-fixes": boolean | undefined;
-    sync: boolean | undefined;
-    usage: boolean | undefined;
-    yes: boolean | undefined;
-}>;
+export type AuditOptions = InferOptions<typeof auditOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/cache/index.ts
+++ b/packages/tooling/vis/src/commands/cache/index.ts
@@ -1,5 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions, InferOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
 const cacheDirectoryOption = {
     description: "Cache directory (overrides config and default). Relative paths are resolved against the workspace root.",
@@ -193,7 +193,27 @@ const cacheVerify: Command = {
     options: [cacheDirectoryOption, scopeOption, formatOption],
 };
 
-const cacheDoctor: Command = {
+const cacheDoctorOptionDefinitions = {
+    backend: {
+        description: "Override backend selector: 'http' or 'reapi'",
+        type: String,
+    },
+    format: {
+        description: "Output format: table or json (default: table)",
+        type: String,
+    },
+    timeout: {
+        defaultValue: 5000,
+        description: "Probe timeout in milliseconds (default: 5000)",
+        type: Number,
+    },
+    url: {
+        description: "Override remote cache URL (otherwise read from vis.config.ts remoteCache.url, or TURBO_API env var)",
+        type: String,
+    },
+} as const;
+
+const cacheDoctor = defineCommand({
     commandPath: ["cache"],
     description: "Probe the configured remote cache (HTTP HEAD or REAPI Capabilities) and report reachability, latency, and negotiated capabilities",
     examples: [
@@ -204,32 +224,10 @@ const cacheDoctor: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./doctor-probe"), "cacheDoctorExecute"),
     name: "doctor",
-    options: [
-        {
-            description: "Override remote cache URL (otherwise read from vis.config.ts remoteCache.url, or TURBO_API env var)",
-            name: "url",
-            type: String,
-        },
-        {
-            description: "Override backend selector: 'http' or 'reapi'",
-            name: "backend",
-            type: String,
-        },
-        {
-            description: "Output format: table or json (default: table)",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: 5000,
-            description: "Probe timeout in milliseconds (default: 5000)",
-            name: "timeout",
-            type: Number,
-        },
-    ],
-};
+    options: cacheDoctorOptionDefinitions,
+});
 
-const cacheCommands = [cacheList, cacheClean, cachePrune, cacheSize, cacheWhy, cacheHash, cacheVerify, cacheDoctor];
+const cacheCommands: AnyCommandInput[] = [cacheList, cacheClean, cachePrune, cacheSize, cacheWhy, cacheHash, cacheVerify, cacheDoctor];
 
 export default cacheCommands;
 
@@ -271,12 +269,7 @@ export type CacheHashOptions = CreateOptions<{
     run: string | undefined;
 }>;
 
-export type CacheDoctorOptions = CreateOptions<{
-    backend: string | undefined;
-    format: string | undefined;
-    timeout: number | undefined;
-    url: string | undefined;
-}>;
+export type CacheDoctorOptions = InferOptions<typeof cacheDoctorOptionDefinitions>;
 
 export type CacheVerifyOptions = CreateOptions<{
     "cache-dir": string | undefined;

--- a/packages/tooling/vis/src/commands/cache/index.ts
+++ b/packages/tooling/vis/src/commands/cache/index.ts
@@ -229,7 +229,7 @@ const cacheDoctor: Command = {
     ],
 };
 
-const cacheCommands: Command[] = [cacheList, cacheClean, cachePrune, cacheSize, cacheWhy, cacheHash, cacheVerify, cacheDoctor];
+const cacheCommands = [cacheList, cacheClean, cachePrune, cacheSize, cacheWhy, cacheHash, cacheVerify, cacheDoctor];
 
 export default cacheCommands;
 

--- a/packages/tooling/vis/src/commands/check/index.ts
+++ b/packages/tooling/vis/src/commands/check/index.ts
@@ -1,6 +1,85 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const check: Command = {
+const checkOptionDefinitions = {
+    ai: {
+        defaultValue: false,
+        description: "Run AI analysis on outdated packages",
+        type: Boolean,
+    },
+    "ai-type": {
+        description: "AI analysis type: impact, security, compatibility, or recommend",
+        type: String,
+    },
+    dev: {
+        alias: "D",
+        conflicts: "prod",
+        description: "Check only devDependencies (npm/yarn mode)",
+        type: Boolean,
+    },
+    exclude: {
+        description: "Glob pattern to exclude packages (repeatable)",
+        lazyMultiple: true,
+        type: String,
+    },
+    "exit-code": {
+        defaultValue: false,
+        description: "Exit with code 1 if outdated dependencies found (for CI)",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table, json, or minimal (default: table)",
+        type: String,
+    },
+    include: {
+        description: "Glob pattern to include packages (repeatable)",
+        lazyMultiple: true,
+        type: String,
+    },
+    "include-internal": {
+        defaultValue: false,
+        description: "Also check workspace-owned package names against the registry",
+        type: Boolean,
+    },
+    "no-security": {
+        defaultValue: false,
+        description: "Skip security vulnerability scanning",
+        type: Boolean,
+    },
+    peer: {
+        defaultValue: false,
+        description: "Include peerDependencies in outdated checks",
+        type: Boolean,
+    },
+    prerelease: {
+        defaultValue: false,
+        description: "Include prerelease versions",
+        type: Boolean,
+    },
+    prod: {
+        alias: "P",
+        conflicts: "dev",
+        description: "Check only dependencies (npm/yarn mode)",
+        type: Boolean,
+    },
+    "security-config": {
+        defaultValue: false,
+        description: "Audit supply chain security settings",
+        type: Boolean,
+    },
+    sync: {
+        defaultValue: false,
+        description: "Sync security settings to pnpm-workspace.yaml (pnpm only, requires --security-config)",
+        type: Boolean,
+    },
+    target: {
+        alias: "t",
+        description: "Update target: latest, minor, or patch (default: latest)",
+        type: String,
+    },
+} as const;
+
+const check = defineCommand({
     alias: ["c", "outdated"],
     argument: {
         description: "Specific packages to check (checks all if omitted)",
@@ -20,116 +99,9 @@ const check: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "check",
-    options: [
-        {
-            alias: "t",
-            description: "Update target: latest, minor, or patch (default: latest)",
-            name: "target",
-            type: String,
-        },
-        {
-            description: "Glob pattern to include packages (repeatable)",
-            lazyMultiple: true,
-            name: "include",
-            type: String,
-        },
-        {
-            description: "Glob pattern to exclude packages (repeatable)",
-            lazyMultiple: true,
-            name: "exclude",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Include prerelease versions",
-            name: "prerelease",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip security vulnerability scanning",
-            name: "no-security",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Audit supply chain security settings",
-            name: "security-config",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Sync security settings to pnpm-workspace.yaml (pnpm only, requires --security-config)",
-            name: "sync",
-            type: Boolean,
-        },
-        {
-            description: "Output format: table, json, or minimal (default: table)",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Exit with code 1 if outdated dependencies found (for CI)",
-            name: "exit-code",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Run AI analysis on outdated packages",
-            name: "ai",
-            type: Boolean,
-        },
-        {
-            description: "AI analysis type: impact, security, compatibility, or recommend",
-            name: "ai-type",
-            type: String,
-        },
-        {
-            alias: "D",
-            conflicts: "prod",
-            description: "Check only devDependencies (npm/yarn mode)",
-            name: "dev",
-            type: Boolean,
-        },
-        {
-            alias: "P",
-            conflicts: "dev",
-            description: "Check only dependencies (npm/yarn mode)",
-            name: "prod",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Include peerDependencies in outdated checks",
-            name: "peer",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Also check workspace-owned package names against the registry",
-            name: "include-internal",
-            type: Boolean,
-        },
-    ],
-};
+    options: checkOptionDefinitions,
+});
 
 export default check;
 
-export type CheckOptions = CreateOptions<{
-    ai: boolean | undefined;
-    "ai-type": string | undefined;
-    dev: boolean | undefined;
-    exclude: string[] | undefined;
-    "exit-code": boolean | undefined;
-    format: string | undefined;
-    include: string[] | undefined;
-    "include-internal": boolean | undefined;
-    "no-security": boolean | undefined;
-    peer: boolean | undefined;
-    prerelease: boolean | undefined;
-    prod: boolean | undefined;
-    "security-config": boolean | undefined;
-    sync: boolean | undefined;
-    target: string | undefined;
-}>;
+export type CheckOptions = InferOptions<typeof checkOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/ci-ignore/index.ts
+++ b/packages/tooling/vis/src/commands/ci-ignore/index.ts
@@ -13,9 +13,47 @@
  * `../ci-ignore-helpers` for test isolation.
  */
 
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ignore: Command = {
+const ignoreOptionDefinitions = {
+    base: {
+        description: "Git base ref for comparison. Defaults to CI provider env vars, then HEAD~1.",
+        type: String,
+    },
+    downstream: {
+        defaultValue: "deep",
+        description: "Downstream scope: \"none\", \"direct\", or \"deep\"",
+        type: String,
+    },
+    "exit-zero-on-build": {
+        defaultValue: false,
+        description: "Exit 0 on build (normal semantics) instead of 1 (inverted Vercel/Netlify semantics)",
+        type: Boolean,
+    },
+    head: {
+        defaultValue: "HEAD",
+        description: "Git head ref for comparison",
+        type: String,
+    },
+    json: {
+        defaultValue: false,
+        description: "Emit the decision as JSON on stdout instead of human text",
+        type: Boolean,
+    },
+    upstream: {
+        defaultValue: "none",
+        description: "Upstream scope: \"none\", \"direct\", or \"deep\"",
+        type: String,
+    },
+    verbose: {
+        defaultValue: false,
+        description: "Enable verbose debug output",
+        type: Boolean,
+    },
+} as const;
+
+const ignore = defineCommand({
     argument: {
         description: "Project name to check (required)",
         name: "project",
@@ -33,59 +71,9 @@ const ignore: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "ignore",
-    options: [
-        {
-            description: "Git base ref for comparison. Defaults to CI provider env vars, then HEAD~1.",
-            name: "base",
-            type: String,
-        },
-        {
-            defaultValue: "HEAD",
-            description: "Git head ref for comparison",
-            name: "head",
-            type: String,
-        },
-        {
-            defaultValue: "deep",
-            description: "Downstream scope: \"none\", \"direct\", or \"deep\"",
-            name: "downstream",
-            type: String,
-        },
-        {
-            defaultValue: "none",
-            description: "Upstream scope: \"none\", \"direct\", or \"deep\"",
-            name: "upstream",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Emit the decision as JSON on stdout instead of human text",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Exit 0 on build (normal semantics) instead of 1 (inverted Vercel/Netlify semantics)",
-            name: "exit-zero-on-build",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Enable verbose debug output",
-            name: "verbose",
-            type: Boolean,
-        },
-    ],
-};
+    options: ignoreOptionDefinitions,
+});
 
 export default ignore;
 
-export type IgnoreOptions = CreateOptions<{
-    base: string | undefined;
-    downstream: string | undefined;
-    "exit-zero-on-build": boolean | undefined;
-    head: string | undefined;
-    json: boolean | undefined;
-    upstream: string | undefined;
-    verbose: boolean | undefined;
-}>;
+export type IgnoreOptions = InferOptions<typeof ignoreOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/ci/handler.ts
+++ b/packages/tooling/vis/src/commands/ci/handler.ts
@@ -61,9 +61,7 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
         Boolean(options.skipToolchain),
     );
 
-    if (options.install === false) {
-        logger.info("▸ Skipping install (--no-install)");
-    } else {
+    if (options.install) {
         logger.info("▸ Installing dependencies");
 
         await runtime.runCommand("install", {
@@ -75,6 +73,8 @@ const execute = async ({ argument, logger, options, runtime, visConfig, workspac
             // silently downgrade vis ci to a mutating install.
             argv: ["--ci", "--frozen-lockfile"],
         });
+    } else {
+        logger.info("▸ Skipping install (--no-install)");
     }
 
     for (const target of targets) {

--- a/packages/tooling/vis/src/commands/ci/index.ts
+++ b/packages/tooling/vis/src/commands/ci/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 import { negatable } from "../../util/negatable-option";
 
@@ -18,7 +19,53 @@ import { negatable } from "../../util/negatable-option";
  * already installed, uses CI-safe defaults, and picks up the base ref
  * from common CI provider environment variables.
  */
-const ci: Command = {
+const ciOptionDefinitions = {
+    ...negatable({
+        defaultValue: true,
+        description: "Install dependencies before running targets (use --no-install to skip)",
+        name: "install",
+        type: Boolean,
+    }),
+    base: {
+        description: "Git base ref for affected detection (default: auto-detected from CI env)",
+        type: String,
+    },
+    downstream: {
+        defaultValue: "deep",
+        description: "Downstream scope: none | direct | deep",
+        type: String,
+    },
+    head: {
+        description: "Git head ref for affected detection (default: HEAD)",
+        type: String,
+    },
+    parallel: {
+        defaultValue: 4,
+        description: "Maximum number of parallel tasks per target",
+        type: Number,
+    },
+    partition: {
+        description: "Partition tasks for distributed CI (e.g., \"1/4\")",
+        type: String,
+    },
+    query: {
+        description: "Filter affected projects by a query (e.g. 'language=typescript && tag=lib')",
+        type: String,
+    },
+    "skip-toolchain": {
+        defaultValue: false,
+        description:
+                "Skip the toolchain pre-flight (no auto-install for any pinned tool: node / pnpm / yarn / npm / bun / deno / go / python / ruby / rust)",
+        type: Boolean,
+    },
+    upstream: {
+        defaultValue: "none",
+        description: "Upstream scope: none | direct | deep",
+        type: String,
+    },
+} as const;
+
+const ci = defineCommand({
     argument: {
         description: "Comma-separated list of targets to run (e.g., lint,test,build)",
         name: "targets",
@@ -34,71 +81,9 @@ const ci: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "ci",
-    options: [
-        ...negatable({
-            defaultValue: true,
-            description: "Install dependencies before running targets (use --no-install to skip)",
-            name: "install",
-            type: Boolean,
-        }),
-        {
-            defaultValue: false,
-            description:
-                "Skip the toolchain pre-flight (no auto-install for any pinned tool: node / pnpm / yarn / npm / bun / deno / go / python / ruby / rust)",
-            name: "skip-toolchain",
-            type: Boolean,
-        },
-        {
-            description: "Git base ref for affected detection (default: auto-detected from CI env)",
-            name: "base",
-            type: String,
-        },
-        {
-            description: "Git head ref for affected detection (default: HEAD)",
-            name: "head",
-            type: String,
-        },
-        {
-            defaultValue: "none",
-            description: "Upstream scope: none | direct | deep",
-            name: "upstream",
-            type: String,
-        },
-        {
-            defaultValue: "deep",
-            description: "Downstream scope: none | direct | deep",
-            name: "downstream",
-            type: String,
-        },
-        {
-            defaultValue: 4,
-            description: "Maximum number of parallel tasks per target",
-            name: "parallel",
-            type: Number,
-        },
-        {
-            description: "Partition tasks for distributed CI (e.g., \"1/4\")",
-            name: "partition",
-            type: String,
-        },
-        {
-            description: "Filter affected projects by a query (e.g. 'language=typescript && tag=lib')",
-            name: "query",
-            type: String,
-        },
-    ],
-};
+    options: ciOptionDefinitions,
+});
 
 export default ci;
 
-export type CiOptions = CreateOptions<{
-    base: string | undefined;
-    downstream: string | undefined;
-    head: string | undefined;
-    install: boolean | undefined;
-    parallel: number | undefined;
-    partition: string | undefined;
-    query: string | undefined;
-    "skip-toolchain": boolean | undefined;
-    upstream: string | undefined;
-}>;
+export type CiOptions = InferOptions<typeof ciOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/clean/index.ts
+++ b/packages/tooling/vis/src/commands/clean/index.ts
@@ -1,6 +1,27 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const clean: Command = {
+const cleanOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Preview what would be removed without deleting",
+        type: Boolean,
+    },
+    "empty-packages": {
+        alias: "e",
+        defaultValue: false,
+        description: "Also remove stale workspace directories that match a workspace pattern but have no package.json",
+        type: Boolean,
+    },
+    lockfile: {
+        alias: "l",
+        defaultValue: false,
+        description: "Also remove lockfiles (pnpm-lock.yaml, package-lock.json, etc.)",
+        type: Boolean,
+    },
+} as const;
+
+const clean = defineCommand({
     description: "Remove node_modules from all workspace projects",
     examples: [
         ["vis clean", "Remove all node_modules directories"],
@@ -11,23 +32,9 @@ const clean: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "clean",
-    options: [
-        { alias: "l", defaultValue: false, description: "Also remove lockfiles (pnpm-lock.yaml, package-lock.json, etc.)", name: "lockfile", type: Boolean },
-        {
-            alias: "e",
-            defaultValue: false,
-            description: "Also remove stale workspace directories that match a workspace pattern but have no package.json",
-            name: "empty-packages",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Preview what would be removed without deleting", name: "dry-run", type: Boolean },
-    ],
-};
+    options: cleanOptionDefinitions,
+});
 
 export default clean;
 
-export type CleanOptions = CreateOptions<{
-    "dry-run": boolean | undefined;
-    "empty-packages": boolean | undefined;
-    lockfile: boolean | undefined;
-}>;
+export type CleanOptions = InferOptions<typeof cleanOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/create/index.ts
+++ b/packages/tooling/vis/src/commands/create/index.ts
@@ -1,6 +1,29 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const create: Command = {
+const createOptionDefinitions = {
+    editor: {
+        description: "Generate editor configs (vscode)",
+        type: String,
+    },
+    "git-init": {
+        defaultValue: false,
+        description: "Initialize a git repository",
+        type: Boolean,
+    },
+    list: {
+        defaultValue: false,
+        description: "Show available templates",
+        type: Boolean,
+    },
+    "no-interactive": {
+        defaultValue: false,
+        description: "Skip interactive prompts",
+        type: Boolean,
+    },
+} as const;
+
+const create = defineCommand({
     argument: {
         description: "Template to use (e.g., vis:app, create-vite, user/repo) — omit for interactive mode",
         name: "template",
@@ -19,13 +42,8 @@ const create: Command = {
     group: "Scaffold & Config",
     loader: () => import("./handler"),
     name: "create",
-    options: [
-        { defaultValue: false, description: "Show available templates", name: "list", type: Boolean },
-        { description: "Generate editor configs (vscode)", name: "editor", type: String },
-        { defaultValue: false, description: "Initialize a git repository", name: "git-init", type: Boolean },
-        { defaultValue: false, description: "Skip interactive prompts", name: "no-interactive", type: Boolean },
-    ],
-};
+    options: createOptionDefinitions,
+});
 
 export default create;
 

--- a/packages/tooling/vis/src/commands/dedupe/index.ts
+++ b/packages/tooling/vis/src/commands/dedupe/index.ts
@@ -1,6 +1,15 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const dedupe: Command = {
+const dedupeOptionDefinitions = {
+    check: {
+        defaultValue: false,
+        description: "Preview changes without modifying files (dry-run)",
+        type: Boolean,
+    },
+} as const;
+
+const dedupe = defineCommand({
     description: "Deduplicate dependencies using the detected package manager",
     examples: [
         ["vis dedupe", "Run deduplication"],
@@ -9,11 +18,9 @@ const dedupe: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "dedupe",
-    options: [{ defaultValue: false, description: "Preview changes without modifying files (dry-run)", name: "check", type: Boolean }],
-};
+    options: dedupeOptionDefinitions,
+});
 
 export default dedupe;
 
-export type DedupeOptions = CreateOptions<{
-    check: boolean | undefined;
-}>;
+export type DedupeOptions = InferOptions<typeof dedupeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/deps/index.ts
+++ b/packages/tooling/vis/src/commands/deps/index.ts
@@ -1,6 +1,115 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const deps: Command = {
+const depsOptionDefinitions = {
+    ban: {
+        description: "Ban a dep name or glob for this run (repeatable). Auto-enables --banned-deps.",
+        multiple: true,
+        type: String,
+    },
+    "banned-deps": {
+        defaultValue: false,
+        description: "Lint deps against policy.bannedDeps in vis config",
+        type: Boolean,
+    },
+    "custom-types": {
+        defaultValue: false,
+        description: "Lint engines.{node,pnpm}, packageManager, volta.*, devEngines.* for drift across packages",
+        type: Boolean,
+    },
+    "dead-workspace-patterns": {
+        defaultValue: false,
+        description: "Flag workspace patterns (in `pnpm-workspace.yaml` / `package.json#workspaces`) that match zero packages",
+        type: Boolean,
+    },
+    dep: {
+        description: "Restrict --workspace-versions to a single dep",
+        type: String,
+    },
+    "empty-deps": {
+        defaultValue: false,
+        description: "Flag empty dependency blocks (`dependencies: {}`, `devDependencies: {}`, …) across the workspace",
+        type: Boolean,
+    },
+    fix: {
+        defaultValue: false,
+        description: "Auto-fix violations in place (writes package.json files)",
+        type: Boolean,
+    },
+    "fix-specifier": {
+        description: "Specifier used by --fix for workspace-protocol (default: workspace:*)",
+        type: String,
+    },
+    format: {
+        description: "Output format: human, json, or minimal (default: human)",
+        type: String,
+    },
+    "missing-package-json": {
+        defaultValue: false,
+        description: "Flag workspace directories that lack a package.json",
+        type: Boolean,
+    },
+    pin: {
+        description: "Pin a dep to an exact specifier for this run, e.g. react@^18.2.0 (repeatable). Auto-enables --workspace-versions.",
+        multiple: true,
+        type: String,
+    },
+    "propose-min": {
+        description: "Propose catalog entries for deps ≥N packages already agree on. Activates with --resolve catalog.",
+        type: Number,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress all output except errors",
+        type: Boolean,
+    },
+    "redefine-root": {
+        defaultValue: false,
+        description: "Lint that no child re-declares a dep already pinned in the workspace root",
+        type: Boolean,
+    },
+    resolve: {
+        description: "Conflict resolution for --workspace-versions: highest, lowest, or catalog (default: highest)",
+        type: String,
+    },
+    "root-deps": {
+        defaultValue: false,
+        description: "Flag runtime dependencies on the private workspace root (move them to devDependencies)",
+        type: Boolean,
+    },
+    "root-package-manager": {
+        defaultValue: false,
+        description: "Ensure the workspace root package.json declares a `packageManager` field",
+        type: Boolean,
+    },
+    "root-private": {
+        defaultValue: false,
+        description: "Ensure the workspace root package.json sets `\"private\": true`",
+        type: Boolean,
+    },
+    "similar-deps": {
+        defaultValue: false,
+        description: "Flag version drift across related dep families (react+react-dom, @babel/*, @storybook/*, …)",
+        type: Boolean,
+    },
+    "types-in-deps": {
+        defaultValue: false,
+        description: "Flag `@types/*` declared in `dependencies` on a private package (should be in devDependencies)",
+        type: Boolean,
+    },
+    "workspace-protocol": {
+        defaultValue: false,
+        description: "Lint that internal deps use the workspace: protocol",
+        type: Boolean,
+    },
+    "workspace-versions": {
+        defaultValue: false,
+        description: "Lint that all packages declare external deps at the same version",
+        type: Boolean,
+    },
+} as const;
+
+const deps = defineCommand({
     description:
         "Lint workspace dependency policies (workspace-protocol, banned-deps, redefine-root, workspace-versions, custom-types, empty-deps, root-private, root-package-manager, root-deps, missing-package-json, dead-workspace-patterns, types-in-deps, similar-deps)",
     examples: [
@@ -31,160 +140,9 @@ const deps: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "deps",
-    options: [
-        {
-            defaultValue: false,
-            description: "Lint that internal deps use the workspace: protocol",
-            name: "workspace-protocol",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Lint that no child re-declares a dep already pinned in the workspace root",
-            name: "redefine-root",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Lint deps against policy.bannedDeps in vis config",
-            name: "banned-deps",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Lint that all packages declare external deps at the same version",
-            name: "workspace-versions",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Lint engines.{node,pnpm}, packageManager, volta.*, devEngines.* for drift across packages",
-            name: "custom-types",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag empty dependency blocks (`dependencies: {}`, `devDependencies: {}`, …) across the workspace",
-            name: "empty-deps",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Ensure the workspace root package.json sets `\"private\": true`",
-            name: "root-private",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Ensure the workspace root package.json declares a `packageManager` field",
-            name: "root-package-manager",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag runtime dependencies on the private workspace root (move them to devDependencies)",
-            name: "root-deps",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag workspace directories that lack a package.json",
-            name: "missing-package-json",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag workspace patterns (in `pnpm-workspace.yaml` / `package.json#workspaces`) that match zero packages",
-            name: "dead-workspace-patterns",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag `@types/*` declared in `dependencies` on a private package (should be in devDependencies)",
-            name: "types-in-deps",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Flag version drift across related dep families (react+react-dom, @babel/*, @storybook/*, …)",
-            name: "similar-deps",
-            type: Boolean,
-        },
-        {
-            description: "Restrict --workspace-versions to a single dep",
-            name: "dep",
-            type: String,
-        },
-        {
-            description: "Ban a dep name or glob for this run (repeatable). Auto-enables --banned-deps.",
-            multiple: true,
-            name: "ban",
-            type: String,
-        },
-        {
-            description: "Pin a dep to an exact specifier for this run, e.g. react@^18.2.0 (repeatable). Auto-enables --workspace-versions.",
-            multiple: true,
-            name: "pin",
-            type: String,
-        },
-        {
-            description: "Conflict resolution for --workspace-versions: highest, lowest, or catalog (default: highest)",
-            name: "resolve",
-            type: String,
-        },
-        {
-            description: "Propose catalog entries for deps ≥N packages already agree on. Activates with --resolve catalog.",
-            name: "propose-min",
-            type: Number,
-        },
-        {
-            defaultValue: false,
-            description: "Auto-fix violations in place (writes package.json files)",
-            name: "fix",
-            type: Boolean,
-        },
-        {
-            description: "Specifier used by --fix for workspace-protocol (default: workspace:*)",
-            name: "fix-specifier",
-            type: String,
-        },
-        {
-            description: "Output format: human, json, or minimal (default: human)",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Suppress all output except errors",
-            name: "quiet",
-            type: Boolean,
-        },
-    ],
-};
+    options: depsOptionDefinitions,
+});
 
 export default deps;
 
-export type DepsOptions = CreateOptions<{
-    ban: string[] | undefined;
-    "banned-deps": boolean | undefined;
-    "custom-types": boolean | undefined;
-    "dead-workspace-patterns": boolean | undefined;
-    dep: string | undefined;
-    "empty-deps": boolean | undefined;
-    fix: boolean | undefined;
-    "fix-specifier": string | undefined;
-    format: string | undefined;
-    "missing-package-json": boolean | undefined;
-    pin: string[] | undefined;
-    "propose-min": number | undefined;
-    quiet: boolean | undefined;
-    "redefine-root": boolean | undefined;
-    resolve: string | undefined;
-    "root-deps": boolean | undefined;
-    "root-package-manager": boolean | undefined;
-    "root-private": boolean | undefined;
-    "similar-deps": boolean | undefined;
-    "types-in-deps": boolean | undefined;
-    "workspace-protocol": boolean | undefined;
-    "workspace-versions": boolean | undefined;
-}>;
+export type DepsOptions = InferOptions<typeof depsOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/devcontainer/index.ts
+++ b/packages/tooling/vis/src/commands/devcontainer/index.ts
@@ -1,6 +1,20 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const devcontainer: Command = {
+const devcontainerOptionDefinitions = {
+    output: {
+        alias: "o",
+        description: "Output path (default: .devcontainer/devcontainer.json)",
+        type: String,
+    },
+    template: {
+        alias: "t",
+        description: "Start from a template: node, node-pnpm, node-postgres, node-dind, fullstack, python, go, rust, java, devops, minimal, custom",
+        type: String,
+    },
+} as const;
+
+const devcontainer = defineCommand({
     alias: "dc",
     description: "Create or update .devcontainer/devcontainer.json interactively",
     examples: [
@@ -11,25 +25,9 @@ const devcontainer: Command = {
     group: "Scaffold & Config",
     loader: () => import("./handler"),
     name: "devcontainer",
-    options: [
-        {
-            alias: "t",
-            description: "Start from a template: node, node-pnpm, node-postgres, node-dind, fullstack, python, go, rust, java, devops, minimal, custom",
-            name: "template",
-            type: String,
-        },
-        {
-            alias: "o",
-            description: "Output path (default: .devcontainer/devcontainer.json)",
-            name: "output",
-            type: String,
-        },
-    ],
-};
+    options: devcontainerOptionDefinitions,
+});
 
 export default devcontainer;
 
-export type DevcontainerOptions = CreateOptions<{
-    output: string | undefined;
-    template: string | undefined;
-}>;
+export type DevcontainerOptions = InferOptions<typeof devcontainerOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/dlx/handler.ts
+++ b/packages/tooling/vis/src/commands/dlx/handler.ts
@@ -26,15 +26,13 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
     const gateTargets = options.shellMode ? additionalPackages : [pkg as string, ...additionalPackages];
 
     for (const target of gateTargets) {
-        // An explicit `--info` flag wins over `--no-info` / `VIS_DLX_NO_INFO`.
-        //
-        // `--no-info` is folded onto `info` before the toolbox is built —
-        // cerebro deletes the negated key — so `options.noInfo` never existed
-        // here and the flag has only ever taken effect through the env var.
-        // Left as-is to keep behaviour identical; see the `no-info` option in
-        // ./index.ts for the fix.
-        const forceInfo = options.info || false;
-        const noInfo = forceInfo ? false : isTruthyEnv(process.env.VIS_DLX_NO_INFO);
+        // cerebro folds `--no-info` onto `info` and deletes the negated key, so
+        // `info` is the only signal that reaches here: `false` means the panel
+        // was explicitly suppressed, `true` means it was not. `--info` and the
+        // default are indistinguishable by design — both leave it `true` — so
+        // the env var stays the second way to suppress.
+        const noInfo = !options.info || isTruthyEnv(process.env.VIS_DLX_NO_INFO);
+        const forceInfo = !noInfo && options.info;
 
         const gate = await maybeGateFirstRun({
             forceInfo,

--- a/packages/tooling/vis/src/commands/dlx/handler.ts
+++ b/packages/tooling/vis/src/commands/dlx/handler.ts
@@ -27,8 +27,14 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
 
     for (const target of gateTargets) {
         // An explicit `--info` flag wins over `--no-info` / `VIS_DLX_NO_INFO`.
+        //
+        // `--no-info` is folded onto `info` before the toolbox is built —
+        // cerebro deletes the negated key — so `options.noInfo` never existed
+        // here and the flag has only ever taken effect through the env var.
+        // Left as-is to keep behaviour identical; see the `no-info` option in
+        // ./index.ts for the fix.
         const forceInfo = options.info || false;
-        const noInfo = forceInfo ? false : options.noInfo || isTruthyEnv(process.env.VIS_DLX_NO_INFO);
+        const noInfo = forceInfo ? false : isTruthyEnv(process.env.VIS_DLX_NO_INFO);
 
         const gate = await maybeGateFirstRun({
             forceInfo,

--- a/packages/tooling/vis/src/commands/dlx/index.ts
+++ b/packages/tooling/vis/src/commands/dlx/index.ts
@@ -1,6 +1,49 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const dlx: Command = {
+const dlxOptionDefinitions = {
+    info: {
+        defaultValue: false,
+        description: "Always show the first-run info panel (size, security score, permissions, changelog), even for an approved package",
+        type: Boolean,
+    },
+    "no-info": {
+        defaultValue: false,
+        description: "Disable the first-run info panel entirely (also via VIS_DLX_NO_INFO)",
+        type: Boolean,
+    },
+    offline: {
+        defaultValue: false,
+        description: "Resolve from local store only — fail rather than fetch from the registry. Pair with `vis install` for hardened npx-style workflows.",
+        type: Boolean,
+    },
+    package: {
+        alias: "p",
+        description: "Additional packages to install (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    "shell-mode": {
+        alias: "c",
+        defaultValue: false,
+        description: "Execute within shell environment",
+        type: Boolean,
+    },
+    silent: {
+        alias: "s",
+        defaultValue: false,
+        description: "Suppress output except command results",
+        type: Boolean,
+    },
+    yes: {
+        alias: "y",
+        defaultValue: false,
+        description: "Skip the first-run info panel and confirmation prompt (also via VIS_DLX_YES — note this auto-approves every package)",
+        type: Boolean,
+    },
+} as const;
+
+const dlx = defineCommand({
     argument: {
         description: "Package to execute (optionally with @version)",
         name: "package",
@@ -18,41 +61,9 @@ const dlx: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "dlx",
-    options: [
-        { alias: "p", description: "Additional packages to install (repeatable)", multiple: true, name: "package", type: String },
-        { alias: "c", defaultValue: false, description: "Execute within shell environment", name: "shell-mode", type: Boolean },
-        { alias: "s", defaultValue: false, description: "Suppress output except command results", name: "silent", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Resolve from local store only — fail rather than fetch from the registry. Pair with `vis install` for hardened npx-style workflows.",
-            name: "offline",
-            type: Boolean,
-        },
-        {
-            alias: "y",
-            defaultValue: false,
-            description: "Skip the first-run info panel and confirmation prompt (also via VIS_DLX_YES — note this auto-approves every package)",
-            name: "yes",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Always show the first-run info panel (size, security score, permissions, changelog), even for an approved package",
-            name: "info",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Disable the first-run info panel entirely (also via VIS_DLX_NO_INFO)", name: "no-info", type: Boolean },
-    ],
-};
+    options: dlxOptionDefinitions,
+});
 
 export default dlx;
 
-export type DlxOptions = CreateOptions<{
-    info: boolean | undefined;
-    "no-info": boolean | undefined;
-    offline: boolean | undefined;
-    package: string[] | undefined;
-    "shell-mode": boolean | undefined;
-    silent: boolean | undefined;
-    yes: boolean | undefined;
-}>;
+export type DlxOptions = InferOptions<typeof dlxOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/dlx/index.ts
+++ b/packages/tooling/vis/src/commands/dlx/index.ts
@@ -3,7 +3,6 @@ import { defineCommand } from "@visulima/cerebro";
 
 const dlxOptionDefinitions = {
     info: {
-        defaultValue: false,
         description: "Always show the first-run info panel (size, security score, permissions, changelog), even for an approved package",
         type: Boolean,
     },

--- a/packages/tooling/vis/src/commands/docker/handler.ts
+++ b/packages/tooling/vis/src/commands/docker/handler.ts
@@ -44,7 +44,7 @@ export const scaffoldExecute: CommandExecute<Toolbox<Console, DockerScaffoldOpti
         },
         outDir,
         projectGraph,
-        pruneLockfile: options.pruneLockfile !== false,
+        pruneLockfile: options.pruneLockfile,
         workspace,
         workspaceRoot: wsRoot,
     });

--- a/packages/tooling/vis/src/commands/docker/index.ts
+++ b/packages/tooling/vis/src/commands/docker/index.ts
@@ -95,7 +95,7 @@ const dockerLint: Command = {
     ],
 };
 
-const dockerCommands: Command[] = [dockerScaffold, dockerPrune, dockerInit, dockerLint];
+const dockerCommands = [dockerScaffold, dockerPrune, dockerInit, dockerLint];
 
 export default dockerCommands;
 

--- a/packages/tooling/vis/src/commands/docker/index.ts
+++ b/packages/tooling/vis/src/commands/docker/index.ts
@@ -1,5 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { AnyCommandInput, InferOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
 import { negatable } from "../../util/negatable-option";
 
@@ -19,7 +19,29 @@ import { negatable } from "../../util/negatable-option";
 
 const GROUP = "Workspace";
 
-const dockerScaffold: Command = {
+const dockerScaffoldOptionDefinitions = {
+    focus: {
+        description: "Project name(s) to focus on — comma-separated for multiple",
+        type: String,
+    },
+    "include-sources": {
+        defaultValue: false,
+        description: "Also copy focus project source trees to <out>/sources",
+        type: Boolean,
+    },
+    out: {
+        description: "Output directory for the scaffold (default: .vis/docker)",
+        type: String,
+    },
+    ...negatable({
+        defaultValue: true,
+        description: "Rewrite the workspace lockfile to drop unfocused projects (use --no-prune-lockfile to copy verbatim)",
+        name: "prune-lockfile",
+        type: Boolean,
+    }),
+} as const;
+
+const dockerScaffold = defineCommand({
     commandPath: ["docker"],
     description: "Build a minimal, cache-friendly Docker context for a focus project + its deps",
     examples: [
@@ -30,30 +52,48 @@ const dockerScaffold: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "scaffoldExecute"),
     name: "scaffold",
-    options: [
-        { description: "Project name(s) to focus on — comma-separated for multiple", name: "focus", type: String },
-        { description: "Output directory for the scaffold (default: .vis/docker)", name: "out", type: String },
-        { defaultValue: false, description: "Also copy focus project source trees to <out>/sources", name: "include-sources", type: Boolean },
-        ...negatable({
-            defaultValue: true,
-            description: "Rewrite the workspace lockfile to drop unfocused projects (use --no-prune-lockfile to copy verbatim)",
-            name: "prune-lockfile",
-            type: Boolean,
-        }),
-    ],
-};
+    options: dockerScaffoldOptionDefinitions,
+});
 
-const dockerPrune: Command = {
+const dockerPruneOptionDefinitions = {
+    context: {
+        description: "Scaffold root for prune (default: .vis/docker)",
+        type: String,
+    },
+} as const;
+
+const dockerPrune = defineCommand({
     commandPath: ["docker"],
     description: "Strip unfocused workspace projects from a scaffolded context (run inside a build stage)",
     examples: [["vis docker prune --context=.vis/docker", "Strip unfocused projects inside a build stage"]],
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "pruneExecute"),
     name: "prune",
-    options: [{ description: "Scaffold root for prune (default: .vis/docker)", name: "context", type: String }],
-};
+    options: dockerPruneOptionDefinitions,
+});
 
-const dockerInit: Command = {
+const dockerInitOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Print the Dockerfile to stdout instead of writing it",
+        type: Boolean,
+    },
+    focus: {
+        description: "Focus project name for the build filter",
+        type: String,
+    },
+    force: {
+        defaultValue: false,
+        description: "Overwrite an existing Dockerfile without prompting",
+        type: Boolean,
+    },
+    node: {
+        description: "Node.js version tag for the base image (default: 22)",
+        type: String,
+    },
+} as const;
+
+const dockerInit = defineCommand({
     argument: { description: "Output path for the Dockerfile (default: ./Dockerfile)", name: "path", type: String },
     commandPath: ["docker"],
     description: "Generate a multi-stage Dockerfile wired to the scaffold/prune flow (create-only)",
@@ -66,15 +106,32 @@ const dockerInit: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "initExecute"),
     name: "init",
-    options: [
-        { description: "Focus project name for the build filter", name: "focus", type: String },
-        { description: "Node.js version tag for the base image (default: 22)", name: "node", type: String },
-        { defaultValue: false, description: "Overwrite an existing Dockerfile without prompting", name: "force", type: Boolean },
-        { defaultValue: false, description: "Print the Dockerfile to stdout instead of writing it", name: "dry-run", type: Boolean },
-    ],
-};
+    options: dockerInitOptionDefinitions,
+});
 
-const dockerLint: Command = {
+const dockerLintOptionDefinitions = {
+    config: {
+        description: "Path to a hadolint config (.hadolint.yaml)",
+        type: String,
+    },
+    fix: {
+        defaultValue: false,
+        description: "Apply safe autofixes, then re-lint and report what remains",
+        type: Boolean,
+    },
+    install: {
+        defaultValue: false,
+        description: "Download hadolint without prompting if it is missing",
+        type: Boolean,
+    },
+    json: {
+        defaultValue: false,
+        description: "Emit findings as JSON",
+        type: Boolean,
+    },
+} as const;
+
+const dockerLint = defineCommand({
     argument: { description: "Dockerfile path(s) to lint (default: ./Dockerfile)", name: "file", type: String },
     commandPath: ["docker"],
     description: "Lint a Dockerfile with hadolint (downloaded on demand); --fix applies safe autofixes",
@@ -87,39 +144,17 @@ const dockerLint: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "lintExecute"),
     name: "lint",
-    options: [
-        { defaultValue: false, description: "Apply safe autofixes, then re-lint and report what remains", name: "fix", type: Boolean },
-        { defaultValue: false, description: "Download hadolint without prompting if it is missing", name: "install", type: Boolean },
-        { description: "Path to a hadolint config (.hadolint.yaml)", name: "config", type: String },
-        { defaultValue: false, description: "Emit findings as JSON", name: "json", type: Boolean },
-    ],
-};
+    options: dockerLintOptionDefinitions,
+});
 
-const dockerCommands = [dockerScaffold, dockerPrune, dockerInit, dockerLint];
+const dockerCommands: AnyCommandInput[] = [dockerScaffold, dockerPrune, dockerInit, dockerLint];
 
 export default dockerCommands;
 
-export type DockerScaffoldOptions = CreateOptions<{
-    focus: string | undefined;
-    "include-sources": boolean | undefined;
-    out: string | undefined;
-    "prune-lockfile": boolean | undefined;
-}>;
+export type DockerScaffoldOptions = InferOptions<typeof dockerScaffoldOptionDefinitions>;
 
-export type DockerPruneOptions = CreateOptions<{
-    context: string | undefined;
-}>;
+export type DockerPruneOptions = InferOptions<typeof dockerPruneOptionDefinitions>;
 
-export type DockerInitOptions = CreateOptions<{
-    "dry-run": boolean | undefined;
-    focus: string | undefined;
-    force: boolean | undefined;
-    node: string | undefined;
-}>;
+export type DockerInitOptions = InferOptions<typeof dockerInitOptionDefinitions>;
 
-export type DockerLintOptions = CreateOptions<{
-    config: string | undefined;
-    fix: boolean | undefined;
-    install: boolean | undefined;
-    json: boolean | undefined;
-}>;
+export type DockerLintOptions = InferOptions<typeof dockerLintOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/doctor/handler.ts
+++ b/packages/tooling/vis/src/commands/doctor/handler.ts
@@ -856,7 +856,7 @@ const execute = async ({ fs, logger, options, visConfig, visConfigError, workspa
         throw new Error("Could not determine workspace root.");
     }
 
-    const isJson = options.format === "json" || options.json === true;
+    const isJson = options.format === "json" || options.json;
     const sections = resolveSections(options.only, options.skip);
     const quiet = Boolean(options.quiet);
     const noProgress = (options as Record<string, unknown>).progress === false;

--- a/packages/tooling/vis/src/commands/doctor/index.ts
+++ b/packages/tooling/vis/src/commands/doctor/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis doctor` — unified project health check.
@@ -14,7 +15,66 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * vis doctor --skip optimization   # skip optimization scans
  * ```
  */
-const doctor: Command = {
+const doctorOptionDefinitions = {
+    "exit-code": {
+        defaultValue: false,
+        description: "Exit with code 1 if issues found",
+        type: Boolean,
+    },
+    filter: {
+        description: "Comma-separated package name patterns to scope findings (supports * globs, e.g. '@types/*,react')",
+        type: String,
+    },
+    fix: {
+        defaultValue: false,
+        description: "Auto-apply safe fixes (security overrides + codemods, SIGTERM orphans)",
+        type: Boolean,
+    },
+    "fix-force": {
+        defaultValue: false,
+        description: "With --fix: escalate orphan cleanup to SIGKILL / taskkill /F (use when SIGTERM is ignored)",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table or json (default: table). Alias: --json",
+        type: String,
+    },
+    json: {
+        defaultValue: false,
+        description: "Shorthand for --format json",
+        type: Boolean,
+    },
+    "no-cache": {
+        defaultValue: false,
+        description: "Bypass the doctor result cache (~/.vis/cache/doctor)",
+        type: Boolean,
+    },
+    "no-progress": {
+        defaultValue: false,
+        description: "Disable live progress UI (forces sequential logs)",
+        type: Boolean,
+    },
+    only: {
+        description: "Comma-separated sections to run: dependencies,security,optimization,runtime",
+        type: String,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress per-section detail; print summary only",
+        type: Boolean,
+    },
+    skip: {
+        description: "Comma-separated sections to skip",
+        type: String,
+    },
+    strict: {
+        defaultValue: false,
+        description: "With --exit-code: also fail on outdated and duplicate deps",
+        type: Boolean,
+    },
+} as const;
+
+const doctor = defineCommand({
     description: "Run a full project health check (outdated, security, duplicates, optimizations)",
     examples: [
         ["vis doctor", "Full project health check"],
@@ -30,44 +90,9 @@ const doctor: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "doctor",
-    options: [
-        { description: "Output format: table or json (default: table). Alias: --json", name: "format", type: String },
-        { defaultValue: false, description: "Shorthand for --format json", name: "json", type: Boolean },
-        { defaultValue: false, description: "Exit with code 1 if issues found", name: "exit-code", type: Boolean },
-        { defaultValue: false, description: "Auto-apply safe fixes (security overrides + codemods, SIGTERM orphans)", name: "fix", type: Boolean },
-        {
-            defaultValue: false,
-            description: "With --fix: escalate orphan cleanup to SIGKILL / taskkill /F (use when SIGTERM is ignored)",
-            name: "fix-force",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "With --exit-code: also fail on outdated and duplicate deps", name: "strict", type: Boolean },
-        { description: "Comma-separated sections to run: dependencies,security,optimization,runtime", name: "only", type: String },
-        { description: "Comma-separated sections to skip", name: "skip", type: String },
-        { defaultValue: false, description: "Suppress per-section detail; print summary only", name: "quiet", type: Boolean },
-        { defaultValue: false, description: "Disable live progress UI (forces sequential logs)", name: "no-progress", type: Boolean },
-        { defaultValue: false, description: "Bypass the doctor result cache (~/.vis/cache/doctor)", name: "no-cache", type: Boolean },
-        {
-            description: "Comma-separated package name patterns to scope findings (supports * globs, e.g. '@types/*,react')",
-            name: "filter",
-            type: String,
-        },
-    ],
-};
+    options: doctorOptionDefinitions,
+});
 
 export default doctor;
 
-export type DoctorOptions = CreateOptions<{
-    "exit-code": boolean | undefined;
-    filter: string | undefined;
-    fix: boolean | undefined;
-    "fix-force": boolean | undefined;
-    format: string | undefined;
-    json: boolean | undefined;
-    "no-cache": boolean | undefined;
-    "no-progress": boolean | undefined;
-    only: string | undefined;
-    quiet: boolean | undefined;
-    skip: string | undefined;
-    strict: boolean | undefined;
-}>;
+export type DoctorOptions = InferOptions<typeof doctorOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/exec/index.ts
+++ b/packages/tooling/vis/src/commands/exec/index.ts
@@ -1,6 +1,44 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const exec: Command = {
+const execOptionDefinitions = {
+    filter: {
+        alias: "F",
+        description: "Filter packages by name pattern",
+        multiple: true,
+        type: String,
+    },
+    parallel: {
+        defaultValue: false,
+        description: "Run concurrently without topological ordering",
+        type: Boolean,
+    },
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Run in every workspace package",
+        type: Boolean,
+    },
+    reverse: {
+        defaultValue: false,
+        description: "Reverse topological execution order",
+        type: Boolean,
+    },
+    "shell-mode": {
+        alias: "c",
+        defaultValue: false,
+        description: "Execute within shell environment",
+        type: Boolean,
+    },
+    "workspace-root": {
+        alias: "w",
+        defaultValue: false,
+        description: "Run on workspace root only",
+        type: Boolean,
+    },
+} as const;
+
+const exec = defineCommand({
     argument: {
         description: "Command to execute followed by arguments",
         name: "command",
@@ -16,23 +54,9 @@ const exec: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "exec",
-    options: [
-        { alias: "c", defaultValue: false, description: "Execute within shell environment", name: "shell-mode", type: Boolean },
-        { alias: "r", defaultValue: false, description: "Run in every workspace package", name: "recursive", type: Boolean },
-        { alias: "w", defaultValue: false, description: "Run on workspace root only", name: "workspace-root", type: Boolean },
-        { alias: "F", description: "Filter packages by name pattern", multiple: true, name: "filter", type: String },
-        { defaultValue: false, description: "Run concurrently without topological ordering", name: "parallel", type: Boolean },
-        { defaultValue: false, description: "Reverse topological execution order", name: "reverse", type: Boolean },
-    ],
-};
+    options: execOptionDefinitions,
+});
 
 export default exec;
 
-export type ExecOptions = CreateOptions<{
-    filter: string[] | undefined;
-    parallel: boolean | undefined;
-    recursive: boolean | undefined;
-    reverse: boolean | undefined;
-    "shell-mode": boolean | undefined;
-    "workspace-root": boolean | undefined;
-}>;
+export type ExecOptions = InferOptions<typeof execOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/fmt/index.ts
+++ b/packages/tooling/vis/src/commands/fmt/index.ts
@@ -1,6 +1,43 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const fmt: Command = {
+const fmtOptionDefinitions = {
+    check: {
+        defaultValue: false,
+        description: "Report files that would change without writing",
+        type: Boolean,
+    },
+    format: {
+        defaultValue: "human",
+        description: "Output format: human, json, minimal, sarif, junit, or github",
+        type: String,
+    },
+    output: {
+        description: "Write formatted output to a file path instead of stdout (also accepts `-`/`stdout`/`stderr`)",
+        type: String,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress per-file logs",
+        type: Boolean,
+    },
+    since: {
+        description: "Only format files changed vs the given git ref (branch, tag, sha)",
+        type: String,
+    },
+    staged: {
+        defaultValue: false,
+        description: "Only format files currently staged in the git index",
+        type: Boolean,
+    },
+    watch: {
+        defaultValue: false,
+        description: "Re-run formatters whenever watched files change",
+        type: Boolean,
+    },
+} as const;
+
+const fmt = defineCommand({
     description: "Orchestrate detected formatters (prettier, …) across the workspace",
     examples: [
         ["vis fmt", "Apply formatting in place using every detected formatter"],
@@ -19,25 +56,9 @@ const fmt: Command = {
     group: "Lint & Format",
     loader: () => import("./handler"),
     name: "fmt",
-    options: [
-        { defaultValue: false, description: "Report files that would change without writing", name: "check", type: Boolean },
-        { defaultValue: "human", description: "Output format: human, json, minimal, sarif, junit, or github", name: "format", type: String },
-        { defaultValue: false, description: "Suppress per-file logs", name: "quiet", type: Boolean },
-        { description: "Only format files changed vs the given git ref (branch, tag, sha)", name: "since", type: String },
-        { defaultValue: false, description: "Only format files currently staged in the git index", name: "staged", type: Boolean },
-        { description: "Write formatted output to a file path instead of stdout (also accepts `-`/`stdout`/`stderr`)", name: "output", type: String },
-        { defaultValue: false, description: "Re-run formatters whenever watched files change", name: "watch", type: Boolean },
-    ],
-};
+    options: fmtOptionDefinitions,
+});
 
 export default fmt;
 
-export type FmtOptions = CreateOptions<{
-    check: boolean | undefined;
-    format: "github" | "human" | "json" | "junit" | "minimal" | "sarif";
-    output: string | undefined;
-    quiet: boolean | undefined;
-    since: string | undefined;
-    staged: boolean | undefined;
-    watch: boolean | undefined;
-}>;
+export type FmtOptions = InferOptions<typeof fmtOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/generate/index.ts
+++ b/packages/tooling/vis/src/commands/generate/index.ts
@@ -6,9 +6,62 @@
  * template through prompts → produce → write.
  */
 
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const generate: Command = {
+const generateOptionDefinitions = {
+    defaults: {
+        defaultValue: false,
+        description: "Skip prompts; use template defaults",
+        type: Boolean,
+    },
+    describe: {
+        defaultValue: false,
+        description: "Print template metadata (about, destination, variables) without running produce",
+        type: Boolean,
+    },
+    "dry-run": {
+        defaultValue: false,
+        description: "Print planned writes without touching disk",
+        type: Boolean,
+    },
+    force: {
+        defaultValue: false,
+        description: "Overwrite existing files without prompting",
+        type: Boolean,
+    },
+    json: {
+        defaultValue: false,
+        description: "Emit JSON output (with --list or --describe)",
+        type: Boolean,
+    },
+    list: {
+        defaultValue: false,
+        description: "List discovered templates",
+        type: Boolean,
+    },
+    "no-interactive": {
+        defaultValue: false,
+        description: "Skip interactive prompts (errors on missing required values)",
+        type: Boolean,
+    },
+    "prefer-offline": {
+        defaultValue: false,
+        description: "Prefer locally cached remote templates over re-downloading",
+        type: Boolean,
+    },
+    "skip-scripts": {
+        defaultValue: false,
+        description: "Skip running post-generation scripts",
+        type: Boolean,
+    },
+    to: {
+        description: "Destination directory",
+        type: String,
+    },
+} as const;
+
+const generate = defineCommand({
     argument: {
         description: "Template name (or remote source like git://… or npm://…) — omit for interactive picker",
         name: "template",
@@ -29,36 +82,9 @@ const generate: Command = {
     group: "Scaffold & Config",
     loader: () => import("./handler"),
     name: "generate",
-    options: [
-        { defaultValue: false, description: "List discovered templates", name: "list", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Print template metadata (about, destination, variables) without running produce",
-            name: "describe",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Emit JSON output (with --list or --describe)", name: "json", type: Boolean },
-        { description: "Destination directory", name: "to", type: String },
-        { defaultValue: false, description: "Print planned writes without touching disk", name: "dry-run", type: Boolean },
-        { defaultValue: false, description: "Overwrite existing files without prompting", name: "force", type: Boolean },
-        { defaultValue: false, description: "Skip prompts; use template defaults", name: "defaults", type: Boolean },
-        { defaultValue: false, description: "Skip running post-generation scripts", name: "skip-scripts", type: Boolean },
-        { defaultValue: false, description: "Skip interactive prompts (errors on missing required values)", name: "no-interactive", type: Boolean },
-        { defaultValue: false, description: "Prefer locally cached remote templates over re-downloading", name: "prefer-offline", type: Boolean },
-    ],
-};
+    options: generateOptionDefinitions,
+});
 
 export default generate;
 
-export type GenerateOptions = CreateOptions<{
-    defaults: boolean | undefined;
-    describe: boolean | undefined;
-    "dry-run": boolean | undefined;
-    force: boolean | undefined;
-    json: boolean | undefined;
-    list: boolean | undefined;
-    "no-interactive": boolean | undefined;
-    "prefer-offline": boolean | undefined;
-    "skip-scripts": boolean | undefined;
-    to: string | undefined;
-}>;
+export type GenerateOptions = InferOptions<typeof generateOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/graph/index.ts
+++ b/packages/tooling/vis/src/commands/graph/index.ts
@@ -1,6 +1,26 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const graph: Command = {
+const graphOptionDefinitions = {
+    depth: {
+        alias: "d",
+        description: "Maximum dependency tree depth for ASCII output (default: unlimited)",
+        type: Number,
+    },
+    format: {
+        alias: "f",
+        defaultValue: undefined,
+        description: "Output format: tui, ascii, dot, json, html (default: tui in TTY, ascii otherwise)",
+        type: String,
+    },
+    output: {
+        alias: "o",
+        description: "Write output to file instead of stdout",
+        type: String,
+    },
+} as const;
+
+const graph = defineCommand({
     description: "Visualize the project dependency graph",
     examples: [
         ["vis graph", "Show colored dependency graph (TUI in TTY, ASCII otherwise)"],
@@ -12,33 +32,9 @@ const graph: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "graph",
-    options: [
-        {
-            alias: "f",
-            defaultValue: undefined,
-            description: "Output format: tui, ascii, dot, json, html (default: tui in TTY, ascii otherwise)",
-            name: "format",
-            type: String,
-        },
-        {
-            alias: "o",
-            description: "Write output to file instead of stdout",
-            name: "output",
-            type: String,
-        },
-        {
-            alias: "d",
-            description: "Maximum dependency tree depth for ASCII output (default: unlimited)",
-            name: "depth",
-            type: Number,
-        },
-    ],
-};
+    options: graphOptionDefinitions,
+});
 
 export default graph;
 
-export type GraphOptions = CreateOptions<{
-    depth: number | undefined;
-    format: string | undefined;
-    output: string | undefined;
-}>;
+export type GraphOptions = InferOptions<typeof graphOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/hook/index.ts
+++ b/packages/tooling/vis/src/commands/hook/index.ts
@@ -173,7 +173,7 @@ const hookAdd: Command = {
     options: [hooksDirectoryOption],
 };
 
-const hookCommands: Command[] = [hookInstall, hookUninstall, hookMigrate, hookList, hookValidate, hookRun, hookAdd];
+const hookCommands = [hookInstall, hookUninstall, hookMigrate, hookList, hookValidate, hookRun, hookAdd];
 
 export default hookCommands;
 

--- a/packages/tooling/vis/src/commands/hook/index.ts
+++ b/packages/tooling/vis/src/commands/hook/index.ts
@@ -1,4 +1,4 @@
-import type { Command, CreateEnv, CreateOptions } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateEnv, CreateOptions } from "@visulima/cerebro";
 
 import { DEFAULT_HOOKS_DIRECTORY } from "./constants";
 
@@ -173,7 +173,7 @@ const hookAdd: Command = {
     options: [hooksDirectoryOption],
 };
 
-const hookCommands = [hookInstall, hookUninstall, hookMigrate, hookList, hookValidate, hookRun, hookAdd];
+const hookCommands: AnyCommandInput[] = [hookInstall, hookUninstall, hookMigrate, hookList, hookValidate, hookRun, hookAdd];
 
 export default hookCommands;
 

--- a/packages/tooling/vis/src/commands/ignore/index.ts
+++ b/packages/tooling/vis/src/commands/ignore/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis ignore` — generate or merge an ignore file for a build/publish
@@ -12,7 +13,24 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * (The CI "Ignored Build Step" gate that used to live here now lives at
  * `vis ci ignore`.)
  */
-const ignore: Command = {
+const ignoreOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit the result as JSON",
+        type: Boolean,
+    },
+    target: {
+        description: "Ignore-file target: docker | vercel | npm | slug (default: docker)",
+        type: String,
+    },
+    write: {
+        defaultValue: false,
+        description: "Write the result to disk instead of printing to stdout",
+        type: Boolean,
+    },
+} as const;
+
+const ignore = defineCommand({
     description: "Generate or merge an ignore file (.dockerignore/.vercelignore/.npmignore/.slugignore) without duplicate entries",
     examples: [
         ["vis ignore", "Print a .dockerignore (deduped against an existing one)"],
@@ -23,17 +41,9 @@ const ignore: Command = {
     group: "Scaffold & Config",
     loader: () => import("./handler"),
     name: "ignore",
-    options: [
-        { description: "Ignore-file target: docker | vercel | npm | slug (default: docker)", name: "target", type: String },
-        { defaultValue: false, description: "Write the result to disk instead of printing to stdout", name: "write", type: Boolean },
-        { defaultValue: false, description: "Emit the result as JSON", name: "json", type: Boolean },
-    ],
-};
+    options: ignoreOptionDefinitions,
+});
 
 export default ignore;
 
-export type IgnoreOptions = CreateOptions<{
-    json: boolean | undefined;
-    target: string | undefined;
-    write: boolean | undefined;
-}>;
+export type IgnoreOptions = InferOptions<typeof ignoreOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/implode/index.ts
+++ b/packages/tooling/vis/src/commands/implode/index.ts
@@ -1,6 +1,16 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const implode: Command = {
+const implodeOptionDefinitions = {
+    yes: {
+        alias: "y",
+        defaultValue: false,
+        description: "Skip confirmation prompt",
+        type: Boolean,
+    },
+} as const;
+
+const implode = defineCommand({
     description: "Remove vis from the system (self-uninstall)",
     examples: [
         ["vis implode", "Interactive uninstall"],
@@ -9,11 +19,9 @@ const implode: Command = {
     group: "System",
     loader: () => import("./handler"),
     name: "implode",
-    options: [{ alias: "y", defaultValue: false, description: "Skip confirmation prompt", name: "yes", type: Boolean }],
-};
+    options: implodeOptionDefinitions,
+});
 
 export default implode;
 
-export type ImplodeOptions = CreateOptions<{
-    yes: boolean | undefined;
-}>;
+export type ImplodeOptions = InferOptions<typeof implodeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/import/index.ts
+++ b/packages/tooling/vis/src/commands/import/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis import` — pull an external repo into the monorepo under a target
@@ -6,7 +7,40 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * add`). Auto-registers the package into the workspace config unless
  * `--no-register` is passed.
  */
-const importCommand: Command = {
+const importCommandOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Print the git plan instead of executing it",
+        type: Boolean,
+    },
+    message: {
+        alias: "m",
+        description: "Commit message for the subtree merge",
+        type: String,
+    },
+    "no-register": {
+        defaultValue: false,
+        description: "Do not register the package into the workspace config",
+        type: Boolean,
+    },
+    prefix: {
+        alias: "p",
+        description: "Target directory in the monorepo (e.g. packages/tooling/foo)",
+        type: String,
+    },
+    ref: {
+        alias: "r",
+        description: "Branch, tag, or commit to import (default: HEAD)",
+        type: String,
+    },
+    squash: {
+        defaultValue: false,
+        description: "Collapse the incoming history into a single merge commit",
+        type: Boolean,
+    },
+} as const;
+
+const importCommand = defineCommand({
     argument: { description: "Source git repository URL or local path to import", name: "source", type: String },
     description: "Import an external repo into the monorepo under a prefix, preserving history",
     examples: [
@@ -18,15 +52,8 @@ const importCommand: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "import",
-    options: [
-        { alias: "p", description: "Target directory in the monorepo (e.g. packages/tooling/foo)", name: "prefix", type: String },
-        { alias: "r", description: "Branch, tag, or commit to import (default: HEAD)", name: "ref", type: String },
-        { defaultValue: false, description: "Collapse the incoming history into a single merge commit", name: "squash", type: Boolean },
-        { alias: "m", description: "Commit message for the subtree merge", name: "message", type: String },
-        { defaultValue: false, description: "Do not register the package into the workspace config", name: "no-register", type: Boolean },
-        { defaultValue: false, description: "Print the git plan instead of executing it", name: "dry-run", type: Boolean },
-    ],
-};
+    options: importCommandOptionDefinitions,
+});
 
 export default importCommand;
 

--- a/packages/tooling/vis/src/commands/info/index.ts
+++ b/packages/tooling/vis/src/commands/info/index.ts
@@ -1,6 +1,15 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const info: Command = {
+const infoOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Output as JSON",
+        type: Boolean,
+    },
+} as const;
+
+const info = defineCommand({
     alias: "view",
     argument: {
         description: "Package name followed by optional metadata fields (e.g. 'react version dependencies')",
@@ -19,11 +28,9 @@ const info: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "info",
-    options: [{ defaultValue: false, description: "Output as JSON", name: "json", type: Boolean }],
-};
+    options: infoOptionDefinitions,
+});
 
 export default info;
 
-export type InfoOptions = CreateOptions<{
-    json: boolean | undefined;
-}>;
+export type InfoOptions = InferOptions<typeof infoOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/init/index.ts
+++ b/packages/tooling/vis/src/commands/init/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis init` — initialize vis configuration with secure defaults.
@@ -11,7 +12,30 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  *
  * In non-interactive mode (CI, piped), creates a minimal config with secure defaults.
  */
-const init: Command = {
+const initOptionDefinitions = {
+    force: {
+        defaultValue: false,
+        description: "Overwrite existing config file",
+        type: Boolean,
+    },
+    "no-interactive": {
+        defaultValue: false,
+        description: "Skip interactive prompts",
+        type: Boolean,
+    },
+    schema: {
+        defaultValue: false,
+        description: "Print workspace-relative $schema paths for project.json and vis.config.ts, then exit",
+        type: Boolean,
+    },
+    "sync-native": {
+        defaultValue: false,
+        description: "Sync settings to native PM config files",
+        type: Boolean,
+    },
+} as const;
+
+const init = defineCommand({
     description: "Initialize vis.config.ts with best-practice security defaults",
     examples: [
         ["vis init", "Interactive setup wizard"],
@@ -23,24 +47,9 @@ const init: Command = {
     group: "Scaffold & Config",
     loader: () => import("./handler"),
     name: "init",
-    options: [
-        { defaultValue: false, description: "Overwrite existing config file", name: "force", type: Boolean },
-        { defaultValue: false, description: "Skip interactive prompts", name: "no-interactive", type: Boolean },
-        { defaultValue: false, description: "Sync settings to native PM config files", name: "sync-native", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Print workspace-relative $schema paths for project.json and vis.config.ts, then exit",
-            name: "schema",
-            type: Boolean,
-        },
-    ],
-};
+    options: initOptionDefinitions,
+});
 
 export default init;
 
-export type InitOptions = CreateOptions<{
-    force: boolean | undefined;
-    "no-interactive": boolean | undefined;
-    schema: boolean | undefined;
-    "sync-native": boolean | undefined;
-}>;
+export type InitOptions = InferOptions<typeof initOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/inspect/handler.ts
+++ b/packages/tooling/vis/src/commands/inspect/handler.ts
@@ -249,7 +249,7 @@ const execute = async ({ argument, options, workspaceRoot: wsRoot }: Toolbox<Con
 
     const snapshot: ReadonlyArray<MarshallFinding> = findings.all();
 
-    if (options.json === true) {
+    if (options.json) {
         process.stdout.write(`${JSON.stringify(formatMarshallFindingsAsJson(snapshot), undefined, 2)}\n`);
     } else {
         const header = `${parsed.name}@${resolvedVersion}`;
@@ -272,7 +272,7 @@ const execute = async ({ argument, options, workspaceRoot: wsRoot }: Toolbox<Con
         }
     }
 
-    if (findings.hasErrors() || (options.strict === true && !findings.isEmpty())) {
+    if (findings.hasErrors() || (options.strict && !findings.isEmpty())) {
         process.exitCode = 1;
     }
 };

--- a/packages/tooling/vis/src/commands/inspect/index.ts
+++ b/packages/tooling/vis/src/commands/inspect/index.ts
@@ -1,11 +1,30 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis inspect &lt;pkg>` — dry-run every marshall against `&lt;pkg>[@&lt;spec>]`
  * without installing anything. Lets users pre-flight a dependency before
  * letting it touch the lockfile.
  */
-const inspect: Command = {
+const inspectOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit findings as a JSON document instead of the human-readable table.",
+        type: Boolean,
+    },
+    only: {
+        description:
+                "Comma-separated subset of marshalls to run. Known: author, archivedRepo, downloads, expiredDomains, metadata, newBin, provenance, signatures. Signatures only runs when explicitly requested here.",
+        type: String,
+    },
+    strict: {
+        defaultValue: false,
+        description: "Exit non-zero on any finding (warnings included). Default exits non-zero only on errors.",
+        type: Boolean,
+    },
+} as const;
+
+const inspect = defineCommand({
     argument: {
         description: "Package to inspect, optionally pinned: `<name>` or `<name>@<spec>`. `<spec>` may be a version, range, or dist-tag.",
         name: "package",
@@ -23,32 +42,9 @@ const inspect: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "inspect",
-    options: [
-        {
-            defaultValue: false,
-            description: "Emit findings as a JSON document instead of the human-readable table.",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Exit non-zero on any finding (warnings included). Default exits non-zero only on errors.",
-            name: "strict",
-            type: Boolean,
-        },
-        {
-            description:
-                "Comma-separated subset of marshalls to run. Known: author, archivedRepo, downloads, expiredDomains, metadata, newBin, provenance, signatures. Signatures only runs when explicitly requested here.",
-            name: "only",
-            type: String,
-        },
-    ],
-};
+    options: inspectOptionDefinitions,
+});
 
 export default inspect;
 
-export type InspectOptions = CreateOptions<{
-    json: boolean | undefined;
-    only: string | undefined;
-    strict: boolean | undefined;
-}>;
+export type InspectOptions = InferOptions<typeof inspectOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/install/handler.ts
+++ b/packages/tooling/vis/src/commands/install/handler.ts
@@ -157,7 +157,7 @@ const execute = async (toolbox: Toolbox<Console, InstallOptions>): Promise<void>
     // silent lockfile rewrites. Greenfield workspaces (no lockfile) skip
     // the default — there's nothing to freeze yet.
     const explicitFrozen = options.frozenLockfile || ciMode;
-    const optedOutOfFrozen = options.frozenLockfile === false || options.force || options.lockfileOnly;
+    const optedOutOfFrozen = !options.frozenLockfile || options.force || options.lockfileOnly;
     const lockfilePresent = hasLockfile(cwd);
     const shouldFreeze = explicitFrozen || (!optedOutOfFrozen && lockfilePresent);
 

--- a/packages/tooling/vis/src/commands/install/index.ts
+++ b/packages/tooling/vis/src/commands/install/index.ts
@@ -1,6 +1,128 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const install: Command = {
+const installOptionDefinitions = {
+    ci: {
+        defaultValue: false,
+        description: "Clean install: wipe node_modules then install with frozen lockfile",
+        type: Boolean,
+    },
+    dev: {
+        alias: "D",
+        conflicts: "prod",
+        description: "Install devDependencies only (no positional args) / add as dev (with positional args, npm-style)",
+        type: Boolean,
+    },
+    exact: {
+        alias: "E",
+        defaultValue: false,
+        description: "Save exact version (only with positional args; mirrors `npm install -E`)",
+        type: Boolean,
+    },
+    filter: {
+        alias: "F",
+        description: "Filter by workspace package name",
+        multiple: true,
+        type: String,
+    },
+    force: {
+        alias: "f",
+        defaultValue: false,
+        description: "Force reinstall all dependencies",
+        type: Boolean,
+    },
+    "frozen-lockfile": {
+        defaultValue: false,
+        description: "Use frozen lockfile (CI mode, maps to npm ci)",
+        type: Boolean,
+    },
+    installer: {
+        description: "Pick the installer explicitly. One of: auto, aube, pnpm, npm, yarn, bun. Overrides VIS_INSTALLER and install.backend in vis.config.",
+        type: String,
+    },
+    "lockfile-only": {
+        defaultValue: false,
+        description: "Update lockfile without installing",
+        type: Boolean,
+    },
+    "no-aube": {
+        defaultValue: false,
+        description: "Skip aube and use the lockfile-detected PM. Wins over --installer / VIS_INSTALLER / install.backend.",
+        type: Boolean,
+    },
+    "no-frozen-lockfile": {
+        defaultValue: false,
+        description: "Opt out of vis's default frozen-lockfile behavior and allow lockfile updates",
+        type: Boolean,
+    },
+    "no-marshall-check": {
+        defaultValue: false,
+        description: "Skip the offline marshall pipeline (only with positional args; mirrors `vis add --no-marshall-check`)",
+        type: Boolean,
+    },
+    "no-optional": {
+        defaultValue: false,
+        description: "Skip optional dependencies",
+        type: Boolean,
+    },
+    "no-socket-check": {
+        defaultValue: false,
+        description: "Skip Socket.dev security check (only with positional args; mirrors `vis add --no-socket-check`)",
+        type: Boolean,
+    },
+    "no-typosquat-check": {
+        defaultValue: false,
+        description: "Skip typosquat name check",
+        type: Boolean,
+    },
+    offline: {
+        defaultValue: false,
+        description: "Use only cached packages",
+        type: Boolean,
+    },
+    "prefer-offline": {
+        defaultValue: false,
+        description: "Prefer cached packages, fall back to network when missing",
+        type: Boolean,
+    },
+    prod: {
+        alias: "P",
+        conflicts: "dev",
+        description: "Skip devDependencies (no positional args) / add as peer (with positional args, npm-style)",
+        type: Boolean,
+    },
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Install in all workspace packages",
+        type: Boolean,
+    },
+    "run-scripts": {
+        defaultValue: false,
+        description:
+                "Run lifecycle scripts (opts out of vis's default block-by-default policy; allowlisted packages run via security.policies.installScripts.allow)",
+        type: Boolean,
+    },
+    "save-optional": {
+        defaultValue: false,
+        description: "Add as optional dependency (only with positional args; mirrors `npm install -O`)",
+        type: Boolean,
+    },
+    silent: {
+        alias: "s",
+        defaultValue: false,
+        description: "Suppress output",
+        type: Boolean,
+    },
+    "workspace-root": {
+        alias: "w",
+        defaultValue: false,
+        description: "Target workspace root",
+        type: Boolean,
+    },
+} as const;
+
+const install = defineCommand({
     alias: "i",
     argument: {
         description: "Optional package names. When provided, delegates to `vis add` (enables npm-style `alias npm='vis install'` wrappers).",
@@ -27,108 +149,9 @@ const install: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "install",
-    options: [
-        {
-            alias: "P",
-            conflicts: "dev",
-            description: "Skip devDependencies (no positional args) / add as peer (with positional args, npm-style)",
-            name: "prod",
-            type: Boolean,
-        },
-        {
-            alias: "D",
-            conflicts: "prod",
-            description: "Install devDependencies only (no positional args) / add as dev (with positional args, npm-style)",
-            name: "dev",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Add as optional dependency (only with positional args; mirrors `npm install -O`)",
-            name: "save-optional",
-            type: Boolean,
-        },
-        {
-            alias: "E",
-            defaultValue: false,
-            description: "Save exact version (only with positional args; mirrors `npm install -E`)",
-            name: "exact",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip Socket.dev security check (only with positional args; mirrors `vis add --no-socket-check`)",
-            name: "no-socket-check",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the offline marshall pipeline (only with positional args; mirrors `vis add --no-marshall-check`)",
-            name: "no-marshall-check",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Use frozen lockfile (CI mode, maps to npm ci)", name: "frozen-lockfile", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Opt out of vis's default frozen-lockfile behavior and allow lockfile updates",
-            name: "no-frozen-lockfile",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Clean install: wipe node_modules then install with frozen lockfile", name: "ci", type: Boolean },
-        { alias: "f", defaultValue: false, description: "Force reinstall all dependencies", name: "force", type: Boolean },
-        {
-            defaultValue: false,
-            description:
-                "Run lifecycle scripts (opts out of vis's default block-by-default policy; allowlisted packages run via security.policies.installScripts.allow)",
-            name: "run-scripts",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Update lockfile without installing", name: "lockfile-only", type: Boolean },
-        { defaultValue: false, description: "Skip optional dependencies", name: "no-optional", type: Boolean },
-        { defaultValue: false, description: "Use only cached packages", name: "offline", type: Boolean },
-        { defaultValue: false, description: "Prefer cached packages, fall back to network when missing", name: "prefer-offline", type: Boolean },
-        { alias: "s", defaultValue: false, description: "Suppress output", name: "silent", type: Boolean },
-        { alias: "r", defaultValue: false, description: "Install in all workspace packages", name: "recursive", type: Boolean },
-        { alias: "w", defaultValue: false, description: "Target workspace root", name: "workspace-root", type: Boolean },
-        { alias: "F", description: "Filter by workspace package name", multiple: true, name: "filter", type: String },
-        { defaultValue: false, description: "Skip typosquat name check", name: "no-typosquat-check", type: Boolean },
-        {
-            description: "Pick the installer explicitly. One of: auto, aube, pnpm, npm, yarn, bun. Overrides VIS_INSTALLER and install.backend in vis.config.",
-            name: "installer",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Skip aube and use the lockfile-detected PM. Wins over --installer / VIS_INSTALLER / install.backend.",
-            name: "no-aube",
-            type: Boolean,
-        },
-    ],
-};
+    options: installOptionDefinitions,
+});
 
 export default install;
 
-export type InstallOptions = CreateOptions<{
-    ci: boolean | undefined;
-    dev: boolean | undefined;
-    exact: boolean | undefined;
-    filter: string[] | undefined;
-    force: boolean | undefined;
-    "frozen-lockfile": boolean | undefined;
-    installer: string | undefined;
-    "lockfile-only": boolean | undefined;
-    "no-aube": boolean | undefined;
-    "no-frozen-lockfile": boolean | undefined;
-    "no-marshall-check": boolean | undefined;
-    "no-optional": boolean | undefined;
-    "no-socket-check": boolean | undefined;
-    "no-typosquat-check": boolean | undefined;
-    offline: boolean | undefined;
-    "prefer-offline": boolean | undefined;
-    prod: boolean | undefined;
-    recursive: boolean | undefined;
-    "run-scripts": boolean | undefined;
-    "save-optional": boolean | undefined;
-    silent: boolean | undefined;
-    "workspace-root": boolean | undefined;
-}>;
+export type InstallOptions = InferOptions<typeof installOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/lint/index.ts
+++ b/packages/tooling/vis/src/commands/lint/index.ts
@@ -1,6 +1,47 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const lint: Command = {
+const lintOptionDefinitions = {
+    fix: {
+        defaultValue: false,
+        description: "Apply auto-fixes in place",
+        type: Boolean,
+    },
+    format: {
+        defaultValue: "human",
+        description: "Output format: human, json, minimal, sarif, junit, or github",
+        type: String,
+    },
+    "max-warnings": {
+        description: "Fail the run if more than N warnings are reported",
+        type: Number,
+    },
+    output: {
+        description: "Write formatted output to a file path instead of stdout (also accepts `-`/`stdout`/`stderr`)",
+        type: String,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress warnings — report errors only",
+        type: Boolean,
+    },
+    since: {
+        description: "Only lint files changed vs the given git ref (branch, tag, sha)",
+        type: String,
+    },
+    staged: {
+        defaultValue: false,
+        description: "Only lint files currently staged in the git index",
+        type: Boolean,
+    },
+    watch: {
+        defaultValue: false,
+        description: "Re-run linters whenever watched files change",
+        type: Boolean,
+    },
+} as const;
+
+const lint = defineCommand({
     description: "Orchestrate detected source-code linters (eslint, …) across the workspace",
     examples: [
         ["vis lint", "Run every detected linter against the workspace"],
@@ -20,27 +61,9 @@ const lint: Command = {
     group: "Lint & Format",
     loader: () => import("./handler"),
     name: "lint",
-    options: [
-        { defaultValue: false, description: "Apply auto-fixes in place", name: "fix", type: Boolean },
-        { defaultValue: "human", description: "Output format: human, json, minimal, sarif, junit, or github", name: "format", type: String },
-        { defaultValue: false, description: "Suppress warnings — report errors only", name: "quiet", type: Boolean },
-        { description: "Fail the run if more than N warnings are reported", name: "max-warnings", type: Number },
-        { description: "Only lint files changed vs the given git ref (branch, tag, sha)", name: "since", type: String },
-        { defaultValue: false, description: "Only lint files currently staged in the git index", name: "staged", type: Boolean },
-        { description: "Write formatted output to a file path instead of stdout (also accepts `-`/`stdout`/`stderr`)", name: "output", type: String },
-        { defaultValue: false, description: "Re-run linters whenever watched files change", name: "watch", type: Boolean },
-    ],
-};
+    options: lintOptionDefinitions,
+});
 
 export default lint;
 
-export type LintOptions = CreateOptions<{
-    fix: boolean | undefined;
-    format: "github" | "human" | "json" | "junit" | "minimal" | "sarif";
-    "max-warnings": number | undefined;
-    output: string | undefined;
-    quiet: boolean | undefined;
-    since: string | undefined;
-    staged: boolean | undefined;
-    watch: boolean | undefined;
-}>;
+export type LintOptions = InferOptions<typeof lintOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/list/handler.ts
+++ b/packages/tooling/vis/src/commands/list/handler.ts
@@ -87,7 +87,7 @@ const execute = async ({ logger, options, visConfig, workspaceRoot: wsRoot }: To
 
     const format = resolveFormat(options.format);
 
-    if (options.deps === true) {
+    if (options.deps) {
         if (options.internalOnly && options.externalOnly) {
             throw new Error("--internal-only and --external-only are mutually exclusive");
         }
@@ -131,7 +131,7 @@ const execute = async ({ logger, options, visConfig, workspaceRoot: wsRoot }: To
         if (format === "json") {
             const records = sorted.map((instance) => toDepRecord(instance, wsRoot));
 
-            logger.info(JSON.stringify(records, null, options.pretty === true ? 2 : undefined));
+            logger.info(JSON.stringify(records, null, options.pretty ? 2 : undefined));
 
             return;
         }
@@ -187,8 +187,8 @@ const execute = async ({ logger, options, visConfig, workspaceRoot: wsRoot }: To
         return;
     }
 
-    const inferredOnly = options.inferred === true;
-    const showTargets = options.targets === true || inferredOnly;
+    const inferredOnly = options.inferred;
+    const showTargets = options.targets || inferredOnly;
 
     if (format === "json") {
         const data = projectNames.map((name) => {

--- a/packages/tooling/vis/src/commands/list/index.ts
+++ b/packages/tooling/vis/src/commands/list/index.ts
@@ -1,6 +1,68 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const list: Command = {
+const listOptionDefinitions = {
+    "dep-type": {
+        description: "Restrict --deps to specific dep blocks (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    deps: {
+        defaultValue: false,
+        description: "Render a dep-instance view (table by default; use --format=ndjson|json for jq-friendly streams)",
+        type: Boolean,
+    },
+    exclude: {
+        description: "With --deps: glob of declaring package names to drop (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    "external-only": {
+        defaultValue: false,
+        description: "With --deps: only show external/registry deps",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table (default), json (single document), or ndjson (one record per line; --deps only)",
+        type: String,
+    },
+    include: {
+        description: "With --deps: glob of declaring package names to keep (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    inferred: {
+        defaultValue: false,
+        description: "Filter target rows to only inferred targets (implies --targets)",
+        type: Boolean,
+    },
+    "internal-only": {
+        defaultValue: false,
+        description: "With --deps: only show internal/workspace deps",
+        type: Boolean,
+    },
+    pretty: {
+        defaultValue: false,
+        description: "Pretty-print with 2-space indent (only meaningful with --format=json)",
+        type: Boolean,
+    },
+    query: {
+        description: "Filter projects by query",
+        type: String,
+    },
+    tag: {
+        description: "Only list projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\".",
+        multiple: true,
+        type: String,
+    },
+    targets: {
+        defaultValue: false,
+        description: "Show per-target rows (type, cache, description)",
+        type: Boolean,
+    },
+} as const;
+
+const list = defineCommand({
     description: "List all workspace projects with metadata",
     examples: [
         ["vis list", "Show all projects"],
@@ -17,93 +79,9 @@ const list: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "list",
-    options: [
-        {
-            defaultValue: false,
-            description: "Filter target rows to only inferred targets (implies --targets)",
-            name: "inferred",
-            type: Boolean,
-        },
-        {
-            description: "Output format: table (default), json (single document), or ndjson (one record per line; --deps only)",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Pretty-print with 2-space indent (only meaningful with --format=json)",
-            name: "pretty",
-            type: Boolean,
-        },
-        {
-            description: "Filter projects by query",
-            name: "query",
-            type: String,
-        },
-        {
-            description: "Only list projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\".",
-            multiple: true,
-            name: "tag",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Show per-target rows (type, cache, description)",
-            name: "targets",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Render a dep-instance view (table by default; use --format=ndjson|json for jq-friendly streams)",
-            name: "deps",
-            type: Boolean,
-        },
-        {
-            description: "Restrict --deps to specific dep blocks (repeatable)",
-            multiple: true,
-            name: "dep-type",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "With --deps: only show internal/workspace deps",
-            name: "internal-only",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "With --deps: only show external/registry deps",
-            name: "external-only",
-            type: Boolean,
-        },
-        {
-            description: "With --deps: glob of declaring package names to keep (repeatable)",
-            multiple: true,
-            name: "include",
-            type: String,
-        },
-        {
-            description: "With --deps: glob of declaring package names to drop (repeatable)",
-            multiple: true,
-            name: "exclude",
-            type: String,
-        },
-    ],
-};
+    options: listOptionDefinitions,
+});
 
 export default list;
 
-export type ListOptions = CreateOptions<{
-    "dep-type": string[] | undefined;
-    deps: boolean | undefined;
-    exclude: string[] | undefined;
-    "external-only": boolean | undefined;
-    format: string | undefined;
-    include: string[] | undefined;
-    inferred: boolean | undefined;
-    "internal-only": boolean | undefined;
-    pretty: boolean | undefined;
-    query: string | undefined;
-    tag: string[] | undefined;
-    targets: boolean | undefined;
-}>;
+export type ListOptions = InferOptions<typeof listOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/migrate/index.ts
+++ b/packages/tooling/vis/src/commands/migrate/index.ts
@@ -1,172 +1,185 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { AnyCommandInput, CreateOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
-const sharedMigrateOptions = [
-    { defaultValue: false, description: "Preview changes without applying", name: "dry-run", type: Boolean },
-    { alias: "y", defaultValue: false, description: "Skip the confirmation prompt", name: "yes", type: Boolean },
-] as const;
+const sharedMigrateOptions = {
+    "dry-run": { defaultValue: false, description: "Preview changes without applying", type: Boolean },
+    yes: { alias: "y", defaultValue: false, description: "Skip the confirmation prompt", type: Boolean },
+} as const;
 
-const migrateDepsCmd: Command = {
+const migrateDepsCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateDepsCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate dependencies and scripts to vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateDepsExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateDepsExecute"),
     name: "deps",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateDepsCmdOptionDefinitions,
+});
 
-const migrateLintStagedCmd: Command = {
+const migrateLintStagedCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateLintStagedCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Inline lint-staged configuration into vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateLintStagedExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateLintStagedExecute"),
     name: "lint-staged",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateLintStagedCmdOptionDefinitions,
+});
 
-const migrateNanoStagedCmd: Command = {
+const migrateNanoStagedCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateNanoStagedCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Inline nano-staged configuration into vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateNanoStagedExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateNanoStagedExecute"),
     name: "nano-staged",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateNanoStagedCmdOptionDefinitions,
+});
 
-const migrateTurborepoCmd: Command = {
+const migrateTurborepoCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateTurborepoCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate turborepo tasks/config to vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateTurborepoExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateTurborepoExecute"),
     name: "turborepo",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateTurborepoCmdOptionDefinitions,
+});
 
-const migrateNxCmd: Command = {
+const migrateNxCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+    aggressive: {
+        defaultValue: false,
+        description:
+                "Auto-apply the safe cleanup items the migrator would otherwise leave on the checklist: delete nx.json + ignore-files-for-nx-affected.yml, strip nx/@nx/*/@nrwl/* devDependencies, rewrite mechanical `nx run-many|run|affected` scripts. Implies --force.",
+        type: Boolean,
+    },
+    force: {
+        defaultValue: false,
+        description: "Overwrite an existing vis.config.ts (a .bak is taken first)",
+        type: Boolean,
+    },
+    "rewrite-sync-generators": {
+        defaultValue: false,
+        description: "For each project.json `syncGenerators`, add a `pre<target>` script to sibling package.json (with a TODO for the user to wire up)",
+        type: Boolean,
+    },
+} as const;
+
+const migrateNxCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate nx targets/config to vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateNxExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateNxExecute"),
     name: "nx",
-    options: [
-        ...sharedMigrateOptions,
-        { defaultValue: false, description: "Overwrite an existing vis.config.ts (a .bak is taken first)", name: "force", type: Boolean },
-        {
-            defaultValue: false,
-            description: "For each project.json `syncGenerators`, add a `pre<target>` script to sibling package.json (with a TODO for the user to wire up)",
-            name: "rewrite-sync-generators",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Auto-apply the safe cleanup items the migrator would otherwise leave on the checklist: delete nx.json + ignore-files-for-nx-affected.yml, strip nx/@nx/*/@nrwl/* devDependencies, rewrite mechanical `nx run-many|run|affected` scripts. Implies --force.",
-            name: "aggressive",
-            type: Boolean,
-        },
-    ],
-};
+    options: migrateNxCmdOptionDefinitions,
+});
 
-const migrateMoonCmd: Command = {
+const migrateMoonCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+    "copy-templates": {
+        defaultValue: false,
+        description: "Copy .moon/templates/* into .vis/templates/* so `vis generate` works without .moon/",
+        type: Boolean,
+    },
+} as const;
+
+const migrateMoonCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate moon tasks/templates to vis",
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateMoonExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateMoonExecute"),
     name: "moon",
-    options: [
-        ...sharedMigrateOptions,
-        {
-            defaultValue: false,
-            description: "Copy .moon/templates/* into .vis/templates/* so `vis generate` works without .moon/",
-            name: "copy-templates",
-            type: Boolean,
-        },
-    ],
-};
+    options: migrateMoonCmdOptionDefinitions,
+});
 
-const migrateGitleaksCmd: Command = {
+const migrateGitleaksCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateGitleaksCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate gitleaks config/baseline/hooks to `vis secrets`",
     examples: [["vis migrate gitleaks", "Migrate gitleaks config/baseline/hooks to `vis secrets`"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateGitleaksExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateGitleaksExecute"),
     name: "gitleaks",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateGitleaksCmdOptionDefinitions,
+});
 
-const migrateKingfisherCmd: Command = {
+const migrateKingfisherCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateKingfisherCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Migrate Kingfisher baseline/hooks/scripts to `vis secrets`",
     examples: [["vis migrate kingfisher", "Migrate Kingfisher baseline/hooks/scripts to `vis secrets`"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateKingfisherExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateKingfisherExecute"),
     name: "kingfisher",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateKingfisherCmdOptionDefinitions,
+});
 
-const migrateSecretlintCmd: Command = {
+const migrateSecretlintCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateSecretlintCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Replace secretlint with `vis secrets`",
     examples: [["vis migrate secretlint", "Replace secretlint with `vis secrets`"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateSecretlintExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateSecretlintExecute"),
     name: "secretlint",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateSecretlintCmdOptionDefinitions,
+});
 
-const migrateSyncpackCmd: Command = {
+const migrateSyncpackCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateSyncpackCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Translate syncpack customTypes into vis policy and strip the syncpack dep/scripts",
     examples: [["vis migrate syncpack", "Translate syncpack customTypes into vis policy and strip the syncpack dep/scripts"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateSyncpackExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateSyncpackExecute"),
     name: "syncpack",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateSyncpackCmdOptionDefinitions,
+});
 
-const migrateSherifCmd: Command = {
+const migrateSherifCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateSherifCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Strip sherif config/dep/scripts and surface ignore-rules as a positive `vis lint --<rule>` command",
     examples: [["vis migrate sherif", "Strip sherif config/dep/scripts and surface ignore-rules as a positive `vis lint --<rule>` command"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateSherifExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateSherifExecute"),
     name: "sherif",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateSherifCmdOptionDefinitions,
+});
 
-const migrateSelfCmd: Command = {
+const migrateSelfCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateSelfCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Auto-rewrite vis.config.ts to use renamed fields (targetDefaults → tasks, taskDefaults → scopedTasks, taskRunnerOptions → taskRunner)",
     examples: [
@@ -174,28 +187,41 @@ const migrateSelfCmd: Command = {
         ["vis migrate self --dry-run", "Preview the rewrite without writing"],
     ],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateSelfExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateSelfExecute"),
     name: "self",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateSelfCmdOptionDefinitions,
+});
 
-const migrateVerify: Command = {
+const migrateVerifyOptionDefinitions = {
+
+} as const;
+
+const migrateVerify = defineCommand({
     commandPath: ["migrate"],
     description: "Audit the workspace for stray gitleaks/secretlint/sherif/syncpack references (exit 1 on issues)",
     examples: [["vis migrate verify", "Audit the workspace for stray gitleaks/secretlint/sherif/syncpack references (exit 1 on issues)"]],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateVerifyExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateVerifyExecute"),
     name: "verify",
-    options: [],
-};
+    options: migrateVerifyOptionDefinitions,
+});
 
-const migrateVerifyGraphCmd: Command = {
+const migrateVerifyGraphCmdOptionDefinitions = {
+    "fail-on": {
+        description: "Exit non-zero on: error (default) | warning",
+        type: String,
+    },
+    format: {
+        description: "Output format: table | json | ndjson (default: table)",
+        type: String,
+    },
+    from: {
+        description: "Source tool to compare against (turbo|nx|moon). Auto-detected when omitted.",
+        type: String,
+    },
+} as const;
+
+const migrateVerifyGraphCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Prove a turbo/nx/moon → vis migration preserved the task graph + cache-key surface (exit 1 on divergence)",
     examples: [
@@ -204,19 +230,16 @@ const migrateVerifyGraphCmd: Command = {
         ["vis migrate verify-graph --fail-on warning", "Also gate CI on additive/extra-target warnings"],
     ],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateVerifyGraphExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateVerifyGraphExecute"),
     name: "verify-graph",
-    options: [
-        { description: "Source tool to compare against (turbo|nx|moon). Auto-detected when omitted.", name: "from", type: String },
-        { description: "Output format: table | json | ndjson (default: table)", name: "format", type: String },
-        { description: "Exit non-zero on: error (default) | warning", name: "fail-on", type: String },
-    ],
-};
+    options: migrateVerifyGraphCmdOptionDefinitions,
+});
 
-const migrateAllCmd: Command = {
+const migrateAllCmdOptionDefinitions = {
+    ...sharedMigrateOptions,
+} as const;
+
+const migrateAllCmd = defineCommand({
     commandPath: ["migrate"],
     description: "Run every applicable migration non-interactively (autodetected)",
     examples: [
@@ -224,15 +247,12 @@ const migrateAllCmd: Command = {
         ["vis migrate all --dry-run", "Preview every detected migration without writing files"],
     ],
     group: "Migrate",
-    loader: () =>
-        import("./handler").then((m) => {
-            return { default: m.migrateAllExecute };
-        }),
+    loader: lazyNamed(() => import("./handler"), "migrateAllExecute"),
     name: "all",
-    options: [...sharedMigrateOptions],
-};
+    options: migrateAllCmdOptionDefinitions,
+});
 
-const migrateCommands = [
+const migrateCommands: AnyCommandInput[] = [
     migrateAllCmd,
     migrateDepsCmd,
     migrateLintStagedCmd,

--- a/packages/tooling/vis/src/commands/migrate/index.ts
+++ b/packages/tooling/vis/src/commands/migrate/index.ts
@@ -232,7 +232,7 @@ const migrateAllCmd: Command = {
     options: [...sharedMigrateOptions],
 };
 
-const migrateCommands: Command[] = [
+const migrateCommands = [
     migrateAllCmd,
     migrateDepsCmd,
     migrateLintStagedCmd,

--- a/packages/tooling/vis/src/commands/optimize/index.ts
+++ b/packages/tooling/vis/src/commands/optimize/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis optimize` — two-phase dependency optimization with interactive TUI.
@@ -13,7 +14,35 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * In TTY mode, presents an interactive TUI (like `vis update`) where users select
  * which optimizations to apply. In non-TTY/CI mode, outputs a static report.
  */
-const optimize: Command = {
+const optimizeOptionDefinitions = {
+    "dry-run": {
+        alias: "d",
+        defaultValue: false,
+        description: "Preview available optimizations without applying",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table or json (default: table)",
+        type: String,
+    },
+    "no-install": {
+        defaultValue: false,
+        description: "Skip running install after applying overrides",
+        type: Boolean,
+    },
+    pin: {
+        defaultValue: false,
+        description: "Pin Socket.dev overrides to exact versions",
+        type: Boolean,
+    },
+    prod: {
+        defaultValue: false,
+        description: "Only optimize production dependencies",
+        type: Boolean,
+    },
+} as const;
+
+const optimize = defineCommand({
     description: "Analyze and optimize dependencies using e18e replacements and @socketregistry overrides",
     examples: [
         ["vis optimize", "Interactive TUI to select and apply optimizations"],
@@ -24,21 +53,9 @@ const optimize: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "optimize",
-    options: [
-        { alias: "d", defaultValue: false, description: "Preview available optimizations without applying", name: "dry-run", type: Boolean },
-        { defaultValue: false, description: "Pin Socket.dev overrides to exact versions", name: "pin", type: Boolean },
-        { defaultValue: false, description: "Only optimize production dependencies", name: "prod", type: Boolean },
-        { defaultValue: false, description: "Skip running install after applying overrides", name: "no-install", type: Boolean },
-        { description: "Output format: table or json (default: table)", name: "format", type: String },
-    ],
-};
+    options: optimizeOptionDefinitions,
+});
 
 export default optimize;
 
-export type OptimizeOptions = CreateOptions<{
-    "dry-run": boolean | undefined;
-    format: string | undefined;
-    "no-install": boolean | undefined;
-    pin: boolean | undefined;
-    prod: boolean | undefined;
-}>;
+export type OptimizeOptions = InferOptions<typeof optimizeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/release/add/index.ts
+++ b/packages/tooling/vis/src/commands/release/add/index.ts
@@ -1,6 +1,34 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const add: Command = {
+const addOptionDefinitions = {
+    empty: {
+        description: "Author an empty change file (no bumps; satisfies non-strict `check`)",
+        type: Boolean,
+    },
+    "from-bot-pr": {
+        description: "Inspect the current PR (via `gh pr view`) and author a change file from its Dependabot / Renovate title (changesets #647)",
+        type: Boolean,
+    },
+    message: {
+        description: "Changelog body for the change file",
+        type: String,
+    },
+    name: {
+        description: "Slug for the filename (default: random animal name)",
+        type: String,
+    },
+    none: {
+        description: "Author a `none` change file (acknowledged but no direct bump)",
+        type: Boolean,
+    },
+    packages: {
+        description: "Comma-separated package:level pairs (e.g. '@scope/a:minor,@scope/b:patch')",
+        type: String,
+    },
+} as const;
+
+const add = defineCommand({
     commandPath: ["release"],
     description: "Author a new change file (interactive, or non-interactive via --packages)",
     examples: [
@@ -13,39 +41,8 @@ const add: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "add",
-    options: [
-        {
-            description: "Comma-separated package:level pairs (e.g. '@scope/a:minor,@scope/b:patch')",
-            name: "packages",
-            type: String,
-        },
-        {
-            description: "Changelog body for the change file",
-            name: "message",
-            type: String,
-        },
-        {
-            description: "Slug for the filename (default: random animal name)",
-            name: "name",
-            type: String,
-        },
-        {
-            description: "Author an empty change file (no bumps; satisfies non-strict `check`)",
-            name: "empty",
-            type: Boolean,
-        },
-        {
-            description: "Author a `none` change file (acknowledged but no direct bump)",
-            name: "none",
-            type: Boolean,
-        },
-        {
-            description: "Inspect the current PR (via `gh pr view`) and author a change file from its Dependabot / Renovate title (changesets #647)",
-            name: "from-bot-pr",
-            type: Boolean,
-        },
-    ],
-};
+    options: addOptionDefinitions,
+});
 
 export default add;
 

--- a/packages/tooling/vis/src/commands/release/changelog/index.ts
+++ b/packages/tooling/vis/src/commands/release/changelog/index.ts
@@ -1,6 +1,26 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const changelog: Command = {
+const changelogOptionDefinitions = {
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    filter: {
+        description: "Limit to packages matching this glob (CSV)",
+        type: String,
+    },
+    json: {
+        description: "Emit machine-readable JSON",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const changelog = defineCommand({
     commandPath: ["release"],
     description: "Render the would-be changelog entries without writing to disk",
     examples: [
@@ -10,29 +30,8 @@ const changelog: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "changelog",
-    options: [
-        {
-            description: "Emit machine-readable JSON",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            description: "Limit to packages matching this glob (CSV)",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: changelogOptionDefinitions,
+});
 
 export default changelog;
 

--- a/packages/tooling/vis/src/commands/release/check/index.ts
+++ b/packages/tooling/vis/src/commands/release/check/index.ts
@@ -1,6 +1,26 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const check: Command = {
+const checkOptionDefinitions = {
+    hook: {
+        description: "Hook context (pre-commit, pre-push) — affects which file states are counted",
+        type: String,
+    },
+    "no-fail": {
+        description: "Always exit 0; warnings still print to stderr",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    strict: {
+        description: "Require every changed package to have its own non-empty change file",
+        type: Boolean,
+    },
+} as const;
+
+const check = defineCommand({
     commandPath: ["release"],
     description: "Verify pending change files cover changed packages — CI / husky gate",
     examples: [
@@ -12,29 +32,8 @@ const check: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "check",
-    options: [
-        {
-            description: "Require every changed package to have its own non-empty change file",
-            name: "strict",
-            type: Boolean,
-        },
-        {
-            description: "Hook context (pre-commit, pre-push) — affects which file states are counted",
-            name: "hook",
-            type: String,
-        },
-        {
-            description: "Always exit 0; warnings still print to stderr",
-            name: "no-fail",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: checkOptionDefinitions,
+});
 
 export default check;
 

--- a/packages/tooling/vis/src/commands/release/ci/check/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/check/index.ts
@@ -1,6 +1,22 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciCheck: Command = {
+const ciCheckOptionDefinitions = {
+    "no-fail": {
+        description: "Always exit 0 (warnings still print)",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    strict: {
+        description: "Require every changed package to be covered by a change file",
+        type: Boolean,
+    },
+} as const;
+
+const ciCheck = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: post or update a sticky PR comment with the pending release plan",
     examples: [
@@ -10,24 +26,8 @@ const ciCheck: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "check",
-    options: [
-        {
-            description: "Require every changed package to be covered by a change file",
-            name: "strict",
-            type: Boolean,
-        },
-        {
-            description: "Always exit 0 (warnings still print)",
-            name: "no-fail",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: ciCheckOptionDefinitions,
+});
 
 export default ciCheck;
 

--- a/packages/tooling/vis/src/commands/release/ci/plan/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/plan/index.ts
@@ -1,20 +1,22 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciPlan: Command = {
+const ciPlanOptionDefinitions = {
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const ciPlan = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: emit JSON plan + write to $GITHUB_OUTPUT for workflow gating",
     examples: [["vis release ci plan", "Emit { mode, packages, json } and set $GITHUB_OUTPUT"]],
     group: "Release",
     loader: () => import("./handler"),
     name: "plan",
-    options: [
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: ciPlanOptionDefinitions,
+});
 
 export default ciPlan;
 

--- a/packages/tooling/vis/src/commands/release/ci/rebase-pr/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/rebase-pr/index.ts
@@ -1,6 +1,18 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciRebasePr: Command = {
+const ciRebasePrOptionDefinitions = {
+    base: {
+        description: "Override the base branch (default: release.baseBranch)",
+        type: String,
+    },
+    branch: {
+        description: "Override the version-PR branch (default: vis-release/version-packages)",
+        type: String,
+    },
+} as const;
+
+const ciRebasePr = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: rebase the open version-PR onto the base branch and force-push",
     examples: [
@@ -10,19 +22,8 @@ const ciRebasePr: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "rebase-pr",
-    options: [
-        {
-            description: "Override the version-PR branch (default: vis-release/version-packages)",
-            name: "branch",
-            type: String,
-        },
-        {
-            description: "Override the base branch (default: release.baseBranch)",
-            name: "base",
-            type: String,
-        },
-    ],
-};
+    options: ciRebasePrOptionDefinitions,
+});
 
 export default ciRebasePr;
 

--- a/packages/tooling/vis/src/commands/release/ci/release/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/release/index.ts
@@ -1,6 +1,31 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciRelease: Command = {
+const ciReleaseOptionDefinitions = {
+    "auto-publish": {
+        description: "Skip version-PR; version + publish inline",
+        type: Boolean,
+    },
+    branch: {
+        description: "Override version-PR branch (default: vis-release/version-packages)",
+        type: String,
+    },
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    "first-release": {
+        description:
+                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const ciRelease = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: maintain a rolling version-PR (default) or version+publish inline (--auto-publish)",
     examples: [
@@ -10,35 +35,8 @@ const ciRelease: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "release",
-    options: [
-        {
-            description: "Skip version-PR; version + publish inline",
-            name: "auto-publish",
-            type: Boolean,
-        },
-        {
-            description: "Override version-PR branch (default: vis-release/version-packages)",
-            name: "branch",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-        {
-            description:
-                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
-            name: "first-release",
-            type: Boolean,
-        },
-    ],
-};
+    options: ciReleaseOptionDefinitions,
+});
 
 export default ciRelease;
 

--- a/packages/tooling/vis/src/commands/release/ci/setup/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/setup/index.ts
@@ -1,14 +1,19 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciSetup: Command = {
+const ciSetupOptionDefinitions = {
+
+} as const;
+
+const ciSetup = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: print setup checklist for tokens (VIS_GH_TOKEN, NPM_TOKEN, OIDC) and workflow permissions",
     examples: [["vis release ci setup", "Walk through the recommended secrets + workflow setup"]],
     group: "Release",
     loader: () => import("./handler"),
     name: "setup",
-    options: [],
-};
+    options: ciSetupOptionDefinitions,
+});
 
 export default ciSetup;
 

--- a/packages/tooling/vis/src/commands/release/ci/snapshot/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/snapshot/index.ts
@@ -1,31 +1,31 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const ciSnapshot: Command = {
+const ciSnapshotOptionDefinitions = {
+    "on-close": {
+        description:
+                "PR-close cleanup mode — enumerate the closed PR's commit SHAs and remove their snapshot tags from the registry (when supported by the backend)",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    tag: {
+        description: "Override dist-tag (default: pr-<PR_NUMBER>)",
+        type: String,
+    },
+} as const;
+
+const ciSnapshot = defineCommand({
     commandPath: ["release", "ci"],
     description: "CI: publish snapshot of affected packages + post sticky PR comment with install instructions",
     examples: [["vis release ci snapshot --tag pr-1234", "Publish PR snapshot + post install snippet"]],
     group: "Release",
     loader: () => import("./handler"),
     name: "snapshot",
-    options: [
-        {
-            description: "Override dist-tag (default: pr-<PR_NUMBER>)",
-            name: "tag",
-            type: String,
-        },
-        {
-            description:
-                "PR-close cleanup mode — enumerate the closed PR's commit SHAs and remove their snapshot tags from the registry (when supported by the backend)",
-            name: "on-close",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: ciSnapshotOptionDefinitions,
+});
 
 export default ciSnapshot;
 

--- a/packages/tooling/vis/src/commands/release/doctor/index.ts
+++ b/packages/tooling/vis/src/commands/release/doctor/index.ts
@@ -1,6 +1,23 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const doctor: Command = {
+const doctorOptionDefinitions = {
+    "first-release": {
+        description:
+                "Bootstrap mode for greenfield monorepos: doctor asserts the workspace has no release tags and no package has been published yet. Pair with `vis release version --first-release`.",
+        type: Boolean,
+    },
+    json: {
+        description: "Emit machine-readable JSON instead of a table",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const doctor = defineCommand({
     commandPath: ["release"],
     description: "Preflight diagnostics for the release subsystem (workspace, PM, OIDC, NAPI, guards)",
     examples: [
@@ -10,25 +27,8 @@ const doctor: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "doctor",
-    options: [
-        {
-            description: "Emit machine-readable JSON instead of a table",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-        {
-            description:
-                "Bootstrap mode for greenfield monorepos: doctor asserts the workspace has no release tags and no package has been published yet. Pair with `vis release version --first-release`.",
-            name: "first-release",
-            type: Boolean,
-        },
-    ],
-};
+    options: doctorOptionDefinitions,
+});
 
 export default doctor;
 

--- a/packages/tooling/vis/src/commands/release/generate/index.ts
+++ b/packages/tooling/vis/src/commands/release/generate/index.ts
@@ -1,6 +1,26 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const generate: Command = {
+const generateOptionDefinitions = {
+    "dry-run": {
+        description: "Print would-be content without writing",
+        type: Boolean,
+    },
+    from: {
+        description: "Git ref to compare against (default: merge-base with baseBranch)",
+        type: String,
+    },
+    name: {
+        description: "Slug for the generated filename (default: random animal name)",
+        type: String,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const generate = defineCommand({
     commandPath: ["release"],
     description: "Auto-derive a change file from branch commits (conventional-commits + path heuristics)",
     examples: [
@@ -11,29 +31,8 @@ const generate: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "generate",
-    options: [
-        {
-            description: "Git ref to compare against (default: merge-base with baseBranch)",
-            name: "from",
-            type: String,
-        },
-        {
-            description: "Slug for the generated filename (default: random animal name)",
-            name: "name",
-            type: String,
-        },
-        {
-            description: "Print would-be content without writing",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: generateOptionDefinitions,
+});
 
 export default generate;
 

--- a/packages/tooling/vis/src/commands/release/index.ts
+++ b/packages/tooling/vis/src/commands/release/index.ts
@@ -11,7 +11,7 @@
  * `vis run`/`vis ci`/`vis audit` cold-start cost is unaffected.
  */
 
-import type { Command } from "@visulima/cerebro";
+import type { AnyCommandInput } from "@visulima/cerebro";
 
 import addCommand from "./add";
 import changelogCommand from "./changelog";
@@ -36,7 +36,7 @@ import stageCommand from "./stage";
 import statusCommand from "./status";
 import versionCommand from "./version";
 
-const releaseCommands: Command[] = [
+const releaseCommands: AnyCommandInput[] = [
     // Read-only / authoring
     addCommand,
     generateCommand,

--- a/packages/tooling/vis/src/commands/release/init/index.ts
+++ b/packages/tooling/vis/src/commands/release/init/index.ts
@@ -1,6 +1,51 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const init: Command = {
+const initOptionDefinitions = {
+    agent: {
+        description: "Append a 'Releasing with vis' section to AGENTS.md so AI agents know how to drive the release flow",
+        type: Boolean,
+    },
+    apply: {
+        description: "Actually perform the migration writes (not dry-run)",
+        type: Boolean,
+    },
+    "dry-run": {
+        description: "Print what would happen without writing files",
+        type: Boolean,
+    },
+    fresh: {
+        description: "Skip migration; start clean",
+        type: Boolean,
+    },
+    "from-bumpy": {
+        description: "Force migration from bumpy",
+        type: Boolean,
+    },
+    "from-changesets": {
+        description: "Force migration from changesets",
+        type: Boolean,
+    },
+    "from-semantic-release": {
+        description: "Force migration from semantic-release / multi-semantic-release",
+        type: Boolean,
+    },
+    "package-manager": {
+        description: "Override package manager when generating workflows (npm | pnpm | yarn | bun). Default: auto-detect",
+        type: String,
+    },
+    workflows: {
+        description: "Generate CI workflow files. GitHub → `.github/workflows/vis-release{,-check,-snapshot}.yml`. GitLab → `.gitlab-ci.yml`.",
+        type: Boolean,
+    },
+    yes: {
+        alias: "y",
+        description: "Auto-confirm prompts (CI-safe)",
+        type: Boolean,
+    },
+} as const;
+
+const init = defineCommand({
     commandPath: ["release"],
     description: "Scaffold .vis/release; migrate from changesets / bumpy / semantic-release",
     examples: [
@@ -14,60 +59,8 @@ const init: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "init",
-    options: [
-        {
-            description: "Force migration from semantic-release / multi-semantic-release",
-            name: "from-semantic-release",
-            type: Boolean,
-        },
-        {
-            description: "Force migration from changesets",
-            name: "from-changesets",
-            type: Boolean,
-        },
-        {
-            description: "Force migration from bumpy",
-            name: "from-bumpy",
-            type: Boolean,
-        },
-        {
-            description: "Skip migration; start clean",
-            name: "fresh",
-            type: Boolean,
-        },
-        {
-            description: "Print what would happen without writing files",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            alias: "y",
-            description: "Auto-confirm prompts (CI-safe)",
-            name: "yes",
-            type: Boolean,
-        },
-        {
-            description: "Generate CI workflow files. GitHub → `.github/workflows/vis-release{,-check,-snapshot}.yml`. GitLab → `.gitlab-ci.yml`.",
-            name: "workflows",
-            type: Boolean,
-        },
-        {
-            description: "Override package manager when generating workflows (npm | pnpm | yarn | bun). Default: auto-detect",
-            name: "package-manager",
-            type: String,
-        },
-        {
-            description: "Actually perform the migration writes (not dry-run)",
-            name: "apply",
-            type: Boolean,
-        },
-        {
-            description: "Append a 'Releasing with vis' section to AGENTS.md so AI agents know how to drive the release flow",
-            name: "agent",
-            type: Boolean,
-        },
-    ],
-};
+    options: initOptionDefinitions,
+});
 
 export default init;
 

--- a/packages/tooling/vis/src/commands/release/next-version/index.ts
+++ b/packages/tooling/vis/src/commands/release/next-version/index.ts
@@ -1,6 +1,31 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const nextVersion: Command = {
+const nextVersionOptionDefinitions = {
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    "first-release": {
+        description:
+                "Bootstrap mode for greenfield monorepos: preview the plan without registry / tag lookups (matches `vis release version --first-release`).",
+        type: Boolean,
+    },
+    json: {
+        description: "Emit a JSON `{ name: { from, to } }` map instead of pretty lines",
+        type: Boolean,
+    },
+    package: {
+        description: "Limit output to a single package",
+        type: String,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const nextVersion = defineCommand({
     commandPath: ["release"],
     description: "Print the next computed version for each package in the release plan. Read-only; no mutations.",
     examples: [
@@ -11,35 +36,8 @@ const nextVersion: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "next-version",
-    options: [
-        {
-            description: "Limit output to a single package",
-            name: "package",
-            type: String,
-        },
-        {
-            description: "Emit a JSON `{ name: { from, to } }` map instead of pretty lines",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description:
-                "Bootstrap mode for greenfield monorepos: preview the plan without registry / tag lookups (matches `vis release version --first-release`).",
-            name: "first-release",
-            type: Boolean,
-        },
-    ],
-};
+    options: nextVersionOptionDefinitions,
+});
 
 export default nextVersion;
 

--- a/packages/tooling/vis/src/commands/release/notifications/index.ts
+++ b/packages/tooling/vis/src/commands/release/notifications/index.ts
@@ -15,9 +15,31 @@
  *      succeeded.
  */
 
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const notifications: Command = {
+const notificationsOptionDefinitions = {
+    action: {
+        defaultOption: true,
+        defaultValue: "test",
+        description: "Subcommand: test",
+        type: String,
+    },
+    channel: {
+        description: "Restrict dispatch to a single channel kind (`slack`, `discord`, `webhook`) or an id'd channel (`slack:eng`)",
+        type: String,
+    },
+    "custom-context": {
+        description: "Path to a JSON file containing a NotificationContext to use instead of the synthetic default",
+        type: String,
+    },
+    json: {
+        description: "Emit machine-readable JSON instead of a per-channel report",
+        type: Boolean,
+    },
+} as const;
+
+const notifications = defineCommand({
     commandPath: ["release"],
     description: "Dry-run the configured notification channels (slack / discord / webhook / plugins) with a synthetic release",
     examples: [
@@ -30,31 +52,8 @@ const notifications: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "notifications",
-    options: [
-        {
-            defaultOption: true,
-            defaultValue: "test",
-            description: "Subcommand: test",
-            name: "action",
-            type: String,
-        },
-        {
-            description: "Restrict dispatch to a single channel kind (`slack`, `discord`, `webhook`) or an id'd channel (`slack:eng`)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Path to a JSON file containing a NotificationContext to use instead of the synthetic default",
-            name: "custom-context",
-            type: String,
-        },
-        {
-            description: "Emit machine-readable JSON instead of a per-channel report",
-            name: "json",
-            type: Boolean,
-        },
-    ],
-};
+    options: notificationsOptionDefinitions,
+});
 
 export default notifications;
 

--- a/packages/tooling/vis/src/commands/release/plan/index.ts
+++ b/packages/tooling/vis/src/commands/release/plan/index.ts
@@ -1,6 +1,31 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const plan: Command = {
+const planOptionDefinitions = {
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    filter: {
+        description: "Filter packages by name glob",
+        type: String,
+    },
+    interactive: {
+        alias: "i",
+        description: "Walk through pending releases interactively and accept / override each bump level",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    write: {
+        description: "When used with --interactive, write the chosen overrides to a new change file (.vis/release/<id>.md)",
+        type: Boolean,
+    },
+} as const;
+
+const plan = defineCommand({
     commandPath: ["release"],
     description: "Inspect the release plan; with --interactive, walk through and override bump levels",
     examples: [
@@ -11,35 +36,8 @@ const plan: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "plan",
-    options: [
-        {
-            description: "Filter packages by name glob",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            alias: "i",
-            description: "Walk through pending releases interactively and accept / override each bump level",
-            name: "interactive",
-            type: Boolean,
-        },
-        {
-            description: "When used with --interactive, write the chosen overrides to a new change file (.vis/release/<id>.md)",
-            name: "write",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: planOptionDefinitions,
+});
 
 export default plan;
 

--- a/packages/tooling/vis/src/commands/release/pre/index.ts
+++ b/packages/tooling/vis/src/commands/release/pre/index.ts
@@ -1,6 +1,31 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const pre: Command = {
+const preOptionDefinitions = {
+    action: {
+        defaultOption: true,
+        defaultValue: "status",
+        description: "Subcommand: enter | exit | status",
+        type: String,
+    },
+    commit: {
+        defaultValue: true,
+        description: "Commit pre.json after writing. Default: commit",
+        type: Boolean,
+    },
+    push: {
+        defaultValue: true,
+        description: "Push the commit. Default: push",
+        type: Boolean,
+    },
+    tag: {
+        description: "Prerelease tag (e.g. alpha, beta, rc). Required for `enter`",
+        multiple: true,
+        type: String,
+    },
+} as const;
+
+const pre = defineCommand({
     commandPath: ["release"],
     description: "Enter / exit pre-release mode (changesets-compatible — every `version` produces a prerelease until exit)",
     examples: [
@@ -12,34 +37,8 @@ const pre: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "pre",
-    options: [
-        {
-            defaultOption: true,
-            defaultValue: "status",
-            description: "Subcommand: enter | exit | status",
-            name: "action",
-            type: String,
-        },
-        {
-            description: "Prerelease tag (e.g. alpha, beta, rc). Required for `enter`",
-            multiple: true,
-            name: "tag",
-            type: String,
-        },
-        {
-            defaultValue: true,
-            description: "Commit pre.json after writing. Default: commit",
-            name: "commit",
-            type: Boolean,
-        },
-        {
-            defaultValue: true,
-            description: "Push the commit. Default: push",
-            name: "push",
-            type: Boolean,
-        },
-    ],
-};
+    options: preOptionDefinitions,
+});
 
 export default pre;
 

--- a/packages/tooling/vis/src/commands/release/pretrust/index.ts
+++ b/packages/tooling/vis/src/commands/release/pretrust/index.ts
@@ -1,6 +1,66 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const pretrust: Command = {
+const pretrustOptionDefinitions = {
+    access: {
+        description: "Publish access: public | restricted (default: public)",
+        type: String,
+    },
+    "allow-stage-publish": {
+        description: "Trust claim: also grant the staged-publish permission (--allow-stage-publish)",
+        type: Boolean,
+    },
+    "dry-run": {
+        description: "Print what would publish without uploading",
+        type: Boolean,
+    },
+    env: {
+        description: "Trust claim: restrict to a deployment environment (npm trust --env)",
+        type: String,
+    },
+    filter: {
+        description: "Glob filter (CSV) — limit to specific packages",
+        type: String,
+    },
+    force: {
+        description: "Publish a placeholder even if the package already exists on the registry",
+        type: Boolean,
+    },
+    "no-trust": {
+        description: "Skip the `npm trust` step (only publish placeholders)",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit",
+        type: String,
+    },
+    provider: {
+        description: "Trust claim: forge provider (github | gitlab). Default: auto-detect from the git remote",
+        type: String,
+    },
+    registry: {
+        description: "Override registry URL",
+        type: String,
+    },
+    repo: {
+        description: "Trust claim: owner/repo (github) or group/project (gitlab). Default: detect from git remote",
+        type: String,
+    },
+    tag: {
+        description: "dist-tag for the placeholder (default: placeholder — keeps `latest` unset)",
+        type: String,
+    },
+    version: {
+        description: "Placeholder version (default: 0.0.0)",
+        type: String,
+    },
+    workflow: {
+        description: "Trust claim: workflow/pipeline filename (npm trust --file). Default: auto-detect the release workflow",
+        type: String,
+    },
+} as const;
+
+const pretrust = defineCommand({
     commandPath: ["release"],
     description: "Publish non-functional placeholder packages so npm Trusted Publishing (OIDC) can be configured before the first release",
     examples: [
@@ -11,79 +71,8 @@ const pretrust: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "pretrust",
-    options: [
-        {
-            description: "Glob filter (CSV) — limit to specific packages",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "dist-tag for the placeholder (default: placeholder — keeps `latest` unset)",
-            name: "tag",
-            type: String,
-        },
-        {
-            description: "Placeholder version (default: 0.0.0)",
-            name: "version",
-            type: String,
-        },
-        {
-            description: "Publish access: public | restricted (default: public)",
-            name: "access",
-            type: String,
-        },
-        {
-            description: "Override registry URL",
-            name: "registry",
-            type: String,
-        },
-        {
-            description: "Publish a placeholder even if the package already exists on the registry",
-            name: "force",
-            type: Boolean,
-        },
-        {
-            description: "Skip the `npm trust` step (only publish placeholders)",
-            name: "no-trust",
-            type: Boolean,
-        },
-        {
-            description: "Trust claim: forge provider (github | gitlab). Default: auto-detect from the git remote",
-            name: "provider",
-            type: String,
-        },
-        {
-            description: "Trust claim: owner/repo (github) or group/project (gitlab). Default: detect from git remote",
-            name: "repo",
-            type: String,
-        },
-        {
-            description: "Trust claim: workflow/pipeline filename (npm trust --file). Default: auto-detect the release workflow",
-            name: "workflow",
-            type: String,
-        },
-        {
-            description: "Trust claim: restrict to a deployment environment (npm trust --env)",
-            name: "env",
-            type: String,
-        },
-        {
-            description: "Trust claim: also grant the staged-publish permission (--allow-stage-publish)",
-            name: "allow-stage-publish",
-            type: Boolean,
-        },
-        {
-            description: "Print what would publish without uploading",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: pretrustOptionDefinitions,
+});
 
 export default pretrust;
 

--- a/packages/tooling/vis/src/commands/release/publish/index.ts
+++ b/packages/tooling/vis/src/commands/release/publish/index.ts
@@ -1,6 +1,51 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const publish: Command = {
+const publishOptionDefinitions = {
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    "check-only": {
+        description: "Run preflight checks (config + workspace + plan + auth) and exit. No mutations.",
+        type: Boolean,
+    },
+    "dry-run": {
+        description: "Skip uploads — print what would happen",
+        type: Boolean,
+    },
+    filter: {
+        description: "Limit to packages matching this glob (CSV)",
+        type: String,
+    },
+    "first-release": {
+        description:
+                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
+        type: Boolean,
+    },
+    "no-push": {
+        description: "Skip `git push --tags` after publish (lands in M5)",
+        type: Boolean,
+    },
+    otp: {
+        description: "2FA OTP token",
+        type: String,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    resume: {
+        description: "Resume from a previous run's state file (skips already-published packages)",
+        type: Boolean,
+    },
+    tag: {
+        description: "Override npm dist-tag",
+        type: String,
+    },
+} as const;
+
+const publish = defineCommand({
     commandPath: ["release"],
     description: "Pack-then-publish unpublished packages, push tags, create GH releases",
     examples: [
@@ -12,60 +57,8 @@ const publish: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "publish",
-    options: [
-        {
-            description: "Skip uploads — print what would happen",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            description: "Override npm dist-tag",
-            name: "tag",
-            type: String,
-        },
-        {
-            description: "Limit to packages matching this glob (CSV)",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Skip `git push --tags` after publish (lands in M5)",
-            name: "no-push",
-            type: Boolean,
-        },
-        {
-            description: "2FA OTP token",
-            name: "otp",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Resume from a previous run's state file (skips already-published packages)",
-            name: "resume",
-            type: Boolean,
-        },
-        {
-            description: "Run preflight checks (config + workspace + plan + auth) and exit. No mutations.",
-            name: "check-only",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-        {
-            description:
-                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
-            name: "first-release",
-            type: Boolean,
-        },
-    ],
-};
+    options: publishOptionDefinitions,
+});
 
 export default publish;
 

--- a/packages/tooling/vis/src/commands/release/snapshot/index.ts
+++ b/packages/tooling/vis/src/commands/release/snapshot/index.ts
@@ -1,6 +1,30 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const snapshot: Command = {
+const snapshotOptionDefinitions = {
+    "dry-run": {
+        description: "Print what would publish without uploading",
+        type: Boolean,
+    },
+    filter: {
+        description: "Glob filter (CSV) — limit snapshots to specific packages",
+        type: String,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+    registry: {
+        description: "Override registry URL (defaults to pkg-pr-new backend or `release.snapshot.registry`)",
+        type: String,
+    },
+    tag: {
+        description: "Required: dist-tag for the snapshot release",
+        type: String,
+    },
+} as const;
+
+const snapshot = defineCommand({
     commandPath: ["release"],
     description: "Publish 0.0.0-<tag>-<sha> snapshot versions of affected packages",
     examples: [
@@ -11,34 +35,8 @@ const snapshot: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "snapshot",
-    options: [
-        {
-            description: "Required: dist-tag for the snapshot release",
-            name: "tag",
-            type: String,
-        },
-        {
-            description: "Override registry URL (defaults to pkg-pr-new backend or `release.snapshot.registry`)",
-            name: "registry",
-            type: String,
-        },
-        {
-            description: "Glob filter (CSV) — limit snapshots to specific packages",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Print what would publish without uploading",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: snapshotOptionDefinitions,
+});
 
 export default snapshot;
 

--- a/packages/tooling/vis/src/commands/release/stage/index.ts
+++ b/packages/tooling/vis/src/commands/release/stage/index.ts
@@ -1,6 +1,43 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const stage: Command = {
+const stageOptionDefinitions = {
+    action: {
+        defaultOption: true,
+        defaultValue: "list",
+        description: "Subcommand: list | approve | reject",
+        type: String,
+    },
+    all: {
+        description: "Approve every pending stage tracked in .vis/release/staged.json",
+        type: Boolean,
+    },
+    commit: {
+        defaultValue: true,
+        description: "Update .vis/release/staged.json but skip the auto-commit. Default: commit",
+        type: Boolean,
+    },
+    filter: {
+        description: "Package name filter for `list`",
+        type: String,
+    },
+    json: {
+        description: "Emit machine-readable JSON",
+        type: Boolean,
+    },
+    push: {
+        defaultValue: true,
+        description: "Skip pushing the registry commit to the remote. Default: push",
+        type: Boolean,
+    },
+    "stage-ids": {
+        description: "Stage IDs (positional args after the action)",
+        multiple: true,
+        type: String,
+    },
+} as const;
+
+const stage = defineCommand({
     commandPath: ["release"],
     description: "List, approve, or reject npm staged-publish records (RFC §13.6 — approve/reject need 2FA)",
     examples: [
@@ -16,49 +53,8 @@ const stage: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "stage",
-    options: [
-        {
-            defaultOption: true,
-            defaultValue: "list",
-            description: "Subcommand: list | approve | reject",
-            name: "action",
-            type: String,
-        },
-        {
-            description: "Stage IDs (positional args after the action)",
-            multiple: true,
-            name: "stage-ids",
-            type: String,
-        },
-        {
-            description: "Approve every pending stage tracked in .vis/release/staged.json",
-            name: "all",
-            type: Boolean,
-        },
-        {
-            description: "Package name filter for `list`",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Emit machine-readable JSON",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            defaultValue: true,
-            description: "Update .vis/release/staged.json but skip the auto-commit. Default: commit",
-            name: "commit",
-            type: Boolean,
-        },
-        {
-            defaultValue: true,
-            description: "Skip pushing the registry commit to the remote. Default: push",
-            name: "push",
-            type: Boolean,
-        },
-    ],
-};
+    options: stageOptionDefinitions,
+});
 
 export default stage;
 

--- a/packages/tooling/vis/src/commands/release/status/index.ts
+++ b/packages/tooling/vis/src/commands/release/status/index.ts
@@ -1,6 +1,30 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const status: Command = {
+const statusOptionDefinitions = {
+    bump: {
+        description: "Filter by bump level (CSV: major,minor,patch)",
+        type: String,
+    },
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    filter: {
+        description: "Filter packages by name glob",
+        type: String,
+    },
+    json: {
+        description: "Emit machine-readable JSON instead of a table",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const status = defineCommand({
     commandPath: ["release"],
     description: "Print pending release plan (which packages will bump and to what version)",
     examples: [
@@ -12,34 +36,8 @@ const status: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "status",
-    options: [
-        {
-            description: "Emit machine-readable JSON instead of a table",
-            name: "json",
-            type: Boolean,
-        },
-        {
-            description: "Filter packages by name glob",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Filter by bump level (CSV: major,minor,patch)",
-            name: "bump",
-            type: String,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-    ],
-};
+    options: statusOptionDefinitions,
+});
 
 export default status;
 

--- a/packages/tooling/vis/src/commands/release/version/index.ts
+++ b/packages/tooling/vis/src/commands/release/version/index.ts
@@ -1,6 +1,39 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { CreateOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const version: Command = {
+const versionOptionDefinitions = {
+    channel: {
+        description: "Override channel (defaults to current branch lookup)",
+        type: String,
+    },
+    "check-only": {
+        description: "Run preflight checks (config + workspace + plan) and exit. No mutations.",
+        type: Boolean,
+    },
+    commit: {
+        description: "Auto-commit after applying",
+        type: Boolean,
+    },
+    "dry-run": {
+        description: "Skip writes — print the diff and exit",
+        type: Boolean,
+    },
+    filter: {
+        description: "Limit to packages matching this glob (CSV)",
+        type: String,
+    },
+    "first-release": {
+        description:
+                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
+        type: Boolean,
+    },
+    "print-config": {
+        description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
+        type: String,
+    },
+} as const;
+
+const version = defineCommand({
     commandPath: ["release"],
     description: "Apply pending change files to disk: bump versions + write CHANGELOG entries",
     examples: [
@@ -11,45 +44,8 @@ const version: Command = {
     group: "Release",
     loader: () => import("./handler"),
     name: "version",
-    options: [
-        {
-            description: "Skip writes — print the diff and exit",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            description: "Override channel (defaults to current branch lookup)",
-            name: "channel",
-            type: String,
-        },
-        {
-            description: "Limit to packages matching this glob (CSV)",
-            name: "filter",
-            type: String,
-        },
-        {
-            description: "Auto-commit after applying",
-            name: "commit",
-            type: Boolean,
-        },
-        {
-            description: "Run preflight checks (config + workspace + plan) and exit. No mutations.",
-            name: "check-only",
-            type: Boolean,
-        },
-        {
-            description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
-            name: "print-config",
-            type: String,
-        },
-        {
-            description:
-                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
-            name: "first-release",
-            type: Boolean,
-        },
-    ],
-};
+    options: versionOptionDefinitions,
+});
 
 export default version;
 

--- a/packages/tooling/vis/src/commands/remove/index.ts
+++ b/packages/tooling/vis/src/commands/remove/index.ts
@@ -1,6 +1,40 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const remove: Command = {
+const removeOptionDefinitions = {
+    filter: {
+        alias: "F",
+        description: "Filter by workspace package name",
+        multiple: true,
+        type: String,
+    },
+    global: {
+        alias: "g",
+        defaultValue: false,
+        description: "Remove global package",
+        type: Boolean,
+    },
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Remove from all workspace packages",
+        type: Boolean,
+    },
+    "save-dev": {
+        alias: "D",
+        defaultValue: false,
+        description: "Remove from devDependencies",
+        type: Boolean,
+    },
+    "workspace-root": {
+        alias: "w",
+        defaultValue: false,
+        description: "Remove from workspace root",
+        type: Boolean,
+    },
+} as const;
+
+const remove = defineCommand({
     alias: ["rm", "un", "uninstall"],
     argument: {
         description: "Packages to remove",
@@ -17,21 +51,9 @@ const remove: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "remove",
-    options: [
-        { alias: "D", defaultValue: false, description: "Remove from devDependencies", name: "save-dev", type: Boolean },
-        { alias: "g", defaultValue: false, description: "Remove global package", name: "global", type: Boolean },
-        { alias: "r", defaultValue: false, description: "Remove from all workspace packages", name: "recursive", type: Boolean },
-        { alias: "w", defaultValue: false, description: "Remove from workspace root", name: "workspace-root", type: Boolean },
-        { alias: "F", description: "Filter by workspace package name", multiple: true, name: "filter", type: String },
-    ],
-};
+    options: removeOptionDefinitions,
+});
 
 export default remove;
 
-export type RemoveOptions = CreateOptions<{
-    filter: string[] | undefined;
-    global: boolean | undefined;
-    recursive: boolean | undefined;
-    "save-dev": boolean | undefined;
-    "workspace-root": boolean | undefined;
-}>;
+export type RemoveOptions = InferOptions<typeof removeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/replay/handler.ts
+++ b/packages/tooling/vis/src/commands/replay/handler.ts
@@ -273,7 +273,7 @@ const replayExecute = async ({ logger, options, process: proc, workspaceRoot: ws
         return;
     }
 
-    if (options.list === true) {
+    if (options.list) {
         const entries = await listRunSummaries(workspaceRoot);
 
         if (format === "json") {
@@ -289,7 +289,7 @@ const replayExecute = async ({ logger, options, process: proc, workspaceRoot: ws
 
     await runReplay(
         {
-            failed: options.failed === true,
+            failed: options.failed,
             format: format as "json" | "table",
             runId: options.run,
             task: options.task,

--- a/packages/tooling/vis/src/commands/replay/index.ts
+++ b/packages/tooling/vis/src/commands/replay/index.ts
@@ -1,15 +1,34 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
-export type ReplayOptions = CreateOptions<{
-    failed: boolean | undefined;
-    format: string | undefined;
-    list: boolean | undefined;
-    run: string | undefined;
-    task: string | undefined;
-}>;
+export type ReplayOptions = InferOptions<typeof replayOptionDefinitions>;
 
-const replay: Command = {
+const replayOptionDefinitions = {
+    failed: {
+        defaultValue: false,
+        description: "Filter the replay to failed tasks only",
+        type: Boolean,
+    },
+    format: {
+        description: "Output format: table or json (default: table)",
+        type: String,
+    },
+    list: {
+        defaultValue: false,
+        description: "List every available run instead of replaying one",
+        type: Boolean,
+    },
+    run: {
+        description: "Run id to replay (defaults to the most recent run)",
+        type: String,
+    },
+    task: {
+        description: "Filter the replay to a single task id (e.g. @my/app:build)",
+        type: String,
+    },
+} as const;
+
+const replay = defineCommand({
     description: "Replay a previous task run from .vis/runs/ — show task results without re-executing",
     examples: [
         ["vis replay", "Show the most recent run summary"],
@@ -22,35 +41,7 @@ const replay: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "replayExecute"),
     name: "replay",
-    options: [
-        {
-            description: "Run id to replay (defaults to the most recent run)",
-            name: "run",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "List every available run instead of replaying one",
-            name: "list",
-            type: Boolean,
-        },
-        {
-            description: "Filter the replay to a single task id (e.g. @my/app:build)",
-            name: "task",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Filter the replay to failed tasks only",
-            name: "failed",
-            type: Boolean,
-        },
-        {
-            description: "Output format: table or json (default: table)",
-            name: "format",
-            type: String,
-        },
-    ],
-};
+    options: replayOptionDefinitions,
+});
 
 export default replay;

--- a/packages/tooling/vis/src/commands/run/handler.ts
+++ b/packages/tooling/vis/src/commands/run/handler.ts
@@ -1264,7 +1264,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
     // "I ran tests 30s ago, show me what happened" case without
     // re-running and (more importantly) without needing the
     // workspace to be in a runnable state.
-    if (options.lastDetails === true) {
+    if (options.lastDetails) {
         await renderLastRunSummary(workspaceRoot, logger);
 
         return;
@@ -1329,7 +1329,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
     if (!options.affected) {
         // `--no-uncommitted` arrives here as `uncommitted: false`, so report
         // the flag the user actually typed rather than its positive twin.
-        const uncommittedFlag = options.uncommitted === false ? "--no-uncommitted" : "--uncommitted";
+        const uncommittedFlag = options.uncommitted ? "--uncommitted" : "--no-uncommitted";
         const affectedOnlyFlags = (
             [
                 ["--base", options.base],
@@ -1568,7 +1568,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
         return;
     }
 
-    const ptyFlag = options.pty === true;
+    const ptyFlag = options.pty;
 
     // First-class task arguments: validate the forwarded args against the
     // invoked target's declared schema, surface per-task `--help`, and expose
@@ -1862,7 +1862,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
     // config; both default to on. The helper logs the warn line itself
     // in TTY; in CI it stays silent and we throw with `formattedMessage`
     // so the user sees the detail exactly once.
-    const preflightEnabled = options.preflight !== false && config.preflight?.lockfile !== false;
+    const preflightEnabled = options.preflight && config.preflight?.lockfile !== false;
     const lockfilePreflight = runLockfilePreflight(
         workspaceRoot,
         isInCi,
@@ -2591,7 +2591,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
      * listener so children don't outlive the run when the dynamic TUI's
      * own `process.exit(1)` short-circuits the normal exit path.
      */
-    const stopServicesOnExit = options.stopServices === true;
+    const stopServicesOnExit = options.stopServices;
     let cleanupRan = false;
     const runCleanupOnce = (): void => {
         if (cleanupRan) {
@@ -3107,7 +3107,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
             // `--no-flaky`. Reuses the history already loaded for the
             // timing comparison above — the runs/ directory hasn't
             // changed since this turn of the loop started.
-            if (options.flaky !== false) {
+            if (options.flaky) {
                 const flakyStats = analyzeFlakiness(workspaceRoot, { minRuns: 2 }, firstRun.runHistory);
 
                 if (flakyStats.length > 0) {
@@ -3135,7 +3135,7 @@ const execute = async ({ argument, logger, options, visConfig, workspaceRoot: ws
                 }
             }
 
-            const failOnRetry = options.failOnRetry === true && retriedTaskIds.length > 0;
+            const failOnRetry = options.failOnRetry && retriedTaskIds.length > 0;
 
             if (failOnRetry) {
                 // Cap the rendered list so a wide flake (every task retried

--- a/packages/tooling/vis/src/commands/run/index.ts
+++ b/packages/tooling/vis/src/commands/run/index.ts
@@ -1,8 +1,212 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 import { negatable } from "../../util/negatable-option";
 
-const run: Command = {
+const runOptionDefinitions = {
+    filter: {
+        alias: "F",
+        description:
+                "pnpm-style package selector (repeatable). Supports name globs (@org/*), graph modifiers (...pkg dependents, pkg... dependencies, ...^pkg / pkg^... exclude self), changed-since ([main], ...[origin/main]), and path globs (./packages/*, {glob}).",
+        multiple: true,
+        type: String,
+    },
+    projects: {
+        alias: "p",
+        description: "Comma-separated list of projects to run",
+        type: String,
+    },
+    "skip-toolchain": {
+        defaultValue: false,
+        description:
+                "Skip the toolchain pre-flight (no auto-install for any pinned tool: node / pnpm / yarn / npm / bun / deno / go / python / ruby / rust)",
+        type: Boolean,
+    },
+    ...negatable({
+        // No `defaultValue` — handler treats `undefined` as "fall
+        // back to config (default: enabled)" so `vis.config.ts`
+        // `preflight.lockfile` can opt out workspace-wide and
+        // `--no-preflight` opts out per-run without conflicting layers.
+        description: "Detect lockfile/node_modules drift before running (warns in TTY, fails in CI). Use --no-preflight to disable.",
+        name: "preflight",
+        type: Boolean,
+    }),
+    parallel: {
+        defaultValue: 3,
+        description: "Maximum number of parallel tasks (falls back to VIS_RUN_CONCURRENCY_LIMIT env var, then 3)",
+        type: Number,
+    },
+    ...negatable({
+        defaultValue: true,
+        description: "Enable caching (use --no-cache to disable)",
+        name: "cache",
+        type: Boolean,
+    }),
+    affected: {
+        defaultValue: false,
+        description: "Only run on projects affected by git changes. Honors --base/--head/--downstream/--upstream, same as `vis affected`.",
+        type: Boolean,
+    },
+    base: {
+        description:
+                "Git base ref for --affected. When omitted, vis auto-resolves it from the active CI provider (GitHub/GitLab/Buildkite/CircleCI) or falls back to `git merge-base HEAD origin/<defaultBase>` locally. Default base branch comes from `vis.config.ts#defaultBase` (or `main`). Requires --affected.",
+        type: String,
+    },
+    "cache-backend": {
+        description: "Remote cache wire backend: http (Turborepo-compatible) or reapi (Bazel Remote Execution API gRPC)",
+        type: String,
+    },
+    "cache-dir": {
+        description: "Custom cache directory",
+        type: String,
+    },
+    "cache-mode": {
+        description: "Remote cache mode: read | write | readwrite (defaults to readwrite when remoteCache is configured)",
+        type: String,
+    },
+    downstream: {
+        description:
+                "Downstream scope for --affected: \"none\", \"direct\", or \"deep\" — controls how far to include dependents of changed projects (default \"deep\"). Requires --affected.",
+        type: String,
+    },
+    "dry-run": {
+        defaultValue: false,
+        description: "Show what would run without executing",
+        type: Boolean,
+    },
+    "hash-mode": {
+        description:
+                "Override how the requested target is hashed for this run: declared (hash listed inputs) or trace (hash the files the task actually reads). Overrides per-target hashMode config for the directly-run target.",
+        type: String,
+    },
+    head: {
+        description:
+                "Git head ref for --affected. When omitted, auto-resolves from CI env (e.g. `$GITHUB_SHA`) or defaults to `HEAD`. Requires --affected.",
+        type: String,
+    },
+    partition: {
+        description: "Partition tasks for distributed CI (e.g., \"1/4\" for first of four runners). Falls back to VIS_PARTITION env var.",
+        type: String,
+    },
+    query: {
+        description: "Filter matched projects by a query (e.g. 'language=typescript && tag=lib')",
+        type: String,
+    },
+    "skip-cache": {
+        description:
+                "Comma-separated selectors of tasks to bypass cache for (e.g. 'app:test', ':e2e', '#flaky:lint'). Other tasks in the run still cache normally. --no-cache wins when both are set.",
+        type: String,
+    },
+    "skip-constraints": {
+        defaultValue: false,
+        description: "Skip project constraint validation",
+        type: Boolean,
+    },
+    summarize: {
+        defaultValue: false,
+        description: "Generate a run summary after execution",
+        type: Boolean,
+    },
+    tag: {
+        description:
+                "Only run projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\"; combines with --query as AND.",
+        multiple: true,
+        type: String,
+    },
+    upstream: {
+        description:
+                "Upstream scope for --affected: \"none\", \"direct\", or \"deep\" — controls how far to include dependencies of changed projects (default \"none\"). Requires --affected.",
+        type: String,
+    },
+    ...negatable({
+        // Mirrors `vis affected --uncommitted`. `undefined` means
+        // "auto": include working-tree changes for local interactive
+        // runs, ignore them in CI where the checkout is the truth.
+        description:
+                "Include uncommitted working-tree changes when computing --affected. Defaults to on for local runs and off in CI; use --no-uncommitted to force off.",
+        name: "uncommitted",
+        type: Boolean,
+    }),
+    "fail-fast": {
+        defaultValue: false,
+        description: "Stop all tasks on first failure",
+        type: Boolean,
+    },
+    "last-details": {
+        defaultValue: false,
+        description: "Render the most-recent run's saved summary (from .vis/last-summary.json) and exit without executing any tasks",
+        type: Boolean,
+    },
+    log: {
+        description: "Output mode: interleaved (pass-through), labeled (prefix each line with [pkg#task]), or grouped (vite-task-style block)",
+        type: String,
+    },
+    "output-style": {
+        description:
+                "Output style: normal (print every task) or quiet (skip output for successful/cached tasks; failed tasks still print in CI mode, and remain in TUI scrollback in interactive mode). Defaults to normal; set run.quietOnSuccess in config to make quiet the default. Per-target options.outputStyle overrides this.",
+        type: String,
+    },
+    profile: {
+        description: "Write a Chrome Tracing JSON profile of the run to this path (open in chrome://tracing or Perfetto)",
+        type: String,
+    },
+    pty: {
+        defaultValue: false,
+        description: "Run every task through a pseudo-terminal so color-aware tools render as if attached to a TTY (disables caching)",
+        type: Boolean,
+    },
+    "retry-budget": {
+        description: "Global retry budget: cap on total task retries across the run (per-target retryCount is still honored up to the budget)",
+        type: Number,
+    },
+    reverse: {
+        defaultValue: false,
+        description:
+                "Run the dependency graph in reverse (leaves first, then their dependents). Useful for teardown targets like `destroy`/`undeploy` where dependents must run before the things they depend on.",
+        type: Boolean,
+    },
+    watch: {
+        defaultValue: false,
+        description: "Rerun affected tasks on file change. Ctrl+C to exit.",
+        type: Boolean,
+    },
+    ...negatable({
+        defaultValue: true,
+        description: "Show flaky task report on failure (use --no-flaky to suppress)",
+        name: "flaky",
+        type: Boolean,
+    }),
+    "fail-on-retry": {
+        defaultValue: false,
+        description:
+                "Treat any task that needed at least one retry as a run failure (exit non-zero), even when retries eventually succeeded. Use in CI to surface flakes that retries would otherwise mask.",
+        type: Boolean,
+    },
+    ...negatable({
+        // No `defaultValue` — `undefined` means "fall back to vis.config.ts strictEnv (default off)".
+        description:
+                "Fail a task if its command references an env var that is unset (no silent empty-string substitution). Use --no-strict-env to disable when set in config.",
+        name: "strict-env",
+        type: Boolean,
+    }),
+    "runner-tags": {
+        description:
+                "Comma-separated tags this runner advertises (e.g. 'gpu,slow'). Tasks declaring `options.runnerTags` only run when at least one tag overlaps. Untagged tasks always run. Falls back to VIS_RUNNER_TAGS env var.",
+        type: String,
+    },
+    services: {
+        description: "Auto-start service deps. One of: auto | ephemeral | persistent | off. Defaults to `auto` in TTY, `off` in CI.",
+        type: String,
+    },
+    "stop-services": {
+        defaultValue: false,
+        description:
+                "Stop services this run auto-started in registry mode when the run exits (clean, q, or Ctrl+C). Ephemeral services already die with the run.",
+        type: Boolean,
+    },
+} as const;
+
+const run = defineCommand({
     argument: {
         description: "The target to run (e.g., build, test, lint)",
         name: "target",
@@ -29,295 +233,9 @@ const run: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "run",
-    options: [
-        {
-            alias: "p",
-            description: "Comma-separated list of projects to run",
-            name: "projects",
-            type: String,
-        },
-        {
-            alias: "F",
-            description:
-                "pnpm-style package selector (repeatable). Supports name globs (@org/*), graph modifiers (...pkg dependents, pkg... dependencies, ...^pkg / pkg^... exclude self), changed-since ([main], ...[origin/main]), and path globs (./packages/*, {glob}).",
-            multiple: true,
-            name: "filter",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Skip the toolchain pre-flight (no auto-install for any pinned tool: node / pnpm / yarn / npm / bun / deno / go / python / ruby / rust)",
-            name: "skip-toolchain",
-            type: Boolean,
-        },
-        ...negatable({
-            // No `defaultValue` — handler treats `undefined` as "fall
-            // back to config (default: enabled)" so `vis.config.ts`
-            // `preflight.lockfile` can opt out workspace-wide and
-            // `--no-preflight` opts out per-run without conflicting layers.
-            description: "Detect lockfile/node_modules drift before running (warns in TTY, fails in CI). Use --no-preflight to disable.",
-            name: "preflight",
-            type: Boolean,
-        }),
-        {
-            defaultValue: 3,
-            description: "Maximum number of parallel tasks (falls back to VIS_RUN_CONCURRENCY_LIMIT env var, then 3)",
-            name: "parallel",
-            type: Number,
-        },
-        ...negatable({
-            defaultValue: true,
-            description: "Enable caching (use --no-cache to disable)",
-            name: "cache",
-            type: Boolean,
-        }),
-        {
-            description:
-                "Comma-separated selectors of tasks to bypass cache for (e.g. 'app:test', ':e2e', '#flaky:lint'). Other tasks in the run still cache normally. --no-cache wins when both are set.",
-            name: "skip-cache",
-            type: String,
-        },
-        {
-            description: "Custom cache directory",
-            name: "cache-dir",
-            type: String,
-        },
-        {
-            description: "Remote cache mode: read | write | readwrite (defaults to readwrite when remoteCache is configured)",
-            name: "cache-mode",
-            type: String,
-        },
-        {
-            description: "Remote cache wire backend: http (Turborepo-compatible) or reapi (Bazel Remote Execution API gRPC)",
-            name: "cache-backend",
-            type: String,
-        },
-        {
-            description:
-                "Override how the requested target is hashed for this run: declared (hash listed inputs) or trace (hash the files the task actually reads). Overrides per-target hashMode config for the directly-run target.",
-            name: "hash-mode",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Show what would run without executing",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Generate a run summary after execution",
-            name: "summarize",
-            type: Boolean,
-        },
-        {
-            description: "Partition tasks for distributed CI (e.g., \"1/4\" for first of four runners). Falls back to VIS_PARTITION env var.",
-            name: "partition",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Skip project constraint validation",
-            name: "skip-constraints",
-            type: Boolean,
-        },
-        {
-            description: "Filter matched projects by a query (e.g. 'language=typescript && tag=lib')",
-            name: "query",
-            type: String,
-        },
-        {
-            description:
-                "Only run projects carrying one of these tags (repeatable, or comma-separated). Shorthand for --query=\"tag=…\"; combines with --query as AND.",
-            multiple: true,
-            name: "tag",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Only run on projects affected by git changes. Honors --base/--head/--downstream/--upstream, same as `vis affected`.",
-            name: "affected",
-            type: Boolean,
-        },
-        {
-            description:
-                "Git base ref for --affected. When omitted, vis auto-resolves it from the active CI provider (GitHub/GitLab/Buildkite/CircleCI) or falls back to `git merge-base HEAD origin/<defaultBase>` locally. Default base branch comes from `vis.config.ts#defaultBase` (or `main`). Requires --affected.",
-            name: "base",
-            type: String,
-        },
-        {
-            description:
-                "Git head ref for --affected. When omitted, auto-resolves from CI env (e.g. `$GITHUB_SHA`) or defaults to `HEAD`. Requires --affected.",
-            name: "head",
-            type: String,
-        },
-        {
-            description:
-                "Downstream scope for --affected: \"none\", \"direct\", or \"deep\" — controls how far to include dependents of changed projects (default \"deep\"). Requires --affected.",
-            name: "downstream",
-            type: String,
-        },
-        {
-            description:
-                "Upstream scope for --affected: \"none\", \"direct\", or \"deep\" — controls how far to include dependencies of changed projects (default \"none\"). Requires --affected.",
-            name: "upstream",
-            type: String,
-        },
-        ...negatable({
-            // Mirrors `vis affected --uncommitted`. `undefined` means
-            // "auto": include working-tree changes for local interactive
-            // runs, ignore them in CI where the checkout is the truth.
-            description:
-                "Include uncommitted working-tree changes when computing --affected. Defaults to on for local runs and off in CI; use --no-uncommitted to force off.",
-            name: "uncommitted",
-            type: Boolean,
-        }),
-        {
-            defaultValue: false,
-            description: "Rerun affected tasks on file change. Ctrl+C to exit.",
-            name: "watch",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Stop all tasks on first failure",
-            name: "fail-fast",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Run the dependency graph in reverse (leaves first, then their dependents). Useful for teardown targets like `destroy`/`undeploy` where dependents must run before the things they depend on.",
-            name: "reverse",
-            type: Boolean,
-        },
-        {
-            description: "Output mode: interleaved (pass-through), labeled (prefix each line with [pkg#task]), or grouped (vite-task-style block)",
-            name: "log",
-            type: String,
-        },
-        {
-            description:
-                "Output style: normal (print every task) or quiet (skip output for successful/cached tasks; failed tasks still print in CI mode, and remain in TUI scrollback in interactive mode). Defaults to normal; set run.quietOnSuccess in config to make quiet the default. Per-target options.outputStyle overrides this.",
-            name: "output-style",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Run every task through a pseudo-terminal so color-aware tools render as if attached to a TTY (disables caching)",
-            name: "pty",
-            type: Boolean,
-        },
-        {
-            description: "Global retry budget: cap on total task retries across the run (per-target retryCount is still honored up to the budget)",
-            name: "retry-budget",
-            type: Number,
-        },
-        {
-            description: "Write a Chrome Tracing JSON profile of the run to this path (open in chrome://tracing or Perfetto)",
-            name: "profile",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Render the most-recent run's saved summary (from .vis/last-summary.json) and exit without executing any tasks",
-            name: "last-details",
-            type: Boolean,
-        },
-        ...negatable({
-            defaultValue: true,
-            description: "Show flaky task report on failure (use --no-flaky to suppress)",
-            name: "flaky",
-            type: Boolean,
-        }),
-        {
-            defaultValue: false,
-            description:
-                "Treat any task that needed at least one retry as a run failure (exit non-zero), even when retries eventually succeeded. Use in CI to surface flakes that retries would otherwise mask.",
-            name: "fail-on-retry",
-            type: Boolean,
-        },
-        ...negatable({
-            // No `defaultValue` — `undefined` means "fall back to vis.config.ts strictEnv (default off)".
-            description:
-                "Fail a task if its command references an env var that is unset (no silent empty-string substitution). Use --no-strict-env to disable when set in config.",
-            name: "strict-env",
-            type: Boolean,
-        }),
-        {
-            description:
-                "Comma-separated tags this runner advertises (e.g. 'gpu,slow'). Tasks declaring `options.runnerTags` only run when at least one tag overlaps. Untagged tasks always run. Falls back to VIS_RUNNER_TAGS env var.",
-            name: "runner-tags",
-            type: String,
-        },
-        {
-            // One knob for the service-preflight feature. Falls back to
-            // `vis.config.ts → run.services` and finally to a TTY-aware
-            // default (auto-pick mode in a terminal, off in CI / pipes).
-            // Values:
-            //   auto       — pick by task: `dev` → ephemeral, others → persistent
-            //   ephemeral  — services die with the run (no registry entry)
-            //   persistent — services persist in the registry across runs
-            //   off        — skip auto-start; print today's diagnostic and abort
-            description: "Auto-start service deps. One of: auto | ephemeral | persistent | off. Defaults to `auto` in TTY, `off` in CI.",
-            name: "services",
-            type: String,
-        },
-        {
-            // Opt-in cleanup for registry-mode services this run started.
-            // Ephemeral services already die with the run; this only
-            // affects services that would otherwise persist (the ones
-            // surfaced by today's "N service(s) started in the background"
-            // hint). Applies on every exit path: clean finish, `q`, Ctrl+C.
-            defaultValue: false,
-            description:
-                "Stop services this run auto-started in registry mode when the run exits (clean, q, or Ctrl+C). Ephemeral services already die with the run.",
-            name: "stop-services",
-            type: Boolean,
-        },
-    ],
-};
+    options: runOptionDefinitions,
+});
 
 export default run;
 
-export type RunOptions = CreateOptions<{
-    affected: boolean | undefined;
-    base: string | undefined;
-    cache: boolean | undefined;
-    "cache-backend": string | undefined;
-    "cache-dir": string | undefined;
-    "cache-mode": string | undefined;
-    downstream: string | undefined;
-    "dry-run": boolean | undefined;
-    "fail-fast": boolean | undefined;
-    "fail-on-retry": boolean | undefined;
-    filter: string[] | undefined;
-    flaky: boolean | undefined;
-    "hash-mode": string | undefined;
-    head: string | undefined;
-    "last-details": boolean | undefined;
-    log: string | undefined;
-    "output-style": string | undefined;
-    parallel: number | undefined;
-    partition: string | undefined;
-    preflight: boolean | undefined;
-    profile: string | undefined;
-    projects: string | undefined;
-    pty: boolean | undefined;
-    query: string | undefined;
-    "retry-budget": number | undefined;
-    reverse: boolean | undefined;
-    "runner-tags": string | undefined;
-    services: string | undefined;
-    "skip-cache": string | undefined;
-    "skip-constraints": boolean | undefined;
-    "skip-toolchain": boolean | undefined;
-    "stop-services": boolean | undefined;
-    "strict-env": boolean | undefined;
-    summarize: boolean | undefined;
-    tag: string[] | undefined;
-    uncommitted: boolean | undefined;
-    upstream: string | undefined;
-    watch: boolean | undefined;
-}>;
+export type RunOptions = InferOptions<typeof runOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/sbom/index.ts
+++ b/packages/tooling/vis/src/commands/sbom/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis sbom` — CycloneDX 1.7 Software Bill of Materials generator.
@@ -7,7 +8,28 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * list, walks the workspace graph, and writes the result to disk
  * (or stdout).
  */
-const sbom: Command = {
+const sbomOptionDefinitions = {
+    focus: {
+        description: "Project name(s) to focus on — comma-separated for multiple",
+        type: String,
+    },
+    format: {
+        defaultValue: "json",
+        description: "Output format: json (default) or xml",
+        type: String,
+    },
+    "include-dev": {
+        defaultValue: false,
+        description: "Include devDependencies (default: production only)",
+        type: Boolean,
+    },
+    output: {
+        description: "Output path (use '-' for stdout; default: sbom.cdx.json)",
+        type: String,
+    },
+} as const;
+
+const sbom = defineCommand({
     description: "Generate a CycloneDX 1.7 Software Bill of Materials for the workspace",
     examples: [
         ["vis sbom", "Write the full-workspace SBOM to sbom.cdx.json"],
@@ -20,37 +42,9 @@ const sbom: Command = {
     group: "Security & Health",
     loader: () => import("./handler"),
     name: "sbom",
-    options: [
-        {
-            description: "Project name(s) to focus on — comma-separated for multiple",
-            name: "focus",
-            type: String,
-        },
-        {
-            defaultValue: "json",
-            description: "Output format: json (default) or xml",
-            name: "format",
-            type: String,
-        },
-        {
-            description: "Output path (use '-' for stdout; default: sbom.cdx.json)",
-            name: "output",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Include devDependencies (default: production only)",
-            name: "include-dev",
-            type: Boolean,
-        },
-    ],
-};
+    options: sbomOptionDefinitions,
+});
 
 export default sbom;
 
-export type SbomOptions = CreateOptions<{
-    focus: string | undefined;
-    format: string | undefined;
-    "include-dev": boolean | undefined;
-    output: string | undefined;
-}>;
+export type SbomOptions = InferOptions<typeof sbomOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/secrets/index.ts
+++ b/packages/tooling/vis/src/commands/secrets/index.ts
@@ -1,6 +1,162 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const secrets: Command = {
+const secretsOptionDefinitions = {
+    affected: {
+        defaultValue: false,
+        description: "Scan only projects affected by the current branch",
+        type: Boolean,
+    },
+    baseline: {
+        description: "Path to a baseline JSON of previously-triaged findings",
+        type: String,
+    },
+    concurrency: {
+        description: "Rayon worker threads (0 / omit = auto)",
+        type: Number,
+    },
+    config: {
+        description: "Path to a JSON config (gitleaks-compatible shape). Defaults to the bundled ruleset.",
+        type: String,
+    },
+    "dry-run": {
+        defaultValue: false,
+        description: "With --init, preview the baseline without writing files",
+        type: Boolean,
+    },
+    "enable-rule": {
+        description:
+                "Enable an opt-in rule or tag without restricting output — additive (e.g. tag:preset:weak-passwords, tag:preset:password-manager). Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    exclude: {
+        description: "Gitignore-syntax pattern to exclude from the walk (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    "exclude-from": {
+        description: "Path to a gitignore-shaped file the walker should honor (repeatable)",
+        multiple: true,
+        type: String,
+    },
+    "exclude-rule": {
+        description: "Rule id or tag:<name> selector — drop matching findings. Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    format: {
+        defaultValue: "text",
+        description: "Output format: text (default), json, sarif",
+        type: String,
+    },
+    history: {
+        defaultValue: false,
+        description:
+                "Scan the entire git history (every added/modified blob across commits) instead of the working tree. Surfaces secrets that were committed and later removed. Cannot be combined with --staged/--since/--affected.",
+        type: Boolean,
+    },
+    "history-range": {
+        description:
+                "With --history, limit the walk to a rev-list range (e.g. main..HEAD, HEAD~50..HEAD, or a single ref). Defaults to all reachable history of HEAD.",
+        type: String,
+    },
+    "include-hidden": {
+        defaultValue: false,
+        description: "Scan dotfiles",
+        type: Boolean,
+    },
+    "include-rule": {
+        description: "Rule id or tag:<name> selector — whitelist, only matching findings are emitted. Implies enablement. Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    init: {
+        defaultValue: false,
+        description: "Scaffold a baseline from current findings",
+        type: Boolean,
+    },
+    "list-rules": {
+        defaultValue: false,
+        description: "Print all bundled detection rules and exit",
+        type: Boolean,
+    },
+    "list-validators": {
+        defaultValue: false,
+        description: "Print non-HTTP validator types referenced by the current ruleset, with install hints for their optional peer dependencies.",
+        type: Boolean,
+    },
+    "max-commits": {
+        description: "With --history, cap the number of commits walked (most-recent first)",
+        type: Number,
+    },
+    "max-size": {
+        description: "Skip files larger than this (bytes). Default: 10 MiB",
+        type: Number,
+    },
+    "min-confidence": {
+        description:
+                "Drop rules below this author-declared confidence: low (default), medium, high. Rules without a declared confidence (every gitleaks rule) are treated as low, so --min-confidence medium or higher drops them along with explicit low-confidence rules.",
+        type: String,
+    },
+    "no-extend-bundled": {
+        defaultValue: false,
+        description: "With --config, do not merge on top of the bundled ruleset — replace it.",
+        type: Boolean,
+    },
+    "no-gitignore": {
+        defaultValue: false,
+        description: "Do not respect .gitignore",
+        type: Boolean,
+    },
+    "only-verified": {
+        defaultValue: false,
+        description: "With --validate, drop every finding whose validation is not 'verified'. Useful for CI gating.",
+        type: Boolean,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress all progress output (only emit findings)",
+        type: Boolean,
+    },
+    redact: {
+        defaultValue: false,
+        description: "Mask secret values in output",
+        type: Boolean,
+    },
+    "replace-baseline": {
+        defaultValue: false,
+        description: "With --update-baseline, replace rather than merge",
+        type: Boolean,
+    },
+    since: {
+        description: "Scan only files changed since <ref> (e.g. main, origin/HEAD)",
+        type: String,
+    },
+    staged: {
+        defaultValue: false,
+        description: "Scan only files staged for commit",
+        type: Boolean,
+    },
+    "update-baseline": {
+        defaultValue: false,
+        description: "Merge current findings into the baseline and exit 0",
+        type: Boolean,
+    },
+    validate: {
+        defaultValue: false,
+        description:
+                "Live-verify each finding against its provider (one HTTP call per finding, max 8 concurrent). Only supports Kingfisher-style HTTP validators with StatusMatch / WordMatch response matchers; other types (gRPC, multi-step, checksum) mark the finding as validation=skipped. WARNING: sends candidate secrets to the provider — some providers alert their security team on failed auth attempts.",
+        type: Boolean,
+    },
+    verbose: {
+        defaultValue: false,
+        description: "Print diagnostic info (skipped rules, etc.)",
+        type: Boolean,
+    },
+} as const;
+
+const secrets = defineCommand({
     argument: {
         description: "One or more paths to scan (defaults to workspace root)",
         name: "paths",
@@ -34,126 +190,9 @@ const secrets: Command = {
     group: "Security",
     loader: () => import("./handler"),
     name: "secrets",
-    options: [
-        { description: "Path to a JSON config (gitleaks-compatible shape). Defaults to the bundled ruleset.", name: "config", type: String },
-        {
-            description:
-                "Drop rules below this author-declared confidence: low (default), medium, high. Rules without a declared confidence (every gitleaks rule) are treated as low, so --min-confidence medium or higher drops them along with explicit low-confidence rules.",
-            name: "min-confidence",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Live-verify each finding against its provider (one HTTP call per finding, max 8 concurrent). Only supports Kingfisher-style HTTP validators with StatusMatch / WordMatch response matchers; other types (gRPC, multi-step, checksum) mark the finding as validation=skipped. WARNING: sends candidate secrets to the provider — some providers alert their security team on failed auth attempts.",
-            name: "validate",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "With --validate, drop every finding whose validation is not 'verified'. Useful for CI gating.",
-            name: "only-verified",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "With --config, do not merge on top of the bundled ruleset — replace it.",
-            name: "no-extend-bundled",
-            type: Boolean,
-        },
-        { defaultValue: "text", description: "Output format: text (default), json, sarif", name: "format", type: String },
-        { description: "Path to a baseline JSON of previously-triaged findings", name: "baseline", type: String },
-        { defaultValue: false, description: "Scan only files staged for commit", name: "staged", type: Boolean },
-        { description: "Scan only files changed since <ref> (e.g. main, origin/HEAD)", name: "since", type: String },
-        { defaultValue: false, description: "Scan only projects affected by the current branch", name: "affected", type: Boolean },
-        {
-            defaultValue: false,
-            description:
-                "Scan the entire git history (every added/modified blob across commits) instead of the working tree. Surfaces secrets that were committed and later removed. Cannot be combined with --staged/--since/--affected.",
-            name: "history",
-            type: Boolean,
-        },
-        {
-            description:
-                "With --history, limit the walk to a rev-list range (e.g. main..HEAD, HEAD~50..HEAD, or a single ref). Defaults to all reachable history of HEAD.",
-            name: "history-range",
-            type: String,
-        },
-        { description: "With --history, cap the number of commits walked (most-recent first)", name: "max-commits", type: Number },
-        {
-            description:
-                "Enable an opt-in rule or tag without restricting output — additive (e.g. tag:preset:weak-passwords, tag:preset:password-manager). Repeatable.",
-            multiple: true,
-            name: "enable-rule",
-            type: String,
-        },
-        {
-            description: "Rule id or tag:<name> selector — whitelist, only matching findings are emitted. Implies enablement. Repeatable.",
-            multiple: true,
-            name: "include-rule",
-            type: String,
-        },
-        {
-            description: "Rule id or tag:<name> selector — drop matching findings. Repeatable.",
-            multiple: true,
-            name: "exclude-rule",
-            type: String,
-        },
-        { description: "Gitignore-syntax pattern to exclude from the walk (repeatable)", multiple: true, name: "exclude", type: String },
-        { description: "Path to a gitignore-shaped file the walker should honor (repeatable)", multiple: true, name: "exclude-from", type: String },
-        { defaultValue: false, description: "Mask secret values in output", name: "redact", type: Boolean },
-        { defaultValue: false, description: "Scan dotfiles", name: "include-hidden", type: Boolean },
-        { defaultValue: false, description: "Do not respect .gitignore", name: "no-gitignore", type: Boolean },
-        { description: "Skip files larger than this (bytes). Default: 10 MiB", name: "max-size", type: Number },
-        { description: "Rayon worker threads (0 / omit = auto)", name: "concurrency", type: Number },
-        { defaultValue: false, description: "Merge current findings into the baseline and exit 0", name: "update-baseline", type: Boolean },
-        { defaultValue: false, description: "With --update-baseline, replace rather than merge", name: "replace-baseline", type: Boolean },
-        { defaultValue: false, description: "Scaffold a baseline from current findings", name: "init", type: Boolean },
-        { defaultValue: false, description: "With --init, preview the baseline without writing files", name: "dry-run", type: Boolean },
-        { defaultValue: false, description: "Print all bundled detection rules and exit", name: "list-rules", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Print non-HTTP validator types referenced by the current ruleset, with install hints for their optional peer dependencies.",
-            name: "list-validators",
-            type: Boolean,
-        },
-        { defaultValue: false, description: "Suppress all progress output (only emit findings)", name: "quiet", type: Boolean },
-        { defaultValue: false, description: "Print diagnostic info (skipped rules, etc.)", name: "verbose", type: Boolean },
-    ],
-};
+    options: secretsOptionDefinitions,
+});
 
 export default secrets;
 
-export type SecretsOptions = CreateOptions<{
-    affected: boolean | undefined;
-    baseline: string | undefined;
-    concurrency: number | undefined;
-    config: string | undefined;
-    "dry-run": boolean | undefined;
-    "enable-rule": string[] | undefined;
-    exclude: string[] | undefined;
-    "exclude-from": string[] | undefined;
-    "exclude-rule": string[] | undefined;
-    format: string | undefined;
-    history: boolean | undefined;
-    "history-range": string | undefined;
-    "include-hidden": boolean | undefined;
-    "include-rule": string[] | undefined;
-    init: boolean | undefined;
-    "list-rules": boolean | undefined;
-    "list-validators": boolean | undefined;
-    "max-commits": number | undefined;
-    "max-size": number | undefined;
-    "min-confidence": string | undefined;
-    "no-extend-bundled": boolean | undefined;
-    "no-gitignore": boolean | undefined;
-    "only-verified": boolean | undefined;
-    quiet: boolean | undefined;
-    redact: boolean | undefined;
-    "replace-baseline": boolean | undefined;
-    since: string | undefined;
-    staged: boolean | undefined;
-    "update-baseline": boolean | undefined;
-    validate: boolean | undefined;
-    verbose: boolean | undefined;
-}>;
+export type SecretsOptions = InferOptions<typeof secretsOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/security/index.ts
+++ b/packages/tooling/vis/src/commands/security/index.ts
@@ -1,6 +1,15 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { AnyCommandInput, InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const securityList: Command = {
+const securityListOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit the report as JSON instead of human-readable text",
+        type: Boolean,
+    },
+} as const;
+
+const securityList = defineCommand({
     commandPath: ["security"],
     description: "List build-script status — allowed, unapproved, and stale allowlist entries",
     examples: [
@@ -10,10 +19,23 @@ const securityList: Command = {
     group: "Security & Health",
     loader: () => import("./list"),
     name: "list",
-    options: [{ defaultValue: false, description: "Emit the report as JSON instead of human-readable text", name: "json", type: Boolean }],
-};
+    options: securityListOptionDefinitions,
+});
 
-const securitySync: Command = {
+const securitySyncOptionDefinitions = {
+    "skip-allow-builds": {
+        defaultValue: false,
+        description: "Skip syncing allowBuilds (trustedDependencies, onlyBuiltDependencies)",
+        type: Boolean,
+    },
+    "skip-min-release-age": {
+        defaultValue: false,
+        description: "Skip syncing minimumReleaseAge and its excludes",
+        type: Boolean,
+    },
+} as const;
+
+const securitySync = defineCommand({
     commandPath: ["security"],
     description: "Push vis.config security settings to the package manager's native config",
     examples: [
@@ -24,23 +46,23 @@ const securitySync: Command = {
     group: "Security & Health",
     loader: () => import("./sync"),
     name: "sync",
-    options: [
-        {
-            defaultValue: false,
-            description: "Skip syncing allowBuilds (trustedDependencies, onlyBuiltDependencies)",
-            name: "skip-allow-builds",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip syncing minimumReleaseAge and its excludes",
-            name: "skip-min-release-age",
-            type: Boolean,
-        },
-    ],
-};
+    options: securitySyncOptionDefinitions,
+});
 
-const securityRun: Command = {
+const securityRunOptionDefinitions = {
+    "root-only": {
+        defaultValue: false,
+        description: "Skip dependency scripts and only run the workspace root's prepublish + prepare hooks",
+        type: Boolean,
+    },
+    "with-root": {
+        defaultValue: false,
+        description: "Also run the workspace root's prepublish + prepare hooks after dependencies",
+        type: Boolean,
+    },
+} as const;
+
+const securityRun = defineCommand({
     commandPath: ["security"],
     description: "Run lifecycle scripts for packages in security.policies.installScripts.allow (LavaMoat 'run' parity)",
     examples: [
@@ -51,18 +73,23 @@ const securityRun: Command = {
     group: "Security & Health",
     loader: () => import("./run"),
     name: "run",
-    options: [
-        { defaultValue: false, description: "Also run the workspace root's prepublish + prepare hooks after dependencies", name: "with-root", type: Boolean },
-        {
-            defaultValue: false,
-            description: "Skip dependency scripts and only run the workspace root's prepublish + prepare hooks",
-            name: "root-only",
-            type: Boolean,
-        },
-    ],
-};
+    options: securityRunOptionDefinitions,
+});
 
-const securityTripwire: Command = {
+const securityTripwireOptionDefinitions = {
+    remove: {
+        defaultValue: false,
+        description: "Remove @lavamoat/preinstall-always-fail from package.json",
+        type: Boolean,
+    },
+    status: {
+        defaultValue: false,
+        description: "Report whether @lavamoat/preinstall-always-fail is installed",
+        type: Boolean,
+    },
+} as const;
+
+const securityTripwire = defineCommand({
     commandPath: ["security"],
     description: "Install @lavamoat/preinstall-always-fail as a devDep so a missing ignore-scripts setting fails loudly",
     examples: [
@@ -73,13 +100,23 @@ const securityTripwire: Command = {
     group: "Security & Health",
     loader: () => import("./tripwire"),
     name: "tripwire",
-    options: [
-        { defaultValue: false, description: "Report whether @lavamoat/preinstall-always-fail is installed", name: "status", type: Boolean },
-        { defaultValue: false, description: "Remove @lavamoat/preinstall-always-fail from package.json", name: "remove", type: Boolean },
-    ],
-};
+    options: securityTripwireOptionDefinitions,
+});
 
-const securityKeysRefresh: Command = {
+const securityKeysRefreshOptionDefinitions = {
+    clear: {
+        defaultValue: false,
+        description: "Only clear the cache, do not refetch",
+        type: Boolean,
+    },
+    json: {
+        defaultValue: false,
+        description: "Emit the result as JSON instead of human-readable text",
+        type: Boolean,
+    },
+} as const;
+
+const securityKeysRefresh = defineCommand({
     commandPath: ["security"],
     description: "Force-refresh the cached npm signing keys used by the signatures marshall",
     examples: [
@@ -90,13 +127,23 @@ const securityKeysRefresh: Command = {
     group: "Security & Health",
     loader: () => import("./keys-refresh"),
     name: "keys-refresh",
-    options: [
-        { defaultValue: false, description: "Only clear the cache, do not refetch", name: "clear", type: Boolean },
-        { defaultValue: false, description: "Emit the result as JSON instead of human-readable text", name: "json", type: Boolean },
-    ],
-};
+    options: securityKeysRefreshOptionDefinitions,
+});
 
-const securityVerifyLockfile: Command = {
+const securityVerifyLockfileOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit the result as JSON instead of human-readable text",
+        type: Boolean,
+    },
+    offline: {
+        defaultValue: false,
+        description: "Skip network-bound policies (firstSeen, publisherChange)",
+        type: Boolean,
+    },
+} as const;
+
+const securityVerifyLockfile = defineCommand({
     commandPath: ["security"],
     description: "Verify the entire lockfile closure against supply-chain policies (firstSeen, publisherChange, blockExoticSubdeps)",
     examples: [
@@ -107,41 +154,21 @@ const securityVerifyLockfile: Command = {
     group: "Security & Health",
     loader: () => import("./verify-lockfile"),
     name: "verify-lockfile",
-    options: [
-        { defaultValue: false, description: "Emit the result as JSON instead of human-readable text", name: "json", type: Boolean },
-        { defaultValue: false, description: "Skip network-bound policies (firstSeen, publisherChange)", name: "offline", type: Boolean },
-    ],
-};
+    options: securityVerifyLockfileOptionDefinitions,
+});
 
-const securityCommands: Command[] = [securityList, securitySync, securityRun, securityTripwire, securityKeysRefresh, securityVerifyLockfile];
+const securityCommands: AnyCommandInput[] = [securityList, securitySync, securityRun, securityTripwire, securityKeysRefresh, securityVerifyLockfile];
 
 export default securityCommands;
 
-export type SecurityListOptions = CreateOptions<{
-    json: boolean | undefined;
-}>;
+export type SecurityListOptions = InferOptions<typeof securityListOptionDefinitions>;
 
-export type SecuritySyncOptions = CreateOptions<{
-    "skip-allow-builds": boolean | undefined;
-    "skip-min-release-age": boolean | undefined;
-}>;
+export type SecuritySyncOptions = InferOptions<typeof securitySyncOptionDefinitions>;
 
-export type SecurityRunOptions = CreateOptions<{
-    "root-only": boolean | undefined;
-    "with-root": boolean | undefined;
-}>;
+export type SecurityRunOptions = InferOptions<typeof securityRunOptionDefinitions>;
 
-export type SecurityTripwireOptions = CreateOptions<{
-    remove: boolean | undefined;
-    status: boolean | undefined;
-}>;
+export type SecurityTripwireOptions = InferOptions<typeof securityTripwireOptionDefinitions>;
 
-export type SecurityKeysRefreshOptions = CreateOptions<{
-    clear: boolean | undefined;
-    json: boolean | undefined;
-}>;
+export type SecurityKeysRefreshOptions = InferOptions<typeof securityKeysRefreshOptionDefinitions>;
 
-export type SecurityVerifyLockfileOptions = CreateOptions<{
-    json: boolean | undefined;
-    offline: boolean | undefined;
-}>;
+export type SecurityVerifyLockfileOptions = InferOptions<typeof securityVerifyLockfileOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/service/handler.ts
+++ b/packages/tooling/vis/src/commands/service/handler.ts
@@ -231,7 +231,7 @@ export const serviceStopExecute = async ({ argument, options, visConfig, workspa
     const targetId = argument[0]?.trim();
     const hookSink = await loadServiceHooks(visConfig);
 
-    if (options.all === true) {
+    if (options.all) {
         if (targetId) {
             // Reject the ambiguity rather than silently picking one. A
             // user typing `vis service stop foo --all` clearly meant
@@ -631,7 +631,7 @@ export const serviceLogsExecute = async ({ argument, options, workspaceRoot: wsR
         return;
     }
 
-    if (options.follow === true) {
+    if (options.follow) {
         await tailLog(entry.logFile);
 
         return;

--- a/packages/tooling/vis/src/commands/service/index.ts
+++ b/packages/tooling/vis/src/commands/service/index.ts
@@ -1,5 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions, InferOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
 const targetIdArgument = {
     description: "Target id, e.g. @my/api:db",
@@ -13,7 +13,19 @@ const formatOption = {
     type: String,
 } as const;
 
-const serviceStart: Command = {
+const serviceStartOptionDefinitions = {
+    "no-readiness": {
+        defaultValue: false,
+        description: "Skip the readiness probe",
+        type: Boolean,
+    },
+    timeout: {
+        description: "Readiness probe timeout in milliseconds",
+        type: Number,
+    },
+} as const;
+
+const serviceStart = defineCommand({
     argument: targetIdArgument,
     commandPath: ["service"],
     description: "Start a service target detached so it survives across `vis run` invocations",
@@ -25,22 +37,22 @@ const serviceStart: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "serviceStartExecute"),
     name: "start",
-    options: [
-        {
-            description: "Readiness probe timeout in milliseconds",
-            name: "timeout",
-            type: Number,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the readiness probe",
-            name: "no-readiness",
-            type: Boolean,
-        },
-    ],
-};
+    options: serviceStartOptionDefinitions,
+});
 
-const serviceStop: Command = {
+const serviceStopOptionDefinitions = {
+    all: {
+        defaultValue: false,
+        description: "Stop every service registered for this workspace",
+        type: Boolean,
+    },
+    "grace-ms": {
+        description: "Override the SIGTERM→SIGKILL grace period in milliseconds",
+        type: Number,
+    },
+} as const;
+
+const serviceStop = defineCommand({
     argument: {
         description: "Target id to stop, or omit when using --all",
         name: "targetId",
@@ -56,20 +68,8 @@ const serviceStop: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "serviceStopExecute"),
     name: "stop",
-    options: [
-        {
-            defaultValue: false,
-            description: "Stop every service registered for this workspace",
-            name: "all",
-            type: Boolean,
-        },
-        {
-            description: "Override the SIGTERM→SIGKILL grace period in milliseconds",
-            name: "grace-ms",
-            type: Number,
-        },
-    ],
-};
+    options: serviceStopOptionDefinitions,
+});
 
 const serviceList: Command = {
     commandPath: ["service"],
@@ -84,7 +84,14 @@ const serviceList: Command = {
     options: [formatOption],
 };
 
-const serviceStatus: Command = {
+const serviceStatusOptionDefinitions = {
+    timeout: {
+        description: "Probe timeout in milliseconds",
+        type: Number,
+    },
+} as const;
+
+const serviceStatus = defineCommand({
     argument: targetIdArgument,
     commandPath: ["service"],
     description: "Re-run the readiness probe and report a service's health",
@@ -92,16 +99,26 @@ const serviceStatus: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "serviceStatusExecute"),
     name: "status",
-    options: [
-        {
-            description: "Probe timeout in milliseconds",
-            name: "timeout",
-            type: Number,
-        },
-    ],
-};
+    options: serviceStatusOptionDefinitions,
+});
 
-const serviceRestart: Command = {
+const serviceRestartOptionDefinitions = {
+    "grace-ms": {
+        description: "Override the SIGTERM→SIGKILL grace period in milliseconds",
+        type: Number,
+    },
+    "no-readiness": {
+        defaultValue: false,
+        description: "Skip the readiness probe after restart",
+        type: Boolean,
+    },
+    timeout: {
+        description: "Readiness probe timeout in milliseconds",
+        type: Number,
+    },
+} as const;
+
+const serviceRestart = defineCommand({
     argument: targetIdArgument,
     commandPath: ["service"],
     description: "Stop and re-start a running service",
@@ -112,27 +129,19 @@ const serviceRestart: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "serviceRestartExecute"),
     name: "restart",
-    options: [
-        {
-            description: "Readiness probe timeout in milliseconds",
-            name: "timeout",
-            type: Number,
-        },
-        {
-            description: "Override the SIGTERM→SIGKILL grace period in milliseconds",
-            name: "grace-ms",
-            type: Number,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the readiness probe after restart",
-            name: "no-readiness",
-            type: Boolean,
-        },
-    ],
-};
+    options: serviceRestartOptionDefinitions,
+});
 
-const serviceLogs: Command = {
+const serviceLogsOptionDefinitions = {
+    follow: {
+        alias: "f",
+        defaultValue: false,
+        description: "Follow the log file (like `tail -f`)",
+        type: Boolean,
+    },
+} as const;
+
+const serviceLogs = defineCommand({
     argument: targetIdArgument,
     commandPath: ["service"],
     description: "Print or tail a service's captured stdout/stderr",
@@ -143,45 +152,23 @@ const serviceLogs: Command = {
     group: "Workspace",
     loader: lazyNamed(() => import("./handler"), "serviceLogsExecute"),
     name: "logs",
-    options: [
-        {
-            alias: "f",
-            defaultValue: false,
-            description: "Follow the log file (like `tail -f`)",
-            name: "follow",
-            type: Boolean,
-        },
-    ],
-};
+    options: serviceLogsOptionDefinitions,
+});
 
-const serviceCommands: Command[] = [serviceStart, serviceStop, serviceList, serviceStatus, serviceRestart, serviceLogs];
+const serviceCommands: AnyCommandInput[] = [serviceStart, serviceStop, serviceList, serviceStatus, serviceRestart, serviceLogs];
 
 export default serviceCommands;
 
-export type ServiceStartOptions = CreateOptions<{
-    "no-readiness": boolean | undefined;
-    timeout: number | undefined;
-}>;
+export type ServiceStartOptions = InferOptions<typeof serviceStartOptionDefinitions>;
 
-export type ServiceStopOptions = CreateOptions<{
-    all: boolean | undefined;
-    "grace-ms": number | undefined;
-}>;
+export type ServiceStopOptions = InferOptions<typeof serviceStopOptionDefinitions>;
 
 export type ServiceListOptions = CreateOptions<{
     format: string | undefined;
 }>;
 
-export type ServiceStatusOptions = CreateOptions<{
-    timeout: number | undefined;
-}>;
+export type ServiceStatusOptions = InferOptions<typeof serviceStatusOptionDefinitions>;
 
-export type ServiceRestartOptions = CreateOptions<{
-    "grace-ms": number | undefined;
-    "no-readiness": boolean | undefined;
-    timeout: number | undefined;
-}>;
+export type ServiceRestartOptions = InferOptions<typeof serviceRestartOptionDefinitions>;
 
-export type ServiceLogsOptions = CreateOptions<{
-    follow: boolean | undefined;
-}>;
+export type ServiceLogsOptions = InferOptions<typeof serviceLogsOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/shim/index.ts
+++ b/packages/tooling/vis/src/commands/shim/index.ts
@@ -1,4 +1,4 @@
-import type { Command } from "@visulima/cerebro";
+import type { AnyCommandInput, Command } from "@visulima/cerebro";
 
 /**
  * `vis shim` — manage the opt-in, project-local PM shim dir (`.vis/shims`). When
@@ -44,6 +44,6 @@ const shimStatus: Command = {
     name: "status",
 };
 
-const shimCommands = [shimInstall, shimUninstall, shimStatus];
+const shimCommands: AnyCommandInput[] = [shimInstall, shimUninstall, shimStatus];
 
 export default shimCommands;

--- a/packages/tooling/vis/src/commands/shim/index.ts
+++ b/packages/tooling/vis/src/commands/shim/index.ts
@@ -44,6 +44,6 @@ const shimStatus: Command = {
     name: "status",
 };
 
-const shimCommands: Command[] = [shimInstall, shimUninstall, shimStatus];
+const shimCommands = [shimInstall, shimUninstall, shimStatus];
 
 export default shimCommands;

--- a/packages/tooling/vis/src/commands/sort-package-json/handler.ts
+++ b/packages/tooling/vis/src/commands/sort-package-json/handler.ts
@@ -481,17 +481,17 @@ const execute = async ({ fs, options, visConfig, workspaceRoot: wsRoot }: Toolbo
     const config = (visConfig as Record<string, unknown> | undefined)?.["sortPackageJson"] as SortPackageJsonConfig | undefined;
     const checkMode = options.check || false;
 
-    const editorconfigEnabled = options.editorconfig === false ? false : (config?.editorconfig ?? true);
+    const editorconfigEnabled = options.editorconfig ? (config?.editorconfig ?? true) : false;
 
     const normalized: NormalizedConfig = {
         editorconfig: editorconfigEnabled,
         finalNewline: options.finalNewline ?? config?.finalNewline ?? true,
-        formatBugs: options.formatBugs === false ? false : (config?.formatBugs ?? true),
-        formatRepository: options.formatRepository === false ? false : (config?.formatRepository ?? true),
+        formatBugs: options.formatBugs ? (config?.formatBugs ?? true) : false,
+        formatRepository: options.formatRepository ? (config?.formatRepository ?? true) : false,
         ignore: [...splitList(options.ignore), ...(config?.ignore ?? [])],
         indent: resolveIndentOverride(options.indent ?? config?.indent),
         lineEnding: validateLineEnding(options.lineEnding ?? config?.lineEnding),
-        sortExports: options.sortExports === false ? false : (config?.sortExports ?? true),
+        sortExports: options.sortExports ? (config?.sortExports ?? true) : false,
         sortOrder: [...splitList(options.sortOrder), ...(config?.sortOrder ?? [])],
         sortScripts: options.sortScripts || config?.sortScripts || false,
         unsorted: [...splitList(options.unsorted), ...(config?.unsorted ?? [])],

--- a/packages/tooling/vis/src/commands/sort-package-json/index.ts
+++ b/packages/tooling/vis/src/commands/sort-package-json/index.ts
@@ -1,6 +1,67 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const sortPackageJson: Command = {
+const sortPackageJsonOptionDefinitions = {
+    check: {
+        alias: "c",
+        defaultValue: false,
+        description: "Check if package.json files are sorted without writing (exits 1 if unsorted)",
+        type: Boolean,
+    },
+    ignore: {
+        description: "Glob pattern of files to skip (basename match, or path-relative when the pattern contains `/`). Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    indent: {
+        description:
+                "Indent override: a number of spaces, the literal `tab`, or a literal whitespace string. When unset, the original file's indent is preserved.",
+        type: String,
+    },
+    "line-ending": {
+        defaultValue: "auto",
+        description: "Line ending to write: auto (per-file detection, default), lf, or crlf.",
+        type: String,
+    },
+    "no-editorconfig": {
+        description: "Disable .editorconfig discovery for indent / line-ending defaults (default: enabled).",
+        type: Boolean,
+    },
+    "no-final-newline": {
+        defaultValue: false,
+        description: "Do not append a trailing newline to the output (default: append one).",
+        type: Boolean,
+    },
+    "no-format-bugs": {
+        description: "Disable collapsing `bugs: { url }` to the bare string form (default: enabled).",
+        type: Boolean,
+    },
+    "no-format-repository": {
+        description: "Disable collapsing `repository: { type, url }` to the GitHub `owner/repo` shorthand (default: enabled).",
+        type: Boolean,
+    },
+    "no-sort-exports": {
+        description: "Disable canonical sorting of `exports` condition keys (default: enabled).",
+        type: Boolean,
+    },
+    "sort-order": {
+        description: "Comma-separated list of top-level keys to place first, before the default field order. Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    "sort-scripts": {
+        defaultValue: false,
+        description: "Also sort the scripts field alphabetically",
+        type: Boolean,
+    },
+    unsorted: {
+        description: "Comma-separated list of top-level sections whose key order should be preserved (e.g. dependencies,devDependencies). Repeatable.",
+        multiple: true,
+        type: String,
+    },
+} as const;
+
+const sortPackageJson = defineCommand({
     description: "Sort package.json files across the workspace using the sort-package-json Rust crate",
     examples: [
         ["vis sort-package-json", "Sort all package.json files in the workspace"],
@@ -17,92 +78,9 @@ const sortPackageJson: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "sort-package-json",
-    options: [
-        {
-            alias: "c",
-            defaultValue: false,
-            description: "Check if package.json files are sorted without writing (exits 1 if unsorted)",
-            name: "check",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Also sort the scripts field alphabetically",
-            name: "sort-scripts",
-            type: Boolean,
-        },
-        {
-            description:
-                "Indent override: a number of spaces, the literal `tab`, or a literal whitespace string. When unset, the original file's indent is preserved.",
-            name: "indent",
-            type: String,
-        },
-        {
-            description: "Glob pattern of files to skip (basename match, or path-relative when the pattern contains `/`). Repeatable.",
-            multiple: true,
-            name: "ignore",
-            type: String,
-        },
-        {
-            description: "Comma-separated list of top-level keys to place first, before the default field order. Repeatable.",
-            multiple: true,
-            name: "sort-order",
-            type: String,
-        },
-        {
-            description: "Comma-separated list of top-level sections whose key order should be preserved (e.g. dependencies,devDependencies). Repeatable.",
-            multiple: true,
-            name: "unsorted",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Do not append a trailing newline to the output (default: append one).",
-            name: "no-final-newline",
-            type: Boolean,
-        },
-        {
-            defaultValue: "auto",
-            description: "Line ending to write: auto (per-file detection, default), lf, or crlf.",
-            name: "line-ending",
-            type: String,
-        },
-        {
-            description: "Disable collapsing `bugs: { url }` to the bare string form (default: enabled).",
-            name: "no-format-bugs",
-            type: Boolean,
-        },
-        {
-            description: "Disable collapsing `repository: { type, url }` to the GitHub `owner/repo` shorthand (default: enabled).",
-            name: "no-format-repository",
-            type: Boolean,
-        },
-        {
-            description: "Disable canonical sorting of `exports` condition keys (default: enabled).",
-            name: "no-sort-exports",
-            type: Boolean,
-        },
-        {
-            description: "Disable .editorconfig discovery for indent / line-ending defaults (default: enabled).",
-            name: "no-editorconfig",
-            type: Boolean,
-        },
-    ],
-};
+    options: sortPackageJsonOptionDefinitions,
+});
 
 export default sortPackageJson;
 
-export type SortPackageJsonOptions = CreateOptions<{
-    check: boolean | undefined;
-    editorconfig: boolean | undefined;
-    "final-newline": boolean | undefined;
-    "format-bugs": boolean | undefined;
-    "format-repository": boolean | undefined;
-    ignore: string[] | undefined;
-    indent: string | undefined;
-    "line-ending": string | undefined;
-    "sort-exports": boolean | undefined;
-    "sort-order": string[] | undefined;
-    "sort-scripts": boolean | undefined;
-    unsorted: string[] | undefined;
-}>;
+export type SortPackageJsonOptions = InferOptions<typeof sortPackageJsonOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/split/index.ts
+++ b/packages/tooling/vis/src/commands/split/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis split` — extract a package out of the monorepo into a new
@@ -6,7 +7,49 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * (built-in `git subtree split`). Optionally wires up a remote, pushes,
  * and removes the package from the monorepo.
  */
-const split: Command = {
+const splitOptionDefinitions = {
+    annotate: {
+        defaultValue: false,
+        description: "Prefix the rewritten commit messages with the package name",
+        type: Boolean,
+    },
+    branch: {
+        alias: "b",
+        description: "Default branch name in the new repo (default: vis.config defaultBase or \"main\")",
+        type: String,
+    },
+    "dry-run": {
+        defaultValue: false,
+        description: "Print the git plan instead of executing it",
+        type: Boolean,
+    },
+    force: {
+        defaultValue: false,
+        description: "Use a non-empty --output directory anyway",
+        type: Boolean,
+    },
+    output: {
+        alias: "o",
+        description: "Destination directory for the new repo (required unless --dry-run)",
+        type: String,
+    },
+    push: {
+        defaultValue: false,
+        description: "Push the new repo to origin (requires --remote)",
+        type: Boolean,
+    },
+    remote: {
+        description: "Git remote URL to set as origin on the new repo",
+        type: String,
+    },
+    remove: {
+        defaultValue: false,
+        description: "Delete the package from the monorepo after extracting and commit the removal",
+        type: Boolean,
+    },
+} as const;
+
+const split = defineCommand({
     argument: { description: "Project name or workspace-relative path of the package to extract", name: "package", type: String },
     description: "Extract a package into a standalone git repo, preserving its history",
     examples: [
@@ -18,27 +61,9 @@ const split: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "split",
-    options: [
-        { alias: "o", description: "Destination directory for the new repo (required unless --dry-run)", name: "output", type: String },
-        { alias: "b", description: "Default branch name in the new repo (default: vis.config defaultBase or \"main\")", name: "branch", type: String },
-        { description: "Git remote URL to set as origin on the new repo", name: "remote", type: String },
-        { defaultValue: false, description: "Push the new repo to origin (requires --remote)", name: "push", type: Boolean },
-        { defaultValue: false, description: "Delete the package from the monorepo after extracting and commit the removal", name: "remove", type: Boolean },
-        { defaultValue: false, description: "Prefix the rewritten commit messages with the package name", name: "annotate", type: Boolean },
-        { defaultValue: false, description: "Use a non-empty --output directory anyway", name: "force", type: Boolean },
-        { defaultValue: false, description: "Print the git plan instead of executing it", name: "dry-run", type: Boolean },
-    ],
-};
+    options: splitOptionDefinitions,
+});
 
 export default split;
 
-export type SplitOptions = CreateOptions<{
-    annotate: boolean | undefined;
-    branch: string | undefined;
-    "dry-run": boolean | undefined;
-    force: boolean | undefined;
-    output: string | undefined;
-    push: boolean | undefined;
-    remote: string | undefined;
-    remove: boolean | undefined;
-}>;
+export type SplitOptions = InferOptions<typeof splitOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/staged/index.ts
+++ b/packages/tooling/vis/src/commands/staged/index.ts
@@ -1,6 +1,91 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const staged: Command = {
+const stagedOptionDefinitions = {
+    "allow-empty": {
+        defaultValue: false,
+        description: "Allow empty commits when tasks revert all staged changes",
+        type: Boolean,
+    },
+    "auto-stage": {
+        defaultValue: false,
+        description: "Automatically stage new files that tasks create during the run",
+        type: Boolean,
+    },
+    concurrent: {
+        description: "Number of concurrent tasks or false for serial",
+        type: String,
+    },
+    "continue-on-error": {
+        defaultValue: false,
+        description: "Run all tasks to completion even if one fails",
+        type: Boolean,
+    },
+    cwd: {
+        description: "Working directory to run all tasks in",
+        type: String,
+    },
+    debug: {
+        defaultValue: false,
+        description: "Enable debug output",
+        type: Boolean,
+    },
+    diff: {
+        description: "Override the default --staged flag of git diff",
+        type: String,
+    },
+    "diff-filter": {
+        description: "Override the default diff-filter",
+        type: String,
+    },
+    "fail-on-changes": {
+        defaultValue: false,
+        description: "Fail with exit code 1 when tasks modify tracked files",
+        type: Boolean,
+    },
+    "force-kill": {
+        defaultValue: false,
+        description: "Kill in-flight tasks with SIGKILL on fast-fail instead of the default SIGTERM",
+        type: Boolean,
+    },
+    "hide-partially-staged": {
+        defaultValue: false,
+        description: "Hide unstaged changes from partially staged files",
+        type: Boolean,
+    },
+    "hide-unstaged": {
+        defaultValue: false,
+        description: "Hide all unstaged changes before running tasks",
+        type: Boolean,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress console output",
+        type: Boolean,
+    },
+    relative: {
+        defaultValue: false,
+        description: "Pass filepaths relative to cwd to tasks",
+        type: Boolean,
+    },
+    revert: {
+        defaultValue: false,
+        description: "Revert to original state in case of errors",
+        type: Boolean,
+    },
+    stash: {
+        defaultValue: true,
+        description: "Enable backup stash",
+        type: Boolean,
+    },
+    verbose: {
+        defaultValue: false,
+        description: "Show task output even when tasks succeed",
+        type: Boolean,
+    },
+} as const;
+
+const staged = defineCommand({
     description: "Run linters on staged files using config from vis.config.ts",
     examples: [
         ["vis staged", "Run staged linters"],
@@ -11,126 +96,9 @@ const staged: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "staged",
-    options: [
-        {
-            defaultValue: false,
-            description: "Allow empty commits when tasks revert all staged changes",
-            name: "allow-empty",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Automatically stage new files that tasks create during the run",
-            name: "auto-stage",
-            type: Boolean,
-        },
-        {
-            description: "Number of concurrent tasks or false for serial",
-            name: "concurrent",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Run all tasks to completion even if one fails",
-            name: "continue-on-error",
-            type: Boolean,
-        },
-        {
-            description: "Working directory to run all tasks in",
-            name: "cwd",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Enable debug output",
-            name: "debug",
-            type: Boolean,
-        },
-        {
-            description: "Override the default --staged flag of git diff",
-            name: "diff",
-            type: String,
-        },
-        {
-            description: "Override the default diff-filter",
-            name: "diff-filter",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Fail with exit code 1 when tasks modify tracked files",
-            name: "fail-on-changes",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Kill in-flight tasks with SIGKILL on fast-fail instead of the default SIGTERM",
-            name: "force-kill",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Hide unstaged changes from partially staged files",
-            name: "hide-partially-staged",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Hide all unstaged changes before running tasks",
-            name: "hide-unstaged",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Suppress console output",
-            name: "quiet",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Pass filepaths relative to cwd to tasks",
-            name: "relative",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Revert to original state in case of errors",
-            name: "revert",
-            type: Boolean,
-        },
-        {
-            defaultValue: true,
-            description: "Enable backup stash",
-            name: "stash",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Show task output even when tasks succeed",
-            name: "verbose",
-            type: Boolean,
-        },
-    ],
-};
+    options: stagedOptionDefinitions,
+});
 
 export default staged;
 
-export type StagedOptions = CreateOptions<{
-    "allow-empty": boolean | undefined;
-    "auto-stage": boolean | undefined;
-    concurrent: string | undefined;
-    "continue-on-error": boolean | undefined;
-    cwd: string | undefined;
-    debug: boolean | undefined;
-    diff: string | undefined;
-    "diff-filter": string | undefined;
-    "fail-on-changes": boolean | undefined;
-    "force-kill": boolean | undefined;
-    "hide-partially-staged": boolean | undefined;
-    "hide-unstaged": boolean | undefined;
-    quiet: boolean | undefined;
-    relative: boolean | undefined;
-    revert: boolean | undefined;
-    stash: boolean | undefined;
-    verbose: boolean | undefined;
-}>;
+export type StagedOptions = InferOptions<typeof stagedOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/status/index.ts
+++ b/packages/tooling/vis/src/commands/status/index.ts
@@ -1,6 +1,15 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const status: Command = {
+const statusOptionDefinitions = {
+    json: {
+        defaultValue: false,
+        description: "Emit JSON output",
+        type: Boolean,
+    },
+} as const;
+
+const status = defineCommand({
     description: "Show a workspace health dashboard at a glance",
     examples: [
         ["vis status", "Full status overview"],
@@ -9,18 +18,9 @@ const status: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "status",
-    options: [
-        {
-            defaultValue: false,
-            description: "Emit JSON output",
-            name: "json",
-            type: Boolean,
-        },
-    ],
-};
+    options: statusOptionDefinitions,
+});
 
 export default status;
 
-export type StatusOptions = CreateOptions<{
-    json: boolean | undefined;
-}>;
+export type StatusOptions = InferOptions<typeof statusOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/sync/handler.ts
+++ b/packages/tooling/vis/src/commands/sync/handler.ts
@@ -161,13 +161,13 @@ const runCodeowners = async ({ fs, logger, options, visConfig, workspaceRoot: ws
     const { workspace } = discoverWorkspace(root, visConfig);
     const codeownersConfig = visConfig?.codeowners;
 
-    if (options.writeGuard === true) {
-        await handleWriteGuard(fs, logger, root, workspace, options.check === true);
+    if (options.writeGuard) {
+        await handleWriteGuard(fs, logger, root, workspace, options.check);
     }
 
     const sources = parseCsvOption<CodeownersSource>(options.from, codeownersConfig?.sources ?? ["project-json"], isCodeownersSource);
     const regenerationCommand = options.regenerationCommand ?? codeownersConfig?.regenerationCommand;
-    const preserveBlock = options.preserveBlock === true || codeownersConfig?.preserveBlock === true;
+    const preserveBlock = options.preserveBlock || codeownersConfig?.preserveBlock === true;
     const marker = codeownersConfig?.blockMarker ?? DEFAULT_BLOCK_MARKER;
     const nestedIncludes = options.nestedIncludes ?? codeownersConfig?.nestedIncludes;
     const outRelative = options.out ?? "CODEOWNERS";
@@ -248,9 +248,9 @@ const runPackageJsonFields = ({ logger, options, visConfig, workspaceRoot: wsRoo
 
     const fields = parseCsvOption(options.fields, DEFAULT_SYNCED_FIELDS);
     const ignoreGlobs = options.ignorePackageName ?? [];
-    const checkMode = options.check === true;
+    const checkMode = options.check;
     const format = (options.format ?? "human").toLowerCase();
-    const quiet = options.quiet === true;
+    const { quiet } = options;
 
     const packageDirs = collectWorkspaceDirectories(root).filter((dir) => dir !== ".");
     const writes: PackageWrite[] = [];

--- a/packages/tooling/vis/src/commands/sync/index.ts
+++ b/packages/tooling/vis/src/commands/sync/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis sync &lt;kind>` performs workspace-wide synchronisations that
@@ -16,7 +17,64 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * Additional kinds will land alongside their features (for example:
  * `tsconfig-references`, `package-json` sort, `hooks`).
  */
-const sync: Command = {
+const syncOptionDefinitions = {
+    check: {
+        defaultValue: false,
+        description: "Verify state without writing (exit non-zero if drift is found)",
+        type: Boolean,
+    },
+    fields: {
+        description: "Comma-separated list of fields to mirror from root → workspace packages (package-json-fields kind only). Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    format: {
+        defaultValue: "human",
+        description: "Output format for package-json-fields: human | json",
+        type: String,
+    },
+    from: {
+        description:
+                "Input sources for codeowners. Comma-separated or repeated. Values: project-json | nested-codeowners | package-json-maintainers. Defaults to project-json.",
+        multiple: true,
+        type: String,
+    },
+    "ignore-package-name": {
+        description: "Glob pattern of package names to skip (package-json-fields kind only). Repeatable.",
+        multiple: true,
+        type: String,
+    },
+    "nested-includes": {
+        description: "Glob (repeatable) used to discover nested CODEOWNERS files. Defaults to `**/CODEOWNERS`.",
+        multiple: true,
+        type: String,
+    },
+    out: {
+        description: "Output path for the generated file (default: <workspace>/CODEOWNERS) — codeowners kind only",
+        type: String,
+    },
+    "preserve-block": {
+        defaultValue: false,
+        description: "Splice the generated block between markers in the existing file instead of overwriting it. Codeowners kind only.",
+        type: Boolean,
+    },
+    quiet: {
+        defaultValue: false,
+        description: "Suppress per-package log lines; print only the summary (package-json-fields kind only)",
+        type: Boolean,
+    },
+    "regeneration-command": {
+        description: "Header instruction shown to reviewers (replaces the default 'update project.json' note). Codeowners kind only.",
+        type: String,
+    },
+    "write-guard": {
+        defaultValue: false,
+        description: "Also emit a .github/workflows/write-guard.yml scoped to projects with `restricted: true` in project.json. Codeowners kind only.",
+        type: Boolean,
+    },
+} as const;
+
+const sync = defineCommand({
     argument: {
         description: "What to sync: codeowners | package-json-fields",
         name: "kind",
@@ -38,87 +96,9 @@ const sync: Command = {
     group: "Workspace",
     loader: () => import("./handler"),
     name: "sync",
-    options: [
-        {
-            description: "Output path for the generated file (default: <workspace>/CODEOWNERS) — codeowners kind only",
-            name: "out",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Verify state without writing (exit non-zero if drift is found)",
-            name: "check",
-            type: Boolean,
-        },
-        {
-            description:
-                "Input sources for codeowners. Comma-separated or repeated. Values: project-json | nested-codeowners | package-json-maintainers. Defaults to project-json.",
-            multiple: true,
-            name: "from",
-            type: String,
-        },
-        {
-            description: "Glob (repeatable) used to discover nested CODEOWNERS files. Defaults to `**/CODEOWNERS`.",
-            multiple: true,
-            name: "nested-includes",
-            type: String,
-        },
-        {
-            description: "Header instruction shown to reviewers (replaces the default 'update project.json' note). Codeowners kind only.",
-            name: "regeneration-command",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Splice the generated block between markers in the existing file instead of overwriting it. Codeowners kind only.",
-            name: "preserve-block",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Also emit a .github/workflows/write-guard.yml scoped to projects with `restricted: true` in project.json. Codeowners kind only.",
-            name: "write-guard",
-            type: Boolean,
-        },
-        {
-            description: "Comma-separated list of fields to mirror from root → workspace packages (package-json-fields kind only). Repeatable.",
-            multiple: true,
-            name: "fields",
-            type: String,
-        },
-        {
-            description: "Glob pattern of package names to skip (package-json-fields kind only). Repeatable.",
-            multiple: true,
-            name: "ignore-package-name",
-            type: String,
-        },
-        {
-            defaultValue: "human",
-            description: "Output format for package-json-fields: human | json",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Suppress per-package log lines; print only the summary (package-json-fields kind only)",
-            name: "quiet",
-            type: Boolean,
-        },
-    ],
-};
+    options: syncOptionDefinitions,
+});
 
 export default sync;
 
-export type SyncOptions = CreateOptions<{
-    check: boolean | undefined;
-    fields: string[] | undefined;
-    format: string | undefined;
-    from: string[] | undefined;
-    "ignore-package-name": string[] | undefined;
-    "nested-includes": string[] | undefined;
-    out: string | undefined;
-    "preserve-block": boolean | undefined;
-    quiet: boolean | undefined;
-    "regeneration-command": string | undefined;
-    "write-guard": boolean | undefined;
-}>;
+export type SyncOptions = InferOptions<typeof syncOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/toolchain/index.ts
+++ b/packages/tooling/vis/src/commands/toolchain/index.ts
@@ -1,5 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
-import { lazyNamed } from "@visulima/cerebro";
+import type { AnyCommandInput, Command, CreateOptions } from "@visulima/cerebro";
+import { defineCommand, lazyNamed } from "@visulima/cerebro";
 
 /**
  * `vis toolchain` — inspect and delegate to the workspace's version
@@ -21,7 +21,20 @@ import { lazyNamed } from "@visulima/cerebro";
 
 const GROUP = "Workspace";
 
-const toolchainStatus: Command = {
+const toolchainStatusOptionDefinitions = {
+    "exit-code": {
+        defaultValue: false,
+        description: "Exit 1 if any tool mismatches",
+        type: Boolean,
+    },
+    json: {
+        defaultValue: false,
+        description: "Emit JSON",
+        type: Boolean,
+    },
+} as const;
+
+const toolchainStatus = defineCommand({
     commandPath: ["toolchain"],
     description: "Show every detected manager + expected vs actual tool versions",
     examples: [
@@ -32,11 +45,8 @@ const toolchainStatus: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "statusExecute"),
     name: "status",
-    options: [
-        { defaultValue: false, description: "Exit 1 if any tool mismatches", name: "exit-code", type: Boolean },
-        { defaultValue: false, description: "Emit JSON", name: "json", type: Boolean },
-    ],
-};
+    options: toolchainStatusOptionDefinitions,
+});
 
 const toolchainDetect: Command = {
     commandPath: ["toolchain"],
@@ -47,7 +57,15 @@ const toolchainDetect: Command = {
     name: "detect",
 };
 
-const toolchainInstall: Command = {
+const toolchainInstallOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Print the command that would run, but don't execute",
+        type: Boolean,
+    },
+} as const;
+
+const toolchainInstall = defineCommand({
     commandPath: ["toolchain"],
     description: "Install pinned versions — per-tool delegation to the right manager",
     examples: [
@@ -57,10 +75,23 @@ const toolchainInstall: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "installExecute"),
     name: "install",
-    options: [{ defaultValue: false, description: "Print the command that would run, but don't execute", name: "dry-run", type: Boolean }],
-};
+    options: toolchainInstallOptionDefinitions,
+});
 
-const toolchainUse: Command = {
+const toolchainUseOptionDefinitions = {
+    "dry-run": {
+        defaultValue: false,
+        description: "Print the command that would run, but don't execute",
+        type: Boolean,
+    },
+    engines: {
+        defaultValue: true,
+        description: "Also mirror the version into engines.<tool> when that field already exists. --no-engines to skip.",
+        type: Boolean,
+    },
+} as const;
+
+const toolchainUse = defineCommand({
     argument: { description: "Tool and version to pin, e.g. node@22.13.0 or pnpm@10.32.1", name: "spec", type: String },
     commandPath: ["toolchain"],
     description: "Pin a version via the best manager for that tool",
@@ -72,16 +103,8 @@ const toolchainUse: Command = {
     group: GROUP,
     loader: lazyNamed(() => import("./handler"), "useExecute"),
     name: "use",
-    options: [
-        { defaultValue: false, description: "Print the command that would run, but don't execute", name: "dry-run", type: Boolean },
-        {
-            defaultValue: true,
-            description: "Also mirror the version into engines.<tool> when that field already exists. --no-engines to skip.",
-            name: "engines",
-            type: Boolean,
-        },
-    ],
-};
+    options: toolchainUseOptionDefinitions,
+});
 
 const toolchainWhich: Command = {
     argument: { description: "Tool to resolve, e.g. node", name: "tool", type: String },
@@ -93,7 +116,7 @@ const toolchainWhich: Command = {
     name: "which",
 };
 
-const toolchainCommands: Command[] = [toolchainStatus, toolchainDetect, toolchainInstall, toolchainUse, toolchainWhich];
+const toolchainCommands: AnyCommandInput[] = [toolchainStatus, toolchainDetect, toolchainInstall, toolchainUse, toolchainWhich];
 
 export default toolchainCommands;
 

--- a/packages/tooling/vis/src/commands/unlink/index.ts
+++ b/packages/tooling/vis/src/commands/unlink/index.ts
@@ -1,6 +1,16 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const unlink: Command = {
+const unlinkOptionDefinitions = {
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Unlink in all workspace packages",
+        type: Boolean,
+    },
+} as const;
+
+const unlink = defineCommand({
     argument: {
         description: "Packages to unlink (omit for current package)",
         name: "packages",
@@ -15,11 +25,9 @@ const unlink: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "unlink",
-    options: [{ alias: "r", defaultValue: false, description: "Unlink in all workspace packages", name: "recursive", type: Boolean }],
-};
+    options: unlinkOptionDefinitions,
+});
 
 export default unlink;
 
-export type UnlinkOptions = CreateOptions<{
-    recursive: boolean | undefined;
-}>;
+export type UnlinkOptions = InferOptions<typeof unlinkOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/update/index.ts
+++ b/packages/tooling/vis/src/commands/update/index.ts
@@ -1,6 +1,209 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const update: Command = {
+const updateOptionDefinitions = {
+    "actions-token": {
+        description: "GitHub token for actions resolution (overrides GITHUB_TOKEN / GH_TOKEN env)",
+        type: String,
+    },
+    ai: {
+        defaultValue: false,
+        description: "Run AI analysis on outdated packages before updating (catalog mode)",
+        type: Boolean,
+    },
+    "ai-type": {
+        description: "AI analysis type: impact, security, compatibility, or recommend (default: impact)",
+        type: String,
+    },
+    changelog: {
+        defaultValue: false,
+        description: "Show changelog URLs for updated packages",
+        type: Boolean,
+    },
+    dev: {
+        alias: "D",
+        conflicts: "prod",
+        description: "Update only devDependencies",
+        type: Boolean,
+    },
+    "dry-run": {
+        alias: "d",
+        defaultValue: false,
+        description: "Preview changes without applying",
+        type: Boolean,
+    },
+    exclude: {
+        description: "Glob pattern to exclude packages (repeatable, catalog mode)",
+        lazyMultiple: true,
+        type: String,
+    },
+    filter: {
+        description: "Filter packages in monorepo (pm-wrapper mode; catalog mode uses --include/--exclude)",
+        type: String,
+    },
+    format: {
+        description: "Output format: table, json, or minimal (default: table)",
+        type: String,
+    },
+    "gitlab-token": {
+        description: "GitLab token for include-ref resolution (overrides GITLAB_TOKEN / CI_JOB_TOKEN env)",
+        type: String,
+    },
+    global: {
+        alias: "g",
+        defaultValue: false,
+        description: "Update global packages",
+        type: Boolean,
+    },
+    "ignore-release-age": {
+        defaultValue: false,
+        description:
+                "Ignore the minimumReleaseAge gate and select the truly latest version even if freshly published. The selected packages are added to the package manager's native age-gate exclude list (pnpm minimumReleaseAgeExclude, bun minimumReleaseAgeExcludes, yarn npmPreapprovedPackages) so the follow-up install isn't blocked; npm has no per-package exclude. Combine with --latest to also cross the semver range.",
+        type: Boolean,
+    },
+    include: {
+        description: "Glob pattern to include packages (repeatable, catalog mode)",
+        lazyMultiple: true,
+        type: String,
+    },
+    "include-branches": {
+        defaultValue: false,
+        description: "Include branch references (e.g. actions/checkout@main) when scanning workflows",
+        type: Boolean,
+    },
+    "include-internal": {
+        defaultValue: false,
+        description: "Also check workspace-owned package names against the registry (catalog mode)",
+        type: Boolean,
+    },
+    "include-locked": {
+        alias: "l",
+        defaultValue: false,
+        description: "Include packages with pinned/exact versions (no ^ or ~ prefix; catalog mode)",
+        type: Boolean,
+    },
+    install: {
+        description: "Run install after catalog update, --no-install to skip (default: true)",
+        type: Boolean,
+    },
+    interactive: {
+        alias: "i",
+        defaultValue: false,
+        description: "Interactive mode",
+        type: Boolean,
+    },
+    latest: {
+        alias: "L",
+        conflicts: "target",
+        description: "Update to latest version (ignore semver range; equivalent to --target latest)",
+        type: Boolean,
+    },
+    "max-concurrent-requests": {
+        description: "Cap concurrent registry requests during outdated checks (default: 8)",
+        type: Number,
+    },
+    "no-actions": {
+        defaultValue: false,
+        description: "Skip the GitHub Actions ecosystem scan (workflows + composite action.yml files)",
+        type: Boolean,
+    },
+    "no-catalog": {
+        defaultValue: false,
+        description: "Skip catalog mode, use package manager directly",
+        type: Boolean,
+    },
+    "no-docker": {
+        defaultValue: false,
+        description: "Skip the Docker ecosystem scan (Dockerfile + docker-compose images)",
+        type: Boolean,
+    },
+    "no-gitlab": {
+        defaultValue: false,
+        description: "Skip the GitLab CI ecosystem scan (.gitlab-ci.yml + .gitlab/ci/**)",
+        type: Boolean,
+    },
+    "no-marshall-check": {
+        defaultValue: false,
+        description:
+                "Skip the offline marshall pipeline (author, provenance, metadata, downloads, expired-domains, new-bin, signatures, archived-repo) when explicit package arguments are supplied",
+        type: Boolean,
+    },
+    "no-optional": {
+        defaultValue: false,
+        description: "Don't update optionalDependencies",
+        type: Boolean,
+    },
+    "no-save": {
+        defaultValue: false,
+        description: "Update lockfile only",
+        type: Boolean,
+    },
+    "no-typosquat-check": {
+        defaultValue: false,
+        description: "Skip typosquat name check for package arguments",
+        type: Boolean,
+    },
+    peer: {
+        defaultValue: false,
+        description: "Include peerDependencies in update checks",
+        type: Boolean,
+    },
+    prerelease: {
+        defaultValue: false,
+        description: "Include prerelease versions (catalog mode)",
+        type: Boolean,
+    },
+    prod: {
+        alias: "P",
+        conflicts: "dev",
+        description: "Update only dependencies",
+        type: Boolean,
+    },
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Update recursively in all workspace packages",
+        type: Boolean,
+    },
+    "release-channel": {
+        description: "Release channel filter: stable (default), same (match current's prerelease channel), or any",
+        type: String,
+    },
+    rollback: {
+        defaultValue: false,
+        description: "Restore catalog file from the last backup",
+        type: Boolean,
+    },
+    security: {
+        description: "Check for known security vulnerabilities via OSV.dev (default: true; --no-security to skip)",
+        type: Boolean,
+    },
+    style: {
+        description: "Reference style for GitHub Actions updates: sha (default, pin to commit SHA + version comment) or preserve",
+        type: String,
+    },
+    target: {
+        alias: "t",
+        conflicts: "latest",
+        description: "Update target: latest, minor, or patch (default: latest, catalog mode)",
+        type: String,
+    },
+    "workspace-root": {
+        alias: "w",
+        defaultValue: false,
+        description: "Include workspace root",
+        type: Boolean,
+    },
+    yes: {
+        alias: "y",
+        defaultValue: false,
+        description:
+                "Skip the confirmation prompt for blanket --latest updates. Required in non-TTY contexts (CI) when running `vis update --latest` without explicit package arguments.",
+        type: Boolean,
+    },
+} as const;
+
+const update = defineCommand({
     alias: "up",
     argument: {
         description: "Packages to update (updates all if omitted)",
@@ -24,288 +227,9 @@ const update: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "update",
-    options: [
-        {
-            alias: "L",
-            conflicts: "target",
-            description: "Update to latest version (ignore semver range; equivalent to --target latest)",
-            name: "latest",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Ignore the minimumReleaseAge gate and select the truly latest version even if freshly published. The selected packages are added to the package manager's native age-gate exclude list (pnpm minimumReleaseAgeExclude, bun minimumReleaseAgeExcludes, yarn npmPreapprovedPackages) so the follow-up install isn't blocked; npm has no per-package exclude. Combine with --latest to also cross the semver range.",
-            name: "ignore-release-age",
-            type: Boolean,
-        },
-        {
-            alias: "t",
-            conflicts: "latest",
-            description: "Update target: latest, minor, or patch (default: latest, catalog mode)",
-            name: "target",
-            type: String,
-        },
-        {
-            alias: "d",
-            defaultValue: false,
-            description: "Preview changes without applying",
-            name: "dry-run",
-            type: Boolean,
-        },
-        {
-            alias: "g",
-            defaultValue: false,
-            description: "Update global packages",
-            name: "global",
-            type: Boolean,
-        },
-        {
-            alias: "r",
-            defaultValue: false,
-            description: "Update recursively in all workspace packages",
-            name: "recursive",
-            type: Boolean,
-        },
-        {
-            description: "Filter packages in monorepo (pm-wrapper mode; catalog mode uses --include/--exclude)",
-            name: "filter",
-            type: String,
-        },
-        {
-            alias: "w",
-            defaultValue: false,
-            description: "Include workspace root",
-            name: "workspace-root",
-            type: Boolean,
-        },
-        {
-            alias: "D",
-            conflicts: "prod",
-            description: "Update only devDependencies",
-            name: "dev",
-            type: Boolean,
-        },
-        {
-            alias: "P",
-            conflicts: "dev",
-            description: "Update only dependencies",
-            name: "prod",
-            type: Boolean,
-        },
-        {
-            alias: "i",
-            defaultValue: false,
-            description: "Interactive mode",
-            name: "interactive",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Don't update optionalDependencies",
-            name: "no-optional",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Include peerDependencies in update checks",
-            name: "peer",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Also check workspace-owned package names against the registry (catalog mode)",
-            name: "include-internal",
-            type: Boolean,
-        },
-        {
-            alias: "l",
-            defaultValue: false,
-            description: "Include packages with pinned/exact versions (no ^ or ~ prefix; catalog mode)",
-            name: "include-locked",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Update lockfile only",
-            name: "no-save",
-            type: Boolean,
-        },
-        {
-            description: "Glob pattern to include packages (repeatable, catalog mode)",
-            lazyMultiple: true,
-            name: "include",
-            type: String,
-        },
-        {
-            description: "Glob pattern to exclude packages (repeatable, catalog mode)",
-            lazyMultiple: true,
-            name: "exclude",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Include prerelease versions (catalog mode)",
-            name: "prerelease",
-            type: Boolean,
-        },
-        {
-            description: "Check for known security vulnerabilities via OSV.dev (default: true; --no-security to skip)",
-            name: "security",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip catalog mode, use package manager directly",
-            name: "no-catalog",
-            type: Boolean,
-        },
-        {
-            description: "Output format: table, json, or minimal (default: table)",
-            name: "format",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Show changelog URLs for updated packages",
-            name: "changelog",
-            type: Boolean,
-        },
-        {
-            description: "Run install after catalog update, --no-install to skip (default: true)",
-            name: "install",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Restore catalog file from the last backup",
-            name: "rollback",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Run AI analysis on outdated packages before updating (catalog mode)",
-            name: "ai",
-            type: Boolean,
-        },
-        {
-            description: "AI analysis type: impact, security, compatibility, or recommend (default: impact)",
-            name: "ai-type",
-            type: String,
-        },
-        {
-            defaultValue: false,
-            description: "Skip typosquat name check for package arguments",
-            name: "no-typosquat-check",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description:
-                "Skip the offline marshall pipeline (author, provenance, metadata, downloads, expired-domains, new-bin, signatures, archived-repo) when explicit package arguments are supplied",
-            name: "no-marshall-check",
-            type: Boolean,
-        },
-        {
-            description: "Cap concurrent registry requests during outdated checks (default: 8)",
-            name: "max-concurrent-requests",
-            type: Number,
-        },
-        {
-            description: "Release channel filter: stable (default), same (match current's prerelease channel), or any",
-            name: "release-channel",
-            type: String,
-        },
-        {
-            alias: "y",
-            defaultValue: false,
-            description:
-                "Skip the confirmation prompt for blanket --latest updates. Required in non-TTY contexts (CI) when running `vis update --latest` without explicit package arguments.",
-            name: "yes",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the GitHub Actions ecosystem scan (workflows + composite action.yml files)",
-            name: "no-actions",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the Docker ecosystem scan (Dockerfile + docker-compose images)",
-            name: "no-docker",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Skip the GitLab CI ecosystem scan (.gitlab-ci.yml + .gitlab/ci/**)",
-            name: "no-gitlab",
-            type: Boolean,
-        },
-        {
-            defaultValue: false,
-            description: "Include branch references (e.g. actions/checkout@main) when scanning workflows",
-            name: "include-branches",
-            type: Boolean,
-        },
-        {
-            description: "Reference style for GitHub Actions updates: sha (default, pin to commit SHA + version comment) or preserve",
-            name: "style",
-            type: String,
-        },
-        {
-            description: "GitHub token for actions resolution (overrides GITHUB_TOKEN / GH_TOKEN env)",
-            name: "actions-token",
-            type: String,
-        },
-        {
-            description: "GitLab token for include-ref resolution (overrides GITLAB_TOKEN / CI_JOB_TOKEN env)",
-            name: "gitlab-token",
-            type: String,
-        },
-    ],
-};
+    options: updateOptionDefinitions,
+});
 
 export default update;
 
-export type UpdateOptions = CreateOptions<{
-    "actions-token": string | undefined;
-    ai: boolean | undefined;
-    "ai-type": string | undefined;
-    changelog: boolean | undefined;
-    dev: boolean | undefined;
-    "dry-run": boolean | undefined;
-    exclude: string[] | undefined;
-    filter: string | undefined;
-    format: string | undefined;
-    "gitlab-token": string | undefined;
-    global: boolean | undefined;
-    "ignore-release-age": boolean | undefined;
-    include: string[] | undefined;
-    "include-branches": boolean | undefined;
-    "include-internal": boolean | undefined;
-    "include-locked": boolean | undefined;
-    install: boolean | undefined;
-    interactive: boolean | undefined;
-    latest: boolean | undefined;
-    "max-concurrent-requests": number | undefined;
-    "no-actions": boolean | undefined;
-    "no-catalog": boolean | undefined;
-    "no-docker": boolean | undefined;
-    "no-gitlab": boolean | undefined;
-    "no-marshall-check": boolean | undefined;
-    "no-optional": boolean | undefined;
-    "no-save": boolean | undefined;
-    "no-typosquat-check": boolean | undefined;
-    peer: boolean | undefined;
-    prerelease: boolean | undefined;
-    prod: boolean | undefined;
-    recursive: boolean | undefined;
-    "release-channel": string | undefined;
-    rollback: boolean | undefined;
-    security: boolean | undefined;
-    style: string | undefined;
-    target: string | undefined;
-    "workspace-root": boolean | undefined;
-    yes: boolean | undefined;
-}>;
+export type UpdateOptions = InferOptions<typeof updateOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/upgrade/index.ts
+++ b/packages/tooling/vis/src/commands/upgrade/index.ts
@@ -1,6 +1,25 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const upgrade: Command = {
+const upgradeOptionDefinitions = {
+    check: {
+        defaultValue: false,
+        description: "Check for updates without installing",
+        type: Boolean,
+    },
+    force: {
+        defaultValue: false,
+        description: "Reinstall even if already current",
+        type: Boolean,
+    },
+    silent: {
+        defaultValue: false,
+        description: "Suppress output (CI mode)",
+        type: Boolean,
+    },
+} as const;
+
+const upgrade = defineCommand({
     argument: {
         description: "Target version (defaults to latest)",
         name: "version",
@@ -15,17 +34,9 @@ const upgrade: Command = {
     group: "System",
     loader: () => import("./handler"),
     name: "self-update",
-    options: [
-        { defaultValue: false, description: "Check for updates without installing", name: "check", type: Boolean },
-        { defaultValue: false, description: "Reinstall even if already current", name: "force", type: Boolean },
-        { defaultValue: false, description: "Suppress output (CI mode)", name: "silent", type: Boolean },
-    ],
-};
+    options: upgradeOptionDefinitions,
+});
 
 export default upgrade;
 
-export type UpgradeOptions = CreateOptions<{
-    check: boolean | undefined;
-    force: boolean | undefined;
-    silent: boolean | undefined;
-}>;
+export type UpgradeOptions = InferOptions<typeof upgradeOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/why/index.ts
+++ b/packages/tooling/vis/src/commands/why/index.ts
@@ -1,6 +1,64 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
-const why: Command = {
+const whyOptionDefinitions = {
+    depth: {
+        description: "Limit dependency tree depth",
+        type: Number,
+    },
+    dev: {
+        alias: "D",
+        conflicts: "prod",
+        description: "Filter to dev dependencies (pnpm)",
+        type: Boolean,
+    },
+    filter: {
+        alias: "F",
+        description: "Filter by workspace package name",
+        multiple: true,
+        type: String,
+    },
+    global: {
+        alias: "g",
+        defaultValue: false,
+        description: "Check globally installed packages (pnpm)",
+        type: Boolean,
+    },
+    json: {
+        defaultValue: false,
+        description: "Output as JSON",
+        type: Boolean,
+    },
+    long: {
+        defaultValue: false,
+        description: "Show extended information (pnpm)",
+        type: Boolean,
+    },
+    "no-optional": {
+        defaultValue: false,
+        description: "Exclude optional dependencies (pnpm)",
+        type: Boolean,
+    },
+    parseable: {
+        defaultValue: false,
+        description: "Machine-readable output (pnpm)",
+        type: Boolean,
+    },
+    prod: {
+        alias: "P",
+        conflicts: "dev",
+        description: "Filter to production dependencies (pnpm)",
+        type: Boolean,
+    },
+    recursive: {
+        alias: "r",
+        defaultValue: false,
+        description: "Check across all workspaces",
+        type: Boolean,
+    },
+} as const;
+
+const why = defineCommand({
     alias: "explain",
     argument: {
         description: "Package(s) to explain",
@@ -17,31 +75,9 @@ const why: Command = {
     group: "Dependencies",
     loader: () => import("./handler"),
     name: "why",
-    options: [
-        { defaultValue: false, description: "Output as JSON", name: "json", type: Boolean },
-        { defaultValue: false, description: "Show extended information (pnpm)", name: "long", type: Boolean },
-        { defaultValue: false, description: "Machine-readable output (pnpm)", name: "parseable", type: Boolean },
-        { alias: "r", defaultValue: false, description: "Check across all workspaces", name: "recursive", type: Boolean },
-        { alias: "D", conflicts: "prod", description: "Filter to dev dependencies (pnpm)", name: "dev", type: Boolean },
-        { alias: "P", conflicts: "dev", description: "Filter to production dependencies (pnpm)", name: "prod", type: Boolean },
-        { defaultValue: false, description: "Exclude optional dependencies (pnpm)", name: "no-optional", type: Boolean },
-        { alias: "g", defaultValue: false, description: "Check globally installed packages (pnpm)", name: "global", type: Boolean },
-        { description: "Limit dependency tree depth", name: "depth", type: Number },
-        { alias: "F", description: "Filter by workspace package name", multiple: true, name: "filter", type: String },
-    ],
-};
+    options: whyOptionDefinitions,
+});
 
 export default why;
 
-export type WhyOptions = CreateOptions<{
-    depth: number | undefined;
-    dev: boolean | undefined;
-    filter: string[] | undefined;
-    global: boolean | undefined;
-    json: boolean | undefined;
-    long: boolean | undefined;
-    "no-optional": boolean | undefined;
-    parseable: boolean | undefined;
-    prod: boolean | undefined;
-    recursive: boolean | undefined;
-}>;
+export type WhyOptions = InferOptions<typeof whyOptionDefinitions>;

--- a/packages/tooling/vis/src/commands/x/index.ts
+++ b/packages/tooling/vis/src/commands/x/index.ts
@@ -1,4 +1,5 @@
-import type { Command, CreateOptions } from "@visulima/cerebro";
+import type { InferOptions } from "@visulima/cerebro";
+import { defineCommand } from "@visulima/cerebro";
 
 /**
  * `vis x &lt;file>` — run a TypeScript/JavaScript file directly under the selected
@@ -11,7 +12,11 @@ import type { Command, CreateOptions } from "@visulima/cerebro";
  * surface + JSX with no second Node boot. On the 22.14.x floor (no `registerHooks`)
  * the loader falls back to transpiling the entry to a temp `.mjs`.
  */
-const x: Command = {
+const xOptionDefinitions = {
+
+} as const;
+
+const x = defineCommand({
     argument: {
         description: "File to run, with any args to forward to it",
         name: "file",
@@ -27,9 +32,9 @@ const x: Command = {
     group: "Run & Execute",
     loader: () => import("./handler"),
     name: "x",
-    options: [],
-};
+    options: xOptionDefinitions,
+});
 
 export default x;
 
-export type XOptions = CreateOptions<Record<string, never>>;
+export type XOptions = InferOptions<typeof xOptionDefinitions>;

--- a/packages/tooling/vis/src/util/negatable-option.ts
+++ b/packages/tooling/vis/src/util/negatable-option.ts
@@ -1,5 +1,11 @@
 import type { OptionDefinition } from "@visulima/cerebro";
 
+/** The positive half of a negatable pair, as authored at the call site. */
+type NegatableOption = Omit<OptionDefinition<boolean>, "name"> & { name: string };
+
+/** The generated `--no-&lt;name>` half. */
+type NegatedTwin = { description: string; hidden: true; type: BooleanConstructor };
+
 /**
  * Pair a boolean option with the hidden `--no-&lt;name>` twin that turns it off.
  *
@@ -10,12 +16,12 @@ import type { OptionDefinition } from "@visulima/cerebro";
  * changes nothing — the same silent-no-op failure that makes a CI job pass
  * without running.
  *
- * Spread the result into an options array so the two can never drift:
+ * Spread the result into an options record so the two can never drift:
  *
  * ```ts
- * options: [
+ * options: {
  *     ...negatable({ defaultValue: true, description: "Enable caching (use --no-cache to disable)", name: "cache", type: Boolean }),
- * ]
+ * }
  * ```
  *
  * The twin is `hidden` so help output stays as-is — `--no-x` is already
@@ -24,15 +30,16 @@ import type { OptionDefinition } from "@visulima/cerebro";
  * Leave `defaultValue` off the positive option when you need a tri-state
  * (`undefined` = "fall back to config"): neither flag present then leaves
  * the value `undefined` rather than collapsing it to a boolean.
- * @param option The positive boolean option.
- * @returns The option followed by its hidden negated twin.
+ * @param option The positive boolean option, including its `name`.
+ * @returns A record holding the option and its hidden negated twin, keyed by name.
  */
-export const negatable = (option: OptionDefinition<boolean>): OptionDefinition<boolean>[] => [
-    option,
-    {
-        description: `Disable --${option.name}.`,
-        hidden: true,
-        name: `no-${option.name}`,
-        type: Boolean,
-    },
-];
+export const negatable = <const O extends NegatableOption>(
+    option: O,
+): { [K in `no-${O["name"]}`]: NegatedTwin } & { [K in O["name"]]: Omit<O, "name"> } => {
+    const { name, ...rest } = option;
+
+    return {
+        [`no-${name}`]: { description: `Disable --${name}.`, hidden: true, type: Boolean },
+        [name]: rest,
+    } as { [K in `no-${O["name"]}`]: NegatedTwin } & { [K in O["name"]]: Omit<O, "name"> };
+};


### PR DESCRIPTION
**Stacked on #842 — review and merge that first.** The base branch is
`feat/cerebro-define-command`; this PR only shows its own commit against it.

Adopts the feature #842 adds. `vis` is the only package that consumes cerebro
commands.

## What changed

57 command definitions move from the array form of `options` to the record form,
wrapped in `defineCommand`. Each command's exported options type is now inferred:

```diff
-const sortPackageJson: Command = {
-    options: [
-        { name: "check", alias: "c", defaultValue: false, type: Boolean, description: "..." },
-        { name: "sort-scripts", defaultValue: false, type: Boolean, description: "..." },
-        // ...10 more
-    ],
-};
-
-export type SortPackageJsonOptions = CreateOptions<{
-    check: boolean | undefined;
-    "final-newline": boolean | undefined;
-    // ...10 more, kept in sync by eye
-}>;
+const sortPackageJsonOptionDefinitions = {
+    check: { alias: "c", defaultValue: false, type: Boolean, description: "..." },
+    "sort-scripts": { defaultValue: false, type: Boolean, description: "..." },
+    // ...10 more
+} as const;
+
+const sortPackageJson = defineCommand({ options: sortPackageJsonOptionDefinitions, ... });
+
+export type SortPackageJsonOptions = InferOptions<typeof sortPackageJsonOptionDefinitions>;
```

The inferred types are **stricter** than the hand-written ones they replace. For
`sort-package-json`, `CreateOptions` declared all twelve keys as `| undefined`;
inference gives `check: boolean` and `lineEnding: string` (they have defaults)
and `finalNewline: boolean` (a `no-final-newline` boolean surfaces under the key
the runtime actually produces).

## Why the options live in a standalone const

Deriving the type from the command — `InferOptions<NonNullable<(typeof cmd)["options"]>>` —
compiles for a single command but closes a cycle wherever `handler.ts` imports
the type back from `index.ts`, since the command's own `loader` type mentions it.
TypeScript reports `Type alias 'XOptions' circularly references itself`. Anchoring
the type on the definitions instead breaks the cycle.

## What kept the array form

- **Commands whose options are assembled from shared spreads** (`run`, `ci`,
  `hook`, `advisories`, `attest`, `affected`, and the `migrate` / `cache` /
  `docker` / `ai` subcommand trees). A record cannot express
  `[...sharedOptions, { name: "x" }]`.
- **`release` and `security`.** Their aggregators collect subcommands into one
  array, and a shared annotation forces a single toolbox shape onto handlers that
  each infer their own. Left alone rather than papered over with a cast.
- **`argument`.** Untouched — converting positionals is a separate change with
  its own behavioural risk.

Both forms are supported, so this is a partial adoption by design, not an
unfinished one.

## Two cerebro fixes this surfaced

Both are in this PR because they are only reachable from a consumer:

- **`Cli.addCommand` on the `Cli` interface still took `Command`.** #842 updated
  the class but not the interface, so any code holding a `Cli` — which is how
  `register-commands.ts` is typed — rejected the record form. 42 errors.
- **`defineCommand` used its `loader` as an inference site.** A command pointing
  at a separately typed handler module collapsed `TEnv` / `TArguments` /
  `TLogger` to `never`. The handler is now behind `NoInfer`, so the toolbox shape
  is decided by `options` / `env` / `arguments` alone.

## A latent bug found, not fixed

`vis dlx` reads `options.noInfo`, which never exists: cerebro folds `--no-info`
onto `info` and deletes the negated key, so `--no-info` has only ever taken
effect through `VIS_DLX_NO_INFO`. The inferred type made this a compile error.
Behaviour is unchanged here — the dead read is removed and the bug documented at
both ends, since fixing it means deciding what `--info` should mean when `info`
already defaults to `true` after the fold.

## Testing

`vis`: 6750 passing, 24 failing — the same 24 that fail on `main` (cache
worktree, `run` token expansion, release doctor). Verified by running the suite
at the base commit and diffing. The one regression this introduced, a secrets
flag assertion reading `options` as an array, is fixed here. The `vis generate`
surface snapshot is updated — that test exists to force review of exactly this
kind of change.

`tsc --noEmit` and `eslint --max-warnings=0` are clean on `vis`. Cerebro's 666
tests still pass.
