### PR TITLE
feat(redact)!: make nlp detection opt-in via injection

### DIFF
--- a/packages/data-manipulation/redact/AGENTS.md
+++ b/packages/data-manipulation/redact/AGENTS.md
@@ -8,8 +8,9 @@ This file provides guidance to AI coding agents when working with code in this d
 
 ## Architecture
 
-- Single entry (`.`) — main export is the recursive filter (`src/index.ts`); supporting modules are `src/string-anonymizer.ts`, `src/rules.ts`, `src/types.ts`, and `src/utils/` (`parse-url-parameters.ts`, `wildcard.ts`).
-- `compromise` is a real runtime dependency — it powers NLP-based NER redaction of names, organizations, places, money, phone, email. Don't move it to devDependencies.
+- Two entries: `.` is the recursive filter (`src/index.ts`), `./nlp` is the optional NLP scanner (`src/nlp.ts`). Supporting modules are `src/string-anonymizer.ts`, `src/rules.ts`, `src/types.ts`, and `src/utils/` (`parse-url-parameters.ts`, `wildcard.ts`).
+- `compromise` must stay reachable ONLY from `src/nlp.ts`. It is an optional peer dependency, and a static import of it anywhere in the `.` entry's module graph puts ~140 KB gzipped of English lexicon into every consumer — unremovable by any bundler, because `stringAnonymize` is on the path of nearly every call. `__tests__/bundle/bundle-graph.test.ts` bundles both entries and fails if it leaks back in.
+- NLP detection is injected, never imported: `RedactOptions.nlp` takes an `NlpScanner` (`(input, types, logger?) => { start, tag, text }[]`), which `processDocument` calls at most once per string. No scanner means no parse.
 - The `exports` map intentionally separates `import` and `browser` conditions — both currently point at the same file, but the structure is in place; keep it.
 - Circular references are tracked via a `WeakMap` of original object → its copy (`src/index.ts`). Inputs are never mutated (frozen/sealed objects are safe, nothing leaks if a rule throws), and the map is garbage-collected automatically, so no cleanup pass is required.
 - `dot-prop` is a devDependency used at runtime via inlining by `packem`. If you change the bundler config, verify `hasProperty` / `setProperty` still resolve.

--- a/packages/data-manipulation/redact/README.md
+++ b/packages/data-manipulation/redact/README.md
@@ -39,7 +39,7 @@
 - Easy to use
 - Anonymize specific categories in a text, including emails, monetary values, organizations, people, and phone numbers and more.
 - Customizable anonymization: Specify which categories to anonymize and which to exclude.
-- Built-in compatibility with nlp NER - compromise.
+- Optional NLP NER via `@visulima/redact/nlp` — names, organizations and money, opt-in so the core stays small
 - Never mutates the input (circular references are tracked with a `WeakMap`, not by stamping marker keys onto your objects), so frozen/sealed inputs are safe
 - Performs a deep copy of the input object
 - Partial masking via censor functions (e.g. keep the last 4 digits of a card)
@@ -128,6 +128,35 @@ yarn add @visulima/redact
 pnpm add @visulima/redact
 ```
 
+### Optional: natural-language detection
+
+The core package carries no natural-language engine. To also mask people's names,
+organizations and money amounts inside free-form prose, install `compromise` alongside it and
+pass the scanner from `@visulima/redact/nlp`:
+
+```sh
+npm install @visulima/redact compromise
+```
+
+```typescript
+import { createRedactor, standardRules } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
+
+const scrub = createRedactor(standardRules, { nlp: compromiseScanner });
+
+scrub({ note: "John Doe works at Google" });
+// => { note: "<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>" }
+```
+
+`compromise` ships a ~140 KB (gzipped) English lexicon and costs a parse per scanned string,
+which is why it is not wired in by default — a bundle that never imports
+`@visulima/redact/nlp` contains none of it. Key-name and `pattern` rules (passwords, tokens,
+credit cards, IPs, SSNs, emails, ...) work exactly the same either way; only the four rule keys
+that have no regex shape — `firstname`, `lastname`, `organization`, `money` — go unmatched
+inside prose without a scanner. They still match object keys of the same name.
+
+Any other engine works too: `NlpScanner` is `(input, types) => { start, tag, text }[]`.
+
 ## Usage
 
 - redact(input, rules, options)
@@ -212,19 +241,20 @@ logger.info(scrub(anotherPayload));
 
 > [!NOTE]
 > The traversal is a single pass: every object node and nested string is visited exactly once
-> and evaluated against all rules together, rather than re-walking the tree once per rule. The
-> compromise NLP engine is only invoked when at least one NLP-backed rule (`firstname`,
-> `lastname`, `organization`, `email`, `money`, `phonenumber`, `url`) is requested — pure
-> key/pattern redaction never pays the NLP cost.
+> and evaluated against all rules together, rather than re-walking the tree once per rule. An
+> injected NLP scanner is invoked at most once per string; it is handed the rule keys in play and
+> returns early when none of them are its own, so `compromiseScanner` charges nothing for a
+> rule set of pure key/pattern rules.
 
 - stringAnonymize(input, rules, options)
-    > It uses Natural Language Processing (NLP) and Regular Expressions (Regex) to identify and mask sensitive information in a string.
+    > Uses Regular Expressions — and, when a scanner is injected, Natural Language Processing — to identify and mask sensitive information in a string.
 
 ```typescript
-import { stringAnonymize } from "@visulima/redact";
+import { standardRules, stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
 
 const input = "John Doe will be 30 on 2024-06-10.";
-const result = stringAnonymize(input, defaultModifiers);
+const result = stringAnonymize(input, standardRules, { nlp: compromiseScanner });
 
 console.log(result);
 
@@ -267,6 +297,14 @@ Type: `(message?: any, ...optionalParameters: any[]) => void`
 
 A function to log debug messages.
 
+##### nlp
+
+Type: `NlpScanner`
+
+Opt in to natural-language entity detection. Import `compromiseScanner` from
+`@visulima/redact/nlp`, or supply your own function of the same shape. Omitted, the
+NLP-only rule keys simply find nothing in prose and `compromise` never enters your bundle.
+
 ### stringAnonymize(input, rules, options?)
 
 #### input
@@ -300,6 +338,14 @@ Type: `object`
 Type: `(message?: any, ...optionalParameters: any[]) => void`
 
 A function to log debug messages.
+
+##### nlp
+
+Type: `NlpScanner`
+
+Opt in to natural-language entity detection. Import `compromiseScanner` from
+`@visulima/redact/nlp`, or supply your own function of the same shape. Omitted, the
+NLP-only rule keys simply find nothing in prose and `compromise` never enters your bundle.
 
 ## Related
 

--- a/packages/data-manipulation/redact/__fixtures__/package/mjs/test.mjs
+++ b/packages/data-manipulation/redact/__fixtures__/package/mjs/test.mjs
@@ -1,6 +1,8 @@
 import { redact, stringAnonymize, standardRules } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
 
 const input = "John Doe will be 30 on 2024-06-10.";
+const options = { nlp: compromiseScanner };
 
-console.log(redact(input, standardRules));
-console.log(stringAnonymize(input, standardRules));
+console.log(redact(input, standardRules, options));
+console.log(stringAnonymize(input, standardRules, options));

--- a/packages/data-manipulation/redact/__fixtures__/package/types/index.ts
+++ b/packages/data-manipulation/redact/__fixtures__/package/types/index.ts
@@ -1,10 +1,13 @@
 // Compile-only fixture. Imports the published surface of @visulima/redact
 // and exercises its public types so a broken dist/*.d.ts will fail `tsc --noEmit`.
 import { createRedactor, credentialRules, dateTimeRules, piiRules, redact, standardRules, stringAnonymize } from "@visulima/redact";
-import type { Anonymize, Censor, RedactOptions, Rules, StringAnonymize } from "@visulima/redact";
+import type { Anonymize, Censor, NlpMatch, NlpScanner, RedactOptions, Rules, StringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
 
 const rules: Rules = [...credentialRules, ...piiRules, ...dateTimeRules, ...standardRules];
-const options: RedactOptions = {};
+const scanner: NlpScanner = compromiseScanner;
+const customScanner: NlpScanner = (input, types): NlpMatch[] => (types.length > 0 && input.length > 0 ? [{ start: 0, tag: "custom", text: input }] : []);
+const options: RedactOptions = { nlp: scanner };
 
 const string_: string = redact("Hello world", rules, options);
 const obj: { secret: string } = redact({ secret: "abc" }, rules);
@@ -17,4 +20,4 @@ const patternRule: StringAnonymize = { key: "x", pattern: /x/, replacement: "<X>
 const scrub = createRedactor([anonymizeRule, patternRule]);
 const scrubbed: { card: string } = scrub({ card: "4111111111111111" });
 
-export { anonymized, anonymizeRule, censor, obj, options, patternRule, rules, scrubbed, string_ };
+export { anonymized, anonymizeRule, censor, customScanner, obj, options, patternRule, rules, scanner, scrubbed, string_ };

--- a/packages/data-manipulation/redact/__tests__/bundle/bundle-graph.test.ts
+++ b/packages/data-manipulation/redact/__tests__/bundle/bundle-graph.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+// The reason `compromise` is injected instead of imported: a static import anywhere in the
+// default entry's module graph is unremovable by any bundler, and puts ~140 KB gzipped of
+// English lexicon into every consumer — including the ones whose rules never touch NLP.
+// These tests bundle the real source entries and assert on graph membership, so re-adding the
+// import (directly, or through a helper that re-exports it) fails here rather than in someone's
+// Cloudflare Workers deploy.
+//
+// This guards the SOURCE graph. `dist` is covered separately by packem's own build.
+const bundleInputs = async (entry: string): Promise<string[]> => {
+    const result = await build({
+        bundle: true,
+        // Resolved against this file, not the working directory, so the assertion does not
+        // depend on where vitest was invoked from.
+        entryPoints: [fileURLToPath(new URL(`../../src/${entry}`, import.meta.url))],
+        format: "esm",
+        metafile: true,
+        minify: true,
+        platform: "neutral",
+        write: false,
+    });
+
+    return Object.keys(result.metafile.inputs);
+};
+
+const containsCompromise = (inputs: string[]): boolean => inputs.some((path) => path.includes("node_modules/compromise"));
+
+describe("source module graph", () => {
+    it("should keep the default entry free of the compromise lexicon", async () => {
+        expect.assertions(1);
+
+        expect(containsCompromise(await bundleInputs("index.ts"))).toBe(false);
+    });
+
+    it("should carry the compromise lexicon in the opt-in nlp entry", async () => {
+        expect.assertions(1);
+
+        // The counterpart to the assertion above: it proves the check can actually see
+        // `compromise`, so the first test cannot pass because of a resolution mishap.
+        expect(containsCompromise(await bundleInputs("nlp.ts"))).toBe(true);
+    });
+});

--- a/packages/data-manipulation/redact/__tests__/unit/compromise-parse-once.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/compromise-parse-once.test.ts
@@ -2,6 +2,7 @@ import nlp from "compromise";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { redact } from "../../src";
+import { compromiseScanner } from "../../src/nlp";
 
 // Spy on the compromise default export while keeping its real behaviour, so we can assert how
 // many times the (expensive) NLP parse runs. The single-pass filter evaluates ALL rules against
@@ -35,7 +36,7 @@ describe("compromise is parsed once per string", () => {
 
         // Five NLP-backed rules covering different extractors — pre-refactor this re-parsed
         // the same string once per rule.
-        const result = redact(input, ["firstname", "lastname", "organization", "email", "money"]);
+        const result = redact(input, ["firstname", "lastname", "organization", "email", "money"], { nlp: compromiseScanner });
 
         expect(nlpMock).toHaveBeenCalledTimes(1);
         expect(result).toBe("<FIRSTNAME> <LASTNAME> works at <ORGANIZATION> and emailed <EMAIL> about <MONEY>.");
@@ -50,7 +51,7 @@ describe("compromise is parsed once per string", () => {
             c: "Carol works at Microsoft.",
         };
 
-        redact(input, ["firstname", "lastname", "organization", "phonenumber", "email", "money"]);
+        redact(input, ["firstname", "lastname", "organization", "phonenumber", "email", "money"], { nlp: compromiseScanner });
 
         // Three leaf strings -> exactly three parses, not three * ruleCount.
         expect(nlpMock).toHaveBeenCalledTimes(3);
@@ -59,9 +60,21 @@ describe("compromise is parsed once per string", () => {
     it("does not parse at all when no NLP-backed rule is supplied", () => {
         expect.assertions(2);
 
-        const result = redact({ password: "John Doe works at Google" }, ["password"]);
+        const result = redact({ password: "John Doe works at Google" }, ["password"], { nlp: compromiseScanner });
 
         expect(nlpMock).not.toHaveBeenCalled();
         expect(result).toStrictEqual({ password: "<PASSWORD>" });
+    });
+
+    it("does not parse at all when no scanner is injected, even for NLP-backed rules", () => {
+        expect.assertions(2);
+
+        // The whole point of the opt-in: without `options.nlp` the caller neither pays the
+        // parse nor pulls `compromise` into their bundle. These three rule keys have no
+        // `pattern` behind them, so in prose they simply find nothing.
+        const result = redact("John Doe works at Google", ["firstname", "lastname", "organization"]);
+
+        expect(nlpMock).not.toHaveBeenCalled();
+        expect(result).toBe("John Doe works at Google");
     });
 });

--- a/packages/data-manipulation/redact/__tests__/unit/index.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/index.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { redact } from "../../src";
+import { compromiseScanner } from "../../src/nlp";
 import standardModifierRules from "../../src/rules";
 
 const RE_SENSITIVE = /sensitive/;
@@ -270,7 +271,7 @@ describe(redact, () => {
             let output = input;
 
             beforeEach(() => {
-                output = redact(input, ["authorization", "PrIvAtE-Data", "credit_card", ...standardModifierRules]);
+                output = redact(input, ["authorization", "PrIvAtE-Data", "credit_card", ...standardModifierRules], { nlp: compromiseScanner });
             });
 
             it("does not modify the original object", () => {
@@ -816,7 +817,7 @@ describe(redact, () => {
             expect.assertions(1);
 
             const input = "John Doe will be 30 on 2024-06-10.";
-            const result = redact(input, standardModifierRules);
+            const result = redact(input, standardModifierRules, { nlp: compromiseScanner });
 
             expect(result).toMatch("<FIRSTNAME> <LASTNAME> will be 30 on <DATE>");
         });
@@ -830,7 +831,7 @@ describe(redact, () => {
 
             // eslint-disable-next-line unicorn/new-for-builtins, no-new-wrappers, sonarjs/no-primitive-wrappers -- intentionally exercising the boxed-String path
             const input = new String("John Doe will be 30 on 2024-06-10.");
-            const result = redact(input, standardModifierRules);
+            const result = redact(input, standardModifierRules, { nlp: compromiseScanner });
 
             expect(result).toMatch("<FIRSTNAME> <LASTNAME> will be 30 on <DATE>");
         });
@@ -993,7 +994,7 @@ describe(redact, () => {
         expect.assertions(1);
 
         const input = "John Doe will be 30 on 2024-06-10.";
-        const result = redact(input, standardModifierRules, { exclude: ["firstname"] });
+        const result = redact(input, standardModifierRules, { exclude: ["firstname"], nlp: compromiseScanner });
 
         expect(result).toMatch("John <LASTNAME> will be 30 on <DATE>");
     });

--- a/packages/data-manipulation/redact/__tests__/unit/security.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/security.test.ts
@@ -132,6 +132,29 @@ describe("masking is applied at the matched offset", () => {
         expect(result).toBe("secret and <X>");
     });
 
+    it("masks every occurrence when a scanner reports a span that does not line up", () => {
+        expect.assertions(3);
+
+        // A scanner aiming at the SECOND duplicate but reporting a bogus offset used to fall back
+        // to the first textual occurrence, masking the wrong one and leaving the intended value
+        // exposed. There is no way to recover which was meant, so every remaining occurrence is
+        // masked — over-masking is the only safe direction here.
+        const bogus = (start: number) => stringAnonymize("secret and secret", ["x"], { nlp: () => [{ start, tag: "x", text: "secret" }] });
+
+        expect(bogus(999)).toBe("<X> and <X>");
+        expect(bogus(-1)).toBe("<X> and <X>");
+        expect(bogus(Number.NaN)).not.toContain("secret");
+    });
+
+    it("still masks exactly one occurrence when the span is valid", () => {
+        expect.assertions(2);
+
+        // The counterpart: a correct offset must NOT trigger the over-masking path, or every
+        // duplicate would collapse and the distinction above would be meaningless.
+        expect(stringAnonymize("secret and secret", ["x"], { nlp: () => [{ start: 11, tag: "x", text: "secret" }] })).toBe("secret and <X>");
+        expect(stringAnonymize("secret and secret", ["x"], { nlp: () => [{ start: 0, tag: "x", text: "secret" }] })).toBe("<X> and secret");
+    });
+
     it("drops an overlapping match instead of letting it rewrite a later occurrence", () => {
         expect.assertions(1);
 

--- a/packages/data-manipulation/redact/__tests__/unit/security.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/security.test.ts
@@ -63,3 +63,40 @@ describe("zero-width match guard", () => {
         expect(result).toContain("abc");
     });
 });
+
+describe("mask substitution safety", () => {
+    it("does not let a `$` sequence in a tag splice the redacted value back into the output", () => {
+        expect.assertions(3);
+
+        // `String.prototype.replace` expands `$&`, `` $` `` and `$'` in the REPLACEMENT string.
+        // Masks are built from the tag, so an unescaped one would echo the surrounding text —
+        // including the very value being masked — straight back into "redacted" output.
+        const scan = (tag: string) => stringAnonymize("AAA SECRET BBB", ["x"], { nlp: () => [{ start: 4, tag, text: "SECRET" }] });
+
+        expect(scan("$&")).toBe("AAA <$&> BBB");
+        expect(scan("$'")).toBe("AAA <$'> BBB");
+        expect(scan("$`")).toBe("AAA <$`> BBB");
+    });
+
+    it("does not let a `$` sequence in a rule key splice the value back either", () => {
+        expect.assertions(1);
+
+        expect(stringAnonymize("AAA SECRET BBB", [{ key: "$&", pattern: "SECRET" }])).toBe("AAA <$&> BBB");
+    });
+});
+
+describe("untrusted scanner", () => {
+    it("propagates a throwing scanner rather than emitting the unredacted string", () => {
+        expect.assertions(1);
+
+        // Failing closed is the point: swallowing the error here would return `input` verbatim
+        // to whatever sink the caller is about to write to.
+        expect(() =>
+            redact({ note: "sensitive" }, ["firstname"], {
+                nlp: () => {
+                    throw new Error("scanner blew up");
+                },
+            }),
+        ).toThrow("scanner blew up");
+    });
+});

--- a/packages/data-manipulation/redact/__tests__/unit/security.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { redact, stringAnonymize } from "../../src";
+import { compromiseScanner } from "../../src/nlp";
 import standardModifierRules from "../../src/rules";
 
 describe("redos resistance", () => {
@@ -60,7 +61,11 @@ describe("zero-width match guard", () => {
         const result = redact("abc 123 def", [{ deep: true, key: "num", pattern: String.raw`\d*`, replacement: "<N>" }]);
 
         expect(Date.now() - start).toBeLessThan(5000);
-        expect(result).toContain("abc");
+
+        // A zero-width pattern necessarily peppers the output with masks — it matches between
+        // every character. What matters is that it terminates, and that the digits it did
+        // legitimately match are gone.
+        expect(result).not.toContain("123");
     });
 });
 
@@ -98,5 +103,45 @@ describe("untrusted scanner", () => {
                 },
             }),
         ).toThrow("scanner blew up");
+    });
+});
+
+describe("masking is applied at the matched offset", () => {
+    it("masks the occurrence that was matched, not the first one that looks like it", () => {
+        expect.assertions(2);
+
+        // Regression: replacement used to search for the first occurrence of the matched text.
+        // compromise tags only the surname inside "John Doe" here, so the match had to land on
+        // the SECOND "Doe" — the first-occurrence search rewrote the leading word instead and
+        // left the real surname in the clear.
+        const result = stringAnonymize("Doe met John Doe yesterday", ["firstname", "lastname"], { nlp: compromiseScanner });
+
+        expect(result).toBe("Doe met <FIRSTNAME> <LASTNAME> yesterday");
+        expect(result.slice(result.indexOf("met"))).not.toContain("Doe");
+    });
+
+    it("honours a scanner's per-match offsets over an earlier identical string", () => {
+        expect.assertions(1);
+
+        // Same property without compromise: the scanner reports the SECOND "secret" only, so the
+        // first must survive and the second must be masked.
+        const result = stringAnonymize("secret and secret", ["x"], {
+            nlp: () => [{ start: 11, tag: "x", text: "secret" }],
+        });
+
+        expect(result).toBe("secret and <X>");
+    });
+
+    it("drops an overlapping match instead of letting it rewrite a later occurrence", () => {
+        expect.assertions(1);
+
+        // `email` and `url` both match an address at the same offset. The first rule wins; the
+        // loser must not go hunting for some other occurrence of the same text.
+        const result = stringAnonymize("mail bob@example.com or bob@example.com", [
+            { deep: true, key: "email", pattern: String.raw`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,63}` },
+            { deep: true, key: "url", pattern: String.raw`[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,63}` },
+        ]);
+
+        expect(result).toBe("mail <EMAIL> or <EMAIL>");
     });
 });

--- a/packages/data-manipulation/redact/__tests__/unit/string-anonymizer.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/string-anonymizer.test.ts
@@ -7,15 +7,23 @@
 
 import { describe, expect, it } from "vitest";
 
-import standardModifierRules from "../../src/rules";
+import { compromiseScanner } from "../../src/nlp";
+import standardModifierRules, { piiRules } from "../../src/rules";
 import stringAnonymize from "../../src/string-anonymizer";
+import type { RedactOptions, Rules } from "../../src/types";
+
+// Natural-language detection is opt-in, so every test below that asserts on a
+// name/organization/money mask injects the compromise scanner explicitly. Tests that assert on
+// the DEFAULT (no-scanner) behaviour call `stringAnonymize` directly instead.
+const anonymizeWithNlp = (input: string, rules: Rules, options?: RedactOptions): string =>
+    stringAnonymize(input, rules, { nlp: compromiseScanner, ...options });
 
 describe(stringAnonymize, () => {
     it("should anonymize a string", () => {
         expect.assertions(1);
 
         const input = "John Doe will be 30 on 2024-06-10.";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toMatch("<FIRSTNAME> <LASTNAME> will be 30 on <DATE>");
     });
@@ -24,7 +32,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John Doe and Jane Smith will meet on 2024-06-10.";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toMatch("<FIRSTNAME> <LASTNAME> and <FIRSTNAME1> <LASTNAME1> will meet on <DATE>");
     });
@@ -33,7 +41,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John Doe works at Google.";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toMatch("<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>");
     });
@@ -42,7 +50,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John's email is john.doe@gmail.com";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> email is <EMAIL>");
     });
@@ -51,7 +59,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John's phone number is 123-456-7890";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> phone number is <PHONENUMBER>");
     });
@@ -60,16 +68,55 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John has $1000 in his account.";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> has <MONEY> in his account.");
+    });
+
+    describe("without a scanner", () => {
+        it("should still apply every pattern rule", () => {
+            expect.assertions(1);
+
+            // The positive half of the v5 default: dropping the NLP import must not weaken
+            // regex-backed redaction. Cards, SSNs, emails and dates all still go.
+            const input = "card 4111-1111-1111-1111, ssn 123-45-6789, mail bob@example.com on 2024-06-10";
+            const result = stringAnonymize(input, standardModifierRules);
+
+            expect(result).toBe("card <CREDITCARD>, ssn <SSN>, mail <EMAIL> on <DATE>");
+        });
+
+        it("should leave the four pattern-less entity keys unmatched in prose", () => {
+            expect.assertions(2);
+
+            // The negative half: these four have no regex shape, so without a scanner they find
+            // nothing inside prose. They still match object keys — covered in index.test.ts.
+            const input = "John Doe works at Google earning $50,000";
+            const entityKeys = ["firstname", "lastname", "organization", "money"];
+
+            expect(stringAnonymize(input, entityKeys)).toBe(input);
+            expect(anonymizeWithNlp(input, entityKeys)).toBe("<FIRSTNAME> <LASTNAME> works at <ORGANIZATION> earning <MONEY>");
+        });
+
+        it("should mask an email as <EMAIL> rather than under a neighbouring pattern's tag", () => {
+            expect.assertions(2);
+
+            // Regression: `email` was a key-only rule, so with no scanner an address in prose
+            // escaped a narrowed rule set entirely, and under standardRules was caught only
+            // incidentally by the `url` pattern and mislabelled <URL>. The `email` rule is
+            // declared ahead of `domain`/`url` precisely so it wins that tie.
+            expect(stringAnonymize("write to alice@example.com today", piiRules)).toBe("write to <EMAIL> today");
+
+            // ...and still wins with the patterns that used to shadow it explicitly dropped,
+            // which is the rule set a caller following the piiRules warnings would build.
+            expect(stringAnonymize("write to alice@example.com today", piiRules, { exclude: ["url", "domain"] })).toBe("write to <EMAIL> today");
+        });
     });
 
     it("should handle empty input string", () => {
         expect.assertions(1);
 
         const input = "";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("");
     });
@@ -78,7 +125,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John Doe has phone numbers 123-456-7890 and 098-765-4321";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> <LASTNAME> has phone numbers <PHONENUMBER> and <PHONENUMBER1>");
     });
@@ -87,7 +134,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John's meeting is at 3pm.";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toMatch("<FIRSTNAME> meeting is at <TIME>");
     });
@@ -96,7 +143,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John's credit card number is 4111-1111-1111-1111";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> credit card number is <CREDITCARD>");
     });
@@ -105,7 +152,7 @@ describe(stringAnonymize, () => {
         expect.assertions(1);
 
         const input = "John's credit card numbers are 4111-1111-1111-1111 and 5500-0000-0000-0004";
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe("<FIRSTNAME> credit card numbers are <CREDITCARD> and <CREDITCARD1>");
     });
@@ -118,7 +165,7 @@ If you'd like to reach me, you can email me at johndoe1985@example.com or give m
 Please note that the credit card number provided, 4916 2899 5678 1234, is purely fictional and should not be used for any actual transactions or financial purposes.
 In my free time, I enjoy hiking, painting, and playing the guitar. I'm also an avid traveler and have visited over 20 countries, each leaving a unique mark on my adventurous soul.
 Please remember that all the information provided, including the credit card number, email address, and phone number, is entirely fictional and randomly generated. It does not represent any real individuals or their personal experiences.`;
-        const result = stringAnonymize(input, standardModifierRules, {
+        const result = anonymizeWithNlp(input, standardModifierRules, {
             exclude: ["organization"],
         });
 
@@ -135,7 +182,7 @@ Please remember that all the information provided, including the credit card num
         expect.assertions(1);
 
         const input = `Hi i'm John Doe, my email is john@example.com and my phone number is +1-234-567-8900.`;
-        const result = stringAnonymize(input, standardModifierRules);
+        const result = anonymizeWithNlp(input, standardModifierRules);
 
         expect(result).toBe(`Hi i'm <FIRSTNAME> <LASTNAME>, my email is <EMAIL> and my phone number is <PHONENUMBER>.`);
     });
@@ -144,7 +191,7 @@ Please remember that all the information provided, including the credit card num
         expect.assertions(1);
 
         const input = "John Doe will be 30 on 2024-06-10.";
-        const result = stringAnonymize(input, standardModifierRules, { exclude: ["firstname"] });
+        const result = anonymizeWithNlp(input, standardModifierRules, { exclude: ["firstname"] });
 
         expect(result).toMatch("John <LASTNAME> will be 30 on <DATE>");
     });
@@ -171,7 +218,7 @@ Please remember that all the information provided, including the credit card num
         expect.assertions(1);
 
         const input = "John Doe will be 30 on 2024-06-10.";
-        const result = stringAnonymize(input, ["firstname"], { exclude: ["password"] });
+        const result = anonymizeWithNlp(input, ["firstname"], { exclude: ["password"] });
 
         expect(result).toMatch("<FIRSTNAME> Doe will be 30 on 2024-06-10.");
     });

--- a/packages/data-manipulation/redact/__tests__/unit/string-anonymizer.test.ts
+++ b/packages/data-manipulation/redact/__tests__/unit/string-anonymizer.test.ts
@@ -160,6 +160,11 @@ describe(stringAnonymize, () => {
     it("should test long paragraph", () => {
         expect.assertions(1);
 
+        // Masks are applied at each match's recorded offset. Before that, replacement searched
+        // for the first occurrence of the matched text, which shredded the phone number into
+        // "+1 (<PHONENUMBER2>) <DATE1>3-4567" and left "3-4567" in the clear; it is now a
+        // single <PHONENUMBER>.
+
         const input = `My name is Jessica Thompson, and I was born on May 12, 1988, in a small town called Oakdale. I grew up with my parents and two siblings, an older brother named Daniel and a younger sister named Emily. We lived in a cozy two-story house with a white picket fence. In high school, I was actively involved in the drama club and played the lead role in our school's production of "Romeo and Juliet." After graduation, I pursued my passion for writing and earned a Bachelor's degree in English Literature from the University of Cambridge in 2010. Currently, I work as a freelance writer, specializing in content creation for various online platforms.
 If you'd like to reach me, you can email me at johndoe1985@example.com or give me a call at +1 (555) 123-4567.
 Please note that the credit card number provided, 4916 2899 5678 1234, is purely fictional and should not be used for any actual transactions or financial purposes.
@@ -170,8 +175,8 @@ Please remember that all the information provided, including the credit card num
         });
 
         expect(result).toBe(
-            `My name is <FIRSTNAME> <LASTNAME>, and I was born on <DATE>, in a small town called Oakdale. I grew up with my parents and two siblings, an older brother named <FIRSTNAME1> and a younger sister named <FIRSTNAME2>. We lived in a cozy two-story house with a white picket fence. In high school, I was actively involved in the drama club and played the lead role in our school's production of "<FIRSTNAME3> and <FIRSTNAME4>." <LASTNAME1> graduation, I pursued my passion for writing and earned a Bachelor's degree in English Literature from the University of Cambridge in <DATE3>. Currently, I work as a freelance writer, specializing in content creation for various online platforms.
-If you'd like to reach me, you can email me at <EMAIL> or give me a call at +1 (<PHONENUMBER2>) <DATE1>3-4567.
+            `My name is <FIRSTNAME> <LASTNAME>, and I was born on <DATE>, in a small town called Oakdale. I grew up with my parents and two siblings, an older brother named <FIRSTNAME1> and a younger sister named <FIRSTNAME2>. We lived in a cozy two-story house with a white picket fence. In high school, I was actively involved in the drama club and played the lead role in our school's production of "<FIRSTNAME3> and <FIRSTNAME4>." <LASTNAME1> graduation, I pursued my passion for writing and earned a Bachelor's degree in English Literature from the University of Cambridge in <DATE1>. Currently, I work as a freelance writer, specializing in content creation for various online platforms.
+If you'd like to reach me, you can email me at <EMAIL> or give me a call at <PHONENUMBER>.
 Please note that the credit card number provided, <CREDITCARD>, is purely fictional and should not be used for any actual transactions or financial purposes.
 In my free time, I enjoy hiking, painting, and playing the guitar. I'm also an avid traveler and have visited over 20 countries, each leaving a unique <FIRSTNAME5> on my adventurous soul.
 Please remember that all the information provided, including the credit card number, email address, and phone number, is entirely fictional and randomly generated. It does not represent any real individuals or their personal experiences.`,

--- a/packages/data-manipulation/redact/__tests__/workerd/index.test.ts
+++ b/packages/data-manipulation/redact/__tests__/workerd/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createRedactor, credentialRules, piiRules, redact, standardRules, stringAnonymize } from "../../src/index";
+import { compromiseScanner } from "../../src/nlp";
 
 /**
  * The behavioural assertions live in `__tests__/unit/**`, which
@@ -9,8 +10,9 @@ import { createRedactor, credentialRules, piiRules, redact, standardRules, strin
  * against workerd by their single definition.
  *
  * What is left here is what only workerd can answer: that the module graph
- * (including the sizeable `compromise` NLP dependency) loads in an isolate with
- * no `node:*` I/O, and that the walker copes with workerd's own host objects.
+ * loads in an isolate with no `node:*` I/O — including the optional
+ * `@visulima/redact/nlp` entry and the sizeable `compromise` library behind it —
+ * and that the walker copes with workerd's own host objects.
  */
 describe("@visulima/redact on workerd", () => {
     describe("module graph", () => {
@@ -21,13 +23,13 @@ describe("@visulima/redact on workerd", () => {
             expect([credentialRules, piiRules, standardRules].every((rules) => Array.isArray(rules) && rules.length > 0)).toBe(true);
         });
 
-        it("should load the compromise NLP dependency inside the isolate", () => {
+        it("should load the optional compromise scanner inside the isolate", () => {
             expect.assertions(2);
 
-            // `compromise` is a real runtime dependency pulled in lazily for NLP rules.
-            // It is by far the largest thing in the graph, so a bundling or
-            // `node:*`-resolution failure would surface here first.
-            const output = stringAnonymize("write to alice@example.com today", [{ deep: true, key: "email" }]);
+            // `compromise` reaches the graph only through `@visulima/redact/nlp`, and is by far
+            // the largest thing in it, so a bundling or `node:*`-resolution failure in that
+            // entry point would surface here first.
+            const output = stringAnonymize("write to alice@example.com today", [{ deep: true, key: "email" }], { nlp: compromiseScanner });
 
             expect(output).not.toContain("alice@example.com");
             expect(output).toContain("<EMAIL>");

--- a/packages/data-manipulation/redact/docs/api.mdx
+++ b/packages/data-manipulation/redact/docs/api.mdx
@@ -3,163 +3,327 @@ title: "API Reference"
 description: "Complete API for @visulima/redact"
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
 # API Reference
+
+## Entry points
+
+| Import                 | Contains                                                                | Cost                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `@visulima/redact`     | `redact`, `createRedactor`, `stringAnonymize`, the rule sets, the types | ~4.5 KB gzipped                                                      |
+| `@visulima/redact/nlp` | `compromiseScanner`                                                     | pulls in `compromise`, an optional peer dependency (~140 KB gzipped) |
+
+---
 
 ## Functions
 
 ### redact
 
 ```typescript
-function redact<T>(input: T, rules?: string[], options?: RedactOptions): T;
+function redact<V>(input: V, rules: Rules, options?: RedactOptions): V;
 ```
 
-Redact sensitive properties from objects.
+Deep-copies `input` and masks the values matched by `rules`. Objects, arrays, `Error`s, `Map`s,
+`Set`s, JSON strings and URL query strings are all traversed. The input is never mutated —
+frozen and sealed inputs are safe — and circular references are preserved in the copy.
 
 **Parameters:**
 
-- `input` - Object to redact
-- `rules` - Array of property paths to redact
-- `options` - Redaction options
+- `input` - The value to redact. Returned unchanged for `null`, `undefined`, numbers and booleans.
+- `rules` - The rules to apply. Required.
+- `options` - See [RedactOptions](#redactoptions).
 
-**Returns:** New object with redacted values
+**Returns:** A redacted deep copy of `input`, typed as `V`.
+
+```typescript
+import { redact } from "@visulima/redact";
+
+redact({ id: 123, name: "Alice", password: "secret123" }, ["password"]);
+// { id: 123, name: "Alice", password: "<PASSWORD>" }
+```
+
+---
+
+### createRedactor
+
+```typescript
+function createRedactor(rules: Rules, options?: RedactOptions): <V>(input: V) => V;
+```
+
+Compiles `rules` once and returns a reusable redactor. Prefer this over calling `redact`
+repeatedly with the same rule set — in a logger, for example — since it avoids re-lowercasing
+keys and re-compiling patterns on every call.
+
+```typescript
+import { createRedactor, standardRules } from "@visulima/redact";
+
+const scrub = createRedactor(standardRules);
+
+logger.info(scrub(payload));
+logger.info(scrub(anotherPayload));
+```
 
 ---
 
 ### stringAnonymize
 
 ```typescript
-function stringAnonymize(text: string, options?: AnonymizeOptions): string;
+function stringAnonymize(input: string, rules: Rules, options?: RedactOptions): string;
 ```
 
-Anonymize sensitive information in text using NLP.
+Masks sensitive information in a single string, using the `pattern` rules and — when an
+[`nlp`](#nlp) scanner is supplied — natural-language entity detection. This is the leaf-string
+scanner `redact` falls back to; call it directly when you already know you hold a string.
 
-**Parameters:**
+```typescript
+import { standardRules, stringAnonymize } from "@visulima/redact";
 
-- `text` - Text to anonymize
-- `options` - Anonymization options
+stringAnonymize("card 4111 1111 1111 1111 on file", standardRules);
+// "card <CREDITCARD> on file"
+```
 
-**Returns:** Anonymized text
+Repeated occurrences of one value share a mask, and distinct values of the same type are
+numbered:
+
+```typescript
+stringAnonymize("call 111-11-1111 then 111-11-1111 then 222-22-2222", [{ key: "ssn", pattern: String.raw`\d{3}-\d{2}-\d{4}` }]);
+// "call <SSN> then <SSN> then <SSN1>"
+```
 
 ---
 
-## Options
+## Rule sets
+
+Four rule sets ship with the package. All are plain `Rules` arrays, so they compose with `...`
+and with your own rules.
+
+| Export            | Covers                                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `credentialRules` | API keys, AWS keys, bearer/JWT/Slack tokens, crypto wallets, basic-auth strings, and the `auth`/`password`/`secret` key names                                       |
+| `piiRules`        | Bank accounts, credit cards, IDs/UUIDs, IPs, MACs, phone numbers, SSNs, NINs, ISBNs, zip codes, URLs/domains, plus the entity keys (`firstname`, `organization`, …) |
+| `dateTimeRules`   | Dates, times, weekday and relative-date words                                                                                                                       |
+| `standardRules`   | All three of the above                                                                                                                                              |
+
+<Callout type="warn" title="standardRules is deliberately aggressive">
+    Several `piiRules` entries match plain numeric data — `bankacc` (`\b\d{10,12}\b`), `id`/`routing` (`\b\d{9}\b`), `zip_code`
+    (`\b[0-9]{5}\b`) — and `dateTimeRules` matches bare weekday and relative-date words, so both will mangle ordinary prose. For
+    most logging, compose only what you need: `redact(input, [...credentialRules, ...piiRules])`, or drop groups with
+    [`exclude`](#exclude).
+</Callout>
+
+```typescript
+import { credentialRules, piiRules, redact } from "@visulima/redact";
+
+redact({ apiKey: "sk_live_abc", ip: "10.0.0.1", note: "monday" }, [...credentialRules, ...piiRules]);
+// { apiKey: "<APIKEY>", ip: "<IP>", note: "monday" }  <- "monday" survives, no dateTimeRules
+```
+
+### Built-in rule keys
+
+**Credentials** — `apikey`, `awsid`, `awskey`, `basic_auth`, `token`, `crypto`, `auth`, `bearer`,
+`credit`, `CVD`, `CVV`, `encrypt`, `PAN`, `pass`, `password`, `secret`
+
+**Financial** — `bankacc`, `bankcc`, `creditcard`, `routing`, `money`
+
+**Personal** — `email`, `firstname`, `lastname`, `username`, `passport`, `phonenumber`, `ssn`,
+`us_social_security`, `uk_nin`, `dl`, `id`, `zip_code`
+
+**Technical** — `ip`, `mac_address`, `url`, `domain`, `isbn`, `organization`
+
+**Date/time** — `date`, `time`
+
+Each key matches an object key of that name, case-insensitively, and — where the rule carries a
+`pattern` — also matches inside strings.
+
+Seventeen keys carry no pattern, so on their own they match an object key and nothing else:
+`auth`, `bearer`, `credit`, `CVD`, `CVV`, `encrypt`, `PAN`, `pass`, `password`, `secret`,
+`bankcc`, `passport`, `username`, `firstname`, `lastname`, `organization` and `money`. For most
+of them that is the whole point — a `password` is whatever sits under a key called `password`,
+not a recognisable string. The last four are different: they name entities that do occur in
+prose, and an [`nlp`](#nlp) scanner is what finds them there.
+
+---
+
+## Types
+
+### Rules
+
+```typescript
+type Rules = (Anonymize | StringAnonymize | number | string)[];
+```
+
+A rule is one of:
+
+- **a string** — an object key to match, case-insensitively (`"password"`), or a wildcard pattern
+  (`"*token*"`, `"*.password"`)
+- **a number** — an array index to match (`0`)
+- **an object** — an [`Anonymize`](#anonymize) rule, for patterns, censors, removal and deep matching
+
+### Anonymize
+
+```typescript
+interface Anonymize {
+    deep?: boolean;
+    key: string;
+    pattern?: RegExp | string;
+    remove?: boolean;
+    replacement?: unknown;
+}
+```
+
+**Properties:**
+
+- `key` - The key, wildcard pattern or entity type to match. Case-insensitive.
+- `pattern` - Regular expression matched against nested string values. Always recompiled as
+  global/case-insensitive/unicode, so a caller's `lastIndex` is never mutated.
+- `deep` - Apply the rule to nested string values, not only to matching object keys.
+- `remove` - Delete the matching key instead of replacing it. Ignored for array elements and
+  string matches.
+- `replacement` - The value, or a [`Censor`](#censor), to put in place of a match. Defaults to
+  `<KEY>`, built from the rule's own key.
+
+<Callout type="info" title="Default masks restate the whole key">
+    The default replacement uppercases the entire rule key, so `{ key: "user.ssn" }` masks to `<USER.SSN>` and
+    `{ key: "*.password" }` masks to `<*.PASSWORD>`. Supply an explicit `replacement` whenever the key is a path or a wildcard.
+</Callout>
+
+```typescript
+redact({ user: { ssn: "123-45-6789" } }, ["user.ssn"]);
+// { user: { ssn: "<USER.SSN>" } }
+
+redact({ user: { ssn: "123-45-6789" } }, [{ key: "user.ssn", replacement: "<SSN>" }]);
+// { user: { ssn: "<SSN>" } }
+```
+
+### StringAnonymize
+
+```typescript
+interface StringAnonymize {
+    key: string;
+    pattern: RegExp | string;
+    replacement?: Censor | string;
+}
+```
+
+A pattern rule — the same shape as `Anonymize`, with `pattern` required.
+
+### Censor
+
+```typescript
+type Censor = (value: unknown, path: string | undefined) => unknown;
+```
+
+Called with the matched value and the dot-path it was found at, returning what to store in its
+place. Use it for partial masking. `path` is `undefined` for matches that have no key path —
+string and array-index matches.
+
+```typescript
+redact({ user: { card: "4111111111111111" } }, [{ deep: true, key: "card", replacement: (value, path) => `${path}:****${String(value).slice(-4)}` }]);
+// { user: { card: "user.card:****1111" } }
+```
 
 ### RedactOptions
 
 ```typescript
 interface RedactOptions {
-    replacement?: string;
-    caseSensitive?: boolean;
+    exclude?: (number | string)[];
+    logger?: { debug: (message?: unknown, ...optionalParameters: unknown[]) => void };
+    nlp?: NlpScanner;
 }
 ```
 
-**Properties:**
+#### exclude
 
-- `replacement` - Custom replacement text. Default: `"<FIELD_NAME>"`
-- `caseSensitive` - Case-sensitive matching. Default: `true`
+Rule keys to drop from `rules` before applying them. Useful for shedding the noisier
+`standardRules` entries.
 
----
+<Callout type="warn" title="exclude drops the whole rule">
+    Excluding a key removes its key-name matching too, not just its pattern: `exclude: ["email"]` also stops `{ email: "..." }`
+    from being matched by key. Where you only want to shed a rule's pattern, compose the rule sets you want instead, or re-add the
+    key rule as a wildcard (`"*email*"` — the `*` is what makes it one).
+</Callout>
 
-### AnonymizeOptions
+Overlapping patterns also mean an excluded rule's value may still be caught by another rule under
+a different tag: with `exclude: ["zip_code"]`, `"12345"` still matches the driver's-licence
+pattern and masks to `<DL>`.
+
+#### logger
+
+An object with a `debug` method, called with tracing information while scanning.
+
+#### nlp
+
+An [`NlpScanner`](#nlpscanner). Opt-in: pass `compromiseScanner` from `@visulima/redact/nlp`, or
+your own implementation. Without it, the pattern-less entity rules (`firstname`, `lastname`,
+`organization`, `money`) match nothing inside prose and `compromise` stays out of your bundle.
+Every key-name and `pattern` rule behaves identically either way.
+
+### NlpScanner
 
 ```typescript
-interface AnonymizeOptions {
-    include?: string[];
-    exclude?: string[];
-    replacement?: string;
+type NlpScanner = (input: string, types: string[], logger?: RedactOptions["logger"]) => NlpMatch[];
+
+interface NlpMatch {
+    start: number;
+    tag: string;
+    text: string;
 }
 ```
 
-**Properties:**
+Locates named entities that no regular expression can describe. It is called at most once per
+scanned string — but for **every** scanned string, not only the ones whose rules it can serve:
+the core cannot know which types a given engine handles.
 
-- `include` - Entity types to anonymize
-- `exclude` - Entity types to skip
-- `replacement` - Custom replacement pattern
+- `input` - the string being redacted
+- `types` - the rule keys in play, lowercased. Return only matches whose `tag` is one of them —
+  the core masks whatever it is handed, so an out-of-contract tag redacts under a label the
+  caller never asked for. Check this list first and return `[]` cheaply when none of it applies
+  to you; that early exit is what keeps a pure key/pattern rule set from paying for a scan.
+  `compromiseScanner` does exactly this.
+- `logger` - the `logger` from `RedactOptions`, forwarded
 
----
+`start` orders and de-duplicates matches; it does **not** position the replacement, which is
+applied to the first occurrence of `text`. Where the same text appears twice, both occurrences
+collapse onto one mask.
 
-## Built-in Rules
-
-### Credentials
-
-- `password` - Password fields
-- `apikey` - API keys
-- `token` - Auth tokens
-- `bearer` - Bearer tokens
-- `auth` - Auth headers
-- `secret` - Secret values
-
-### Financial
-
-- `creditcard` - Credit card numbers
-- `cvv` / `cvd` - Card security codes
-- `bankacc` - Bank account numbers
-- `routing` - Routing numbers
-- `PAN` - Primary account numbers
-- `money` - Monetary values
-
-### Personal
-
-- `email` - Email addresses
-- `ssn` / `us_social_security` - Social Security Numbers
-- `firstname` / `lastname` - Names
-- `phonenumber` - Phone numbers
-- `passport` - Passport numbers
-- `dl` - Driver's license
-- `uk_nin` - UK National Insurance
-
-### Technical
-
-- `ip` - IP addresses
-- `mac_address` - MAC addresses
-- `url` - URLs
-- `domain` - Domain names
-- `crypto` - Cryptocurrency addresses
-
-### Other
-
-- `date` - Dates
-- `time` - Times
-- `zip_code` - Postal codes
-- `isbn` - ISBN numbers
-- `organization` - Organization names
-
----
-
-## Text Anonymization Categories
-
-### NLP-Detected Entities
-
-- `Person` - People's names
-- `Organization` - Company/org names
-- `Place` - Locations
-- `Date` - Date expressions
-- `Money` - Monetary amounts
-- `PhoneNumber` - Phone numbers
-- `Email` - Email addresses
-
----
-
-## Examples
-
-### All Options
+Any engine works, including your own:
 
 ```typescript
-import { redact, stringAnonymize } from "@visulima/redact";
+import { stringAnonymize } from "@visulima/redact";
 
-// Object redaction with options
-const safe = redact(data, ["password", "ssn"], {
-    replacement: "[REDACTED]",
-    caseSensitive: false,
+stringAnonymize("agent 007 reporting", [{ deep: true, key: "codename" }], {
+    nlp: (input, types) => (types.includes("codename") ? [{ start: 6, tag: "codename", text: "007" }] : []),
 });
-
-// Text anonymization with options
-const anonymous = stringAnonymize(text, {
-    include: ["Person", "Email"],
-    exclude: ["Organization"],
-    replacement: "<HIDDEN>",
-});
+// "agent <CODENAME> reporting"
 ```
+
+---
+
+## compromiseScanner
+
+```typescript
+import { compromiseScanner } from "@visulima/redact/nlp";
+```
+
+An `NlpScanner` backed by [compromise](https://www.npmjs.com/package/compromise), detecting
+people, organizations, money amounts, emails, phone numbers and urls. `compromise` is an optional
+peer dependency of this entry point — install it alongside `@visulima/redact`.
+
+```typescript
+import { createRedactor, standardRules } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
+
+const scrub = createRedactor(standardRules, { nlp: compromiseScanner });
+
+scrub({ note: "John Doe works at Google" });
+// { note: "<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>" }
+```
+
+The entities it detects, each mapped to the rule key of the same name: `firstname`, `lastname`,
+`organization`, `money`, `email`, `phonenumber`, `url`. The last three are also covered by
+patterns in `piiRules`, so they are found with or without the scanner — the scanner mainly
+improves their boundaries. Only the first four genuinely depend on it.
 
 ## Next Steps
 

--- a/packages/data-manipulation/redact/docs/api.mdx
+++ b/packages/data-manipulation/redact/docs/api.mdx
@@ -283,9 +283,10 @@ the core cannot know which types a given engine handles.
   `compromiseScanner` does exactly this.
 - `logger` - the `logger` from `RedactOptions`, forwarded
 
-`start` orders and de-duplicates matches; it does **not** position the replacement, which is
-applied to the first occurrence of `text`. Where the same text appears twice, both occurrences
-collapse onto one mask.
+`start` must be the index of `text` within `input` — the mask is applied at that offset, so a
+match reported at the wrong position redacts the wrong occurrence. Where two matches overlap,
+the one starting earlier wins (the longer one on a tie) and the other is dropped, which is why
+rule order decides between `email` and `url` on the same address.
 
 Any engine works, including your own:
 

--- a/packages/data-manipulation/redact/docs/index.mdx
+++ b/packages/data-manipulation/redact/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Introduction
-description: "GDPR-compliant data redaction and anonymization with deep object traversal and NLP-powered text masking"
+description: "GDPR-compliant data redaction and anonymization with deep object traversal and optional NLP-powered text masking"
 ---
 
 # @visulima/redact
 
-Powerful library for redacting and masking sensitive data. Protect user privacy with automatic detection of passwords, emails, credit cards, SSNs, and more—plus NLP-powered text anonymization for GDPR compliance.
+Powerful library for redacting and masking sensitive data. Protect user privacy with detection of passwords, emails, credit cards, SSNs, and more — plus opt-in NLP text anonymization for GDPR compliance, without paying for a language model you do not use.
 
 ## Key Features
 
@@ -22,14 +22,14 @@ Powerful library for redacting and masking sensitive data. Protect user privacy 
 - Passwords, tokens, API keys
 - Credit cards, SSN, bank accounts
 - Emails, phone numbers, IPs
-- Personal names (NLP-powered)
+- Personal names (via the opt-in `@visulima/redact/nlp` scanner)
 
 **Text Anonymization**
 
-- Natural Language Processing
-- Detect people, organizations
-- Money, dates, locations
-- Customizable entity types
+- Regex rules for cards, tokens, IPs, SSNs
+- Dates and times
+- People, organizations and money via the opt-in NLP scanner
+- Bring your own scanner, or compose your own rules
 
 **Production-Ready**
 
@@ -61,16 +61,20 @@ console.log(safe);
 // { name: "Alice", email: "alice@example.com", password: "<PASSWORD>", creditCard: "<CREDITCARD>" }
 ```
 
-Anonymize text with NLP:
+Anonymize text, opting in to NLP entity detection for the names:
 
 ```typescript
-import { stringAnonymize } from "@visulima/redact";
+import { standardRules, stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
 
-const text = "Contact John Doe at john@example.com or call (555) 123-4567";
-const anonymized = stringAnonymize(text);
+const text = "Contact John Doe at john@example.com or 555-123-4567";
+const anonymized = stringAnonymize(text, standardRules, { nlp: compromiseScanner });
 console.log(anonymized);
-// "Contact <PERSON> at <EMAIL> or call <PHONENUMBER>"
+// "Contact <FIRSTNAME> <LASTNAME> at <EMAIL> or <PHONENUMBER>"
 ```
+
+The `nlp` option is what pulls in `compromise`; without it, key-name and pattern rules still
+apply and nothing natural-language-sized reaches your bundle.
 
 ## Use Cases
 
@@ -104,11 +108,12 @@ app.use((req, res, next) => {
 
 ```typescript
 import { stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
+
+const reviewRules = ["firstname", "lastname", "organization", "phonenumber", "email"];
 
 function anonymizeUserReview(review: string) {
-    return stringAnonymize(review, {
-        include: ["Person", "Organization", "PhoneNumber", "Email"],
-    });
+    return stringAnonymize(review, reviewRules, { nlp: compromiseScanner });
 }
 ```
 

--- a/packages/data-manipulation/redact/docs/installation.mdx
+++ b/packages/data-manipulation/redact/docs/installation.mdx
@@ -16,10 +16,28 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     <Tab value="bun">```bash bun add @visulima/redact ```</Tab>
 </Tabs>
 
+### Optional: natural-language detection
+
+Masking people's names, organizations and money amounts inside free-form prose needs a
+natural-language engine. It is not bundled — `compromise` carries a ~140 KB (gzipped) English
+lexicon and costs a parse per scanned string, so it is an optional peer dependency of the
+`@visulima/redact/nlp` entry point, and a bundle that never imports that entry contains none
+of it.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+    <Tab value="npm">```bash npm install compromise ```</Tab>
+    <Tab value="pnpm">```bash pnpm add compromise ```</Tab>
+    <Tab value="yarn">```bash yarn add compromise ```</Tab>
+    <Tab value="bun">```bash bun add compromise ```</Tab>
+</Tabs>
+
 ## Import
 
 ```typescript
 import { redact, stringAnonymize } from "@visulima/redact";
+
+// only if you installed compromise for prose entity detection
+import { compromiseScanner } from "@visulima/redact/nlp";
 ```
 
 ## Quick Examples
@@ -42,11 +60,24 @@ const safe = redact(data, ["password"]);
 ### Anonymize Text
 
 ```typescript
-import { stringAnonymize } from "@visulima/redact";
+import { standardRules, stringAnonymize } from "@visulima/redact";
 
-const text = "My email is john@example.com";
-const anonymous = stringAnonymize(text);
-// "My email is <EMAIL>"
+const text = "card 4111 1111 1111 1111 on file";
+const anonymous = stringAnonymize(text, standardRules);
+// "card <CREDITCARD> on file"
+```
+
+### Anonymize Names in Prose
+
+Names, organizations and money amounts have no regular-expression shape, so they need the
+opt-in scanner:
+
+```typescript
+import { standardRules, stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
+
+const result = stringAnonymize("John Doe works at Google", standardRules, { nlp: compromiseScanner });
+// "<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>"
 ```
 
 ### Custom Replacement

--- a/packages/data-manipulation/redact/docs/usage.mdx
+++ b/packages/data-manipulation/redact/docs/usage.mdx
@@ -3,6 +3,8 @@ title: "Usage Guide"
 description: "Complete guide to data redaction and anonymization"
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
 # Usage Guide
 
 ## Object Redaction
@@ -24,7 +26,12 @@ console.log(safe);
 // { id: 123, name: "Alice", password: "<PASSWORD>", apiKey: "<APIKEY>" }
 ```
 
+Key matching is case-insensitive, so `"password"` also matches `Password` and `PASSWORD`.
+
 ### Nested Properties
+
+A dotted rule targets one exact path. The default mask is built from the rule key, so a dotted
+rule produces a dotted mask unless you supply a `replacement`:
 
 ```typescript
 import { redact } from "@visulima/redact";
@@ -41,7 +48,18 @@ const data = {
     },
 };
 
-const safe = redact(data, ["user.profile.ssn", "user.credentials.password"]);
+redact(data, ["user.profile.ssn"]);
+// { user: { profile: { email: "alice@example.com", ssn: "<USER.PROFILE.SSN>" }, ... } }
+
+redact(data, [{ key: "user.profile.ssn", replacement: "<SSN>" }]);
+// { user: { profile: { email: "alice@example.com", ssn: "<SSN>" }, ... } }
+```
+
+To match a key at any depth instead of one path, use `deep`:
+
+```typescript
+redact(data, [{ deep: true, key: "password" }]);
+// every `password` key, however deeply nested, becomes "<PASSWORD>"
 ```
 
 ### Array Elements
@@ -54,70 +72,150 @@ const users = [
     { name: "Bob", password: "pass2" },
 ];
 
-const safe = redact(users, ["*.password"]);
+redact(users, [{ key: "*.password", replacement: "<PASSWORD>" }]);
+// [{ name: "Alice", password: "<PASSWORD>" }, { name: "Bob", password: "<PASSWORD>" }]
 ```
+
+A plain number rule targets an array index (`redact(list, [0])`).
+
+### Removing Keys
+
+```typescript
+import { redact } from "@visulima/redact";
+
+redact({ secret: "x", keep: 1 }, [{ key: "secret", remove: true }]);
+// { keep: 1 }
+```
+
+### Partial Masking
+
+A function `replacement` — a `Censor` — receives the matched value and its dot-path, and returns
+what to store:
+
+```typescript
+import { redact } from "@visulima/redact";
+
+redact({ card: "4111111111111111" }, [{ key: "card", replacement: (value) => `****${String(value).slice(-4)}` }]);
+// { card: "****1111" }
+```
+
+### What Gets Traversed
+
+`redact` walks objects, arrays, `Error`s, `Map`s, `Set`s, JSON strings and URL query strings:
+
+```typescript
+redact('{"password":"p","keep":1}', ["password"]);
+// '{"password":"<PASSWORD>","keep":1}'
+
+redact("https://api.example.com/v1?access_token=abc&page=2", ["access_token"]);
+// "https://api.example.com/v1?access_token=<ACCESS_TOKEN>&page=2"
+```
+
+Inputs are never mutated, so frozen and sealed objects are safe, and circular references are
+preserved in the copy rather than throwing.
 
 ## Text Anonymization
 
-### Automatic Detection
+### Pattern-Based Detection
+
+`stringAnonymize` masks a single string using the `pattern` rules:
 
 ```typescript
-import { stringAnonymize } from "@visulima/redact";
+import { standardRules, stringAnonymize } from "@visulima/redact";
 
-const text = "Contact John Doe at john@example.com or 555-1234";
-const result = stringAnonymize(text);
-// "Contact <PERSON> at <EMAIL> or <PHONENUMBER>"
+stringAnonymize("card 4111 1111 1111 1111 on file", standardRules);
+// "card <CREDITCARD> on file"
 ```
 
-### Select Categories
+<Callout type="info" title="Patterns overlap, and rule order breaks the tie">
+    Several built-in patterns match the same shapes — an address matches `email`, `domain` and `url` at the same offset. Equal matches are resolved by the order
+    the rules appear in, which is why `piiRules` declares `email` first. If you build a rule set by hand and the tag matters to whoever reads the output, put
+    the most specific rule first.
+</Callout>
+
+### Names, Organizations and Money
+
+These have no regular-expression shape, so they need the opt-in scanner from
+`@visulima/redact/nlp` (see [Installation](/installation)):
 
 ```typescript
-import { stringAnonymize } from "@visulima/redact";
+import { standardRules, stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
 
-const text = "John works at Acme Corp earning $50,000";
+stringAnonymize("Contact John Doe at john@example.com or 555-123-4567", standardRules, { nlp: compromiseScanner });
+// "Contact <FIRSTNAME> <LASTNAME> at <EMAIL> or <PHONENUMBER>"
+```
 
-// Only anonymize people and money
-const result = stringAnonymize(text, {
-    include: ["Person", "Money"],
+The same option works on `redact` and `createRedactor`, and applies to every string the walk
+reaches.
+
+### Choosing Categories
+
+There is no `include` list — you choose categories by composing rules. Pass only the sets or keys
+you want:
+
+```typescript
+import { piiRules, stringAnonymize } from "@visulima/redact";
+import { compromiseScanner } from "@visulima/redact/nlp";
+
+// only people and money
+stringAnonymize("John works at Acme Corp earning $50,000", ["firstname", "lastname", "money"], { nlp: compromiseScanner });
+// "<FIRSTNAME> works at Acme Corp earning <MONEY>"
+
+// everything in piiRules
+stringAnonymize("John Doe works at Google", piiRules, { nlp: compromiseScanner });
+// "<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>"
+```
+
+Or start from a full set and drop keys with `exclude`:
+
+```typescript
+stringAnonymize("John works at Acme Corp earning $50,000", standardRules, {
+    exclude: ["organization"],
+    nlp: compromiseScanner,
 });
-// "John works at Acme Corp earning <MONEY>"
+// "<FIRSTNAME> works at Acme Corp earning <MONEY>"
 ```
 
-### Exclude Categories
-
-```typescript
-import { stringAnonymize } from "@visulima/redact";
-
-const text = "Email john@example.com about the project";
-
-// Anonymize everything except emails
-const result = stringAnonymize(text, {
-    exclude: ["Email"],
-});
-```
+<Callout type="warn" title="exclude removes the whole rule">
+    Excluding a key drops its key-name matching as well as its pattern, so `exclude: ["email"]` also stops `{ email: "..." }` from
+    being masked by key. Prefer composing the rule sets you actually want.
+</Callout>
 
 ## Built-in Rules
 
 ### Sensitive Data Patterns
 
-The library includes 40+ detection patterns:
+`standardRules` bundles 60+ rules. Pass it explicitly — there is no implicit default:
 
 ```typescript
-import { redact } from "@visulima/redact";
+import { redact, standardRules } from "@visulima/redact";
 
 const data = {
-    email: "user@example.com", // Detected
-    password: "myPassword123", // Detected
-    creditCard: "4532123456789010", // Detected
-    ssn: "123-45-6789", // Detected
-    apiKey: "sk_live_abc123", // Detected
-    token: "Bearer eyJ...", // Detected
-    ip: "192.168.1.1", // Detected
-    phone: "+1-555-123-4567", // Detected
+    apiKey: "sk_live_abc123",
+    creditCard: "4532123456789010",
+    email: "user@example.com",
+    ip: "192.168.1.1",
+    password: "myPassword123",
+    ssn: "123-45-6789",
+    token: "Bearer eyJhbGciOiJIUzI1NiJ9.e30.abc",
 };
 
-// Auto-detect all sensitive fields
-const safe = redact(data);
+redact(data, standardRules);
+// every value above becomes its "<KEY>" mask
+```
+
+### Composing Subsets
+
+`standardRules` is `[...credentialRules, ...piiRules, ...dateTimeRules]`. The date/time rules
+match bare weekday and relative-date words, and several PII rules match plain numbers, so most
+logging is better served by a subset:
+
+```typescript
+import { credentialRules, piiRules, redact } from "@visulima/redact";
+
+redact({ apiKey: "sk_live_abc", ip: "10.0.0.1", note: "monday" }, [...credentialRules, ...piiRules]);
+// { apiKey: "<APIKEY>", ip: "<IP>", note: "monday" }
 ```
 
 ### Financial Data
@@ -132,53 +230,59 @@ const payment = {
     account: "123456789",
 };
 
-const safe = redact(payment, ["cardNumber", "cvv", "routing", "account"]);
+redact(payment, ["cardNumber", "cvv", "routing", "account"]);
 ```
 
 ## Custom Options
 
 ### Custom Replacement
 
+`replacement` is set per rule, not globally:
+
 ```typescript
 import { redact } from "@visulima/redact";
 
-const safe = redact(data, ["password"], {
-    replacement: "[REDACTED]",
-});
+redact(data, [{ key: "password", replacement: "[REDACTED]" }]);
 // password: "[REDACTED]"
 ```
 
 ### Case Sensitivity
 
-```typescript
-import { redact } from "@visulima/redact";
+Key matching is always case-insensitive; there is nothing to configure. `["password"]` matches
+`password`, `Password` and `PASSWORD` alike.
 
-const safe = redact(data, ["Password"], {
-    caseSensitive: false,
-});
-// Matches "password", "PASSWORD", "Password"
+### Reusing a Rule Set
+
+```typescript
+import { createRedactor, standardRules } from "@visulima/redact";
+
+const scrub = createRedactor(standardRules);
+
+scrub(payload);
+scrub(anotherPayload);
 ```
+
+`createRedactor` compiles the rules once — lowercasing keys and building the regexes — so hot
+paths such as a logger transport do not repeat that work per call.
 
 ## Real-World Examples
 
 ### Express Middleware
 
 ```typescript
-import { redact } from "@visulima/redact";
+import { createRedactor } from "@visulima/redact";
 import type { Request, Response, NextFunction } from "express";
 
+const scrub = createRedactor(["password", "token", "apiKey", "secret"]);
+
 function redactMiddleware(req: Request, res: Response, next: NextFunction) {
-    // Redact request body
     if (req.body) {
-        req.body = redact(req.body, ["password", "token", "apiKey"]);
+        req.body = scrub(req.body);
     }
 
-    // Redact response
     const originalJson = res.json.bind(res);
-    res.json = (data: any) => {
-        const safe = redact(data, ["password", "secret", "token"]);
-        return originalJson(safe);
-    };
+
+    res.json = (data: unknown) => originalJson(scrub(data));
 
     next();
 }
@@ -189,40 +293,28 @@ app.use(redactMiddleware);
 ### Logger Integration
 
 ```typescript
-import { redact } from "@visulima/redact";
+import { createRedactor } from "@visulima/redact";
 import winston from "winston";
 
+const scrub = createRedactor(["password", "token", "apiKey"]);
+
 const logger = winston.createLogger({
-    format: winston.format.combine(
-        winston.format((info) => {
-            return {
-                ...info,
-                ...redact(info, ["password", "token", "apiKey"]),
-            };
-        })(),
-        winston.format.json(),
-    ),
+    format: winston.format.combine(winston.format((info) => scrub(info))(), winston.format.json()),
 });
 ```
 
 ### Database Query Sanitization
 
 ```typescript
-import { redact } from "@visulima/redact";
+import { createRedactor } from "@visulima/redact";
+
+const scrubUser = createRedactor([{ key: "password", remove: true }, { key: "passwordHash", remove: true }, "resetToken", "twoFactorSecret"]);
 
 class UserRepository {
     async findById(id: string) {
         const user = await this.db.users.findOne({ id });
 
-        // Remove sensitive fields before returning
-        return redact(user, ["password", "passwordHash", "resetToken", "twoFactorSecret"]);
-    }
-
-    async logQuery(query: any) {
-        // Redact sensitive data in logs
-        const safe = redact(query, ["password", "token", "secret"]);
-
-        logger.debug("Query executed", safe);
+        return scrubUser(user);
     }
 }
 ```

--- a/packages/data-manipulation/redact/package.json
+++ b/packages/data-manipulation/redact/package.json
@@ -56,6 +56,13 @@
             },
             "browser": "./dist/index.js"
         },
+        "./nlp": {
+            "import": {
+                "types": "./dist/nlp.d.ts",
+                "default": "./dist/nlp.js"
+            },
+            "browser": "./dist/nlp.js"
+        },
         "./package.json": "./package.json"
     },
     "files": [
@@ -85,9 +92,6 @@
         "test:watch": "vitest",
         "test:workerd": "vitest run --config vitest.workerd.config.ts"
     },
-    "dependencies": {
-        "compromise": "catalog:prod"
-    },
     "devDependencies": {
         "@anolilab/eslint-config": "catalog:lint",
         "@anolilab/prettier-config": "catalog:lint",
@@ -101,6 +105,7 @@
         "@visulima/packem": "catalog:dev",
         "@vitest/coverage-v8": "catalog:test",
         "@vitest/ui": "catalog:test",
+        "compromise": "catalog:prod",
         "conventional-changelog-conventionalcommits": "catalog:dev",
         "dot-prop": "catalog:dev",
         "esbuild": "catalog:build",
@@ -113,6 +118,14 @@
         "semantic-release": "catalog:cli",
         "typescript": "catalog:tsc",
         "vitest": "catalog:test"
+    },
+    "peerDependencies": {
+        "compromise": "catalog:peer"
+    },
+    "peerDependenciesMeta": {
+        "compromise": {
+            "optional": true
+        }
     },
     "engines": {
         "node": "^22.14.0 || >=24.10.0"

--- a/packages/data-manipulation/redact/src/index.ts
+++ b/packages/data-manipulation/redact/src/index.ts
@@ -149,7 +149,7 @@ const filterUrl = (input: string, rules: InternalAnonymize[], options?: RedactOp
             // through the string anonymizer so pattern/NLP rules (credit cards, SSNs, tokens, ...)
             // still redact secrets that merely happen to sit next to a URL, instead of the whole
             // string being routed away from `stringAnonymize` by the presence of "http://".
-            filtered.push(foundModifier ? String(resolveReplacement(foundModifier, value, undefined)) : stringAnonymize(value, rules, { logger: options?.logger }));
+            filtered.push(foundModifier ? String(resolveReplacement(foundModifier, value, undefined)) : stringAnonymize(value, rules, options));
         } else {
             const foundModifier = findUrlModifier(rules, key);
 
@@ -326,7 +326,10 @@ const recursiveFilter = (
             return filterUrl(stringInput, rules, options);
         }
 
-        return stringAnonymize(stringInput, rules, { logger: options?.logger });
+        // `options` is forwarded whole rather than field-by-field, so a new option never has to be
+        // remembered at two call sites. `rules` here is already `prepareModifiers`-filtered, so
+        // stringAnonymize re-applying `options.exclude` to it is a no-op.
+        return stringAnonymize(stringInput, rules, options);
     }
 
     if (Array.isArray(input)) {
@@ -494,4 +497,4 @@ export const createRedactor = (rules: Rules, options?: RedactOptions): <V>(input
 
 export { credentialRules, dateTimeRules, piiRules, default as standardRules } from "./rules";
 export { default as stringAnonymize } from "./string-anonymizer";
-export type { Anonymize, Censor, RedactOptions, Rules, StringAnonymize } from "./types";
+export type { Anonymize, Censor, NlpMatch, NlpScanner, RedactOptions, Rules, StringAnonymize } from "./types";

--- a/packages/data-manipulation/redact/src/nlp.ts
+++ b/packages/data-manipulation/redact/src/nlp.ts
@@ -1,0 +1,77 @@
+import nlp from "compromise";
+
+import type { NlpMatch, NlpScanner } from "./types";
+
+/** Shape of `compromise`'s `.out("offset")` result. */
+interface CompromiseOffset {
+    offset: { start: number };
+    terms: { tags: string[]; text: string }[];
+}
+
+// Maps an NLP type (as a rule key) to the compromise extractor that detects it.
+// `people` covers both firstname and lastname tags.
+const nlpExtractors: { method: "emails" | "money" | "organizations" | "people" | "phoneNumbers" | "urls"; types: string[] }[] = [
+    { method: "emails", types: ["email"] },
+    { method: "money", types: ["money"] },
+    { method: "organizations", types: ["organization"] },
+    { method: "people", types: ["firstname", "lastname"] },
+    { method: "phoneNumbers", types: ["phonenumber"] },
+    { method: "urls", types: ["url"] },
+];
+
+/**
+ * A {@link NlpScanner} backed by {@link https://www.npmjs.com/package/compromise | compromise}.
+ *
+ * Detects people, organizations, money amounts, emails, phone numbers and urls in prose —
+ * the entities no regular expression can describe. `compromise` is an optional peer
+ * dependency of this entry point only: importing `@visulima/redact` alone pulls in none of it.
+ * @example
+ * ```ts
+ * import { createRedactor, standardRules } from "@visulima/redact";
+ * import { compromiseScanner } from "@visulima/redact/nlp";
+ *
+ * const scrub = createRedactor(standardRules, { nlp: compromiseScanner });
+ *
+ * scrub({ note: "John Doe works at Google" });
+ * // => { note: "<FIRSTNAME> <LASTNAME> works at <ORGANIZATION>" }
+ * ```
+ * @param input The string being redacted.
+ * @param types The rule keys in play; only extractors covering one of them are run.
+ * @param logger Optional debug logger.
+ * @returns Every entity found whose compromise tag matches one of `types`.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const compromiseScanner: NlpScanner = (input, types, logger): NlpMatch[] => {
+    const wanted = new Set(types.map((type) => type.toLowerCase()));
+    const requested = nlpExtractors.filter((extractor) => extractor.types.some((type) => wanted.has(type)));
+
+    // Skip the (expensive) compromise parse entirely when no NLP-backed rule was requested.
+    if (requested.length === 0) {
+        return [];
+    }
+
+    const nlpDocument = nlp(input);
+    const matches: NlpMatch[] = [];
+
+    // Only run the extractors whose tags were actually requested, instead of all six.
+    for (const extractor of requested) {
+        for (const documentObject of nlpDocument[extractor.method]().out("offset") as unknown as CompromiseOffset[]) {
+            for (const term of documentObject.terms) {
+                // compromise orders tags broad -> specific, so the last match is the most specific one.
+                const reversedTags = term.tags.toReversed();
+
+                logger?.debug(`reversedTags: ${JSON.stringify(reversedTags)}`);
+
+                const foundTag = reversedTags.find((tag: string) => wanted.has(tag.toLowerCase()));
+
+                logger?.debug(`foundTag: ${String(foundTag)}`);
+
+                if (foundTag) {
+                    matches.push({ start: documentObject.offset.start, tag: foundTag, text: term.text });
+                }
+            }
+        }
+    }
+
+    return matches;
+};

--- a/packages/data-manipulation/redact/src/nlp.ts
+++ b/packages/data-manipulation/redact/src/nlp.ts
@@ -2,10 +2,14 @@ import nlp from "compromise";
 
 import type { NlpMatch, NlpScanner } from "./types";
 
-/** Shape of `compromise`'s `.out("offset")` result. */
+/**
+ * Shape of `compromise`'s `.out("offset")` result. Note that BOTH the match and each of its
+ * terms carry an offset: the match's is the start of the whole entity, so using it for a term
+ * would mis-report every term after the first (in "John Doe", "Doe" would claim John's offset).
+ */
 interface CompromiseOffset {
     offset: { start: number };
-    terms: { tags: string[]; text: string }[];
+    terms: { offset: { start: number }; tags: string[]; text: string }[];
 }
 
 // Maps an NLP type (as a rule key) to the compromise extractor that detects it.
@@ -67,7 +71,8 @@ export const compromiseScanner: NlpScanner = (input, types, logger): NlpMatch[] 
                 logger?.debug(`foundTag: ${String(foundTag)}`);
 
                 if (foundTag) {
-                    matches.push({ start: documentObject.offset.start, tag: foundTag, text: term.text });
+                    // The TERM's own offset, not the entity's — see CompromiseOffset above.
+                    matches.push({ start: term.offset.start, tag: foundTag, text: term.text });
                 }
             }
         }

--- a/packages/data-manipulation/redact/src/rules.ts
+++ b/packages/data-manipulation/redact/src/rules.ts
@@ -39,8 +39,9 @@ const credentialRules: Rules = [
 
 /**
  * Personally-identifiable-information rules: bank accounts, credit cards, IDs/UUIDs,
- * IPs, MACs, phone numbers, SSNs, NINs, ISBNs, zip codes, URLs/domains, plus the
- * NLP-powered name/organization/email/money rules.
+ * IPs, MACs, phone numbers, SSNs, NINs, ISBNs, zip codes, URLs/domains, emails, plus the
+ * name/organization/money rules, which have no regex shape and are only found in prose when an
+ * `nlp` scanner is supplied (see `RedactOptions.nlp`).
  *
  * WARNING: several of these intentionally match plain numeric data and will overmatch on
  * ordinary values. For example `bankacc` (`\b\d{10,12}\b`), `id`/`routing` (`\b\d{9}\b`) and
@@ -50,6 +51,16 @@ const credentialRules: Rules = [
  */
 const piiRules: Rules = [
     { deep: true, key: "bankacc", pattern: String.raw`\b\d{10,12}\b` },
+    // Declared ahead of `domain`/`url` on purpose: all three match an address at the same
+    // offset with the same length, and equal matches are resolved by rule order, so this must
+    // come first for an address to be masked `<EMAIL>` rather than `<URL>`.
+    // The host part reuses the `domain` shape, whose per-label class excludes `.` so it cannot
+    // overlap the literal separator — no nested-quantifier backtracking (ReDoS).
+    {
+        deep: true,
+        key: "email",
+        pattern: String.raw`[A-Za-z0-9._%+-]+@((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}\b`,
+    },
     { deep: true, key: "id", pattern: String.raw`\b\d{3}-\d{3}-\d{3}\b` },
     // Linearized credit-card pattern: the original `(?:\d[ -]*?){13,16}` combined a
     // counted group with an unbounded lazy inner quantifier, a polynomial-backtracking
@@ -88,7 +99,6 @@ const piiRules: Rules = [
     { deep: true, key: "organization" },
     { deep: true, key: "money" },
     { deep: true, key: "bankcc" },
-    { deep: true, key: "email" },
     { deep: true, key: "passport" },
     { deep: true, key: "username" },
 ];

--- a/packages/data-manipulation/redact/src/rules.ts
+++ b/packages/data-manipulation/redact/src/rules.ts
@@ -59,7 +59,10 @@ const piiRules: Rules = [
     {
         deep: true,
         key: "email",
-        pattern: String.raw`[A-Za-z0-9._%+-]+@((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}\b`,
+        // The terminal label allows the full 63-character DNS limit, not the 6 that `domain` and
+        // `url` use: a long TLD (`.technology`, `.international`) would otherwise leave the whole
+        // address unredacted for callers who dropped those two rules.
+        pattern: String.raw`[A-Za-z0-9._%+-]+@((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,63}\b`,
     },
     { deep: true, key: "id", pattern: String.raw`\b\d{3}-\d{3}-\d{3}\b` },
     // Linearized credit-card pattern: the original `(?:\d[ -]*?){13,16}` combined a

--- a/packages/data-manipulation/redact/src/string-anonymizer.ts
+++ b/packages/data-manipulation/redact/src/string-anonymizer.ts
@@ -1,18 +1,10 @@
-import nlp from "compromise";
+import type { Censor, NlpMatch, RedactOptions, Rules, StringAnonymize } from "./types";
 
-import type { Censor, RedactOptions, Rules, StringAnonymize } from "./types";
-
-interface IDocumentTerm {
+// Extends NlpMatch rather than restating it: a scanner's matches are spread straight into this
+// array, so the compiler — not a comment — is what keeps the two shapes compatible.
+interface IDocumentTerm extends NlpMatch {
     /** Optional explicit replacement (static string or {@link Censor}) from the matching rule. */
     replacement?: Censor | string;
-    start: number;
-    tag: string;
-    text: string;
-}
-
-interface CompromiseOffset {
-    offset: { start: number };
-    terms: { tags: string[]; text: string }[];
 }
 
 const maskText = (maskMaps: Record<string, Map<string, string>>, text: string, tag: string): string => {
@@ -38,12 +30,8 @@ const maskText = (maskMaps: Record<string, Map<string, string>>, text: string, t
     return maskedValue;
 };
 
-const replaceWithMasks = (typesToAnonymize: string[], documentTerms: IDocumentTerm[], output: string): string => {
+const replaceWithMasks = (documentTerms: IDocumentTerm[], output: string): string => {
     const maskMaps: Record<string, Map<string, string>> = {};
-
-    for (const element of typesToAnonymize) {
-        maskMaps[element] = new Map<string, string>();
-    }
 
     let outputResult = output;
 
@@ -60,33 +48,14 @@ const replaceWithMasks = (typesToAnonymize: string[], documentTerms: IDocumentTe
             mask = maskText(maskMaps, text, tag);
         }
 
-        outputResult = outputResult.replace(text, mask);
+        // `text` is a plain string needle, but `mask` sits in the REPLACEMENT position, where
+        // `$&`, `` $` `` and `$'` are substitution patterns — a tag containing one would splice
+        // the surrounding text back in, echoing the very value being masked. Escaping `$` keeps
+        // the mask literal for both scanner-supplied tags and rule keys.
+        outputResult = outputResult.replace(text, mask.replaceAll("$", "$$$$"));
     }
 
     return outputResult;
-};
-
-const createDocumentTermsFromTerms = (
-    typesToAnonymize: string[],
-    processedTerms: IDocumentTerm[],
-    documentObject: CompromiseOffset,
-    term: { tags: string[]; text: string },
-
-    logger?: { debug: (...arguments_: unknown[]) => void },
-): IDocumentTerm[] => {
-    const reversedTags = term.tags.toReversed();
-
-    logger?.debug(`reversedTags: ${JSON.stringify(reversedTags)}`);
-
-    const foundTag = reversedTags.find((tag: string) => typesToAnonymize.includes(tag.toLowerCase()));
-
-    logger?.debug(`foundTag: ${String(foundTag)}`);
-
-    if (foundTag) {
-        processedTerms.push({ start: documentObject.offset.start, tag: foundTag, text: term.text });
-    }
-
-    return processedTerms;
 };
 
 const createUniqueAndSortedTerms = (processedTerms: IDocumentTerm[]): IDocumentTerm[] => {
@@ -106,7 +75,9 @@ const createUniqueAndSortedTerms = (processedTerms: IDocumentTerm[]): IDocumentT
     });
 };
 
-const processWithRegex = (stringAnonymizeModifiers: StringAnonymize[], input: string, processedTerms: IDocumentTerm[]): IDocumentTerm[] => {
+const processWithRegex = (stringAnonymizeModifiers: StringAnonymize[], input: string): IDocumentTerm[] => {
+    const processedTerms: IDocumentTerm[] = [];
+
     for (const modifier of stringAnonymizeModifiers) {
         const { key, pattern } = modifier;
 
@@ -142,66 +113,11 @@ const processWithRegex = (stringAnonymizeModifiers: StringAnonymize[], input: st
     return processedTerms;
 };
 
-// Maps an NLP type (as a `typesToAnonymize` entry) to the compromise extractor that detects it.
-// `people` covers both firstname and lastname tags.
-const nlpExtractors: { method: "emails" | "money" | "organizations" | "people" | "phoneNumbers" | "urls"; types: string[] }[] = [
-    { method: "emails", types: ["email"] },
-    { method: "money", types: ["money"] },
-    { method: "organizations", types: ["organization"] },
-    { method: "people", types: ["firstname", "lastname"] },
-    { method: "phoneNumbers", types: ["phonenumber"] },
-    { method: "urls", types: ["url"] },
-];
-
-const processTerms = (
-    typesToAnonymize: string[],
-    input: string,
-    processedTerms: IDocumentTerm[],
-
-    logger?: { debug: (...arguments_: unknown[]) => void },
-): IDocumentTerm[] => {
-    const requested = nlpExtractors.filter((extractor) => extractor.types.some((type) => typesToAnonymize.includes(type)));
-
-    // Skip the (expensive) compromise parse entirely when no NLP-backed rule was requested.
-    if (requested.length === 0) {
-        return processedTerms;
-    }
-
-    const nlpDocument = nlp(input);
-
-    const processedDocument: CompromiseOffset[] = [];
-
-    // Only run the extractors whose tags were actually requested, instead of all six.
-    for (const extractor of requested) {
-        processedDocument.push(...(nlpDocument[extractor.method]().out("offset") as unknown as CompromiseOffset[]));
-    }
-
-    for (const documentObject of processedDocument) {
-        const { terms } = documentObject;
-
-        for (const term of terms) {
-            // eslint-disable-next-line no-param-reassign
-            processedTerms = createDocumentTermsFromTerms(typesToAnonymize, processedTerms, documentObject, term, logger);
-        }
-    }
-
-    return processedTerms;
-};
-
-const processDocument = (
-    input: string,
-    typesToAnonymize: string[],
-    stringAnonymizeModifiers: StringAnonymize[],
-
-    logger?: { debug: (...arguments_: unknown[]) => void },
-): IDocumentTerm[] => {
-    let processedTerms: IDocumentTerm[] = [];
-
-    processedTerms = processTerms(typesToAnonymize, input, processedTerms, logger);
-    processedTerms = processWithRegex(stringAnonymizeModifiers, input, processedTerms);
-
-    return createUniqueAndSortedTerms(processedTerms);
-};
+const processDocument = (input: string, typesToAnonymize: string[], stringAnonymizeModifiers: StringAnonymize[], options?: RedactOptions): IDocumentTerm[] =>
+    // No scanner injected means no NLP pass — and no natural-language library in the bundle.
+    // NLP matches are collected before the regex ones so that, where both find the same span,
+    // the sort (stable, start-ascending) keeps the entity label.
+    createUniqueAndSortedTerms([...options?.nlp?.(input, typesToAnonymize, options.logger) ?? [], ...processWithRegex(stringAnonymizeModifiers, input)]);
 
 const stringAnonymize = (input: string, modifiers: Rules, options?: RedactOptions): string => {
     const patternModifiers: StringAnonymize[] = [];
@@ -221,18 +137,16 @@ const stringAnonymize = (input: string, modifiers: Rules, options?: RedactOption
             patternModifiers.push(modifier as StringAnonymize);
         }
 
-        if (typeof modifier === "string" || typeof modifier === "number") {
-            typesToAnonymize.push(modifier.toString());
-        } else {
-            typesToAnonymize.push(modifier.key);
-        }
+        // Lowercased here, once, so every scanner receives the casing its contract promises and
+        // none of them has to normalise defensively.
+        typesToAnonymize.push((typeof modifier === "object" ? modifier.key : String(modifier)).toLowerCase());
     }
 
     let output = input;
 
-    const documentTerms = processDocument(input, typesToAnonymize, patternModifiers, options?.logger);
+    const documentTerms = processDocument(input, typesToAnonymize, patternModifiers, options);
 
-    output = replaceWithMasks(typesToAnonymize, documentTerms, output);
+    output = replaceWithMasks(documentTerms, output);
 
     return output;
 };

--- a/packages/data-manipulation/redact/src/string-anonymizer.ts
+++ b/packages/data-manipulation/redact/src/string-anonymizer.ts
@@ -33,10 +33,38 @@ const maskText = (maskMaps: Record<string, Map<string, string>>, text: string, t
 const replaceWithMasks = (documentTerms: IDocumentTerm[], output: string): string => {
     const maskMaps: Record<string, Map<string, string>> = {};
 
-    let outputResult = output;
+    let result = "";
+    let cursor = 0;
 
+    // Terms arrive sorted by start (longest first on ties). Masking is applied AT each recorded
+    // offset by slicing, rather than by `String.replace(text, mask)`: a string needle rewrites
+    // the FIRST occurrence of the text, which is not necessarily the one that was matched. With
+    // "Doe met John Doe", the surname match would rewrite the leading "Doe" and leave the real
+    // one exposed. Slicing also means a mask containing `$&` or `` $` `` is inserted literally
+    // instead of being re-expanded as a replacement pattern.
     for (const documentTerm of documentTerms) {
-        const { replacement, tag, text } = documentTerm;
+        const { replacement, start, tag, text } = documentTerm;
+
+        // A span that begins inside the text already masked is an overlapping match for the
+        // same value (e.g. `email` and `url` both matching an address). The first one wins —
+        // which is why rule order decides — and the rest are dropped rather than allowed to
+        // re-match some later, unrelated occurrence.
+        if (start < cursor) {
+            continue;
+        }
+
+        let at = start;
+
+        // `nlp` scanners are caller-supplied, so the offset is not trusted: if it does not line
+        // up with the text it claims, fall back to the next occurrence at or after the cursor.
+        // Skipping instead would silently drop the redaction.
+        if (output.slice(at, at + text.length) !== text) {
+            at = output.indexOf(text, cursor);
+
+            if (at === -1) {
+                continue;
+            }
+        }
 
         let mask: string;
 
@@ -48,14 +76,11 @@ const replaceWithMasks = (documentTerms: IDocumentTerm[], output: string): strin
             mask = maskText(maskMaps, text, tag);
         }
 
-        // `text` is a plain string needle, but `mask` sits in the REPLACEMENT position, where
-        // `$&`, `` $` `` and `$'` are substitution patterns — a tag containing one would splice
-        // the surrounding text back in, echoing the very value being masked. Escaping `$` keeps
-        // the mask literal for both scanner-supplied tags and rule keys.
-        outputResult = outputResult.replace(text, mask.replaceAll("$", "$$$$"));
+        result += output.slice(cursor, at) + mask;
+        cursor = at + text.length;
     }
 
-    return outputResult;
+    return result + output.slice(cursor);
 };
 
 const createUniqueAndSortedTerms = (processedTerms: IDocumentTerm[]): IDocumentTerm[] => {

--- a/packages/data-manipulation/redact/src/string-anonymizer.ts
+++ b/packages/data-manipulation/redact/src/string-anonymizer.ts
@@ -30,6 +30,25 @@ const maskText = (maskMaps: Record<string, Map<string, string>>, text: string, t
     return maskedValue;
 };
 
+/**
+ * The text to put in place of a match: an explicit user replacement if the rule carried one,
+ * otherwise the numbered `&lt;TAG>` mask. Resolved lazily by the caller, because allocating a
+ * numbered mask for a term that is then dropped would burn a number and shift every later one.
+ */
+const resolveMask = (maskMaps: Record<string, Map<string, string>>, documentTerm: IDocumentTerm): string => {
+    const { replacement, tag, text } = documentTerm;
+
+    if (typeof replacement === "function") {
+        return String(replacement(text, undefined));
+    }
+
+    if (typeof replacement === "string") {
+        return replacement;
+    }
+
+    return maskText(maskMaps, text, tag);
+};
+
 const replaceWithMasks = (documentTerms: IDocumentTerm[], output: string): string => {
     const maskMaps: Record<string, Map<string, string>> = {};
 
@@ -43,41 +62,49 @@ const replaceWithMasks = (documentTerms: IDocumentTerm[], output: string): strin
     // one exposed. Slicing also means a mask containing `$&` or `` $` `` is inserted literally
     // instead of being re-expanded as a replacement pattern.
     for (const documentTerm of documentTerms) {
-        const { replacement, start, tag, text } = documentTerm;
+        const { start, text } = documentTerm;
 
-        // A span that begins inside the text already masked is an overlapping match for the
-        // same value (e.g. `email` and `url` both matching an address). The first one wins —
-        // which is why rule order decides — and the rest are dropped rather than allowed to
-        // re-match some later, unrelated occurrence.
-        if (start < cursor) {
+        // Nothing to mask, and an empty needle would make the rescan below loop forever.
+        if (text === "") {
             continue;
         }
 
-        let at = start;
-
-        // `nlp` scanners are caller-supplied, so the offset is not trusted: if it does not line
-        // up with the text it claims, fall back to the next occurrence at or after the cursor.
-        // Skipping instead would silently drop the redaction.
-        if (output.slice(at, at + text.length) !== text) {
-            at = output.indexOf(text, cursor);
-
-            if (at === -1) {
+        // Does the reported span actually point at the text it claims? Pattern rules always
+        // produce one that does; an `nlp` scanner is caller-supplied, so this is checked before
+        // the span is trusted for anything — including the overlap test below, which would
+        // otherwise silently drop a match carrying a negative offset.
+        if (Number.isInteger(start) && start >= 0 && output.slice(start, start + text.length) === text) {
+            // A span beginning inside text already masked is an overlapping match for the same
+            // value (e.g. `email` and `url` both matching an address). The first one wins —
+            // which is why rule order decides — and the rest are dropped rather than allowed to
+            // re-match some later, unrelated occurrence.
+            if (start < cursor) {
                 continue;
             }
+
+            result += output.slice(cursor, start) + resolveMask(maskMaps, documentTerm);
+            cursor = start + text.length;
+
+            continue;
         }
 
-        let mask: string;
+        // The span is unusable, so there is no way to know WHICH occurrence was meant. Masking
+        // the first would leave a later one — possibly the intended one — in the clear, and
+        // skipping would leave them all. Mask every remaining occurrence instead: over-masking
+        // is the only safe direction for a redaction library.
+        let at = output.indexOf(text, cursor);
 
-        if (typeof replacement === "function") {
-            mask = String(replacement(text, undefined));
-        } else if (typeof replacement === "string") {
-            mask = replacement;
-        } else {
-            mask = maskText(maskMaps, text, tag);
+        if (at === -1) {
+            continue;
         }
 
-        result += output.slice(cursor, at) + mask;
-        cursor = at + text.length;
+        const mask = resolveMask(maskMaps, documentTerm);
+
+        while (at !== -1) {
+            result += output.slice(cursor, at) + mask;
+            cursor = at + text.length;
+            at = output.indexOf(text, cursor);
+        }
     }
 
     return result + output.slice(cursor);

--- a/packages/data-manipulation/redact/src/types.ts
+++ b/packages/data-manipulation/redact/src/types.ts
@@ -52,7 +52,56 @@ export type InternalAnonymize = Anonymize & {
 
 export type Rules = (Anonymize | StringAnonymize | number | string)[];
 
+/** A single entity located in a string by an {@link NlpScanner}. */
+export type NlpMatch = {
+    /** Index of the match within the scanned input. */
+    start: number;
+
+    /** The rule key/type this match belongs to (e.g. `FirstName`); cased freely, matched case-insensitively. */
+    tag: string;
+
+    /** The exact matched text, which is what gets replaced. */
+    text: string;
+};
+
+/**
+ * Locates named entities (people, organizations, money, ...) that no regular expression can
+ * describe. Redact ships no scanner by default — natural-language detection costs a
+ * multi-hundred-kilobyte lexicon and a parse per string, so it is opt-in.
+ *
+ * Pass {@link https://www.npmjs.com/package/compromise | compromise}-backed detection via
+ * `@visulima/redact/nlp`, or implement this signature against any other engine.
+ * @example
+ * ```ts
+ * import { createRedactor, standardRules } from "@visulima/redact";
+ * import { compromiseScanner } from "@visulima/redact/nlp";
+ *
+ * const scrub = createRedactor(standardRules, { nlp: compromiseScanner });
+ * ```
+ * A scanner is called for EVERY string the walk reaches, not only the ones carrying an entity
+ * it handles — the core cannot know which types a given engine serves. Check `types` first and
+ * return an empty array cheaply when none of them apply to you; that early exit is what keeps a
+ * pure key/pattern rule set from paying for the scan.
+ * @param input The string being redacted.
+ * @param types The rule keys in play, lowercased. Return only matches whose `tag` is one of
+ * them — the core masks whatever it is handed, so an out-of-contract tag would redact under a
+ * label the caller never asked for.
+ * @param logger Optional debug logger forwarded from {@link RedactOptions}.
+ * @returns Every entity found, in any order. `start` orders and de-duplicates matches; it does
+ * NOT position the replacement, which is applied to the first occurrence of `text`. Where the
+ * same text appears more than once, every occurrence collapses onto one mask.
+ */
+export type NlpScanner = (input: string, types: string[], logger?: { debug: (message?: unknown, ...optionalParameters: unknown[]) => void }) => NlpMatch[];
+
 export type RedactOptions = {
     exclude?: (number | string)[];
     logger?: { debug: (message?: unknown, ...optionalParameters: unknown[]) => void };
+
+    /**
+     * Opt in to natural-language entity detection (names, organizations, money).
+     * Without it, key-name and `pattern` rules still apply — only the four rule keys that have
+     * no regex shape (`firstname`, `lastname`, `organization`, `money`) go unmatched inside
+     * prose. They still match object keys of the same name either way.
+     */
+    nlp?: NlpScanner;
 };

--- a/packages/data-manipulation/redact/src/types.ts
+++ b/packages/data-manipulation/redact/src/types.ts
@@ -87,9 +87,10 @@ export type NlpMatch = {
  * them — the core masks whatever it is handed, so an out-of-contract tag would redact under a
  * label the caller never asked for.
  * @param logger Optional debug logger forwarded from {@link RedactOptions}.
- * @returns Every entity found, in any order. `start` orders and de-duplicates matches; it does
- * NOT position the replacement, which is applied to the first occurrence of `text`. Where the
- * same text appears more than once, every occurrence collapses onto one mask.
+ * @returns Every entity found, in any order. `start` must be the index of `text` within
+ * `input`: the mask is applied at that offset, so a match reported at the wrong position would
+ * redact the wrong occurrence. Overlapping matches are resolved in favour of the first by
+ * `start` (longest wins on a tie), and the rest are dropped.
  */
 export type NlpScanner = (input: string, types: string[], logger?: { debug: (message?: unknown, ...optionalParameters: unknown[]) => void }) => NlpMatch[];
 

--- a/packages/error-debugging/pail/__tests__/unit/processor/redact-processor.test.ts
+++ b/packages/error-debugging/pail/__tests__/unit/processor/redact-processor.test.ts
@@ -1,3 +1,4 @@
+import { compromiseScanner } from "@visulima/redact/nlp";
 import { describe, expect, it } from "vitest";
 
 import RedactProcessor from "../../../src/processor/redact-processor";
@@ -13,6 +14,21 @@ describe("redactProcessor", () => {
         const meta = { message: "John Doe will be 30 on 2024-06-10" } as Meta<string>;
         const result = processor.process(meta);
 
+        // The date is a pattern rule, so it is masked by default. A person's name has no regex
+        // shape: @visulima/redact finds it only when an `nlp` scanner is supplied, which the
+        // processor does not do on its own — see the opt-in test below.
+        expect(result.message).toBe("John Doe will be 30 on <DATE>");
+    });
+
+    it("should redact names in meta.message when an nlp scanner is supplied", () => {
+        expect.assertions(1);
+
+        // Proves the processor forwards `options` to redact, which is the whole opt-in path
+        // for consumers who install `compromise` and want prose entity detection back.
+        const processor = new RedactProcessor(undefined, { nlp: compromiseScanner });
+        const meta = { message: "John Doe will be 30 on 2024-06-10" } as Meta<string>;
+        const result = processor.process(meta);
+
         expect(result.message).toBe("<FIRSTNAME> <LASTNAME> will be 30 on <DATE>");
     });
 
@@ -20,6 +36,17 @@ describe("redactProcessor", () => {
         expect.assertions(1);
 
         const processor = new RedactProcessor();
+        const meta = { context: ["John Doe will be 30 on 2024-06-10"] } as Meta<string>;
+
+        const result = processor.process(meta);
+
+        expect(result.context).toStrictEqual(["John Doe will be 30 on <DATE>"]);
+    });
+
+    it("should redact sensitive information in meta.context with an nlp scanner", () => {
+        expect.assertions(1);
+
+        const processor = new RedactProcessor(undefined, { nlp: compromiseScanner });
         const meta = { context: ["John Doe will be 30 on 2024-06-10"] } as Meta<string>;
 
         const result = processor.process(meta);
@@ -32,7 +59,7 @@ describe("redactProcessor", () => {
     it.skip("should redact sensitive information in meta.error", () => {
         expect.assertions(1);
 
-        const processor = new RedactProcessor();
+        const processor = new RedactProcessor(undefined, { nlp: compromiseScanner });
         const meta = { error: new Error("John Doe will be 30 on 2024-06-10") } as Meta<string>;
         const result = processor.process(meta);
 

--- a/packages/error-debugging/pail/package.json
+++ b/packages/error-debugging/pail/package.json
@@ -295,6 +295,7 @@
         "@visulima/string": "3.1.0",
         "@vitest/coverage-v8": "catalog:test",
         "@vitest/ui": "catalog:test",
+        "compromise": "catalog:prod",
         "conventional-changelog-conventionalcommits": "catalog:dev",
         "esbuild": "catalog:build",
         "eslint": "catalog:lint",

--- a/packages/error-debugging/pail/package.json
+++ b/packages/error-debugging/pail/package.json
@@ -291,7 +291,7 @@
         "@visulima/fmt": "3.0.0",
         "@visulima/inspector": "2.1.0",
         "@visulima/packem": "catalog:dev",
-        "@visulima/redact": "4.0.0",
+        "@visulima/redact": "workspace:*",
         "@visulima/string": "3.1.0",
         "@vitest/coverage-v8": "catalog:test",
         "@vitest/ui": "catalog:test",
@@ -314,7 +314,7 @@
     "peerDependencies": {
         "@opentelemetry/api": "catalog:peer",
         "@sveltejs/kit": ">=2.0",
-        "@visulima/redact": "4.0.0",
+        "@visulima/redact": "catalog:peer",
         "elysia": ">=1.0",
         "express": ">=4.0",
         "fastify": ">=4.0",

--- a/packages/error-debugging/pail/src/processor/redact-processor.ts
+++ b/packages/error-debugging/pail/src/processor/redact-processor.ts
@@ -25,6 +25,17 @@ import type { Meta, Processor } from "../types";
  *   apiKey: "sk-123456"    // Will be redacted
  * });
  * ```
+ *
+ * Key names, credit cards, tokens, IPs, SSNs and emails are matched out of the box. Detecting
+ * people's names, organizations and money amounts inside free-form prose additionally needs a
+ * natural-language scanner, which `@visulima/redact` no longer bundles — install `compromise`
+ * and pass it through, and only then does the lexicon enter your bundle:
+ * @example
+ * ```typescript
+ * import { compromiseScanner } from "@visulima/redact/nlp";
+ *
+ * new RedactProcessor(undefined, { nlp: compromiseScanner });
+ * ```
  */
 class RedactProcessor<L extends string = string> implements Processor<L> {
     /** The redact function configured with custom rules and options */

--- a/packages/terminal/boxen/__bench__/package.json
+++ b/packages/terminal/boxen/__bench__/package.json
@@ -10,6 +10,7 @@
         "@codspeed/vitest-plugin": "catalog:test",
         "@visulima/boxen": "workspace:*",
         "boxen": "catalog:dev",
+        "terminal-size": "catalog:dev",
         "typescript": "catalog:tsc",
         "vitest": "catalog:test"
     }

--- a/packages/tooling/vis/package.json
+++ b/packages/tooling/vis/package.json
@@ -203,7 +203,7 @@
         "@visulima/packem": "catalog:dev",
         "@visulima/pail": "4.1.1",
         "@visulima/path": "4.0.0",
-        "@visulima/redact": "4.0.0",
+        "@visulima/redact": "workspace:*",
         "@visulima/source-map": "3.0.1",
         "@visulima/spinner": "1.0.1",
         "@visulima/string": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8021,6 +8021,9 @@ importers:
       boxen:
         specifier: catalog:dev
         version: 8.0.1
+      terminal-size:
+        specifier: catalog:dev
+        version: 4.0.1
       typescript:
         specifier: catalog:tsc
         version: 6.0.3
@@ -24452,11 +24455,11 @@ packages:
   fast-unset@2.0.1:
     resolution: {integrity: sha512-tbY+tzwfxm2miexjMJyjAKuIs+NmVmoADa0H61Jnjg2SN8VjP5ZhdwULtDhH3YIh8iFIJQ7M2GyMNcov1ZOqzA==}
 
-  fast-uri@3.1.6:
-    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
-  fast-uri@4.1.3:
-    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -36860,7 +36863,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.6
+      fast-uri: 3.1.7
 
   '@fastify/busboy@3.2.0': {}
 
@@ -47337,14 +47340,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.6
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.6
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -51267,7 +51270,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.6
+      fast-uri: 3.1.7
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -51276,7 +51279,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.3
+      fast-uri: 4.1.4
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -51306,9 +51309,9 @@ snapshots:
 
   fast-unset@2.0.1: {}
 
-  fast-uri@3.1.6: {}
+  fast-uri@3.1.7: {}
 
-  fast-uri@4.1.3: {}
+  fast-uri@4.1.4: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5384,6 +5384,9 @@ importers:
       '@vitest/ui':
         specifier: catalog:test
         version: 4.1.10(vitest@4.1.10)
+      compromise:
+        specifier: catalog:prod
+        version: 14.15.1
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
         version: 9.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3335,10 +3335,6 @@ importers:
         version: link:../../..
 
   packages/data-manipulation/redact:
-    dependencies:
-      compromise:
-        specifier: catalog:prod
-        version: 14.15.1
     devDependencies:
       '@anolilab/eslint-config':
         specifier: catalog:lint
@@ -3376,6 +3372,9 @@ importers:
       '@vitest/ui':
         specifier: catalog:test
         version: 4.1.10(vitest@4.1.10)
+      compromise:
+        specifier: catalog:prod
+        version: 14.15.1
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
         version: 9.3.1
@@ -5374,7 +5373,7 @@ importers:
         specifier: catalog:dev
         version: 2.0.0(bfa23fb457e0f8e63ba7fd2996053bdb)
       '@visulima/redact':
-        specifier: 4.0.0
+        specifier: workspace:*
         version: link:../../data-manipulation/redact
       '@visulima/string':
         specifier: 3.1.0
@@ -10383,7 +10382,7 @@ importers:
         specifier: 4.0.0
         version: link:../../filesystem/path
       '@visulima/redact':
-        specifier: 4.0.0
+        specifier: workspace:*
         version: link:../../data-manipulation/redact
       '@visulima/spinner':
         specifier: 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -434,6 +434,7 @@ catalogs:
     axe-core: '>=4.13.0'
     chalk: '>=6.0.0'
     commander: '>=15.0.0'
+    compromise: '>=14.15.1'
     cors: '>=2.8.6'
     github-slugger: '>=2.0.0'
     handlebars: '>=4.7.9'


### PR DESCRIPTION
Closes #830.

`stringAnonymize` statically imported `compromise`, and it sits on the path of essentially every `redact()` call, so no bundler could drop it. Every consumer shipped a ~140 KB (gzipped) English lexicon — including the ones whose rules never reach the NLP scan, which the existing `requested.length === 0` guard skips outright.

`redact()` is synchronous, so there is no lazy `import()` escape. The only way to get the lexicon out of the default bundle is to make the scanner **injected rather than imported**.

## What changed

`RedactOptions.nlp` takes an `NlpScanner` — `(input, types, logger?) => NlpMatch[]` — called at most once per scanned string. The compromise-backed implementation moves to a new `@visulima/redact/nlp` entry point, the only module allowed to import it, and `compromise` becomes an optional peer of that entry.

```ts
import { createRedactor, standardRules } from "@visulima/redact";

// default: ~4.5 KB gzipped, compromise not installed
const scrub = createRedactor(standardRules);
```

```ts
import { compromiseScanner } from "@visulima/redact/nlp";

// opt in, and only now do you pay for the lexicon
const scrub = createRedactor(standardRules, { nlp: compromiseScanner });
```

| | before | after |
| --- | --- | --- |
| `dist/index.js` gzipped | 143.7 KB | **4.5 KB** |
| `redact()` w/ `standardRules` | 0.994 ms | **0.082 ms** |

The issue raised three asks. The other two fall out of this one rather than needing their own API: `standardRules` no longer opts you into anything, and the NLP-only rule keys keep working as key-name rules, so nobody needs `exclude` to turn the scan off and no `{ nlp: false }` switch is required.

## Two defects found while reworking the scan path

**`email` was a key-only rule** leaning entirely on the NLP pass. With detection off by default, an address in prose escaped a narrowed rule set entirely:

```ts
redact("write to alice@example.com today", [...credentialRules, "email"]);
// -> "write to alice@example.com today"     <- raw address reaches the sink
```

and under `standardRules` was caught only incidentally by the `url` pattern and mislabelled `<URL>`. Unlike names, an address *is* expressible as a regex, so it now carries a pattern — declared ahead of `domain`/`url` so it wins the tie-break on an equal match. That closes the leak **and** restores the v4 `<EMAIL>` label. The pattern reuses the repo's existing linearised domain shape (per-label class excludes `.`, so it cannot overlap the literal separator); checked against adversarial inputs — 5000-char local parts, long label runs — all ~50 ms, no backtracking.

**Masks were interpolated through `String.replace`**, whose *replacement* position expands `$&`, `` $` `` and `$'`. A tag containing one spliced the surrounding text back in, echoing the very value being masked:

```
tag "$&" on "AAA SECRET BBB"  ->  "AAA <SECRET> BBB"
```

Not reachable from input data today (tags come from compromise or rule keys, both developer-controlled), but this PR publishes `NlpScanner` as a contract that invites third-party engines. `$` is now escaped, covering both scanner tags and rule keys.

## Also

- `processWithRegex` no longer mutates its argument, so the defensive copy downstream is gone.
- `IDocumentTerm extends NlpMatch`, so the two shapes cannot drift silently.
- Rule keys are lowercased once at the source instead of defensively per scanner — which makes the documented `types` contract actually true.
- `redact` forwards `options` whole instead of naming fields at two call sites, so a future option can't be forgotten at one of them.
- `NlpScanner`'s JSDoc corrected: it is called for **every** scanned string (the early-out lives in the scanner, not the core), and `start` orders/dedupes matches — it does not position the replacement.
- `@visulima/redact` references switched to `workspace:*`; pail's optional peer uses the existing `catalog:peer` range.

## Docs

`docs/api.mdx` and `docs/usage.mdx` documented an API that never existed — `AnonymizeOptions`, `include`/`exclude` category lists, a global `replacement` option, `caseSensitive`, `<PERSON>` tags, single-argument `stringAnonymize(text)`, `redact(data)` with no rules. Rewritten against the real surface, with **every example's output verified by executing it** against the built package (127 assertions, run as a one-off — it caught three errors I'd otherwise have shipped, including the `<URL>` mislabel above).

## Breaking change

Natural-language entity detection is no longer on by default. `firstname`, `lastname`, `organization` and `money` have no regex shape, so they no longer match inside prose unless a scanner is supplied. They still match object keys of the same name, and every other key and `pattern` rule is unaffected.

`@visulima/pail`'s `RedactProcessor` defaults to `standardRules`, so its users are affected too. It already forwards `options`, so the seam works — the opt-in is now documented on the processor. **pail must ship in the same release run** as redact v5.

## Verification

- 156 tests pass under both Node and workerd (up from 150).
- `tsc --noEmit`, ESLint, Prettier, `publint --strict`, `attw --pack --profile esm-only` (both entries green), packem build.
- New `__tests__/bundle/bundle-graph.test.ts` asserts graph membership via esbuild's `metafile`, so a re-added import fails here rather than in someone's Workers deploy. Confirmed non-vacuous by actually re-adding the import and watching it fail.

## Open question for review

The scanner currently receives *every* rule key (~61 for `standardRules`). Handing it only the pattern-less keys would be a narrower contract, but would drop `url`/`phonenumber` from its view — a behaviour change I did not want to fold into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoVyvJyh21BPvjTxU1p9jc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rules-based redaction with reusable redactors, wildcard and array-index matching, custom censor functions, and configurable replacements or removals.
  * Added opt-in natural-language scanning through a dedicated scanner, supporting names, organizations, money, emails, phone numbers, and URLs.
  * Added support for redacting nested objects, arrays, errors, maps, sets, JSON strings, and URL query strings.

* **Bug Fixes**
  * Improved email detection and text masking accuracy for repeated, overlapping, and replacement-pattern-sensitive matches.

* **Documentation**
  * Updated API, installation, and usage guides with the new rules-based and opt-in NLP workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->