### PR TITLE
fix(vis): install git hooks in every checkout, not just one

### DIFF
--- a/packages/tooling/vis/__tests__/commands/hook/hook-commands.test.ts
+++ b/packages/tooling/vis/__tests__/commands/hook/hook-commands.test.ts
@@ -11,9 +11,35 @@ import { formatListResult, listHooks, parseStageScript } from "../../../src/comm
 import { runHookStage } from "../../../src/commands/hook/run";
 import { validateHooks } from "../../../src/commands/hook/validate";
 
+/**
+ * Git exports `GIT_DIR`, `GIT_INDEX_FILE` and friends into hook processes, so
+ * these tests retarget the outer repo when the suite runs from a pre-commit
+ * hook. Clear them for the duration so every git call resolves from cwd.
+ */
+const INHERITED_GIT_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
+
+const detachGitEnvironment = (): (() => void) => {
+    const saved = new Map(INHERITED_GIT_VARS.map((name) => [name, process.env[name]]));
+
+    for (const name of INHERITED_GIT_VARS) {
+        Reflect.deleteProperty(process.env, name);
+    }
+
+    return () => {
+        for (const [name, value] of saved) {
+            if (value === undefined) {
+                Reflect.deleteProperty(process.env, name);
+            } else {
+                process.env[name] = value;
+            }
+        }
+    };
+};
+
 const createTemporaryGitRepo = (): { cleanup: () => void; root: string } => {
     const root = mkdtempSync(join(tmpdir(), "vis-hook-cmd-test-"));
     const originalCwd = process.cwd();
+    const restoreEnvironment = detachGitEnvironment();
 
     spawnSync("git", ["init"], { cwd: root, stdio: "ignore" });
     spawnSync("git", ["config", "user.email", "test@test.test"], { cwd: root });
@@ -24,6 +50,7 @@ const createTemporaryGitRepo = (): { cleanup: () => void; root: string } => {
     return {
         cleanup: () => {
             process.chdir(originalCwd);
+            restoreEnvironment();
             rmSync(root, { force: true, recursive: true });
         },
         root,
@@ -141,6 +168,56 @@ describe(validateHooks, () => {
 
         expect(result.ok).toBe(true);
         expect(result.issues.every((i) => i.kind !== "error")).toBe(true);
+    });
+
+    it.skipIf(process.platform === "win32")("accepts an install anchored at a subdirectory prefix", () => {
+        expect.assertions(2);
+
+        // `core.hooksPath` carries the prefix install ran from. Validate has to
+        // resolve the dispatcher the same way install writes it, or it reports
+        // a missing dispatcher for a repo that is correctly installed.
+        mkdirSync(join(temporary.root, "packages/app/.vis/hooks/_"), { recursive: true });
+        writeHookScript(temporary.root, "pre-commit", "#!/usr/bin/env sh\necho hi\n");
+        writeHookConfig(temporary.root, ".vis/hooks", {
+            stages: { "pre-commit": [{ entry: "echo hi", id: "noop" }] },
+            version: HOOK_CONFIG_VERSION,
+        });
+        spawnSync("git", ["config", "core.hooksPath", "packages/app/.vis/hooks/_"], { cwd: temporary.root });
+
+        const result = validateHooks(temporary.root, ".vis/hooks");
+
+        expect(result.issues.filter((i) => i.kind === "error")).toStrictEqual([]);
+        expect(result.ok).toBe(true);
+    });
+
+    it.skipIf(process.platform === "win32")("reports a worktree without a dispatcher as a warning, not a repo-wide failure", () => {
+        expect.assertions(3);
+
+        const worktreeParent = mkdtempSync(join(tmpdir(), "vis-hook-wt-"));
+        const worktree = join(worktreeParent, "wt");
+
+        try {
+            mkdirSync(join(temporary.root, ".vis/hooks/_"), { recursive: true });
+            writeHookScript(temporary.root, "pre-commit", "#!/usr/bin/env sh\necho hi\n");
+            writeHookConfig(temporary.root, ".vis/hooks", {
+                stages: { "pre-commit": [{ entry: "echo hi", id: "noop" }] },
+                version: HOOK_CONFIG_VERSION,
+            });
+            spawnSync("git", ["config", "core.hooksPath", ".vis/hooks/_"], { cwd: temporary.root });
+            spawnSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], { cwd: temporary.root });
+            spawnSync("git", ["worktree", "add", "-q", worktree, "-b", "wt"], { cwd: temporary.root });
+
+            const result = validateHooks(temporary.root, ".vis/hooks");
+
+            expect(result.issues.some((i) => i.kind === "warning" && i.message.includes("runs no hooks there"))).toBe(true);
+            expect(result.issues.filter((i) => i.kind === "error")).toStrictEqual([]);
+            // Transient worktrees are normal here; a non-zero exit for one of
+            // them would make validate useless as a CI gate.
+            expect(result.ok).toBe(true);
+        } finally {
+            spawnSync("git", ["worktree", "remove", "--force", worktree], { cwd: temporary.root });
+            rmSync(worktreeParent, { force: true, recursive: true });
+        }
     });
 
     it.skipIf(process.platform === "win32")("detects shell syntax errors in a stage script", () => {

--- a/packages/tooling/vis/__tests__/commands/hook/hook.test.ts
+++ b/packages/tooling/vis/__tests__/commands/hook/hook.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,12 +23,38 @@ const countDirnameCalls = (script: string): number => {
 };
 
 /**
+ * Git exports `GIT_DIR`, `GIT_INDEX_FILE` and friends into hook processes, so
+ * these tests retarget the outer repo when the suite runs from a pre-commit
+ * hook. Clear them for the duration so every git call resolves from cwd.
+ */
+const INHERITED_GIT_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
+
+const detachGitEnvironment = (): (() => void) => {
+    const saved = new Map(INHERITED_GIT_VARS.map((name) => [name, process.env[name]]));
+
+    for (const name of INHERITED_GIT_VARS) {
+        Reflect.deleteProperty(process.env, name);
+    }
+
+    return () => {
+        for (const [name, value] of saved) {
+            if (value === undefined) {
+                Reflect.deleteProperty(process.env, name);
+            } else {
+                process.env[name] = value;
+            }
+        }
+    };
+};
+
+/**
  * Creates a temp directory with `git init` and returns cleanup helpers.
  * execSync used with hardcoded "git init" — no user input, safe for test setup.
  */
 const createTemporaryGitRepo = (): { cleanup: () => void; restore: () => void; root: string } => {
     const root = mkdtempSync(join(tmpdir(), "vis-hook-test-"));
     const originalCwd = process.cwd();
+    const restoreEnvironment = detachGitEnvironment();
 
     execSync("git init", { cwd: root, stdio: "ignore" });
     process.chdir(root);
@@ -36,10 +62,12 @@ const createTemporaryGitRepo = (): { cleanup: () => void; restore: () => void; r
     return {
         cleanup: () => {
             process.chdir(originalCwd);
+            restoreEnvironment();
             rmSync(root, { force: true, recursive: true });
         },
         restore: () => {
             process.chdir(originalCwd);
+            restoreEnvironment();
         },
         root,
     };
@@ -54,6 +82,13 @@ const createTemporaryDirectory = (): { cleanup: () => void; root: string } => {
         },
         root,
     };
+};
+
+const commitEmpty = (root: string): void => {
+    execSync("git config user.email vis@example.com", { cwd: root, stdio: "ignore" });
+    execSync("git config user.name vis", { cwd: root, stdio: "ignore" });
+    execSync("git config commit.gpgsign false", { cwd: root, stdio: "ignore" });
+    execSync("git commit -q --allow-empty -m init", { cwd: root, stdio: "ignore" });
 };
 
 describe(hookScript, () => {
@@ -259,34 +294,175 @@ describe(installHooks, () => {
         }
     });
 
-    it.skipIf(process.platform === "win32")("should skip when core.hooksPath is already set to a different path", () => {
-        expect.assertions(2);
+    it.skipIf(process.platform === "win32")("should skip with a warning when core.hooksPath points at another tool's populated hooks", () => {
+        expect.assertions(4);
 
-        const { cleanup } = createTemporaryGitRepo();
+        const { cleanup, root } = createTemporaryGitRepo();
 
         try {
+            mkdirSync(join(root, ".other-hooks"), { recursive: true });
+            writeFileSync(join(root, ".other-hooks", "pre-commit"), "#!/usr/bin/env sh\n", { mode: 0o755 });
             execSync("git config core.hooksPath .other-hooks", { stdio: "ignore" });
 
             const result = installHooks(".vis/hooks");
 
             expect(result.isError).toBe(false);
+            expect(result.isWarning).toBe(true);
             expect(result.message).toContain("already set");
+            // The message has to name the way out, or the repo stays stuck here forever.
+            expect(result.message).toContain("--force");
         } finally {
             cleanup();
         }
     });
 
-    it.skipIf(process.platform === "win32")("should work with custom directory name", () => {
+    it.skipIf(process.platform === "win32")("should fail when core.hooksPath points at a directory with no hooks", () => {
+        expect.assertions(3);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+
+        try {
+            // What `.git/hooks` looks like: samples only, so git runs nothing.
+            mkdirSync(join(root, ".empty-hooks"), { recursive: true });
+            writeFileSync(join(root, ".empty-hooks", "pre-commit.sample"), "#!/usr/bin/env sh\n");
+            execSync("git config core.hooksPath .empty-hooks", { stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks");
+
+            expect(result.isError).toBe(true);
+            expect(result.message).toContain("no hooks");
+            expect(result.message).toContain("--force");
+        } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should take over an unexpected core.hooksPath with force", () => {
+        expect.assertions(3);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+
+        try {
+            mkdirSync(join(root, ".other-hooks"), { recursive: true });
+            writeFileSync(join(root, ".other-hooks", "pre-commit"), "#!/usr/bin/env sh\n", { mode: 0o755 });
+            execSync("git config core.hooksPath .other-hooks", { stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks", { force: true });
+
+            expect(result.isError).toBe(false);
+            expect(execSync("git config --local core.hooksPath", { encoding: "utf8" }).trim()).toBe(".vis/hooks/_");
+            expect(existsSync(join(root, ".vis", "hooks", "_", "pre-commit"))).toBe(true);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should install a dispatcher into every linked worktree", () => {
+        expect.assertions(3);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+        const { cleanup: cleanupWorktree, root: worktreeParent } = createTemporaryDirectory();
+        const worktree = join(worktreeParent, "wt");
+
+        try {
+            commitEmpty(root);
+            execFileSync("git", ["worktree", "add", "-q", worktree, "-b", "wt"], { cwd: root, stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks");
+
+            expect(result.isError).toBe(false);
+            expect(existsSync(join(root, ".vis", "hooks", "_", "pre-commit"))).toBe(true);
+            // `core.hooksPath` is shared but resolved per checkout — without a
+            // dispatcher here the worktree commits with no hooks at all.
+            expect(existsSync(join(worktree, ".vis", "hooks", "_", "pre-commit"))).toBe(true);
+        } finally {
+            execFileSync("git", ["worktree", "remove", "--force", worktree], { cwd: root, stdio: "ignore" });
+            cleanupWorktree();
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should adopt an existing vis hooksPath anchored at another checkout prefix", () => {
+        expect.assertions(3);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+
+        try {
+            // What a repo installed from `packages/app` looks like from the
+            // root of a freshly added worktree: same hooks dir, different
+            // prefix. Treating it as a foreign path made install refuse to
+            // create the very dispatcher it exists to create.
+            execSync("git config core.hooksPath packages/app/.vis/hooks/_", { cwd: root, stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks");
+
+            expect(result.isError).toBe(false);
+            expect(existsSync(join(root, "packages", "app", ".vis", "hooks", "_", "pre-commit"))).toBe(true);
+            // The repo-wide path must not move just because cwd differs.
+            expect(execSync("git config --local core.hooksPath", { encoding: "utf8" }).trim()).toBe("packages/app/.vis/hooks/_");
+        } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should not error when core.hooksPath is the git-native /dev/null disable", () => {
+        expect.assertions(2);
+
+        const { cleanup } = createTemporaryGitRepo();
+
+        try {
+            execSync("git config core.hooksPath /dev/null", { stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks");
+
+            // Deliberate, not broken — failing here would break `pnpm install`
+            // through the `prepare` script.
+            expect(result.isError).toBe(false);
+            expect(result.isWarning).toBe(true);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should treat a hooks directory of unsupported stages as populated", () => {
         expect.assertions(2);
 
         const { cleanup, root } = createTemporaryGitRepo();
 
         try {
-            const result = installHooks(".my-hooks");
+            // `reference-transaction` is a real git hook vis writes no shim
+            // for. Calling that "no hooks" would block install on a working setup.
+            mkdirSync(join(root, ".other-hooks"), { recursive: true });
+            writeFileSync(join(root, ".other-hooks", "reference-transaction"), "#!/usr/bin/env sh\n", { mode: 0o755 });
+            execSync("git config core.hooksPath .other-hooks", { stdio: "ignore" });
+
+            const result = installHooks(".vis/hooks");
 
             expect(result.isError).toBe(false);
-            expect(existsSync(join(root, ".my-hooks", "_", "pre-commit"))).toBe(true);
+            expect(result.isWarning).toBe(true);
         } finally {
+            cleanup();
+        }
+    });
+
+    it.skipIf(process.platform === "win32")("should not resurrect a deleted worktree directory", () => {
+        expect.assertions(2);
+
+        const { cleanup, root } = createTemporaryGitRepo();
+        const { cleanup: cleanupWorktree, root: worktreeParent } = createTemporaryDirectory();
+        const worktree = join(worktreeParent, "gone");
+
+        try {
+            commitEmpty(root);
+            execFileSync("git", ["worktree", "add", "-q", worktree, "-b", "gone"], { cwd: root, stdio: "ignore" });
+            rmSync(worktree, { force: true, recursive: true });
+
+            const result = installHooks(".vis/hooks");
+
+            expect(result.isError).toBe(false);
+            expect(existsSync(worktree)).toBe(false);
+        } finally {
+            cleanupWorktree();
             cleanup();
         }
     });

--- a/packages/tooling/vis/docs/commands/hook.mdx
+++ b/packages/tooling/vis/docs/commands/hook.mdx
@@ -25,6 +25,33 @@ vis hook install
 
 > **Migrating from `.vis-hooks`.** The hooks directory moved from `.vis-hooks` to `.vis/hooks`. `vis hook install` performs the move automatically: an existing `.vis-hooks` is renamed to `.vis/hooks` (your stage scripts and `config.json` come along) and `core.hooksPath` is re-pointed. Re-run `vis hook install` once after upgrading.
 
+#### When `core.hooksPath` is already set
+
+If another tool owns `core.hooksPath`, install yields to it and warns instead of taking over. Take it over with:
+
+```bash
+vis hook install --force
+```
+
+If that path is a directory holding no hooks at all — `.git/hooks` with only `*.sample` files, say — install **fails** instead of yielding, because git would silently run nothing. Set `VIS_GIT_HOOKS=0` to skip installing hooks entirely.
+
+A `core.hooksPath` that is not a directory at all (`/dev/null`, the git-native way to disable hooks for a clone) is treated as deliberate: install warns and exits 0.
+
+#### Git worktrees
+
+`core.hooksPath` lives in the shared git config, but its value is relative, so git resolves it inside whichever checkout you commit from. The `_` dispatcher is generated and gitignored, so a worktree without one makes git find no hooks — silently.
+
+`vis hook install` writes the dispatcher into **every** linked worktree, so one run repairs them all. Worktrees that are bare, prunable, locked, or not currently on disk are skipped, and a worktree that cannot be written (ejected volume, another user's checkout) is reported as a warning rather than failing the install. A worktree added afterwards needs its own run:
+
+```bash
+git worktree add ../feature -b feature
+cd ../feature && vis hook install   # or any `pnpm install`, via the `prepare` script
+```
+
+`vis hook validate` reports linked worktrees that are missing a dispatcher — as warnings, so one transient worktree does not fail the whole check. A missing dispatcher in the current checkout is still an error.
+
+`vis hook uninstall` clears the dispatcher from every checkout, matching install.
+
 ### uninstall
 
 Remove git hooks and reset `core.hooksPath`:
@@ -43,7 +70,7 @@ vis hook list
 
 ### validate
 
-Sanity-check the hooks directory: verifies `core.hooksPath`, the dispatcher scripts, each stage script's shell syntax (`sh -n`), executable permissions, and — if any stage references the bundled `prek-runner.mjs` — that the runner exists and parses with `node --check`. Exits non-zero on any error.
+Sanity-check the hooks directory: verifies `core.hooksPath`, the dispatcher scripts (in this checkout and in every linked worktree), each stage script's shell syntax (`sh -n`), executable permissions, and — if any stage references the bundled `prek-runner.mjs` — that the runner exists and parses with `node --check`. Exits non-zero on any error.
 
 ```bash
 vis hook validate

--- a/packages/tooling/vis/src/commands/hook/constants.ts
+++ b/packages/tooling/vis/src/commands/hook/constants.ts
@@ -63,7 +63,11 @@ const PREK_STAGES_WITH_GIT_ARGS: ReadonlySet<string> = new Set<string>([
 const PREK_TRANSLATABLE_LANGUAGES: ReadonlySet<string> = new Set<string>(["fail", "script", "system"]);
 
 interface InstallResult {
+    /** Hooks were actually written, so the caller should finish setting the workspace up. */
+    installed?: boolean;
     isError: boolean;
+    /** Surface `message` at warn level — the command succeeded but left something for the user to act on. */
+    isWarning?: boolean;
     message: string;
 }
 

--- a/packages/tooling/vis/src/commands/hook/handler.ts
+++ b/packages/tooling/vis/src/commands/hook/handler.ts
@@ -6,6 +6,7 @@ import type { CommandExecute, Toolbox } from "@visulima/cerebro";
 import { isAccessibleSync, readFileSync } from "@visulima/fs";
 import { join } from "@visulima/path";
 
+import { VisUserError } from "../../errors/vis-user-error";
 import { DEFAULT_HOOKS_DIRECTORY } from "./constants";
 import type {
     HookAddOptions,
@@ -44,7 +45,7 @@ const confirmPrompt = (question: string): Promise<boolean> =>
         });
     });
 
-const executeInstall = async (hooksDirectory: string, logger: HookLogger, useEditorconfig?: boolean): Promise<void> => {
+const executeInstall = async (hooksDirectory: string, logger: HookLogger, options: { force?: boolean; useEditorconfig?: boolean } = {}): Promise<void> => {
     const root = cwd();
     const huskyDirectory = detectHuskyDirectory(root);
     const prekConfig = detectPrekConfig(root);
@@ -59,7 +60,7 @@ const executeInstall = async (hooksDirectory: string, logger: HookLogger, useEdi
         const shouldMigrate = await confirmPrompt("Would you like to migrate your husky hooks to vis?");
 
         if (shouldMigrate) {
-            const migrateResult = migrateFromHusky(root, hooksDirectory, logger as Console, { useEditorconfig });
+            const migrateResult = migrateFromHusky(root, hooksDirectory, logger as Console, { useEditorconfig: options.useEditorconfig });
 
             if (migrateResult.isError) {
                 throw new Error(migrateResult.message);
@@ -83,7 +84,7 @@ const executeInstall = async (hooksDirectory: string, logger: HookLogger, useEdi
         const shouldMigrate = await confirmPrompt("Would you like to migrate your prek hooks to vis?");
 
         if (shouldMigrate) {
-            const migrateResult = migrateFromPrek(root, hooksDirectory, logger, { useEditorconfig });
+            const migrateResult = migrateFromPrek(root, hooksDirectory, logger, { useEditorconfig: options.useEditorconfig });
 
             if (migrateResult.isError) {
                 throw new Error(migrateResult.message);
@@ -103,15 +104,24 @@ const executeInstall = async (hooksDirectory: string, logger: HookLogger, useEdi
 
     logger.info(`Installing git hooks in ${hooksDirectory}/...`);
 
-    const result = installHooks(hooksDirectory);
+    const result = installHooks(hooksDirectory, { force: options.force });
+
+    if (result.isError) {
+        // The message alone says what to do (`--force`, unset the config,
+        // VIS_GIT_HOOKS=0); a stack into minified bundle internals would push
+        // it off screen.
+        throw new VisUserError(result.message);
+    }
 
     if (result.message) {
-        if (result.isError) {
-            throw new Error(result.message);
+        if (result.isWarning) {
+            logger.warn(result.message);
+        } else {
+            logger.info(result.message);
         }
+    }
 
-        logger.info(result.message);
-
+    if (!result.installed) {
         return;
     }
 
@@ -204,12 +214,16 @@ const executeUninstall = (hooksDirectory: string, logger: HookLogger): void => {
 
     const result = uninstallHooks(hooksDirectory);
 
-    if (result.message) {
-        if (result.isError) {
-            throw new Error(result.message);
-        }
+    if (result.isError) {
+        throw new VisUserError(result.message);
+    }
 
-        logger.info(result.message);
+    if (result.message) {
+        if (result.isWarning) {
+            logger.warn(result.message);
+        } else {
+            logger.info(result.message);
+        }
 
         return;
     }
@@ -218,7 +232,7 @@ const executeUninstall = (hooksDirectory: string, logger: HookLogger): void => {
 };
 
 const hookInstallImpl = async ({ logger, options, visConfig }: Toolbox<Console, HookInstallOptions, HookEnv>): Promise<void> => {
-    await executeInstall(resolveHooksDirectory(options), logger, visConfig?.editorconfig ?? true);
+    await executeInstall(resolveHooksDirectory(options), logger, { force: Boolean(options.force), useEditorconfig: visConfig?.editorconfig ?? true });
 };
 
 const hookUninstallImpl = ({ logger, options }: Toolbox<Console, HookUninstallOptions, HookEnv>): void => {

--- a/packages/tooling/vis/src/commands/hook/index.ts
+++ b/packages/tooling/vis/src/commands/hook/index.ts
@@ -28,6 +28,7 @@ const hookInstall: Command = {
     examples: [
         ["vis hook install", "Install git hooks in .vis/hooks/"],
         ["vis hook install --hooks-dir=.githooks", "Install hooks in a custom directory"],
+        ["vis hook install --force", "Take over core.hooksPath even when another tool set it"],
     ],
     group: "Git Hooks",
     loader: () =>
@@ -35,7 +36,15 @@ const hookInstall: Command = {
             return { default: m.hookInstallExecute };
         }),
     name: "install",
-    options: [hooksDirectoryOption],
+    options: [
+        hooksDirectoryOption,
+        {
+            defaultValue: false,
+            description: "Overwrite core.hooksPath even when it points somewhere unexpected",
+            name: "force",
+            type: Boolean,
+        },
+    ],
 };
 
 const hookUninstall: Command = {
@@ -182,6 +191,7 @@ export type HookEnv = CreateEnv<{
 }>;
 
 export type HookInstallOptions = CreateOptions<{
+    force: boolean | undefined;
     "hooks-dir": string | undefined;
 }>;
 

--- a/packages/tooling/vis/src/commands/hook/install.ts
+++ b/packages/tooling/vis/src/commands/hook/install.ts
@@ -1,15 +1,16 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import { ensureDirSync } from "@visulima/fs";
-import { join } from "@visulima/path";
+import { isAbsolute, join } from "@visulima/path";
 
 import { loadHookConfig } from "./config";
 import type { InstallResult } from "./constants";
 import { DEFAULT_HOOKS_DIRECTORY, HOOKS, LEGACY_HOOKS_DIRECTORY } from "./constants";
 
 const TRAILING_SLASH_RE = /\/$/;
+const WORKTREE_LINE_PREFIX = "worktree ";
 
 /**
  * One-time move of the pre-1.0 `.vis-hooks` directory to its new home under
@@ -89,7 +90,165 @@ c=$?
 exit $c`;
 };
 
-const installHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallResult => {
+/** Writes the generated `_` dispatcher into one checkout. */
+const writeDispatcher = (internalDirectory: string, directory: string, skipInCI: boolean): void => {
+    ensureDirSync(internalDirectory);
+    writeFileSync(join(internalDirectory, ".gitignore"), "*");
+    writeFileSync(join(internalDirectory, "h"), hookScript(directory, { skipInCI }), { mode: 0o755 });
+
+    for (const hook of HOOKS) {
+        writeFileSync(join(internalDirectory, hook), `#!/usr/bin/env sh\n. "$(dirname "$0")/h"`, { mode: 0o755 });
+    }
+};
+
+/**
+ * Every working checkout attached to this repository — the main one plus any
+ * linked worktree.
+ *
+ * Bare entries have no files to dispatch from, and `prunable` entries name a
+ * directory the user already deleted: writing there would resurrect the path
+ * on disk (and, when the worktree lived on removable media, create a tree
+ * under the mountpoint that keeps the volume from mounting cleanly). Both are
+ * skipped, as is any checkout that is not currently present.
+ *
+ * Falls back to `cwd` when `git worktree list` is unavailable.
+ */
+const checkoutRoots = (cwd?: string): string[] => {
+    const result = spawnSync("git", ["worktree", "list", "--porcelain"], { cwd, encoding: "utf8" });
+    const roots: string[] = [];
+
+    if (result.status === 0) {
+        let current: string | undefined;
+
+        for (const line of result.stdout.split("\n")) {
+            if (line.startsWith(WORKTREE_LINE_PREFIX)) {
+                current = line.slice(WORKTREE_LINE_PREFIX.length).trim() || undefined;
+            } else if (line === "bare" || line === "locked" || line.startsWith("locked ") || line.startsWith("prunable")) {
+                current = undefined;
+            } else if (line === "" && current) {
+                roots.push(current);
+                current = undefined;
+            }
+        }
+
+        if (current) {
+            roots.push(current);
+        }
+    }
+
+    const present = roots.filter((root) => existsSync(root));
+
+    return present.length > 0 ? present : [cwd ?? process.cwd()];
+};
+
+/**
+ * Where the `_` dispatcher belongs in every checkout of this repository.
+ *
+ * `core.hooksPath` is written with `git config --local`, which lands in the
+ * shared `$GIT_COMMON_DIR/config`, but its value is relative so git resolves
+ * it inside whichever checkout the commit happens in. The dispatcher is
+ * generated and gitignored, so a checkout without one leaves git pointing at
+ * a directory that does not exist there — which git treats as "no hooks",
+ * silently and with exit 0.
+ *
+ * `hooksTarget` is the configured `core.hooksPath` value, itself relative to
+ * a checkout root, so joining it onto each root is exactly how git resolves
+ * it there. Install and validate share this so they cannot disagree about
+ * where a dispatcher should be — a disagreement reads as a missing dispatcher
+ * in whichever of them is wrong.
+ */
+const dispatcherDirectories = (hooksTarget: string, cwd?: string): string[] => checkoutRoots(cwd).map((root) => join(root, hooksTarget));
+
+const resolveHooksPath = (hooksPath: string, root: string): string => (isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath));
+
+/**
+ * Does this `core.hooksPath` value name `directory`, whatever checkout prefix
+ * it carries? `git rev-parse --show-prefix` depends on the directory install
+ * was invoked from, so the same repo reports `packages/app/.vis/hooks/_` from
+ * one cwd and `.vis/hooks/_` from another.
+ */
+const namesHooksDirectory = (value: string, directory: string): boolean => value === `${directory}/_` || value.endsWith(`/${directory}/_`);
+
+/** A dispatcher vis generated — `h` is our script, whatever directory it sits in. */
+const isVisDispatcher = (hooksPath: string, root: string): boolean => {
+    try {
+        return readFileSync(join(resolveHooksPath(hooksPath, root), "h"), "utf8").includes("VIS_GIT_HOOKS");
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * What is actually at someone else's `core.hooksPath`?
+ *
+ * `populated` is the only state where yielding is graceful. `empty` is a real
+ * directory holding nothing git would run — `.git/hooks` with just its
+ * `*.sample` files is the common one — so git runs no hooks at all and
+ * reporting success is how a repo ends up with no gate and nobody notices.
+ * `missing` is neither: `core.hooksPath=/dev/null` is the git-native way to
+ * turn hooks off for a clone, and an absent directory may belong to a tool
+ * whose files simply are not checked out yet.
+ */
+const probeHooksPath = (hooksPath: string, root: string): "empty" | "missing" | "populated" => {
+    let entries: string[];
+
+    try {
+        entries = readdirSync(resolveHooksPath(hooksPath, root));
+    } catch {
+        return "missing";
+    }
+
+    return entries.some((entry) => !entry.startsWith(".") && !entry.endsWith(".sample")) ? "populated" : "empty";
+};
+
+/**
+ * Picks the `core.hooksPath` install should end up with, or refuses to touch
+ * it. Returns `{ target }` to proceed, or `{ yielded }` to stop.
+ */
+const arbitrateHooksPath = (directory: string, target: string, topLevel: string, force: boolean): { target: string } | { yielded: InstallResult } => {
+    const checkResult = spawnSync("git", ["config", "--local", "core.hooksPath"]);
+    const existing = checkResult.status === 0 ? (checkResult.stdout?.toString().trim() ?? "") : "";
+
+    if (!existing || force) {
+        return { target };
+    }
+
+    // Already ours, just anchored at a different checkout prefix. Keep the
+    // configured value: rewriting it would move the whole repo's hooks path as
+    // a side effect of which directory install happened to run from, and this
+    // is the ordinary state inside a fresh worktree that needs a dispatcher.
+    if (namesHooksDirectory(existing, directory)) {
+        return { target: existing };
+    }
+
+    // The pre-1.0 default lived at `.vis-hooks/_`, and a dispatcher we
+    // generated under a different `--hooks-dir` is still ours: re-point both.
+    if (namesHooksDirectory(existing, LEGACY_HOOKS_DIRECTORY) || isVisDispatcher(existing, topLevel)) {
+        return { target };
+    }
+
+    if (probeHooksPath(existing, topLevel) === "empty") {
+        return {
+            yielded: {
+                isError: true,
+                message:
+                    `core.hooksPath is set to "${existing}", which holds no hooks — git is currently running none. `
+                    + "Re-run with `vis hook install --force` to take it over, unset it with `git config --local --unset core.hooksPath`, "
+                    + "or set VIS_GIT_HOOKS=0 to skip installing hooks entirely.",
+            },
+        };
+    }
+
+    return {
+        yielded: {
+            isError: false,
+            isWarning: true,
+            message: `core.hooksPath is already set to "${existing}" by another tool, skipping. Re-run with \`vis hook install --force\` to take it over.`,
+        },
+    };
+};
+
+const installHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY, options: { force?: boolean } = {}): InstallResult => {
     if (process.env["VIS_GIT_HOOKS"] === "0") {
         return { isError: false, message: "skip install (git hooks disabled via VIS_GIT_HOOKS=0)" };
     }
@@ -110,32 +269,17 @@ const installHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallResul
 
     const migrationNote = migrateLegacyHooksDirectory(directory);
 
-    const internal = (path = ""): string => join(directory, "_", path);
     const relative = prefixResult.stdout.toString().trim().replace(TRAILING_SLASH_RE, "");
-    const target = relative ? `${relative}/${directory}/_` : `${directory}/_`;
-    // The pre-1.0 default lived at `.vis-hooks/_`; treat a config still pointing
-    // there as ours so the migration re-points it instead of bailing out.
-    const legacyTarget = relative ? `${relative}/${LEGACY_HOOKS_DIRECTORY}/_` : `${LEGACY_HOOKS_DIRECTORY}/_`;
+    const topLevelResult = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+    const topLevel = topLevelResult.status === 0 && topLevelResult.stdout.trim() ? topLevelResult.stdout.trim() : process.cwd();
 
-    const checkResult = spawnSync("git", ["config", "--local", "core.hooksPath"]);
-    const existingHooksPath = checkResult.status === 0 ? checkResult.stdout?.toString().trim() : "";
+    const arbitration = arbitrateHooksPath(directory, relative ? `${relative}/${directory}/_` : `${directory}/_`, topLevel, Boolean(options.force));
 
-    if (existingHooksPath && existingHooksPath !== target && existingHooksPath !== legacyTarget) {
-        return {
-            isError: false,
-            message: `core.hooksPath is already set to "${existingHooksPath}", skipping`,
-        };
+    if ("yielded" in arbitration) {
+        return arbitration.yielded;
     }
 
-    const { status, stderr } = spawnSync("git", ["config", "core.hooksPath", target]);
-
-    if (status === null) {
-        return { isError: true, message: "git command not found" };
-    }
-
-    if (status) {
-        return { isError: true, message: String(stderr) };
-    }
+    const { target } = arbitration;
 
     // Read `skipInCI` from config.json (created by migrate / hand-authored)
     // so the dispatcher we write below carries the CI kill-switch. A
@@ -149,15 +293,60 @@ const installHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallResul
         }
     })();
 
-    ensureDirSync(internal());
-    writeFileSync(internal(".gitignore"), "*");
-    writeFileSync(internal("h"), hookScript(directory, { skipInCI }), { mode: 0o755 });
+    // This checkout's dispatcher has to work — without it there is nothing for
+    // `core.hooksPath` to resolve to here — so write it before touching the
+    // config and fail outright if it cannot be written. Otherwise a partial
+    // install leaves the config pointing at a directory that does not exist,
+    // which is exactly the silent no-hooks state being fixed.
+    const currentDispatcher = join(topLevel, target);
 
-    for (const hook of HOOKS) {
-        writeFileSync(internal(hook), `#!/usr/bin/env sh\n. "$(dirname "$0")/h"`, { mode: 0o755 });
+    try {
+        writeDispatcher(currentDispatcher, directory, skipInCI);
+    } catch (error) {
+        return { isError: true, message: `failed to write ${currentDispatcher}: ${error instanceof Error ? error.message : String(error)}` };
     }
 
-    return { isError: false, message: migrationNote ?? "" };
+    // Every other checkout is best-effort: one unreachable worktree (ejected
+    // volume, another user's checkout) must not abort an install that already
+    // succeeded where it was run.
+    const failures: string[] = [];
+    let alsoWritten = 0;
+
+    for (const dispatcher of dispatcherDirectories(target, topLevel)) {
+        if (dispatcher === currentDispatcher) {
+            continue;
+        }
+
+        try {
+            writeDispatcher(dispatcher, directory, skipInCI);
+            alsoWritten += 1;
+        } catch (error) {
+            failures.push(`${dispatcher} (${error instanceof Error ? error.message : String(error)})`);
+        }
+    }
+
+    const { status, stderr } = spawnSync("git", ["config", "core.hooksPath", target]);
+
+    if (status === null) {
+        return { isError: true, message: "git command not found" };
+    }
+
+    if (status) {
+        return { isError: true, message: String(stderr) };
+    }
+
+    const notes = [migrationNote, alsoWritten > 0 ? `installed dispatchers in ${alsoWritten} linked worktree(s)` : undefined].filter(Boolean);
+
+    if (failures.length > 0) {
+        return {
+            installed: true,
+            isError: false,
+            isWarning: true,
+            message: `could not install hooks in ${failures.length} linked worktree(s) — they will run no hooks until \`vis hook install\` succeeds there: ${failures.join(", ")}`,
+        };
+    }
+
+    return { installed: true, isError: false, message: notes.join("; ") };
 };
 
-export { hookScript, installHooks };
+export { dispatcherDirectories, hookScript, installHooks };

--- a/packages/tooling/vis/src/commands/hook/migrate.ts
+++ b/packages/tooling/vis/src/commands/hook/migrate.ts
@@ -216,7 +216,11 @@ const migrateFromHusky = (root: string, hooksDirectory: string, logger: Console,
         }
 
         if (installResult.message) {
-            logger.info(installResult.message);
+            if (installResult.isWarning) {
+                logger.warn(installResult.message);
+            } else {
+                logger.info(installResult.message);
+            }
         }
     }
 

--- a/packages/tooling/vis/src/commands/hook/prek.ts
+++ b/packages/tooling/vis/src/commands/hook/prek.ts
@@ -578,7 +578,11 @@ const migrateFromPrek = (root: string, hooksDirectory: string, logger: MigrateLo
         }
 
         if (installResult.message) {
-            logger.info(installResult.message);
+            if (installResult.isWarning) {
+                logger.warn(installResult.message);
+            } else {
+                logger.info(installResult.message);
+            }
         }
     }
 

--- a/packages/tooling/vis/src/commands/hook/uninstall.ts
+++ b/packages/tooling/vis/src/commands/hook/uninstall.ts
@@ -2,17 +2,23 @@ import { spawnSync } from "node:child_process";
 import { rmSync } from "node:fs";
 
 import { isAccessibleSync } from "@visulima/fs";
-import { join } from "@visulima/path";
 
 import type { InstallResult } from "./constants";
 import { DEFAULT_HOOKS_DIRECTORY } from "./constants";
+import { dispatcherDirectories } from "./install";
 
 const uninstallHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallResult => {
-    const checkResult = spawnSync("git", ["config", "--local", "core.hooksPath"]);
+    const checkResult = spawnSync("git", ["config", "--local", "core.hooksPath"], { encoding: "utf8" });
 
     if (checkResult.status !== 0) {
         return { isError: false, message: "No custom hooks path configured" };
     }
+
+    // Read the configured value before unsetting it: install anchors it at
+    // whichever checkout prefix it ran from, and it is what tells us where the
+    // dispatchers actually live in each worktree.
+    const target = checkResult.stdout.trim() || `${directory}/_`;
+    const dispatchers = dispatcherDirectories(target);
 
     const { status, stderr } = spawnSync("git", ["config", "--local", "--unset", "core.hooksPath"]);
 
@@ -24,10 +30,24 @@ const uninstallHooks = (directory: string = DEFAULT_HOOKS_DIRECTORY): InstallRes
         return { isError: true, message: String(stderr) };
     }
 
-    const internalDirectory = join(directory, "_");
+    // Install writes a dispatcher into every checkout, so uninstall clears
+    // every checkout; otherwise each linked worktree keeps an orphan copy.
+    const failures: string[] = [];
 
-    if (isAccessibleSync(internalDirectory)) {
-        rmSync(internalDirectory, { force: true, recursive: true });
+    for (const dispatcher of dispatchers) {
+        if (!isAccessibleSync(dispatcher)) {
+            continue;
+        }
+
+        try {
+            rmSync(dispatcher, { force: true, recursive: true });
+        } catch (error) {
+            failures.push(`${dispatcher} (${error instanceof Error ? error.message : String(error)})`);
+        }
+    }
+
+    if (failures.length > 0) {
+        return { isError: false, isWarning: true, message: `could not remove ${failures.length} dispatcher director(ies): ${failures.join(", ")}` };
     }
 
     return { isError: false, message: "" };

--- a/packages/tooling/vis/src/commands/hook/validate.ts
+++ b/packages/tooling/vis/src/commands/hook/validate.ts
@@ -7,6 +7,7 @@ import { join } from "@visulima/path";
 
 import { HOOK_CONFIG_FILENAME, loadHookConfig } from "./config";
 import { HOOKS } from "./constants";
+import { dispatcherDirectories } from "./install";
 
 /* eslint-disable no-bitwise -- Unix mode bits need bit-level masking. */
 interface ValidationIssue {
@@ -42,21 +43,38 @@ const validateHooks = (root: string, hooksDirectory: string): ValidationResult =
 
     // core.hooksPath sanity
     const configResult = spawnSync("git", ["config", "--local", "core.hooksPath"], { cwd: root, encoding: "utf8" });
+    const expectedSuffix = `${hooksDirectory}/_`;
+    const configured = configResult.status === 0 ? configResult.stdout.trim() : "";
 
-    if (configResult.status === 0) {
-        const current = configResult.stdout.trim();
-        const expected = `${hooksDirectory}/_`;
-
-        if (current && current !== expected) {
-            issues.push({ kind: "warning", message: `core.hooksPath is "${current}" — expected "${expected}". Re-run \`vis hook install\` to fix.` });
-        }
-    } else {
+    if (!configured) {
         issues.push({ kind: "warning", message: "core.hooksPath is not set — run `vis hook install`." });
+    } else if (configured !== expectedSuffix && !configured.endsWith(`/${expectedSuffix}`)) {
+        // A leading checkout prefix is expected — `core.hooksPath` is relative
+        // to a checkout root, and install anchors it wherever it was run from.
+        issues.push({ kind: "warning", message: `core.hooksPath is "${configured}" — expected "${expectedSuffix}". Re-run \`vis hook install\` to fix.` });
     }
 
-    // dispatcher directory
-    if (!isAccessibleSync(join(directory, "_"))) {
-        issues.push({ kind: "error", message: `Dispatcher directory ${hooksDirectory}/_ is missing. Run \`vis hook install\`.` });
+    // The dispatcher is generated and gitignored, so every checkout needs its
+    // own. A linked worktree without one runs no hooks — silently, exit 0 —
+    // and nothing else in the toolchain reports it. Resolved through the same
+    // helper install writes with, so the two cannot disagree about the path.
+    const target = configured || expectedSuffix;
+    const topLevelResult = spawnSync("git", ["rev-parse", "--show-toplevel"], { cwd: root, encoding: "utf8" });
+    const topLevel = topLevelResult.status === 0 && topLevelResult.stdout.trim() ? topLevelResult.stdout.trim() : root;
+    const currentDispatcher = join(topLevel, target);
+
+    for (const dispatcher of dispatcherDirectories(target, topLevel)) {
+        if (isAccessibleSync(dispatcher)) {
+            continue;
+        }
+
+        if (dispatcher === currentDispatcher) {
+            issues.push({ kind: "error", message: `Dispatcher directory ${target} is missing. Run \`vis hook install\`.` });
+        } else {
+            // Only a warning: transient worktrees are normal, and a repo-wide
+            // non-zero exit for one of them would make validate useless as a gate.
+            issues.push({ kind: "warning", message: `Worktree ${dispatcher} is missing — git runs no hooks there. Run \`vis hook install\` in that worktree.` });
+        }
     }
 
     if (!isAccessibleSync(directory)) {


### PR DESCRIPTION
Closes #845.

`vis hook install` was a silent no-op in linked git worktrees, and silently skipped forever whenever `core.hooksPath` pointed somewhere unexpected. Both exited 0, so `prepare` stayed green while no hook ran.

## 1. Linked worktrees never got a dispatcher

`core.hooksPath` is written with `git config --local`, which lands in the shared `$GIT_COMMON_DIR/config`, but its value is relative so git resolves it inside whichever checkout the commit happens in. The `_` dispatcher is generated and gitignored, so a linked worktree pointed at a directory that did not exist there — which git treats as "no hooks", silently and with exit 0.

- Install writes the dispatcher into every working checkout from `git worktree list --porcelain`; uninstall clears them all.
- Bare, prunable, locked, and absent checkouts are skipped, so a deleted worktree path is not resurrected on disk (which, for a worktree on removable media, would create a tree under the mountpoint).
- The current checkout is written **before** `core.hooksPath` is set and is fatal on failure. Every other checkout is best-effort and reported as a warning, so one unreachable volume cannot leave the config aimed at a directory that was never created.
- An existing `core.hooksPath` naming the same hooks directory under a different checkout prefix is recognised as ours and kept. That is the ordinary state inside a fresh worktree, and treating it as foreign blocked the repair the command exists to perform.

A worktree created after the last install still needs its own `vis hook install` — or any `pnpm install`, via `prepare`. That is documented, and `vis hook validate` now reports it.

## 2. An unexpected `core.hooksPath` disabled vis permanently

- `--force` takes over `core.hooksPath` unconditionally.
- Yielding to another tool warns instead of informing, and names `--force`.
- A hooksPath **directory** holding nothing git would run (`.git/hooks` with only `*.sample` files) now fails, naming `--force`, the unset command, and `VIS_GIT_HOOKS=0`.
- A hooksPath that is **not a directory** (`/dev/null`, the git-native way to disable hooks for a clone) stays a warning, so `prepare` keeps working for people who chose it deliberately.
- Detection covers every hook git runs rather than just the stages vis writes shims for, so a directory holding only `reference-transaction` is not misreported as empty.

## Shared path resolution

Install and validate derived the dispatcher location independently and disagreed whenever install ran from a subdirectory: `git rev-parse --show-prefix` is baked into the configured value and validate dropped it, so `vis hook validate` exited non-zero on a correctly installed repo. Both now resolve through one helper.

`vis hook validate` reports a missing dispatcher as an error for the current checkout and a warning for linked worktrees — a transient worktree should not fail the whole check.

## Testing

- 121 hook tests pass, including new coverage for the worktree fan-out, the subdirectory-prefix adoption, `/dev/null`, prunable worktrees, unsupported-but-real git hooks, and validate from a subdirectory.
- Test git repos now clear inherited `GIT_DIR` / `GIT_INDEX_FILE`, so the suite is hermetic when it runs from inside a pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111EdBwxAMbkE16gv9d9PiT