### PR TITLE
build(vis): bump the docker example image to node 26.7.0

### DIFF
--- a/packages/tooling/vis/examples/docker/Dockerfile
+++ b/packages/tooling/vis/examples/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 # 1) deps — only manifests + pruned lockfile, so this layer is reused
 #    on every source-only change.
-FROM node:26.4.0 AS deps
+FROM node:26.7.0 AS deps
 WORKDIR /app
 RUN corepack enable
 COPY .vis/docker/workspace/ ./
@@ -18,7 +18,7 @@ RUN pnpm --filter api build
 RUN pnpm exec vis docker prune --context=.vis/docker
 
 # 3) runtime — only the focus project's built output and pruned deps.
-FROM node:26.4.0
+FROM node:26.7.0
 WORKDIR /app
 COPY --from=build /app/packages/api ./packages/api
 COPY --from=build /app/packages/shared ./packages/shared


### PR DESCRIPTION
The example Dockerfile at `packages/tooling/vis/examples/docker/Dockerfile`
pinned `node:26.4.0` on both the `deps` and runtime stages while the rest of
the workspace targets a newer runtime, so anyone copy-pasting the example
built on an outdated base.

Unlike the images in `docker-compose.yml`, this one isn't digest-pinned by
Renovate, so the bump has to be made by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111EdBwxAMbkE16gv9d9PiT