### PR TITLE
docs: add security policy, testing policy and Scorecard badge

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -229,8 +229,8 @@ Once you've filed the PR:
 This project has a standing policy for tests, and it applies to maintainers and outside contributors alike:
 
 -   **Every change that adds or alters behaviour must ship with tests in the same pull request.** That covers new features, new public API surface, new options and bug fixes — a bug fix adds the regression test that fails without the fix.
--   Tests live next to the package they cover (`packages/<group>/<name>/__tests__`) and run with `pnpm test`. A change is not reviewable until `pnpm test` passes in CI.
--   The only exemptions are changes that cannot meaningfully be tested — documentation, comments, formatting, dependency bumps and release chores. A maintainer may also waive the requirement when a test would be impossible or wildly disproportionate to the change; when that happens the reason is written into the pull request.
+-   Tests live next to the package they cover (`packages/<group>/<name>/__tests__`). Locally, `pnpm test` runs the whole workspace and `pnpm run test:affected` runs only what your change touches. CI runs `pnpm run test:affected:coverage` (or `pnpm run test:affected` where coverage is not collected), and a change is not reviewable until that passes.
+-   The only exemptions are changes that cannot meaningfully be tested — documentation, comments, formatting, release chores, and dependency updates that cannot affect behaviour (a lockfile refresh, a tooling-only devDependency bump). An upgrade that changes runtime behaviour is a behaviour change and needs tests like any other. A maintainer may also waive the requirement when a test would be impossible or wildly disproportionate to the change; when that happens the reason is written into the pull request.
 -   Pull requests that add behaviour without tests are labelled `needs-tests` and held until tests arrive.
 
 Coverage is reported to [Codecov](https://app.codecov.io/gh/visulima/visulima) on every pull request, and a drop in coverage on changed lines is treated as a review finding.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Here are a few guidelines that will help you along the way.
     -   [Project Setup](#project-setup)
     -   [Contribute Documentation](#contribute-documentation)
     -   [Contribute Code](#contribute-code)
+        -   [Testing policy](#testing-policy)
         -   [Deprecation workflow](#deprecation-workflow)
         -   [Documenting changes for new major versions](#major-version-docs)
         -   [JSDocs](#js-docs)
@@ -222,6 +223,17 @@ Once you've filed the PR:
 -   If the maintainer decides to pass on your PR, they will thank you for the contribution and explain why they won't be accepting the changes. That's ok! We still really appreciate you taking the time to do it, and we don't take that lightly. 💚
 -   If your PR gets accepted, it will be marked as such, and merged into the `main` branch soon after.
     Your contribution will be distributed to the masses with our [release process](#release-process).
+
+### <a name="testing-policy"></a> Testing policy
+
+This project has a standing policy for tests, and it applies to maintainers and outside contributors alike:
+
+-   **Every change that adds or alters behaviour must ship with tests in the same pull request.** That covers new features, new public API surface, new options and bug fixes — a bug fix adds the regression test that fails without the fix.
+-   Tests live next to the package they cover (`packages/<group>/<name>/__tests__`) and run with `pnpm test`. A change is not reviewable until `pnpm test` passes in CI.
+-   The only exemptions are changes that cannot meaningfully be tested — documentation, comments, formatting, dependency bumps and release chores. A maintainer may also waive the requirement when a test would be impossible or wildly disproportionate to the change; when that happens the reason is written into the pull request.
+-   Pull requests that add behaviour without tests are labelled `needs-tests` and held until tests arrive.
+
+Coverage is reported to [Codecov](https://app.codecov.io/gh/visulima/visulima) on every pull request, and a drop in coverage on changed lines is treated as a review finding.
 
 ### <a name="deprecation-workflow"></a> Deprecation Workflow
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 [![mit licence][license-badge]][license]
 [![Chat][chat-badge]][chat]
 [![PRs Welcome][prs-welcome-badge]][prs-welcome]
+[![OpenSSF Scorecard][scorecard-badge]][scorecard]
 
 </div>
 
@@ -244,6 +245,8 @@ We have a list of [good first issues](https://github.com/visulima/visulima/label
 
 <!-- badges -->
 
+[scorecard-badge]: https://api.scorecard.dev/projects/github.com/visulima/visulima/badge?style=for-the-badge
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/visulima/visulima
 [license-badge]: https://img.shields.io/badge/LICENSE-MIT-green?style=for-the-badge
 [license]: https://github.com/visulima/visulima/blob/main/LICENSE
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+Thanks for helping keep Visulima and its users safe.
+
+## Reporting a vulnerability
+
+**Email `security@anolilab.de`** with as much detail as you can share. PGP / encrypted mail is welcome — request a key in your first message if you'd like to use one.
+
+Alternatively, file a [GitHub Security Advisory](https://github.com/visulima/visulima/security/advisories/new) directly. **Do not** open a public issue or discussion for security problems.
+
+Useful things to include:
+
+-   A clear description of the vulnerability and the affected package(s) (`@visulima/fmt`, `@visulima/pail`, etc.).
+-   Reproduction steps — a minimal repro repo, proof-of-concept script, or command invocation is ideal.
+-   Impact assessment as you see it (data exposure, RCE, path traversal, prototype pollution, ReDoS, DoS, …).
+-   The commit SHA or package version you tested against.
+-   Your name or handle if you'd like public credit once the issue is fixed.
+
+## What to expect from us
+
+-   **Acknowledgement within 72 hours** of receipt.
+-   A coordinated disclosure timeline negotiated with you. Default target: a fix published within 30 days of confirmation for high-severity issues; longer is fine if the bug is low-severity or hard to reproduce.
+-   Credit in the release notes, unless you prefer to stay anonymous.
+-   No legal action against good-faith research that follows this policy.
+
+## Supported versions
+
+Visulima is a monorepo of independently versioned packages. Security fixes are published for the **latest released major of each `@visulima/*` package**. Older majors are not patched — upgrade to the current major to receive fixes.
+
+| Version                          | Supported          |
+| -------------------------------- | ------------------ |
+| Latest major of a given package  | :white_check_mark: |
+| Any previous major               | :x:                |
+
+## Scope
+
+In scope:
+
+-   Code in this repository: all packages under `packages/` and applications under `apps/`.
+-   The published `@visulima/*` packages on npm, including their build and release pipeline.
+
+Out of scope:
+
+-   Vulnerabilities in upstream dependencies — please report them to that dependency's maintainers. If one materially affects Visulima, we handle the coordinated upgrade.
+-   Findings that require a compromised local machine, a malicious dependency the user installed deliberately, or physical access.
+
+## How releases are protected
+
+-   All packages are published from CI with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) (SLSA build provenance), so you can verify a published tarball was built from this repository.
+-   The repository runs CodeQL, dependency review, OpenSSF Scorecard, zizmor (workflow hardening) and secret scanning with push protection on every change.


### PR DESCRIPTION
Prepares the repository for the [OpenSSF Best Practices Badge](https://www.bestpractices.dev/en/criteria/0). Three passing-level MUST criteria were unmet; this closes them.

- **`SECURITY.md`** — the repository had no published vulnerability reporting process. Closes `vulnerability_report_process`, `vulnerability_report_private` and `vulnerability_report_response` (72h acknowledgement, well inside the required 14 days).
- **Testing policy in CONTRIBUTING** — `test_policy` requires the policy to be written down, not just practised. The section states what has been the de-facto rule: behaviour changes ship with tests in the same pull request, with the exemptions spelled out.
- **OpenSSF Scorecard badge in the README** — the Scorecard workflow already runs with `publish_results: true`; this surfaces the score.

Everything else the badge asks for is already in place: MIT licence, per-package licence files, CONTRIBUTING and Code of Conduct, Discussions, per-package changelogs from semantic-release, Vitest + Codecov, ESLint and TypeScript strict mode, CodeQL, dependency review, secretlint with push protection, and npm provenance on published packages.

Dependabot alerts and security updates plus private vulnerability reporting have been enabled on the repository settings side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a testing policy to the contribution guide.
  - Documented required test placement and commands, including CI commands for affected tests.
  - Clarified test requirements for behavior-changing pull requests.
  - Narrowed dependency-related exemptions to non-behavioral updates.
  - Documented maintainer waivers, handling for changes submitted without tests, and Codecov coverage expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->