### PR TITLE
fix(vis): make release init --apply per-package opt-in

### DIFF
--- a/packages/tooling/vis/__tests__/commands/init/init.test.ts
+++ b/packages/tooling/vis/__tests__/commands/init/init.test.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -266,12 +267,14 @@ describe("init --from-semantic-release", () => {
         // surfaces as a camelCase property; absent flags are `undefined`.
         const options = {
             apply: undefined,
+            cutover: undefined,
             dryRun: undefined,
             fresh: undefined,
             fromBumpy: undefined,
             fromChangesets: undefined,
             fromSemanticRelease: true,
             packageManager: undefined,
+            packages: undefined,
             workflows: undefined,
             yes: undefined,
             ...overrides,
@@ -283,6 +286,8 @@ describe("init --from-semantic-release", () => {
             command: { name: "init" } as never,
             commandName: "init",
             env: {},
+            // The real `node:fs/promises`, in the shape cerebro injects it.
+            fs: { access, mkdir, readdir, readFile, rm, stat, writeFile },
             logger: fakeLogger(),
             options,
             projectRoot: undefined,
@@ -300,6 +305,9 @@ describe("init --from-semantic-release", () => {
 
     afterEach(() => {
         rmSync(tmpDir, { force: true, recursive: true });
+        // The refusal paths set `process.exitCode`; leaving it set would fail
+        // the whole vitest run even when every test passed.
+        process.exitCode = undefined;
         vi.restoreAllMocks();
     });
 
@@ -329,7 +337,7 @@ describe("init --from-semantic-release", () => {
         expect(pkgA["vis-release"]).toBeUndefined();
     });
 
-    it("writes vis.config.ts, adds release.managed to packages, and deletes .releaserc.json files with --apply", async () => {
+    it("writes vis.config.ts but leaves .releaserc.json + manifests alone with --apply (issue #862)", async () => {
         expect.assertions(8);
 
         const toolbox = fakeToolbox({ apply: true });
@@ -345,6 +353,34 @@ describe("init --from-semantic-release", () => {
 
         expect(visConfig).toContain("defineConfig");
         expect(visConfig).toContain("release: {");
+        expect(visConfig).toContain("defaultManaged: false");
+
+        // Migration off semantic-release is per-package opt-in: no manifest is
+        // marked managed and no .releaserc.json is deleted without --cutover.
+        const pkgA = JSON.parse(readFileSync(join(tmpDir, "packages", "pkg-a", "package.json"), "utf8")) as Record<string, unknown>;
+
+        expect(pkgA["vis-release"]).toBeUndefined();
+        expect(existsSync(join(tmpDir, ".releaserc.json"))).toBe(true);
+        expect(existsSync(join(tmpDir, "packages", "pkg-a", ".releaserc.json"))).toBe(true);
+        expect(existsSync(join(tmpDir, "packages", "pkg-b", ".releaserc.json"))).toBe(true);
+    });
+
+    it("adds release.managed to packages and deletes .releaserc.json files with --apply --cutover", async () => {
+        expect.assertions(8);
+
+        const toolbox = fakeToolbox({ apply: true, cutover: true, yes: true });
+
+        await initExecute(toolbox);
+
+        // vis.config.ts is written and already says the packages are managed.
+        const visConfigPath = join(tmpDir, "vis.config.ts");
+
+        expect(existsSync(visConfigPath)).toBe(true);
+
+        const visConfig = readFileSync(visConfigPath, "utf8");
+
+        expect(visConfig).toContain("release: {");
+        expect(visConfig).toContain("defaultManaged: true,");
 
         // Per-package package.json files gained `"vis-release": { "managed": true }`.
         const pkgA = JSON.parse(readFileSync(join(tmpDir, "packages", "pkg-a", "package.json"), "utf8")) as Record<string, unknown>;

--- a/packages/tooling/vis/__tests__/release/commands/release-init-config-scan.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-init-config-scan.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the `vis.config.ts` scanner behind `vis release init`
+ * (CodeRabbit F1 on PR #867).
+ *
+ * The scanner replaced a `/\brelease\s*:/` test. That regex fired on a
+ * comment, on a string and on a nested key, and each false hit told the
+ * migration "this repo already has a release config" — which is precisely the
+ * claim `--cutover` deletes every `.releaserc.*` on. So the cases below are
+ * split into "these must NOT count as a root release key" (the regex said they
+ * did) and "these must".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { scanVisConfigSource } from "../../../src/commands/release/init/vis-config-source";
+
+/** The `hasReleaseKey` answer, asserting the scan located the object at all. */
+const hasRelease = (source: string): boolean => {
+    const scan = scanVisConfigSource(source);
+
+    if (scan.kind !== "found") {
+        throw new Error(`expected the config object to be found, got "${scan.kind}"`);
+    }
+
+    return scan.hasReleaseKey;
+};
+
+/** Wrap `body` in the canonical generated-config shape. */
+const config = (body: string): string => `import { defineConfig } from "@visulima/vis/config";\n\nexport default defineConfig({\n${body}\n});\n`;
+
+describe(scanVisConfigSource, () => {
+    describe("a root `release` property", () => {
+        it.each([
+            ["a plain key", "    release: { baseBranch: \"main\" },"],
+            ["a quoted key", "    \"release\": { baseBranch: \"main\" },"],
+            ["a single-quoted key", "    'release': {},"],
+            ["a shorthand property", "    release,"],
+            ["a method", "    release() { return {}; },"],
+            ["a key after another key", "    tasks: {},\n    release: {},"],
+            ["a key on one line", "    tasks: {}, release: {},"],
+        ])("detects %s", (_label, body) => {
+            expect.hasAssertions();
+
+            expect(hasRelease(config(body))).toBe(true);
+        });
+
+        it("detects it through an `export default {` anchor too", () => {
+            expect.hasAssertions();
+
+            expect(hasRelease("export default {\n    release: {},\n};\n")).toBe(true);
+        });
+    });
+
+    describe("text that only looks like one", () => {
+        it.each([
+            ["a line comment", "    // release: { baseBranch: \"main\" } — TODO"],
+            ["a trailing line comment", "    tasks: {}, // release: TODO"],
+            ["a block comment", "    /* release: {} is not configured yet */"],
+            ["a JSDoc block", "    /**\n     * release: wired up in phase 6.\n     */"],
+            ["a string value", "    name: \"release: prod\","],
+            ["a single-quoted string value", "    name: 'release: prod',"],
+            ["a string with an escaped quote", String.raw`    name: "he said \"release:\" once",`],
+            ["a template literal", "    name: `release: ${process.env.CHANNEL}`,"],
+            ["a regular expression", "    match: /release:/,"],
+            ["a nested key", "    tasks: {\n        release: { command: \"echo\" },\n    },"],
+            ["a key nested in an array of objects", "    plugins: [{ release: true }],"],
+            ["a key two objects deep", "    a: { b: { release: {} } },"],
+            ["a spread of a `release` variable", "    ...release,"],
+            ["a key inside a template interpolation", "    name: `${JSON.stringify({ release: 1 })}`,"],
+        ])("ignores %s", (_label, body) => {
+            expect.hasAssertions();
+
+            expect(hasRelease(config(body))).toBe(false);
+        });
+
+        it("ignores a `release` key that only appears after the config object closes", () => {
+            expect.hasAssertions();
+
+            expect(hasRelease("export default defineConfig({\n    tasks: {},\n});\n\nconst other = { release: {} };\n")).toBe(false);
+        });
+    });
+
+    describe("sources it refuses to guess at", () => {
+        it("reports no anchor when the object is behind a variable", () => {
+            expect.hasAssertions();
+
+            expect(scanVisConfigSource("const config = { tasks: {} };\n\nexport default config;\n")).toStrictEqual({ kind: "no-anchor" });
+        });
+
+        it("reports an unterminated object when a brace is missing", () => {
+            expect.hasAssertions();
+
+            expect(scanVisConfigSource("export default defineConfig({\n    tasks: {},\n")).toStrictEqual({ kind: "unterminated" });
+        });
+
+        it("does not mistake a brace inside a comment for the object's end", () => {
+            expect.hasAssertions();
+
+            expect(hasRelease("export default defineConfig({\n    // }\n    release: {},\n});\n")).toBe(true);
+        });
+    });
+
+    describe("bodyStart", () => {
+        it("points just past the opening brace so the block splices in as the first property", () => {
+            expect.hasAssertions();
+
+            const source = "export default defineConfig({\n    tasks: {},\n});\n";
+            const scan = scanVisConfigSource(source);
+
+            if (scan.kind !== "found") {
+                throw new Error("expected the config object to be found");
+            }
+
+            expect(source.slice(0, scan.bodyStart)).toBe("export default defineConfig({");
+            expect(`${source.slice(0, scan.bodyStart)}\n    release: {},${source.slice(scan.bodyStart)}`).toBe(
+                "export default defineConfig({\n    release: {},\n    tasks: {},\n});\n",
+            );
+        });
+
+        it("prefers the `defineConfig(` anchor over a later `export default {`", () => {
+            expect.hasAssertions();
+
+            const source = "const base = defineConfig({ tasks: {} });\n\nexport default { ...base };\n";
+            const scan = scanVisConfigSource(source);
+
+            if (scan.kind !== "found") {
+                throw new Error("expected the config object to be found");
+            }
+
+            expect(source.slice(0, scan.bodyStart)).toBe("const base = defineConfig({");
+        });
+    });
+});

--- a/packages/tooling/vis/__tests__/release/commands/release-init-cutover.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-init-cutover.test.ts
@@ -1,0 +1,761 @@
+/**
+ * Regression tests for issue #862 — `vis release init --from-semantic-release
+ * --apply` used to perform a full cutover (delete every `.releaserc.*`, mark
+ * every manifest managed) while the dry-run promised a per-package opt-in.
+ *
+ * The contract these lock in:
+ *   - plain `--apply` is non-destructive: scaffold + ignore files + the
+ *     `vis.config.ts` release block, nothing else;
+ *   - `--cutover` is the explicit opt-in for the destructive writes, and its
+ *     generated config says `defaultManaged: true`;
+ *   - `--packages a,b` routes the manifest opt-in through a selection;
+ *   - `--dry-run` previews exactly the run the same flags would perform.
+ *
+ * The last five describes cover the CodeRabbit review of PR #867, which found
+ * five more ways the same run could destroy something it did not promise to
+ * touch: a release config that only *looks* declared, a symlink that walks the
+ * cutover out of the workspace, a run that half-writes without `--apply`, an
+ * unreadable file mistaken for an absent one, and an ignore rule shadowed by a
+ * comment.
+ */
+
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import initHandler from "../../../src/commands/release/init/handler";
+
+/**
+ * Stand-in for the readline confirm prompt. `answer` decides per question, so
+ * a test can accept the cutover while still declining the workflow-generation
+ * prompt that follows it.
+ */
+const prompts = vi.hoisted(() => {
+    return {
+        answer: (_question: string): boolean => false,
+        questions: [] as string[],
+    };
+});
+
+vi.mock(import("../../../src/release/core/prompts"), () => {
+    return {
+        confirmPrompt: async (question: string): Promise<boolean> => {
+            prompts.questions.push(question);
+
+            return prompts.answer(question);
+        },
+    };
+});
+
+const originalIsTty = process.stdout.isTTY;
+
+/** `process.stdout.isTTY` is a plain property, so the interactivity probe is toggled by hand. */
+const setTty = (value: boolean | undefined): void => {
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value });
+};
+
+/** The real `node:fs/promises` in the shape cerebro injects as `toolbox.fs`. */
+const testFs = { access, mkdir, readdir, readFile, rm, stat, writeFile } as never;
+
+const writeJson = (path: string, value: unknown, indent: number = 4): void => {
+    writeFileSync(path, `${JSON.stringify(value, null, indent)}\n`);
+};
+
+/** Two publishable packages, each with its own `.releaserc.json`. */
+const setupFixture = (): string => {
+    const cwd = mkdtempSync(join(tmpdir(), "vis-release-init-"));
+
+    writeJson(join(cwd, "package.json"), { name: "fixture-root", private: true, version: "0.0.0" });
+    writeFileSync(join(cwd, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+
+    for (const name of ["a", "b"]) {
+        const dir = join(cwd, "packages", name);
+
+        mkdirSync(dir, { recursive: true });
+        writeJson(join(dir, "package.json"), { name: `@scope/${name}`, version: "1.0.0" });
+        writeJson(join(dir, ".releaserc.json"), {
+            branches: ["main", { name: "alpha", prerelease: true }],
+            extends: "@anolilab/semantic-release-preset/pnpm",
+        });
+    }
+
+    return cwd;
+};
+
+interface Captured {
+    errors: string[];
+    infos: string[];
+    out: string;
+    warns: string[];
+}
+
+const runInit = async (cwd: string, options: Record<string, unknown>): Promise<Captured> => {
+    const infos: string[] = [];
+    const warns: string[] = [];
+    const errors: string[] = [];
+
+    const logger = {
+        error: (message: string) => errors.push(message),
+        info: (message: string) => infos.push(message),
+        warn: (message: string) => warns.push(message),
+    };
+
+    await initHandler({ fs: testFs, logger, options: { fromSemanticRelease: true, ...options }, workspaceRoot: cwd });
+
+    return { errors, infos, out: infos.join("\n"), warns };
+};
+
+const readManifest = async (cwd: string, name: string): Promise<Record<string, unknown>> =>
+    JSON.parse(await readFile(join(cwd, "packages", name, "package.json"), "utf8")) as Record<string, unknown>;
+
+const rcPath = (cwd: string, name: string): string => join(cwd, "packages", name, ".releaserc.json");
+
+/** A throwaway directory outside the fixture workspace, cleaned up by the caller. */
+const makeOutsideDir = (): string => mkdtempSync(join(tmpdir(), "vis-release-outside-"));
+
+/**
+ * `true` when `chmod` actually denies a read on this platform and for this
+ * user. Windows ignores the mode bits and root walks straight past them, so
+ * the permission-failure tests only mean something where this holds.
+ */
+const chmodDeniesReads = (): boolean => {
+    const directory = mkdtempSync(join(tmpdir(), "vis-release-chmod-"));
+    const probe = join(directory, "probe");
+
+    try {
+        writeFileSync(probe, "x");
+        chmodSync(probe, 0o222);
+        readFileSync(probe, "utf8");
+
+        return false;
+    } catch {
+        return true;
+    } finally {
+        chmodSync(probe, 0o644);
+        rmSync(directory, { force: true, recursive: true });
+    }
+};
+
+const symlinksSupported = process.platform !== "win32";
+
+describe("vis release init --from-semantic-release (issue #862)", () => {
+    let cwd: string;
+
+    beforeEach(() => {
+        // Keeps `offerWorkflowGeneration` / `offerHuskyWiring` on their
+        // non-interactive paths so the handler never blocks on a prompt.
+        vi.stubEnv("CI", "true");
+        prompts.answer = () => false;
+        prompts.questions = [];
+        cwd = setupFixture();
+    });
+
+    afterEach(async () => {
+        vi.unstubAllEnvs();
+        setTty(originalIsTty);
+        // The refusal paths set `process.exitCode`; leaving it set would fail
+        // the whole vitest run even when every test passed.
+        process.exitCode = undefined;
+        await rm(cwd, { force: true, recursive: true });
+    });
+
+    describe("--apply without --cutover", () => {
+        it("leaves every .releaserc.json and manifest untouched", async () => {
+            expect.hasAssertions();
+
+            const before = {
+                a: await readFile(join(cwd, "packages", "a", "package.json"), "utf8"),
+                b: await readFile(join(cwd, "packages", "b", "package.json"), "utf8"),
+            };
+
+            await runInit(cwd, { apply: true });
+
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(true);
+            await expect(readFile(join(cwd, "packages", "a", "package.json"), "utf8")).resolves.toBe(before.a);
+            await expect(readFile(join(cwd, "packages", "b", "package.json"), "utf8")).resolves.toBe(before.b);
+        });
+
+        it("still scaffolds .vis/release, the ignore files and the config block", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true });
+
+            expect(existsSync(join(cwd, ".vis", "release"))).toBe(true);
+            await expect(readFile(join(cwd, ".gitignore"), "utf8")).resolves.toContain(".vis/release/.state.json");
+            await expect(readFile(join(cwd, ".secretlintignore"), "utf8")).resolves.toContain(".vis/release/**");
+
+            const config = await readFile(join(cwd, "vis.config.ts"), "utf8");
+
+            expect(config).toContain("defaultManaged: false");
+            expect(config).toContain("--cutover flips this to true");
+        });
+
+        it("keeps printing the per-package opt-in instructions", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, { apply: true });
+
+            expect(out).toContain("Migration is per-package opt-in");
+            expect(out).toContain("Existing .releaserc.json files are kept in place during transition.");
+            expect(out).toContain("re-run with `--apply --cutover` to delete them");
+        });
+    });
+
+    describe("--cutover", () => {
+        it("deletes the migrated .releaserc.json files and marks every manifest managed", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const [pkgA, pkgB] = [await readManifest(cwd, "a"), await readManifest(cwd, "b")];
+
+            expect(existsSync(rcPath(cwd, "a"))).toBe(false);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(false);
+            expect(pkgA["vis-release"]).toStrictEqual({ managed: true });
+            expect(pkgB["vis-release"]).toStrictEqual({ managed: true });
+        });
+
+        it("generates a config that already says defaultManaged: true", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const config = await readFile(join(cwd, "vis.config.ts"), "utf8");
+
+            expect(config).toContain("defaultManaged: true,");
+            expect(config).not.toContain("flips this to true");
+            expect(config).not.toContain("Phase 6");
+        });
+
+        it("does not print the per-package opt-in tail after the writes", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            expect(out).not.toContain("Migration is per-package opt-in");
+            expect(out).not.toContain("Re-run with `--apply`");
+            expect(out).toContain("Full cutover (--cutover)");
+        });
+
+        it("lists the deletions and manifest edits in --dry-run without performing them", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, { cutover: true, dryRun: true });
+
+            expect(out).toContain(`[dry-run] would delete ${join("packages", "a", ".releaserc.json")}`);
+            expect(out).toContain(`[dry-run] would update ${join("packages", "a", "package.json")} (add vis-release.managed = true)`);
+            expect(out).toContain("[dry-run] would create vis.config.ts (release block)");
+
+            const pkgA = await readManifest(cwd, "a");
+
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(join(cwd, "vis.config.ts"))).toBe(false);
+            expect(pkgA["vis-release"]).toBeUndefined();
+        });
+
+        it("previews exactly the paths a subsequent --apply touches", async () => {
+            expect.hasAssertions();
+
+            const preview = await runInit(cwd, { cutover: true, dryRun: true });
+            const applied = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const previewed = preview.infos
+                .filter((line) => line.startsWith("[dry-run] would delete ") || line.startsWith("[dry-run] would update "))
+                .map((line) => line.replace(/^\[dry-run\] would (?:delete|update) /, "").replace(/ \(.*\)$/, ""))
+                .sort();
+
+            const written = applied.infos
+                .filter((line) => line.startsWith("  deleted ") || line.startsWith("  updated "))
+                .map((line) => line.replace(/^ {2}(?:deleted|updated) /, "").replace(/ \(.*\)$/, ""))
+                .sort();
+
+            expect(previewed).toStrictEqual(written);
+        });
+
+        it("warns that --packages is ignored", async () => {
+            expect.hasAssertions();
+
+            const { warns } = await runInit(cwd, { apply: true, cutover: true, packages: "@scope/a", yes: true });
+
+            const pkgB = await readManifest(cwd, "b");
+
+            expect(warns).toContain("--packages is ignored because --cutover opts every detected package in.");
+            expect(pkgB["vis-release"]).toStrictEqual({ managed: true });
+        });
+
+        it("performs no writes when --dry-run is also set", async () => {
+            expect.hasAssertions();
+
+            const { warns } = await runInit(cwd, { apply: true, cutover: true, dryRun: true });
+
+            expect(warns).toContain("--apply is ignored because --dry-run is set (dry-run takes precedence).");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(join(cwd, "vis.config.ts"))).toBe(false);
+        });
+    });
+
+    describe("--packages", () => {
+        it("marks only the selected package and keeps every .releaserc.json", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true, packages: "@scope/a" });
+
+            const [pkgA, pkgB] = [await readManifest(cwd, "a"), await readManifest(cwd, "b")];
+
+            expect(pkgA["vis-release"]).toStrictEqual({ managed: true });
+            expect(pkgB["vis-release"]).toBeUndefined();
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(true);
+        });
+
+        it("accepts a workspace-relative directory as the selector", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true, packages: "packages/b" });
+
+            const [pkgA, pkgB] = [await readManifest(cwd, "a"), await readManifest(cwd, "b")];
+
+            expect(pkgB["vis-release"]).toStrictEqual({ managed: true });
+            expect(pkgA["vis-release"]).toBeUndefined();
+        });
+
+        it("warns about an entry that matches nothing", async () => {
+            expect.hasAssertions();
+
+            const { warns } = await runInit(cwd, { apply: true, packages: "@scope/nope" });
+
+            expect(warns).toContain("--packages: no package with a sibling .releaserc.* matched \"@scope/nope\".");
+        });
+    });
+
+    describe("--dry-run without --cutover", () => {
+        it("says no manifest or .releaserc.* is touched", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, { dryRun: true });
+
+            expect(out).toContain("no package.json or .releaserc.* is touched");
+            expect(out).toContain("Migration is per-package opt-in");
+            expect(out).toContain("Re-run with `--apply`");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+        });
+
+        it("previews the selection when --packages is given", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, { dryRun: true, packages: "@scope/a" });
+
+            expect(out).toContain(`[dry-run] would update ${join("packages", "a", "package.json")} (add vis-release.managed = true)`);
+            expect(out).not.toContain(join("packages", "b", "package.json"));
+            expect(out).not.toContain("[dry-run] would delete");
+        });
+    });
+
+    it("warns when --cutover is used on a non-semantic-release source", async () => {
+        expect.hasAssertions();
+
+        const { warns } = await runInit(cwd, { cutover: true, fresh: true, fromSemanticRelease: false });
+
+        expect(warns).toContain("`--cutover` / `--packages` only affect the semantic-release migration path.");
+    });
+
+    describe("cutover with an unwritable release config", () => {
+        /**
+         * A `vis.config.ts` that init cannot inject into: no `defineConfig({`,
+         * no `export default {`, and no `release` key to leave alone.
+         */
+        const writeUninjectableConfig = (): void => {
+            writeFileSync(join(cwd, "vis.config.ts"), "const config = { tasks: {} };\n\nexport default config;\n");
+        };
+
+        it("refuses to delete a single .releaserc.* when the config write is skipped", async () => {
+            expect.hasAssertions();
+
+            writeUninjectableConfig();
+
+            const { errors } = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            expect(errors.join("\n")).toContain("Refusing to run the cutover");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(true);
+        });
+
+        it("leaves the manifests untouched and exits non-zero", async () => {
+            expect.hasAssertions();
+
+            writeUninjectableConfig();
+
+            await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const [pkgA, pkgB] = [await readManifest(cwd, "a"), await readManifest(cwd, "b")];
+
+            expect(pkgA["vis-release"]).toBeUndefined();
+            expect(pkgB["vis-release"]).toBeUndefined();
+            expect(process.exitCode).toBe(1);
+        });
+
+        it("warns in --dry-run that the cutover would be refused", async () => {
+            expect.hasAssertions();
+
+            writeUninjectableConfig();
+
+            const { warns } = await runInit(cwd, { cutover: true, dryRun: true });
+
+            expect(warns.join("\n")).toContain("This cutover would be refused");
+        });
+
+        it("still runs the cutover when the config already declares a release key (Phase 6 re-run)", async () => {
+            expect.hasAssertions();
+
+            // What a prior `--apply` leaves behind: a config init will not
+            // rewrite, but one the repo can still release from.
+            writeFileSync(join(cwd, "vis.config.ts"), "export default defineConfig({\n    release: { baseBranch: \"main\" },\n});\n");
+
+            await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const pkgA = await readManifest(cwd, "a");
+
+            expect(existsSync(rcPath(cwd, "a"))).toBe(false);
+            expect(pkgA["vis-release"]).toStrictEqual({ managed: true });
+        });
+    });
+
+    describe("cutover confirmation gate", () => {
+        it("refuses a non-interactive cutover that was not confirmed with --yes", async () => {
+            expect.hasAssertions();
+
+            const { errors } = await runInit(cwd, { apply: true, cutover: true });
+
+            expect(errors.join("\n")).toContain("Refusing to delete 2 .releaserc.* file(s) without confirmation.");
+            expect(errors.join("\n")).toContain("Re-run with `--yes`");
+            expect(process.exitCode).toBe(1);
+        });
+
+        it("writes nothing at all when the confirmation is refused", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { apply: true, cutover: true });
+
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(true);
+
+            const pkgA = await readManifest(cwd, "a");
+
+            expect(existsSync(join(cwd, "vis.config.ts"))).toBe(false);
+            expect(pkgA["vis-release"]).toBeUndefined();
+        });
+
+        it("aborts without an error exit when an interactive operator declines", async () => {
+            expect.hasAssertions();
+
+            prompts.answer = () => false;
+            vi.stubEnv("CI", "");
+            setTty(true);
+
+            const { out } = await runInit(cwd, { apply: true, cutover: true });
+
+            expect(out).toContain("Cutover cancelled — no migration writes were made.");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(process.exitCode).toBeUndefined();
+        });
+
+        it("proceeds when an interactive operator confirms", async () => {
+            expect.hasAssertions();
+
+            // Only the cutover question is answered yes — the workflow-generation
+            // prompt further down stays declined.
+            prompts.answer = (question: string) => question.startsWith("Delete ");
+            vi.stubEnv("CI", "");
+            setTty(true);
+
+            await runInit(cwd, { apply: true, cutover: true });
+
+            expect(prompts.questions.join("\n")).toContain("Delete 2 .releaserc.* file(s) and mark 2 package.json file(s) managed?");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(false);
+            expect(process.exitCode).toBeUndefined();
+        });
+    });
+
+    describe("manifest writes", () => {
+        it("never opts a private manifest in, even when it has its own .releaserc.json", async () => {
+            expect.hasAssertions();
+
+            // The workspace root is private and carries a root-level config —
+            // deleting that config is fine, marking the root managed is not.
+            writeJson(join(cwd, ".releaserc.json"), { branches: ["main"] });
+
+            const { warns } = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const root = JSON.parse(await readFile(join(cwd, "package.json"), "utf8")) as Record<string, unknown>;
+
+            expect(root["vis-release"]).toBeUndefined();
+            expect(warns.join("\n")).toContain("`private: true` packages are not published");
+            expect(existsSync(join(cwd, ".releaserc.json"))).toBe(false);
+        });
+
+        it("preserves a 2-space manifest's indentation instead of reformatting it", async () => {
+            expect.hasAssertions();
+
+            const manifestPath = join(cwd, "packages", "a", "package.json");
+
+            writeJson(manifestPath, { name: "@scope/a", scripts: { build: "tsc" }, version: "1.0.0" }, 2);
+
+            await runInit(cwd, { apply: true, packages: "@scope/a" });
+
+            const after = await readFile(manifestPath, "utf8");
+
+            expect(after).toContain("\n  \"name\": \"@scope/a\",");
+            expect(after).toContain("\n    \"build\": \"tsc\"");
+            expect(after).not.toContain("\n    \"name\"");
+            expect(after.endsWith("}\n")).toBe(true);
+        });
+
+        it("preserves a tab-indented manifest and its missing trailing newline", async () => {
+            expect.hasAssertions();
+
+            const manifestPath = join(cwd, "packages", "b", "package.json");
+
+            writeFileSync(manifestPath, JSON.stringify({ name: "@scope/b", version: "1.0.0" }, null, "\t"));
+
+            await runInit(cwd, { apply: true, packages: "@scope/b" });
+
+            const after = await readFile(manifestPath, "utf8");
+
+            expect(after).toContain("\n\t\"name\": \"@scope/b\",");
+            expect(after).toContain("\n\t\"vis-release\": {");
+            expect(after.endsWith("}")).toBe(true);
+        });
+    });
+    describe("a config that only looks configured (CodeRabbit F1)", () => {
+        /**
+         * The cutover's safety guard asks one question: "will this repo still
+         * have a release config once every `.releaserc.*` is gone?" A textual
+         * `/\brelease\s*:/` answered yes for a comment, a string and a
+         * nested key — a non-blocking skip, which let the deletions run
+         * against a config that declares nothing.
+         */
+        it.each([
+            ["a commented-out release key", "export default defineConfig({\n    // release: { baseBranch: \"main\" },\n    tasks: {},\n});\n"],
+            ["a release key nested under tasks", "export default defineConfig({\n    tasks: { release: { command: \"echo\" } },\n});\n"],
+            ["the word release inside a string", "export default defineConfig({\n    tasks: { build: { command: \"echo release: prod\" } },\n});\n"],
+        ])("writes a real release block before deleting anything when the config has %s", async (_label, source) => {
+            expect.hasAssertions();
+
+            writeFileSync(join(cwd, "vis.config.ts"), source);
+
+            await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            const config = await readFile(join(cwd, "vis.config.ts"), "utf8");
+
+            // The block landed, so the repo is releasable after the deletions.
+            expect(config).toContain("defaultManaged: true,");
+            expect(config).toContain("channels: {");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(false);
+        });
+
+        it("still leaves a genuinely declared root release key alone", async () => {
+            expect.hasAssertions();
+
+            const source = "export default defineConfig({\n    release: { baseBranch: \"main\" },\n    tasks: {},\n});\n";
+
+            writeFileSync(join(cwd, "vis.config.ts"), source);
+
+            const { warns } = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            await expect(readFile(join(cwd, "vis.config.ts"), "utf8")).resolves.toBe(source);
+            expect(warns.join("\n")).toContain("already has a `release` key");
+        });
+
+        it("blocks the cutover when the config object never closes", async () => {
+            expect.hasAssertions();
+
+            writeFileSync(join(cwd, "vis.config.ts"), "export default defineConfig({\n    tasks: {},\n");
+
+            const { errors } = await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+            expect(errors.join("\n")).toContain("Refusing to run the cutover");
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+        });
+    });
+
+    describe("workspace containment (CodeRabbit F2)", () => {
+        it.skipIf(!symlinksSupported)("never walks a symlinked directory out of the workspace", async () => {
+            expect.hasAssertions();
+
+            const outside = makeOutsideDir();
+            const victim = join(outside, "victim");
+
+            mkdirSync(victim, { recursive: true });
+            writeJson(join(victim, "package.json"), { name: "@outside/victim", version: "1.0.0" });
+            writeJson(join(victim, ".releaserc.json"), { branches: ["main"] });
+            symlinkSync(outside, join(cwd, "packages", "vendor"), "dir");
+
+            try {
+                await runInit(cwd, { apply: true, cutover: true, yes: true });
+
+                // Nothing outside `cwd` was read, marked managed or deleted.
+                expect(existsSync(join(victim, ".releaserc.json"))).toBe(true);
+
+                const manifest = JSON.parse(readFileSync(join(victim, "package.json"), "utf8")) as Record<string, unknown>;
+
+                expect(manifest["vis-release"]).toBeUndefined();
+
+                // The packages that really are in the workspace still migrated.
+                expect(existsSync(rcPath(cwd, "a"))).toBe(false);
+            } finally {
+                rmSync(outside, { force: true, recursive: true });
+            }
+        });
+    });
+
+    describe("a migration run without --apply (CodeRabbit F3)", () => {
+        it("writes nothing at all — not even the scaffold or the ignore files", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, {});
+
+            expect(existsSync(join(cwd, ".vis", "release"))).toBe(false);
+            expect(existsSync(join(cwd, ".gitignore"))).toBe(false);
+            expect(existsSync(join(cwd, ".secretlintignore"))).toBe(false);
+            expect(existsSync(join(cwd, "vis.config.ts"))).toBe(false);
+        });
+
+        it("says it is a preview and lists the writes --apply would make", async () => {
+            expect.hasAssertions();
+
+            const { out } = await runInit(cwd, {});
+
+            expect(out).toContain("Preview only — a semantic-release migration writes nothing without `--apply`.");
+            expect(out).toContain(`[dry-run] would create directory: ${join(cwd, ".vis", "release")}`);
+            expect(out).toContain("[dry-run] would create vis.config.ts (release block)");
+        });
+
+        it("still scaffolds by default on a fresh repo — only migrations preview", async () => {
+            expect.hasAssertions();
+
+            await runInit(cwd, { fresh: true, fromSemanticRelease: false });
+
+            expect(existsSync(join(cwd, ".vis", "release"))).toBe(true);
+            await expect(readFile(join(cwd, ".gitignore"), "utf8")).resolves.toContain(".vis/release/.state.json");
+        });
+    });
+
+    describe("unreadable is not missing (CodeRabbit F4)", () => {
+        it("aborts the cutover instead of silently skipping a package.json it cannot read", async () => {
+            expect.hasAssertions();
+
+            // A directory in the manifest's place fails every read with EISDIR
+            // — the error the old catch-all folded into "no package.json here".
+            rmSync(join(cwd, "packages", "a", "package.json"));
+            mkdirSync(join(cwd, "packages", "a", "package.json"));
+
+            await expect(runInit(cwd, { apply: true, cutover: true, yes: true })).rejects.toThrow(/EISDIR/);
+
+            // The migration stopped before the deletions, so nothing is lost.
+            expect(existsSync(rcPath(cwd, "a"))).toBe(true);
+            expect(existsSync(rcPath(cwd, "b"))).toBe(true);
+        });
+
+        it.skipIf(!chmodDeniesReads())("does not replace a .gitignore it cannot read", async () => {
+            expect.hasAssertions();
+
+            const gitignore = join(cwd, ".gitignore");
+            const before = "node_modules\ndist\n";
+
+            writeFileSync(gitignore, before);
+            // Write-only: the read fails, the write would have succeeded — the
+            // exact shape that turned an EACCES into a brand-new .gitignore.
+            chmodSync(gitignore, 0o222);
+
+            try {
+                await expect(runInit(cwd, { apply: true })).rejects.toThrow(/EACCES/);
+            } finally {
+                chmodSync(gitignore, 0o644);
+            }
+
+            expect(readFileSync(gitignore, "utf8")).toBe(before);
+        });
+    });
+
+    describe("ignore rules are matched as whole lines (CodeRabbit F5)", () => {
+        it("adds the real rules even when a comment mentions them", async () => {
+            expect.hasAssertions();
+
+            writeFileSync(join(cwd, ".gitignore"), "node_modules\n# .vis/release/.state.json\n# .vis/release/.lock\n");
+
+            await runInit(cwd, { apply: true });
+
+            const gitignore = await readFile(join(cwd, ".gitignore"), "utf8");
+
+            expect(gitignore.split(/\r?\n/)).toContain(".vis/release/.state.json");
+            expect(gitignore.split(/\r?\n/)).toContain(".vis/release/.lock");
+        });
+
+        it("treats a longer path that merely contains the rule as a different rule", async () => {
+            expect.hasAssertions();
+
+            writeFileSync(join(cwd, ".secretlintignore"), "vendor/.vis/release/**\n");
+
+            await runInit(cwd, { apply: true });
+
+            const secretlintignore = await readFile(join(cwd, ".secretlintignore"), "utf8");
+
+            expect(secretlintignore.split(/\r?\n/)).toContain(".vis/release/**");
+        });
+
+        it("does not re-add a rule the file already declares", async () => {
+            expect.hasAssertions();
+
+            const before = "node_modules\n.vis/release/.state.json\n.vis/release/.lock\n";
+
+            writeFileSync(join(cwd, ".gitignore"), before);
+
+            await runInit(cwd, { apply: true });
+
+            await expect(readFile(join(cwd, ".gitignore"), "utf8")).resolves.toBe(before);
+        });
+    });
+
+    describe("writes never follow a symlink (CodeRabbit F6)", () => {
+        it.skipIf(!symlinksSupported)("refuses to write a .gitignore that is a dangling symlink", async () => {
+            expect.hasAssertions();
+
+            const outside = makeOutsideDir();
+            const target = join(outside, "stolen");
+
+            symlinkSync(target, join(cwd, ".gitignore"));
+
+            try {
+                await expect(runInit(cwd, { apply: true })).rejects.toThrow(/symlink/);
+
+                expect(existsSync(target)).toBe(false);
+            } finally {
+                rmSync(outside, { force: true, recursive: true });
+            }
+        });
+
+        it.skipIf(!symlinksSupported)("refuses to copy a change file through a symlinked destination", async () => {
+            expect.hasAssertions();
+
+            const outside = makeOutsideDir();
+            const target = join(outside, "stolen.md");
+
+            mkdirSync(join(cwd, ".changeset"), { recursive: true });
+            writeFileSync(join(cwd, ".changeset", "sample.md"), "---\n\"@scope/a\": patch\n---\n\nfix a thing\n");
+            mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
+            symlinkSync(target, join(cwd, ".vis", "release", "sample.md"));
+
+            try {
+                await expect(runInit(cwd, { fromChangesets: true, fromSemanticRelease: false })).rejects.toThrow(/symlink/);
+
+                expect(existsSync(target)).toBe(false);
+            } finally {
+                rmSync(outside, { force: true, recursive: true });
+            }
+        });
+    });
+});

--- a/packages/tooling/vis/docs/commands/release.mdx
+++ b/packages/tooling/vis/docs/commands/release.mdx
@@ -57,6 +57,8 @@ vis release init --from-changesets
 vis release init --fresh
 vis release init --dry-run
 vis release init --from-semantic-release --apply
+vis release init --from-semantic-release --apply --packages '@scope/a,@scope/b'
+vis release init --from-semantic-release --apply --cutover --yes
 vis release init --workflows
 ```
 
@@ -66,6 +68,38 @@ vis release init --workflows
 2. Creates `.vis/release/` with a sample change file and `.gitignore` entries.
 3. With `--workflows`, generates a GitHub Actions or GitLab CI workflow for the active provider.
 
+**A semantic-release migration previews by default.** Without `--apply` the run writes nothing at all — not the scaffold, not the ignore
+files, not the config — it only prints what `--apply` would do. (`--fresh` and the changesets / bumpy lanes still scaffold straight away;
+only the semantic-release lane waits for `--apply`.)
+
+**And `--apply` itself is incremental.** It scaffolds `.vis/release/`, writes the ignore-file entries and the `vis.config.ts` `release`
+block — and stops there. It never deletes a `.releaserc.*` and never marks a `package.json` managed on its own:
+
+| Flag               | What `--apply` additionally writes                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| _(none)_           | Nothing. `.releaserc.*` files and manifests stay exactly as they are (RFC §17.1 per-package transition) |
+| `--packages <csv>` | `"vis-release": { "managed": true }` on the listed packages only; their `.releaserc.*` stay in place    |
+| `--cutover`        | Marks **every** detected package managed and deletes **every** migrated `.releaserc.*` (RFC Phase 6)    |
+
+`--cutover` also flips the generated config to `defaultManaged: true`, since after a cutover every package is managed by vis. `--dry-run`
+previews exactly the run the same flags would perform, listing each deletion and manifest edit up front.
+
+Because `--cutover` deletes files, it asks before it does: an interactive shell gets a confirm prompt (defaulting to no), and a
+non-interactive one is **refused** unless you pass `--yes`. Two things stop it outright rather than half-migrating the repo:
+
+- the `vis.config.ts` `release` block could not be written (no `defineConfig({` or `export default {` to inject into, or its object literal
+  never closes) — deleting every `.releaserc.*` then would leave the repo with no release config at all, so the run exits non-zero and
+  touches nothing. A config that already declares a root `release` property is fine and the cutover proceeds; that property is looked for
+  structurally, so a commented-out `release:`, one inside a string, and one nested under another key do **not** count as configuration;
+- a `package.json` marked `private: true` is never opted into `vis-release.managed` — a private root or app is not publishable. Its
+  `.releaserc.*` is still removed by the cutover.
+
+Manifest edits keep the file's own indentation and trailing-newline style, so opting a 2-space `package.json` in is a one-line diff.
+
+Discovery stays inside the workspace: the walk over `packages/` and `apps/` never descends through a symlinked directory, so a cutover
+cannot delete a `.releaserc.*` that lives outside the repo. A file the command cannot read (a permissions failure, a directory in a file's
+place) aborts the run rather than being treated as absent and overwritten, and no write follows a symlink planted at its target.
+
 **Options**
 
 | Option                     | Type    | Description                                                                                                               |
@@ -74,8 +108,10 @@ vis release init --workflows
 | `--from-changesets`        | boolean | Force migration from changesets                                                                                           |
 | `--from-bumpy`             | boolean | Force migration from bumpy                                                                                                |
 | `--fresh`                  | boolean | Skip migration; start clean                                                                                               |
-| `--dry-run`                | boolean | Print what would happen without writing files (default for migration runs)                                                |
-| `--apply`                  | boolean | Actually perform the migration writes (opt out of the implicit dry-run)                                                   |
+| `--dry-run`                | boolean | Print what would happen without writing files (implicit for a semantic-release migration)                                 |
+| `--apply`                  | boolean | Actually perform the writes (opt out of the implicit dry-run). Non-destructive on its own                                 |
+| `--cutover`                | boolean | Full cutover (Phase 6): mark every detected package managed and delete every migrated `.releaserc.*`                      |
+| `--packages <csv>`         | string  | Opt only these packages into `vis-release.managed` — names or workspace-relative dirs (`@scope/a,packages/b`)             |
 | `--yes`, `-y`              | boolean | Auto-confirm prompts (CI-safe)                                                                                            |
 | `--workflows`              | boolean | Generate CI workflow files for the active provider                                                                        |
 | `--package-manager <name>` | string  | Override the package manager used in generated workflows (npm / pnpm / yarn / bun)                                        |

--- a/packages/tooling/vis/docs/guides/release-comparison.mdx
+++ b/packages/tooling/vis/docs/guides/release-comparison.mdx
@@ -195,7 +195,9 @@ vis release init                                  # Auto-detect; preview only
 vis release init --from-changesets                # Force changesets migration; preview
 vis release init --from-semantic-release          # Force semantic-release migration; preview
 vis release init --from-bumpy                     # Force bumpy migration; preview
-vis release init --from-semantic-release --apply  # Actually perform the writes
+vis release init --from-semantic-release --apply  # Scaffold + write the config (leaves .releaserc.* alone)
+vis release init --from-semantic-release --apply --packages '@scope/a'  # Opt one package in
+vis release init --from-semantic-release --apply --cutover  # Phase 6: all packages, delete every .releaserc.* (confirms first; --yes in CI)
 vis release init --fresh                          # Skip migration; start clean
 vis release init --dry-run                        # Print what would happen and exit
 vis release init --workflows                      # Scaffold CI workflows too

--- a/packages/tooling/vis/docs/guides/release.mdx
+++ b/packages/tooling/vis/docs/guides/release.mdx
@@ -193,11 +193,28 @@ vis release init --from-semantic-release
 vis release init --from-bumpy
 ```
 
-By default `init` runs in **plan mode** — it prints what would change without writing files. Add `--apply` to perform the writes (currently wired for `--from-semantic-release`: writes the suggested `vis.config.ts` block, opts every detected package into `vis-release.managed: true`, and deletes migrated `.releaserc.*` files):
+A semantic-release migration runs in **plan mode** by default — the whole run, scaffold included, prints what would change and writes
+nothing. Add `--apply` to perform the writes: it scaffolds `.vis/release/`, writes the ignore-file entries and injects the suggested
+`vis.config.ts` block. (`--from-changesets` / `--from-bumpy` / `--fresh` still scaffold straight away; only the semantic-release lane
+waits for `--apply`, because it is the lane with a destructive Phase 6 behind it.)
+
+`--apply` on its own is deliberately non-destructive — migrating off semantic-release is per-package opt-in, so it leaves every
+`.releaserc.*` and every manifest alone. Opt packages in as you go with `--packages`, and only run the full Phase-6 cutover once they are
+all migrated:
 
 ```bash
-vis release init --from-semantic-release --apply
+vis release init --from-semantic-release --apply                                  # Scaffold + config only
+vis release init --from-semantic-release --apply --packages '@scope/a,@scope/b'   # Opt two packages in
+vis release init --from-semantic-release --apply --cutover --yes                  # Phase 6: all packages, delete every .releaserc.*
 ```
+
+`--cutover` is the only flag that deletes `.releaserc.*` files, and it flips the generated config to `defaultManaged: true`. It confirms
+before deleting anything — interactively with a prompt, non-interactively only with `--yes` — and refuses to run at all if the
+`vis.config.ts` release block could not be written, so a failed config write can never leave you with neither release system. "Could be
+written" is decided structurally: an existing root `release` property means the repo is already configured and the cutover proceeds, but a
+`release:` inside a comment, a string, or another object is not configuration and does not unlock it. Deletions also stay inside the
+workspace — the walk never descends through a symlinked directory. Pair any of these with `--dry-run` to see the exact list of files that
+run would touch.
 
 See the [comparison page](./release-comparison.mdx#migration) for what carries over and what doesn't.
 
@@ -313,29 +330,29 @@ Explicit `managed: false` always wins. Private packages (`"private": true`) are 
 
 ## Commands
 
-| Command                          | What it does                                                                              |
-| -------------------------------- | ----------------------------------------------------------------------------------------- |
-| `vis release init`               | Scaffold the subsystem; auto-detect migration source. `--apply` writes                    |
-| `vis release add`                | Author a change file (interactive or `--packages '@a:minor,@b:patch'`)                    |
-| `vis release generate`           | Derive a change file from branch commits                                                  |
-| `vis release status`             | Human-readable pending plan (table)                                                       |
-| `vis release plan`               | JSON plan; `--interactive` walks you through overrides                                    |
-| `vis release next-version`       | Print `<pkg> <old> -> <new>` for every package in the plan                                |
-| `vis release changelog`          | Render the would-be changelog entries without writing                                     |
-| `vis release check`              | Verify change files cover every changed package (husky / CI gate)                         |
-| `vis release doctor`             | Preflight diagnostics                                                                     |
-| `vis release version`            | Apply the plan to disk                                                                    |
-| `vis release publish`            | Pack + publish + tag + push                                                               |
-| `vis release snapshot`           | Ephemeral `0.0.0-<tag>-<sha>` PR previews                                                 |
-| `vis release pre enter/exit`     | Toggle changesets-compatible pre-mode (every `version` is a prerelease)                   |
-| `vis release stage list/approve` | Manage `npm stage publish` records ([staged publishing](./release-staged-publishing.mdx)) |
-| `vis release notifications test` | Dry-run configured Slack / Discord / webhook destinations                                 |
-| `vis release ci release`         | The CI driver — opens / updates the version-PR (or `--auto-publish` to skip)              |
-| `vis release ci snapshot`        | CI snapshot publish + sticky PR comment                                                   |
-| `vis release ci check`           | Sticky-comment the pending plan on the PR                                                 |
-| `vis release ci plan`            | Emit JSON plan + write to `$GITHUB_OUTPUT` for workflow gating                            |
-| `vis release ci rebase-pr`       | Rebase the version-PR onto base — wire to a cron when `versionPr.autoRebase` is on        |
-| `vis release ci setup`           | Print the recommended secrets / permissions checklist                                     |
+| Command                          | What it does                                                                                    |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `vis release init`               | Scaffold the subsystem; auto-detect migration source. `--apply` writes, `--cutover` for Phase 6 |
+| `vis release add`                | Author a change file (interactive or `--packages '@a:minor,@b:patch'`)                          |
+| `vis release generate`           | Derive a change file from branch commits                                                        |
+| `vis release status`             | Human-readable pending plan (table)                                                             |
+| `vis release plan`               | JSON plan; `--interactive` walks you through overrides                                          |
+| `vis release next-version`       | Print `<pkg> <old> -> <new>` for every package in the plan                                      |
+| `vis release changelog`          | Render the would-be changelog entries without writing                                           |
+| `vis release check`              | Verify change files cover every changed package (husky / CI gate)                               |
+| `vis release doctor`             | Preflight diagnostics                                                                           |
+| `vis release version`            | Apply the plan to disk                                                                          |
+| `vis release publish`            | Pack + publish + tag + push                                                                     |
+| `vis release snapshot`           | Ephemeral `0.0.0-<tag>-<sha>` PR previews                                                       |
+| `vis release pre enter/exit`     | Toggle changesets-compatible pre-mode (every `version` is a prerelease)                         |
+| `vis release stage list/approve` | Manage `npm stage publish` records ([staged publishing](./release-staged-publishing.mdx))       |
+| `vis release notifications test` | Dry-run configured Slack / Discord / webhook destinations                                       |
+| `vis release ci release`         | The CI driver — opens / updates the version-PR (or `--auto-publish` to skip)                    |
+| `vis release ci snapshot`        | CI snapshot publish + sticky PR comment                                                         |
+| `vis release ci check`           | Sticky-comment the pending plan on the PR                                                       |
+| `vis release ci plan`            | Emit JSON plan + write to `$GITHUB_OUTPUT` for workflow gating                                  |
+| `vis release ci rebase-pr`       | Rebase the version-PR onto base — wire to a cron when `versionPr.autoRebase` is on              |
+| `vis release ci setup`           | Print the recommended secrets / permissions checklist                                           |
 
 See [the commands reference](../commands/release.mdx) for per-flag detail.
 

--- a/packages/tooling/vis/src/commands/release/init/fs-helpers.ts
+++ b/packages/tooling/vis/src/commands/release/init/fs-helpers.ts
@@ -1,0 +1,175 @@
+/**
+ * Filesystem + text helpers shared by the `vis release init` lanes.
+ *
+ * Reads and writes go through the injected `CerebroFs` rather than
+ * `node:fs/promises` so the command stays runnable under an in-memory
+ * adapter (tests) or a sandboxed runtime (MCP / JustBash).
+ *
+ * Two rules the whole command depends on live here:
+ *
+ *   - **Only a confirmed "not found" counts as absent.** Every caller reads
+ *     "missing" as permission to create the file. Folding an `EACCES` or an
+ *     `EISDIR` into the same answer turns an unreadable `.gitignore` into a
+ *     brand-new one, silently destroying its contents — so anything that is
+ *     not `ENOENT`/`ENOTDIR` propagates and stops the run.
+ *   - **A write never follows a symlink.** `access()`/`stat()` say "missing"
+ *     for a dangling symlink while `writeFile()` happily follows it, so a
+ *     write aimed at `.vis/release/x.md` can land wherever the link points.
+ *     {@link writeFileNoFollow} refuses that instead.
+ */
+
+import { lstat } from "node:fs/promises";
+
+import type { CerebroFs } from "@visulima/cerebro";
+
+import { VisUserError } from "../../../errors/vis-user-error";
+
+/** Errno codes that mean "this path does not exist", and nothing else. */
+const NOT_FOUND_CODES: ReadonlySet<string> = new Set(["ENOENT", "ENOTDIR"]);
+
+/**
+ * `true` only for a confirmed not-found failure.
+ *
+ * Everything else — `EACCES`, `EISDIR`, `EIO`, `EPERM`, … — is a real error
+ * that has to reach the operator rather than being reported as an absent
+ * file, because "absent" is what licenses this command to write.
+ */
+export const isNotFoundError = (error: unknown): boolean => NOT_FOUND_CODES.has((error as NodeJS.ErrnoException | undefined)?.code ?? "");
+
+/**
+ * A `CerebroFs` adapter that can answer the no-follow question itself.
+ *
+ * `CerebroFs` (cerebro 3.1) exposes no `lstat`, so this is duck-typed rather
+ * than required: an adapter that grows one is used, and one that has not is
+ * handled by {@link isSymbolicLink}'s fallback.
+ */
+type NoFollowCapableFs = CerebroFs & { lstat?: (path: string) => Promise<{ isSymbolicLink: () => boolean }> };
+
+/**
+ * `true` when `path` is a symlink — including a dangling one, which is the
+ * case `access()` and `stat()` both report as "missing".
+ *
+ * The injected adapter answers when it can. Otherwise the probe falls back to
+ * the host filesystem, which is the same escape hatch the TTY probe in
+ * `semantic-release.ts` uses and is safe for an in-memory adapter: its paths
+ * are not on the host filesystem, so the fallback answers "not a symlink" —
+ * which is exactly right, since an in-memory tree has no symlinks to follow.
+ *
+ * This is a guard, never a data source. It only ever decides whether a write
+ * is allowed to proceed.
+ */
+export const isSymbolicLink = async (fs: CerebroFs, path: string): Promise<boolean> => {
+    const adapterLstat = (fs as NoFollowCapableFs).lstat;
+
+    try {
+        const stats = typeof adapterLstat === "function" ? await adapterLstat.call(fs, path) : await lstat(path);
+
+        return stats.isSymbolicLink();
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+/**
+ * Write `data` to `path`, refusing to follow a symlink planted at the target.
+ *
+ * Every write this command makes is a check-then-write: it reads the file (or
+ * probes for it), decides the file is missing or needs an edit, and writes.
+ * A symlink at the target turns that into a write *through* the link — into
+ * `~/.ssh/authorized_keys`, say — for anyone who can plant one in the repo
+ * before `vis release init` runs on it.
+ *
+ * Refusing is deliberately not the same as an exclusive create: the probe and
+ * the write are still two calls, so a file created in between is overwritten.
+ * Closing that window needs an `O_EXCL|O_NOFOLLOW` create, which `CerebroFs`
+ * cannot express — see the comment on the symlink rule in the module header.
+ */
+export const writeFileNoFollow = async (fs: CerebroFs, path: string, data: string): Promise<void> => {
+    if (await isSymbolicLink(fs, path)) {
+        throw new VisUserError(
+            `Refusing to write ${path}: it is a symlink, and following it would write somewhere else. Remove or replace the link, then re-run.`,
+        );
+    }
+
+    await fs.writeFile(path, data);
+};
+
+/** `true` when `path` is reachable — the `access()` idiom, minus the throw. */
+export const fileExists = async (fs: CerebroFs, path: string): Promise<boolean> => {
+    try {
+        await fs.access(path);
+
+        return true;
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+/** `true` when `path` exists and is a directory. */
+export const isDirectory = async (fs: CerebroFs, path: string): Promise<boolean> => {
+    try {
+        const stats = await fs.stat(path);
+
+        return stats.isDirectory();
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+/** Read a UTF-8 file, or `undefined` when it does not exist. */
+export const readTextFile = async (fs: CerebroFs, path: string): Promise<string | undefined> => {
+    try {
+        return await fs.readFile(path, "utf8");
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+};
+
+/**
+ * The indent unit `source` is written with.
+ *
+ * The first indented line of a pretty-printed document sits exactly one level
+ * deep, so its leading whitespace *is* the unit. A single-line document has no
+ * indent to detect and stays compact; anything else falls back to four spaces
+ * (the monorepo default).
+ */
+export const detectIndent = (source: string): string => {
+    const match = /\n([\t ]+)\S/.exec(source);
+
+    if (match?.[1] !== undefined) {
+        return match[1];
+    }
+
+    return source.includes("\n") ? "    " : "";
+};
+
+/**
+ * Re-serialise `value` in the style of the `source` text it came from —
+ * same indent unit, same line endings, same trailing-newline habit.
+ *
+ * Without this a `JSON.stringify(value, undefined, 4)` write reformats every
+ * line of a 2-space `package.json`, turning a one-key addition into a
+ * whole-file diff.
+ */
+export const serialiseJsonLike = (value: unknown, source: string): string => {
+    const eol = source.includes("\r\n") ? "\r\n" : "\n";
+    const body = JSON.stringify(value, undefined, detectIndent(source)).replaceAll("\n", eol);
+
+    return source.endsWith("\n") ? `${body}${eol}` : body;
+};

--- a/packages/tooling/vis/src/commands/release/init/handler.ts
+++ b/packages/tooling/vis/src/commands/release/init/handler.ts
@@ -15,229 +15,173 @@
  *     pending staged-publish ids across CI runs (see RFC §13.6 + the
  *     staged-publishing guide).
  *     Print snippet for vis.config.ts release block
- *   - Semantic-release reader: walk root + per-package .releaserc.json,
- *     map branches → channels, print TODO list
- *   - `--apply` (semantic-release path only, for now): write the
- *     suggested `vis.config.ts` block, opt every detected package into
- *     `vis-release.managed = true`, and delete migrated `.releaserc.*`
- *     files. `--dry-run` takes precedence and short-circuits the writes.
+ *   - Semantic-release reader + migration (see `./semantic-release.ts`):
+ *     `--apply` is deliberately NON-destructive — no `package.json` is marked
+ *     managed and no `.releaserc.*` is deleted unless the operator opts in
+ *     with `--packages &lt;a,b>` (per-package, RFC §17.1) or `--cutover` (all of
+ *     them, Phase 6, behind a confirmation). `--dry-run` takes precedence and
+ *     short-circuits the writes (issue #862).
+ *
+ * A semantic-release migration previews by default: without `--apply` the
+ * whole run — scaffold, ignore files, husky, workflows and the migration
+ * itself — only describes what it would do. The alternative is a run whose
+ * output says "would" while half of it has already happened.
  *
  * Future (M10 follow-on):
  *   - Changesets reader: copy .changeset/*.md verbatim, map config.json
  *   - Husky integration prompt
- *   - --remove-releaserc flag (Phase 6)
  */
 
-import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
-import type { CommandExecute, Toolbox } from "@visulima/cerebro";
+import type { CerebroFs, CommandExecute, Toolbox } from "@visulima/cerebro";
 
+import { fileExists, isNotFoundError, readTextFile, writeFileNoFollow } from "./fs-helpers";
 import type { ReleaseInitOptions } from "./index";
+import type { InitLogger } from "./semantic-release";
+import { hasSemanticReleaseConfig, migrateFromSemanticRelease } from "./semantic-release";
 
 type Source = "semantic-release" | "changesets" | "bumpy" | "fresh";
 
-const fileExists = async (path: string): Promise<boolean> => {
-    try {
-        await access(path);
-
-        return true;
-    } catch {
-        return false;
-    }
-};
-
-const detectSource = async (cwd: string): Promise<Source> => {
-    if (await fileExists(join(cwd, ".changeset"))) {
+const detectSource = async (fs: CerebroFs, cwd: string): Promise<Source> => {
+    if (await fileExists(fs, join(cwd, ".changeset"))) {
         return "changesets";
     }
 
-    if (await fileExists(join(cwd, ".bumpy"))) {
+    if (await fileExists(fs, join(cwd, ".bumpy"))) {
         return "bumpy";
     }
 
-    // Find any .releaserc.* at the repo root or under packages/ + apps/.
-    const hasSemanticRelease = async (): Promise<boolean> => {
-        for (const name of [".releaserc.json", ".releaserc.cjs", ".releaserc.js"]) {
-            if (await fileExists(join(cwd, name))) {
-                return true;
-            }
-        }
-
-        const queue: string[] = [join(cwd, "packages"), join(cwd, "apps")];
-
-        while (queue.length > 0) {
-            const dir = queue.shift()!;
-
-            let entries;
-
-            try {
-                entries = await readdir(dir, { withFileTypes: true });
-            } catch {
-                continue;
-            }
-
-            for (const entry of entries) {
-                if (entry.isDirectory()) {
-                    // Match findReleaseRcFiles' guards: node_modules + dotfile
-                    // dirs are huge attractors for the queue-size bail.
-                    if (entry.name === "node_modules" || entry.name.startsWith(".")) {
-                        continue;
-                    }
-
-                    queue.push(join(dir, entry.name));
-                } else if (entry.name === ".releaserc.json" || entry.name === ".releaserc.cjs" || entry.name === ".releaserc.js") {
-                    return true;
-                }
-            }
-
-            if (queue.length > 200) {
-                // safety: bail if we're walking a huge tree
-                break;
-            }
-        }
-
-        return false;
-    };
-
-    if (await hasSemanticRelease()) {
+    if (await hasSemanticReleaseConfig(fs, cwd)) {
         return "semantic-release";
     }
 
     return "fresh";
 };
 
-const findReleaseRcFiles = async (cwd: string): Promise<string[]> => {
-    const out: string[] = [];
-
-    for (const name of [".releaserc.json", ".releaserc.cjs", ".releaserc.js"]) {
-        const root = join(cwd, name);
-
-        if (await fileExists(root)) {
-            out.push(root);
-        }
-    }
-
-    const queue: string[] = [join(cwd, "packages"), join(cwd, "apps")];
-    let count = 0;
-
-    while (queue.length > 0 && count < 5000) {
-        const dir = queue.shift()!;
-
-        count += 1;
-
-        let entries;
-
-        try {
-            entries = await readdir(dir, { withFileTypes: true });
-        } catch {
-            continue;
-        }
-
-        for (const entry of entries) {
-            const path = join(dir, entry.name);
-
-            if (entry.isDirectory()) {
-                // Skip node_modules + dotfile dirs only — never skip the
-                // `.releaserc.*` files themselves (they start with a dot too).
-                if (entry.name === "node_modules" || entry.name.startsWith(".")) {
-                    continue;
-                }
-
-                queue.push(path);
-            } else if (entry.name === ".releaserc.json" || entry.name === ".releaserc.cjs" || entry.name === ".releaserc.js") {
-                out.push(path);
-            }
-        }
-    }
-
-    return out;
-};
-
-interface ReleaseRcFile {
-    branches?: unknown;
-    extends?: string;
-    path: string;
-    plugins?: unknown[];
-}
-
-const readReleaseRc = async (path: string): Promise<ReleaseRcFile | undefined> => {
-    if (!path.endsWith(".json")) {
-        // Skip .cjs/.js — would need to require/import; out of scope for M10 first cut.
-        return { path };
-    }
-
-    try {
-        const content = await readFile(path, "utf8");
-        const parsed = JSON.parse(content) as { branches?: unknown; extends?: unknown; plugins?: unknown };
-
-        return {
-            branches: parsed.branches,
-            extends: typeof parsed.extends === "string" ? parsed.extends : undefined,
-            path,
-            plugins: Array.isArray(parsed.plugins) ? parsed.plugins : undefined,
-        };
-    } catch {
+/**
+ * Comma-separated `--packages` value → trimmed entry list. Entries are
+ * matched against a manifest `name` OR its workspace-relative directory,
+ * so a scoped package name and `packages/b` both work.
+ */
+const parsePackageSelection = (raw: string | undefined): string[] | undefined => {
+    if (typeof raw !== "string") {
         return undefined;
     }
+
+    const entries = raw
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+
+    return entries.length > 0 ? entries : undefined;
 };
 
-interface BranchEntry {
-    channel?: string;
-    name: string;
-    prerelease?: boolean | string;
+/** An ignore file `init` keeps a managed block of entries in. */
+interface IgnoreFileScaffold {
+    entries: string[];
+    /** Comment written above the entries so the block explains itself. */
+    header: string;
+    /** Display name used in the log lines. */
+    label: string;
+    path: string;
 }
 
-const normaliseBranches = (raw: unknown): BranchEntry[] => {
-    if (!Array.isArray(raw)) {
-        return [];
+/**
+ * The rules an ignore file already declares, one normalised line each.
+ *
+ * Whole lines, not substrings: `existing.includes(".vis/release/.lock")` is
+ * also satisfied by a commented-out `# .vis/release/.lock` and by a longer
+ * path that merely contains it, and either one suppresses the real rule —
+ * leaving the state and lock files tracked, and letting secretlint walk
+ * `.vis/release/**`.
+ */
+const ignoreFileRules = (source: string): Set<string> =>
+    new Set(
+        source
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0),
+    );
+
+/** Append the missing `entries` to an ignore file, creating it when absent. */
+const upsertIgnoreEntries = async (fs: CerebroFs, dryRun: boolean, scaffold: IgnoreFileScaffold, logger: InitLogger): Promise<void> => {
+    const { entries, header, label, path } = scaffold;
+    const existing = await readTextFile(fs, path);
+    const declared = existing === undefined ? undefined : ignoreFileRules(existing);
+    const missing = declared === undefined ? entries : entries.filter((entry) => !declared.has(entry.trim()));
+
+    if (missing.length === 0) {
+        return;
     }
 
-    return raw
-        .map((entry): BranchEntry | undefined => {
-            if (typeof entry === "string") {
-                return { name: entry };
-            }
+    if (dryRun) {
+        logger.info(`[dry-run] would add to ${label}:\n${missing.map((entry) => `    ${entry}`).join("\n")}`);
 
-            if (typeof entry === "object" && entry !== null && typeof (entry as { name?: unknown }).name === "string") {
-                const e = entry as { channel?: string; name: string; prerelease?: boolean | string };
+        return;
+    }
 
-                return { channel: e.channel, name: e.name, prerelease: e.prerelease };
-            }
+    if (existing === undefined) {
+        await writeFileNoFollow(fs, path, `${header}\n${missing.join("\n")}\n`);
+        logger.info(`Created ${label}.`);
 
-            return undefined;
-        })
-        .filter((b): b is BranchEntry => b !== undefined);
+        return;
+    }
+
+    await writeFileNoFollow(fs, path, `${existing.replace(/\n*$/, "\n")}\n${header}\n${missing.join("\n")}\n`);
+    logger.info(`Updated ${label}.`);
 };
 
-const renderChannelsFromBranches = (branches: BranchEntry[]): Record<string, { mode?: string; prerelease?: string; tag: string }> => {
-    const channels: Record<string, { mode?: string; prerelease?: string; tag: string }> = {};
+/**
+ * `--agent`: scaffold the AGENTS.md guidance so AI agents author change files
+ * instead of hand-bumping versions.
+ */
+const scaffoldAgentsSection = async (fs: CerebroFs, cwd: string, dryRun: boolean, logger: InitLogger): Promise<void> => {
+    const { upsertAgentSection } = await import("../../../release/core/agent-instructions");
+    const agentsPath = join(cwd, "AGENTS.md");
+    let existing: string | undefined;
 
-    for (const branch of branches) {
-        const cfg: { mode?: string; prerelease?: string; tag: string } = { tag: "latest" };
-
-        if (typeof branch.prerelease === "string") {
-            cfg.prerelease = branch.prerelease;
-            cfg.tag = branch.prerelease;
-            cfg.mode = "auto-publish";
-        } else if (branch.prerelease === true) {
-            cfg.prerelease = branch.name;
-            cfg.tag = branch.name;
-            cfg.mode = "auto-publish";
-        } else {
-            cfg.tag = branch.channel ?? (branch.name === "main" || branch.name === "master" ? "latest" : branch.name);
-            cfg.mode = "version-pr";
+    try {
+        existing = await fs.readFile(agentsPath, "utf8");
+    } catch (error) {
+        // Only a missing file is a "create from scratch" signal. Any other
+        // read failure (EACCES, EISDIR, …) must surface — otherwise the
+        // write below would clobber an existing-but-unreadable AGENTS.md,
+        // dropping content outside the managed block.
+        if (!isNotFoundError(error)) {
+            throw error;
         }
 
-        channels[branch.name] = cfg;
+        existing = undefined;
     }
 
-    return channels;
+    const { changed, content } = upsertAgentSection(existing);
+
+    if (!changed) {
+        logger.info("AGENTS.md already up to date.");
+    } else if (dryRun) {
+        logger.info(`[dry-run] would ${existing ? "update" : "create"} AGENTS.md with the 'Releasing with vis' section`);
+    } else {
+        await writeFileNoFollow(fs, agentsPath, content);
+        logger.info(`${existing ? "Updated" : "Created"} AGENTS.md.`);
+    }
 };
 
-const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, ReleaseInitOptions>): Promise<void> => {
+const printNextSteps = (logger: InitLogger): void => {
+    logger.info("");
+    logger.info("Next steps:");
+    logger.info("  1. Add the `release: { ... }` block above to your vis.config.ts");
+    logger.info("  2. Author your first change file: vis release add");
+    logger.info("  3. Preview the plan: vis release status");
+    logger.info("  4. Apply: vis release version --dry-run");
+};
+
+const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, ReleaseInitOptions>): Promise<void> => {
     const cwd = workspaceRoot ?? process.cwd();
     const dryRun = options.dryRun === true;
+    const cutover = options.cutover === true;
+    const autoYes = options.yes === true;
+    const selection = parsePackageSelection(options.packages);
     let apply = options.apply === true;
 
     // Dry-run takes precedence over --apply; warn the operator so they don't
@@ -245,6 +189,13 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
     if (dryRun && apply) {
         logger.warn("--apply is ignored because --dry-run is set (dry-run takes precedence).");
         apply = false;
+    }
+
+    // `--cutover` already opts every detected package in, so a narrower
+    // `--packages` list can only be a mistake — say so instead of silently
+    // widening the operator's selection.
+    if (cutover && selection !== undefined) {
+        logger.warn("--packages is ignored because --cutover opts every detected package in.");
     }
 
     let source: Source;
@@ -258,120 +209,86 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
     } else if (options.fresh) {
         source = "fresh";
     } else {
-        source = await detectSource(cwd);
+        source = await detectSource(fs, cwd);
     }
 
     logger.info(`Detected source: ${source}`);
+
+    if ((cutover || selection !== undefined) && source !== "semantic-release") {
+        logger.warn("`--cutover` / `--packages` only affect the semantic-release migration path.");
+    }
+
+    // The semantic-release lane previews by default — without `--apply` it
+    // describes its writes instead of performing them. Every other write in
+    // this run has to make the same call, or a plain
+    // `vis release init --from-semantic-release` half-migrates: it really
+    // creates `.vis/release/` and rewrites the ignore files while the lane
+    // below only says what it *would* do. One decision, one run (issue #862).
+    const previewOnly = dryRun || (source === "semantic-release" && !apply);
+
+    if (previewOnly && !dryRun) {
+        logger.info("Preview only — a semantic-release migration writes nothing without `--apply`.");
+    }
+
     logger.info("");
 
     // 1) Always: scaffold .vis/release/ + .gitignore line
     const changesDir = join(cwd, ".vis", "release");
-    const stateEntry = ".vis/release/.state.json";
-    const lockEntry = ".vis/release/.lock";
-    const gitignorePath = join(cwd, ".gitignore");
 
-    if (dryRun) {
+    if (previewOnly) {
         logger.info(`[dry-run] would create directory: ${changesDir}`);
-        logger.info(`[dry-run] would append to .gitignore:\n    ${stateEntry}\n    ${lockEntry}`);
     } else {
-        await mkdir(changesDir, { recursive: true });
+        await fs.mkdir(changesDir, { recursive: true });
         logger.info(`Created ${relative(cwd, changesDir)}/`);
-
-        try {
-            const existing = await readFile(gitignorePath, "utf8");
-            const missing: string[] = [];
-
-            if (!existing.includes(stateEntry)) {
-                missing.push(stateEntry);
-            }
-
-            if (!existing.includes(lockEntry)) {
-                missing.push(lockEntry);
-            }
-
-            if (missing.length > 0) {
-                await writeFile(gitignorePath, `${existing.replace(/\n*$/, "\n")}\n# vis release subsystem\n${missing.join("\n")}\n`);
-                logger.info("Updated .gitignore.");
-            }
-        } catch {
-            await writeFile(gitignorePath, `# vis release subsystem\n${stateEntry}\n${lockEntry}\n`);
-            logger.info("Created .gitignore.");
-        }
     }
 
-    // 1a) Optional: scaffold AGENTS.md guidance (`--agent`) so AI agents know
-    // how to author change files instead of hand-bumping versions.
+    await upsertIgnoreEntries(
+        fs,
+        previewOnly,
+        {
+            entries: [".vis/release/.state.json", ".vis/release/.lock"],
+            header: "# vis release subsystem",
+            label: ".gitignore",
+            path: join(cwd, ".gitignore"),
+        },
+        logger,
+    );
+
+    // 1a) Optional: AGENTS.md guidance (`--agent`).
     if (options.agent) {
-        const { upsertAgentSection } = await import("../../../release/core/agent-instructions");
-        const agentsPath = join(cwd, "AGENTS.md");
-        let existing: string | undefined;
-
-        try {
-            existing = await readFile(agentsPath, "utf8");
-        } catch (error) {
-            // Only a missing file is a "create from scratch" signal. Any other
-            // read failure (EACCES, EISDIR, …) must surface — otherwise the
-            // write below would clobber an existing-but-unreadable AGENTS.md,
-            // dropping content outside the managed block.
-            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-                throw error;
-            }
-
-            existing = undefined;
-        }
-
-        const { changed, content } = upsertAgentSection(existing);
-
-        if (!changed) {
-            logger.info("AGENTS.md already up to date.");
-        } else if (dryRun) {
-            logger.info(`[dry-run] would ${existing ? "update" : "create"} AGENTS.md with the 'Releasing with vis' section`);
-        } else {
-            await writeFile(agentsPath, content);
-            logger.info(`${existing ? "Updated" : "Created"} AGENTS.md.`);
-        }
+        await scaffoldAgentsSection(fs, cwd, previewOnly, logger);
     }
 
     // 1b) secretlintignore for change files (RFC §20.3). Author-handle
     // patterns (`@danielbannert`) in change-file bodies false-positive on some
     // secretlint rules; ignore the directory so the pre-commit hook stays
     // green.
-    const secretlintEntry = ".vis/release/**";
-    const secretlintignorePath = join(cwd, ".secretlintignore");
-
-    if (dryRun) {
-        logger.info(`[dry-run] would add to .secretlintignore:\n    ${secretlintEntry}`);
-    } else {
-        try {
-            const existing = await readFile(secretlintignorePath, "utf8");
-
-            if (!existing.includes(secretlintEntry)) {
-                await writeFile(
-                    secretlintignorePath,
-                    `${existing.replace(/\n*$/, "\n")}\n# vis release change files (author handles false-positive secretlint)\n${secretlintEntry}\n`,
-                );
-                logger.info("Updated .secretlintignore.");
-            }
-        } catch {
-            await writeFile(secretlintignorePath, `# vis release change files (author handles false-positive secretlint)\n${secretlintEntry}\n`);
-            logger.info("Created .secretlintignore.");
-        }
-    }
+    await upsertIgnoreEntries(
+        fs,
+        previewOnly,
+        {
+            entries: [".vis/release/**"],
+            header: "# vis release change files (author handles false-positive secretlint)",
+            label: ".secretlintignore",
+            path: join(cwd, ".secretlintignore"),
+        },
+        logger,
+    );
 
     // 2) Source-specific migration
     switch (source) {
         case "bumpy": {
-            await migrateFromBumpy(cwd, dryRun, logger);
+            await migrateFromBumpy(fs, cwd, previewOnly, logger);
 
             break;
         }
         case "changesets": {
-            await migrateFromChangesets(cwd, dryRun, logger);
+            await migrateFromChangesets(fs, cwd, previewOnly, logger);
 
             break;
         }
         case "semantic-release": {
-            await migrateFromSemanticRelease(cwd, dryRun, apply, logger);
+            await migrateFromSemanticRelease(fs, cwd, { apply, autoYes, cutover, dryRun: previewOnly, selection }, logger);
 
             break;
         }
@@ -381,270 +298,84 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
     }
 
     // 3) Optional husky integration (RFC §22.5)
-    await offerHuskyWiring(cwd, dryRun, options.yes === true, logger);
+    await offerHuskyWiring(fs, cwd, previewOnly, autoYes, logger);
 
     // 4) Optional CI workflow generation
-    await offerWorkflowGeneration(cwd, dryRun, options, logger);
+    await offerWorkflowGeneration(fs, cwd, previewOnly, options, logger);
 
-    logger.info("");
-    logger.info("Next steps:");
-    logger.info("  1. Add the `release: { ... }` block above to your vis.config.ts");
-    logger.info("  2. Author your first change file: vis release add");
-    logger.info("  3. Preview the plan: vis release status");
-    logger.info("  4. Apply: vis release version --dry-run");
-};
-
-const migrateFromSemanticRelease = async (
-    cwd: string,
-    _dryRun: boolean,
-    apply: boolean,
-    logger: Toolbox<Console, ReleaseInitOptions>["logger"],
-): Promise<void> => {
-    const rcFiles = await findReleaseRcFiles(cwd);
-
-    logger.info(`Found ${rcFiles.length} .releaserc file(s).`);
-
-    if (rcFiles.length === 0) {
-        return;
-    }
-
-    let mergedBranches: BranchEntry[] = [];
-    let nativeAddonCount = 0;
-
-    for (const path of rcFiles) {
-        const rc = await readReleaseRc(path);
-
-        if (!rc) {
-            continue;
-        }
-
-        if (rc.branches) {
-            mergedBranches = [...mergedBranches, ...normaliseBranches(rc.branches)];
-        }
-
-        if (rc.plugins?.some((p) => typeof p === "string" && p.includes("native-addons"))) {
-            nativeAddonCount += 1;
-        }
-
-        if (rc.plugins?.some((p) => Array.isArray(p) && typeof p[0] === "string" && p[0].includes("native-addons"))) {
-            nativeAddonCount += 1;
-        }
-    }
-
-    // Deduplicate branches by name (keep first-seen)
-    const seen = new Set<string>();
-    const dedupedBranches = mergedBranches.filter((b) => {
-        if (seen.has(b.name)) {
-            return false;
-        }
-
-        seen.add(b.name);
-
-        return true;
-    });
-
-    const channels
-        = dedupedBranches.length > 0
-            ? renderChannelsFromBranches(dedupedBranches)
-            : { alpha: { mode: "auto-publish", prerelease: "alpha", tag: "alpha" }, main: { mode: "version-pr", tag: "latest" } };
-
-    logger.info("");
-    logger.info("Suggested vis.config.ts release block (paste into your existing config):");
-    logger.info("");
-
-    const channelsRendered = Object.entries(channels)
-        .map(([name, cfg]) => `        ${JSON.stringify(name)}: ${JSON.stringify(cfg)},`)
-        .join("\n");
-
-    const block = `    release: {
-        baseBranch: "main",
-        defaultManaged: false, // flip to true after Phase 6
-        channels: {
-${channelsRendered}
-        },
-        publish: {
-            packManager: "auto",
-            publishStrategy: "npm-publish-tarball",
-            publishArgs: ["--provenance"],
-            protocolResolution: "pack",
-            catalogResolution: "auto",
-            cleanPackageJson: true,
-        },
-        gitUser: { name: "release-bot", email: "release-bot@example.com" },
-    },`;
-
-    logger.info(block);
-    logger.info("");
-
-    if (nativeAddonCount > 0) {
-        logger.info(`Found ${nativeAddonCount} package(s) using a NAPI native-addons plugin.`);
-        logger.info("These will auto-detect via the `napi` field in package.json — no config needed.");
-        logger.info("");
-    }
-
-    logger.info("Migration is per-package opt-in (RFC §17.1). For each package you want to migrate:");
-    logger.info("  1. Add to its package.json:  \"vis-release\": { \"managed\": true }");
-    logger.info("  2. Backfill any missing git tags so already-published detection works.");
-    logger.info("  3. Add to multi-semantic-release's --ignore-packages list in your release workflow.");
-    logger.info("");
-
-    if (!apply) {
-        logger.info("Existing .releaserc.json files are kept in place during transition (deleted in Phase 6).");
-        logger.info("Re-run with `--apply` to perform the writes automatically.");
-
-        return;
-    }
-
-    // --apply path: actually perform the migration writes.
-    logger.info("");
-    logger.info("Applying migration writes (--apply set)…");
-
-    await applySemanticReleaseMigration(cwd, rcFiles, block, logger);
-
-    logger.info("");
-    logger.info("Migration writes complete. Follow-up steps you still need to do manually:");
-    logger.info(
-        "  - Update your CI workflow: remove `multi-semantic-release` step, add `vis release ci/release` step (see `.github/workflows/vis-release.yml` example in the vis package)",
-    );
-    logger.info("  - Run `pnpm install` to drop semantic-release deps once you remove them from root package.json");
-    logger.info("  - Run `vis release doctor` to verify the migration");
+    printNextSteps(logger);
 };
 
 /**
- * Execute the migration writes for `--apply`:
- *   1. Write/merge `vis.config.ts` at the repo root with the suggested
- *      `release: { … }` block.
- *   2. Add `"vis-release": { "managed": true }` to each detected
- *      package's `package.json` (a package counts as "detected" iff it
- *      has a sibling `.releaserc.*` file).
- *   3. Delete the migrated `.releaserc.*` files.
- *
- * Uses `node:fs/promises` only (no extra deps). JSON writes preserve a
- * 4-space indent + trailing newline to match the rest of the monorepo's
- * package.json style. `vis.config.ts` generation uses a template literal
- * rather than a TS-AST library (see lane constraints).
+ * Copy the pending `*.md` change files out of a legacy tool's directory into
+ * `.vis/release/`. The frontmatter format is compatible, so this is a verbatim
+ * copy that never clobbers a file the operator already authored.
  */
-const applySemanticReleaseMigration = async (
+const copyPendingChangeFiles = async (
+    fs: CerebroFs,
     cwd: string,
-    rcFiles: string[],
-    releaseBlock: string,
-    logger: Toolbox<Console, ReleaseInitOptions>["logger"],
-): Promise<void> => {
-    // 1) vis.config.ts at the repo root — create or merge.
-    const visConfigPath = join(cwd, "vis.config.ts");
-    const existingVisConfig = await readFile(visConfigPath, "utf8").catch(() => undefined);
+    sourceDir: string,
+    dryRun: boolean,
+    logger: InitLogger,
+): Promise<{ found: number; preserved: number }> => {
+    const mdFiles: string[] = [];
 
-    if (existingVisConfig === undefined) {
-        const content = `import { defineConfig } from "@visulima/vis/config";\n\nexport default defineConfig({\n${releaseBlock}\n});\n`;
-
-        await writeFile(visConfigPath, content);
-        logger.info(`  wrote ${relative(cwd, visConfigPath)}`);
-    } else if (/\brelease\s*:/.test(existingVisConfig)) {
-        // Existing config already has a `release` key — leave it alone so we
-        // don't clobber the operator's tuning. They can paste the suggested
-        // block (already printed above) themselves.
-        logger.warn(`  skipped ${relative(cwd, visConfigPath)} — already has a \`release\` key; merge the suggested block manually.`);
-    } else {
-        // Inject the release block as the first child of defineConfig({ … }).
-        const injected = injectReleaseBlock(existingVisConfig, releaseBlock);
-
-        if (injected === undefined) {
-            logger.warn(
-                `  skipped ${relative(cwd, visConfigPath)} — could not locate \`defineConfig({\` or \`export default {\` to inject into; merge the suggested block manually.`,
-            );
-        } else {
-            await writeFile(visConfigPath, injected);
-            logger.info(`  updated ${relative(cwd, visConfigPath)} (injected release block)`);
+    try {
+        for (const name of await fs.readdir(sourceDir)) {
+            if (name.endsWith(".md") && name !== "README.md") {
+                mdFiles.push(name);
+            }
+        }
+    } catch (error) {
+        // A missing directory means nothing is pending. An unreadable one
+        // means the copy would silently drop the operator's change files.
+        if (!isNotFoundError(error)) {
+            throw error;
         }
     }
 
-    // 2) Add `"vis-release": { "managed": true }` to each detected
-    //    package's package.json. "Detected" = has a sibling .releaserc.*.
-    for (const rcPath of rcFiles) {
-        const pkgDir = dirname(rcPath);
-        const pkgJsonPath = join(pkgDir, "package.json");
+    const targetDir = join(cwd, ".vis", "release");
+    let preserved = 0;
+    let skipped = 0;
 
-        if (!(await fileExists(pkgJsonPath))) {
-            // Root .releaserc.* with no sibling package.json is uncommon but
-            // possible — skip silently so we don't fabricate one.
-            continue;
-        }
+    for (const name of mdFiles) {
+        const source = join(sourceDir, name);
+        const destination = join(targetDir, name);
 
-        const raw = await readFile(pkgJsonPath, "utf8");
-
-        let parsed: Record<string, unknown>;
-
-        try {
-            parsed = JSON.parse(raw) as Record<string, unknown>;
-        } catch {
-            logger.warn(`  skipped ${relative(cwd, pkgJsonPath)} — invalid JSON.`);
+        if (dryRun) {
+            logger.info(`[dry-run] would copy ${source} → ${destination}`);
 
             continue;
         }
 
-        const existing = parsed["vis-release"];
+        if (await fileExists(fs, destination)) {
+            logger.info(`Skipping existing ${relative(cwd, destination)}.`);
+            skipped += 1;
 
-        if (existing !== null && typeof existing === "object" && (existing as { managed?: unknown }).managed === true) {
-            // Already opted-in — leave it alone.
             continue;
         }
 
-        const merged = existing !== null && typeof existing === "object" ? { ...(existing as Record<string, unknown>), managed: true } : { managed: true };
-
-        parsed["vis-release"] = merged;
-
-        await writeFile(pkgJsonPath, `${JSON.stringify(parsed, undefined, 4)}\n`);
-        logger.info(`  updated ${relative(cwd, pkgJsonPath)} (added vis-release.managed = true)`);
+        await writeFileNoFollow(fs, destination, await fs.readFile(source, "utf8"));
+        preserved += 1;
     }
 
-    // 3) Delete .releaserc.* files for migrated packages.
-    for (const rcPath of rcFiles) {
-        await rm(rcPath, { force: true });
-        logger.info(`  deleted ${relative(cwd, rcPath)}`);
-    }
-};
-
-/**
- * Inject `releaseBlock` as the first child of `defineConfig({ … })` or
- * `export default { … }` in an existing vis.config.ts source. Returns
- * `undefined` if neither anchor is found.
- *
- * Template-literal injection (not a TS-AST rewrite) — sufficient for the
- * generated configs vis init emits and the canonical `defineConfig(`
- * pattern used across the visulima monorepo.
- */
-const injectReleaseBlock = (source: string, releaseBlock: string): string | undefined => {
-    const defineConfigMatch = /defineConfig\s*\(\s*\{/.exec(source);
-
-    if (defineConfigMatch !== null) {
-        const insertAt = defineConfigMatch.index + defineConfigMatch[0].length;
-
-        return `${source.slice(0, insertAt)}\n${releaseBlock}\n${source.slice(insertAt)}`;
+    if (skipped > 0) {
+        logger.info(`Skipped ${skipped} file(s) that already exist in .vis/release/.`);
     }
 
-    const exportDefaultMatch = /export\s+default\s+\{/.exec(source);
-
-    if (exportDefaultMatch !== null) {
-        const insertAt = exportDefaultMatch.index + exportDefaultMatch[0].length;
-
-        return `${source.slice(0, insertAt)}\n${releaseBlock}\n${source.slice(insertAt)}`;
-    }
-
-    return undefined;
+    return { found: mdFiles.length, preserved };
 };
 
 /**
  * Migrate `.changeset/config.json` + `.changeset/*.md` to `.vis/release/`.
  * RFC §17.2.
  */
-const migrateFromChangesets = async (cwd: string, dryRun: boolean, logger: Toolbox<Console, ReleaseInitOptions>["logger"]): Promise<void> => {
+const migrateFromChangesets = async (fs: CerebroFs, cwd: string, dryRun: boolean, logger: InitLogger): Promise<void> => {
     const changesetDir = join(cwd, ".changeset");
     const configPath = join(changesetDir, "config.json");
 
     // Check pre-release mode — abort if active.
-    const preJsonPath = join(changesetDir, "pre.json");
-
-    if (await fileExists(preJsonPath)) {
+    if (await fileExists(fs, join(changesetDir, "pre.json"))) {
         logger.error("Pre-release mode is active in changesets (.changeset/pre.json exists).");
         logger.error("Run `changeset pre exit && changeset version` to consume pending changes, then re-run `vis release init`.");
         process.exitCode = 1;
@@ -655,7 +386,7 @@ const migrateFromChangesets = async (cwd: string, dryRun: boolean, logger: Toolb
     let cfg: Record<string, unknown> = {};
 
     try {
-        cfg = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+        cfg = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
     } catch {
         logger.warn(".changeset/config.json missing or unreadable; using defaults.");
     }
@@ -688,61 +419,9 @@ const migrateFromChangesets = async (cwd: string, dryRun: boolean, logger: Toolb
         changelog = "\"default\"";
     }
 
-    // Walk + copy change files (frontmatter is compatible)
-    const mdFiles: string[] = [];
-    let preserved = 0;
+    const { found, preserved } = await copyPendingChangeFiles(fs, cwd, changesetDir, dryRun, logger);
 
-    try {
-        const entries = await readdir(changesetDir);
-
-        for (const name of entries) {
-            if (!name.endsWith(".md") || name === "README.md") {
-                continue;
-            }
-
-            mdFiles.push(name);
-        }
-    } catch {
-        // ignore
-    }
-
-    if (mdFiles.length > 0) {
-        const targetDir = join(cwd, ".vis", "release");
-        let skipped = 0;
-
-        for (const name of mdFiles) {
-            const src = join(changesetDir, name);
-            const dst = join(targetDir, name);
-
-            if (dryRun) {
-                logger.info(`[dry-run] would copy ${src} → ${dst}`);
-
-                continue;
-            }
-
-            // Don't clobber an existing change file with the same name —
-            // operators may have already authored a .vis/release/<x>.md.
-            if (await fileExists(dst)) {
-                logger.info(`Skipping existing ${relative(cwd, dst)}.`);
-                skipped += 1;
-
-                continue;
-            }
-
-            const content = await readFile(src, "utf8");
-
-            await writeFile(dst, content);
-            preserved += 1;
-        }
-
-        if (skipped > 0) {
-            logger.info(`Skipped ${skipped} file(s) that already exist in .vis/release/.`);
-        }
-    }
-
-    logger.info(
-        `Found ${mdFiles.length} pending .changeset/*.md file(s); ${preserved > 0 ? `copied ${preserved} to .vis/release/` : "(dry-run — would copy)"}.`,
-    );
+    logger.info(`Found ${found} pending .changeset/*.md file(s); ${preserved > 0 ? `copied ${preserved} to .vis/release/` : "(dry-run — would copy)"}.`);
     logger.info("");
     logger.info("Suggested vis.config.ts release block:");
     logger.info("");
@@ -770,14 +449,14 @@ const migrateFromChangesets = async (cwd: string, dryRun: boolean, logger: Toolb
  * Migrate `.bumpy/_config.json` + `.bumpy/*.md` to `.vis/release/`.
  * Format is essentially identical — just a directory rename + config translation.
  */
-const migrateFromBumpy = async (cwd: string, dryRun: boolean, logger: Toolbox<Console, ReleaseInitOptions>["logger"]): Promise<void> => {
+const migrateFromBumpy = async (fs: CerebroFs, cwd: string, dryRun: boolean, logger: InitLogger): Promise<void> => {
     const bumpyDir = join(cwd, ".bumpy");
     const configPath = join(bumpyDir, "_config.json");
 
     let cfg: Record<string, unknown> = {};
 
     try {
-        cfg = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+        cfg = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
     } catch {
         logger.warn(".bumpy/_config.json missing or unreadable; using defaults.");
     }
@@ -788,57 +467,9 @@ const migrateFromBumpy = async (cwd: string, dryRun: boolean, logger: Toolbox<Co
         .map((line) => `    ${line}`)
         .join("\n");
 
-    // Walk + copy change files
-    const mdFiles: string[] = [];
-    let preserved = 0;
+    const { found, preserved } = await copyPendingChangeFiles(fs, cwd, bumpyDir, dryRun, logger);
 
-    try {
-        const entries = await readdir(bumpyDir);
-
-        for (const name of entries) {
-            if (!name.endsWith(".md") || name === "README.md") {
-                continue;
-            }
-
-            mdFiles.push(name);
-        }
-    } catch {
-        // ignore
-    }
-
-    if (mdFiles.length > 0) {
-        const targetDir = join(cwd, ".vis", "release");
-        let skipped = 0;
-
-        for (const name of mdFiles) {
-            const src = join(bumpyDir, name);
-            const dst = join(targetDir, name);
-
-            if (dryRun) {
-                logger.info(`[dry-run] would copy ${src} → ${dst}`);
-
-                continue;
-            }
-
-            if (await fileExists(dst)) {
-                logger.info(`Skipping existing ${relative(cwd, dst)}.`);
-                skipped += 1;
-
-                continue;
-            }
-
-            const content = await readFile(src, "utf8");
-
-            await writeFile(dst, content);
-            preserved += 1;
-        }
-
-        if (skipped > 0) {
-            logger.info(`Skipped ${skipped} file(s) that already exist in .vis/release/.`);
-        }
-    }
-
-    logger.info(`Found ${mdFiles.length} pending .bumpy/*.md file(s); ${preserved > 0 ? `copied ${preserved} to .vis/release/` : "(dry-run)"}.`);
+    logger.info(`Found ${found} pending .bumpy/*.md file(s); ${preserved > 0 ? `copied ${preserved} to .vis/release/` : "(dry-run)"}.`);
     logger.info("");
     logger.info("Suggested vis.config.ts release block (bumpy config translates 1:1):");
     logger.info("");
@@ -855,14 +486,14 @@ const migrateFromBumpy = async (cwd: string, dryRun: boolean, logger: Toolbox<Co
  * modifies. `--yes` auto-wires; `--no-husky` skips entirely (handled
  * upstream by not calling this function).
  */
-const offerHuskyWiring = async (cwd: string, dryRun: boolean, autoYes: boolean, logger: Toolbox<Console, ReleaseInitOptions>["logger"]): Promise<void> => {
+const offerHuskyWiring = async (fs: CerebroFs, cwd: string, dryRun: boolean, autoYes: boolean, logger: InitLogger): Promise<void> => {
     const huskyHook = join(cwd, ".husky", "pre-commit");
 
-    if (!(await fileExists(huskyHook))) {
+    if (!(await fileExists(fs, huskyHook))) {
         return;
     }
 
-    const existing = await readFile(huskyHook, "utf8").catch(() => "");
+    const existing = (await readTextFile(fs, huskyHook)) ?? "";
 
     if (existing.includes("vis release check")) {
         return; // already wired
@@ -905,9 +536,7 @@ const offerHuskyWiring = async (cwd: string, dryRun: boolean, autoYes: boolean, 
         return;
     }
 
-    const updated = `${existing.replace(/\n*$/, "\n")}${snippet}\n`;
-
-    await writeFile(huskyHook, updated);
+    await writeFileNoFollow(fs, huskyHook, `${existing.replace(/\n*$/, "\n")}${snippet}\n`);
 
     logger.info("Wired vis release check into .husky/pre-commit.");
 };
@@ -921,12 +550,7 @@ const offerHuskyWiring = async (cwd: string, dryRun: boolean, autoYes: boolean, 
  * Skipped silently when target files already exist UNLESS user confirms
  * overwrite.
  */
-const offerWorkflowGeneration = async (
-    cwd: string,
-    dryRun: boolean,
-    options: ReleaseInitOptions,
-    logger: Toolbox<Console, ReleaseInitOptions>["logger"],
-): Promise<void> => {
+const offerWorkflowGeneration = async (fs: CerebroFs, cwd: string, dryRun: boolean, options: ReleaseInitOptions, logger: InitLogger): Promise<void> => {
     const explicit = options.workflows === true;
     const autoYes = options.yes === true;
 
@@ -988,7 +612,7 @@ const offerWorkflowGeneration = async (
     for (const file of files) {
         const target = join(cwd, file.path);
 
-        if (await fileExists(target)) {
+        if (await fileExists(fs, target)) {
             logger.warn(`  ${file.path} — already exists, skipping`);
             continue;
         }
@@ -998,16 +622,14 @@ const offerWorkflowGeneration = async (
             continue;
         }
 
-        const path = await import("node:path");
-
-        await mkdir(path.dirname(target), { recursive: true });
-        await writeFile(target, file.content);
+        await fs.mkdir(dirname(target), { recursive: true });
+        await writeFileNoFollow(fs, target, file.content);
 
         logger.info(`  ${file.path} — wrote ${file.content.length} bytes`);
     }
 };
 
-const printFreshConfig = (logger: Toolbox<Console, ReleaseInitOptions>["logger"]): void => {
+const printFreshConfig = (logger: InitLogger): void => {
     logger.info("");
     logger.info("Suggested vis.config.ts release block:");
     logger.info("");

--- a/packages/tooling/vis/src/commands/release/init/index.ts
+++ b/packages/tooling/vis/src/commands/release/init/index.ts
@@ -10,6 +10,11 @@ const initOptionDefinitions = {
         description: "Actually perform the migration writes (not dry-run)",
         type: Boolean,
     },
+    cutover: {
+        description:
+            "Full cutover: mark every detected package `vis-release.managed` and delete its `.releaserc.*` (Phase 6). Confirms before deleting — pass `--yes` in a non-interactive shell. Without it, `--apply` never touches manifests or `.releaserc.*`.",
+        type: Boolean,
+    },
     "dry-run": {
         description: "Print what would happen without writing files",
         type: Boolean,
@@ -34,6 +39,10 @@ const initOptionDefinitions = {
         description: "Override package manager when generating workflows (npm | pnpm | yarn | bun). Default: auto-detect",
         type: String,
     },
+    packages: {
+        description: "Comma-separated package names (or workspace-relative dirs) to opt into `vis-release.managed` — e.g. '@scope/a,@scope/b'",
+        type: String,
+    },
     workflows: {
         description: "Generate CI workflow files. GitHub → `.github/workflows/vis-release{,-check,-snapshot}.yml`. GitLab → `.gitlab-ci.yml`.",
         type: Boolean,
@@ -54,7 +63,9 @@ const init = defineCommand({
         ["vis release init --from-changesets", "Force changesets migration"],
         ["vis release init --fresh", "Skip migration; start clean"],
         ["vis release init --dry-run", "Print what would happen without writing files"],
-        ["vis release init --from-semantic-release --apply", "Actually perform the semantic-release migration writes"],
+        ["vis release init --from-semantic-release --apply", "Scaffold + write the config; leaves .releaserc.* and manifests untouched"],
+        ["vis release init --from-semantic-release --apply --packages '@scope/a,@scope/b'", "Opt two packages into vis-release"],
+        ["vis release init --from-semantic-release --apply --cutover --yes", "Full cutover: mark every package managed and delete every .releaserc.*"],
     ],
     group: "Release",
     loader: () => import("./handler"),

--- a/packages/tooling/vis/src/commands/release/init/semantic-release.ts
+++ b/packages/tooling/vis/src/commands/release/init/semantic-release.ts
@@ -1,0 +1,805 @@
+/**
+ * The semantic-release / multi-semantic-release migration lane of
+ * `vis release init` (RFC §17.1).
+ *
+ * The lane is deliberately incremental. `--apply` writes the `vis.config.ts`
+ * `release` block and nothing else; the two destructive opt-ins are explicit:
+ *
+ *   - `--packages &lt;a,b>` marks the listed manifests `vis-release.managed`,
+ *     leaving their `.releaserc.*` in place;
+ *   - `--cutover` is the Phase 6 flag — every detected package is marked
+ *     managed and every migrated `.releaserc.*` is deleted.
+ *
+ * Every run resolves to a {@link SemanticReleaseMigrationPlan} first: the
+ * final bytes of every file the run would write, computed before anything
+ * touches the disk. `--dry-run` prints that plan and `--apply` executes the
+ * same plan, so the preview cannot describe a different run than the one that
+ * follows it (issue #862). Applying it writes first and deletes last, and a
+ * failed write rolls the earlier ones back, so an aborted run never leaves the
+ * repo half-migrated — and a cutover never runs at all unless the release
+ * config it depends on was actually written.
+ */
+
+import { dirname, join, relative } from "node:path";
+
+import type { CerebroFs, Toolbox } from "@visulima/cerebro";
+
+import { fileExists, isDirectory, isNotFoundError, isSymbolicLink, readTextFile, serialiseJsonLike, writeFileNoFollow } from "./fs-helpers";
+import type { ReleaseInitOptions } from "./index";
+import { scanVisConfigSource } from "./vis-config-source";
+
+export type InitLogger = Toolbox<Console, ReleaseInitOptions>["logger"];
+
+const RELEASE_RC_NAMES = new Set([".releaserc.cjs", ".releaserc.js", ".releaserc.json"]);
+
+/** Safety bail: stop walking after this many directories. */
+const WALK_LIMIT = 5000;
+
+/**
+ * Walk the repo root plus `packages/` + `apps/` for `.releaserc.*` files.
+ *
+ * `CerebroFs.readdir` yields plain names, so directories are told apart with
+ * `stat` instead of `withFileTypes` — that keeps the whole walk inside the
+ * injected adapter.
+ *
+ * The walk never descends through a symlink. `stat` follows one, so a
+ * `packages/vendor -> ../../other-repo` link would put paths from a completely
+ * different tree on this list — and `--cutover` deletes everything on it. The
+ * paths it builds are all lexically under `cwd`, so a symlinked *directory* is
+ * the only way out of the workspace; refusing to queue one keeps every
+ * deletion inside the repo the operator actually ran the command in.
+ */
+const walkReleaseRcFiles = async (fs: CerebroFs, cwd: string, stopAtFirst: boolean): Promise<string[]> => {
+    const out: string[] = [];
+
+    for (const name of RELEASE_RC_NAMES) {
+        const root = join(cwd, name);
+
+        if (await fileExists(fs, root)) {
+            out.push(root);
+
+            if (stopAtFirst) {
+                return out;
+            }
+        }
+    }
+
+    const queue: string[] = [join(cwd, "packages"), join(cwd, "apps")];
+    let visited = 0;
+
+    while (queue.length > 0 && visited < WALK_LIMIT) {
+        const dir = queue.shift()!;
+
+        visited += 1;
+
+        let entries: string[];
+
+        try {
+            entries = await fs.readdir(dir);
+        } catch (error) {
+            // `packages/` or `apps/` simply not existing is the normal case.
+            // An unreadable directory is not: skipping it would plan a
+            // migration against a partial view of the workspace.
+            if (!isNotFoundError(error)) {
+                throw error;
+            }
+
+            continue;
+        }
+
+        for (const entry of entries) {
+            const path = join(dir, entry);
+
+            if (RELEASE_RC_NAMES.has(entry)) {
+                out.push(path);
+
+                if (stopAtFirst) {
+                    return out;
+                }
+
+                continue;
+            }
+
+            // node_modules + dotfile dirs are huge attractors for the walk.
+            // The `.releaserc.*` files start with a dot too, but they were
+            // already collected above.
+            if (entry === "node_modules" || entry.startsWith(".")) {
+                continue;
+            }
+
+            if ((await isDirectory(fs, path)) && !(await isSymbolicLink(fs, path))) {
+                queue.push(path);
+            }
+        }
+    }
+
+    return out;
+};
+
+/** Detection probe for `detectSource()` — short-circuits on the first hit. */
+export const hasSemanticReleaseConfig = async (fs: CerebroFs, cwd: string): Promise<boolean> => {
+    const found = await walkReleaseRcFiles(fs, cwd, true);
+
+    return found.length > 0;
+};
+
+/** Every `.releaserc.*` in the repo, root first. */
+export const findReleaseRcFiles = (fs: CerebroFs, cwd: string): Promise<string[]> => walkReleaseRcFiles(fs, cwd, false);
+
+interface ReleaseRcFile {
+    branches?: unknown;
+    extends?: string;
+    path: string;
+    plugins?: unknown[];
+}
+
+const readReleaseRc = async (fs: CerebroFs, path: string): Promise<ReleaseRcFile | undefined> => {
+    if (!path.endsWith(".json")) {
+        // Skip .cjs/.js — would need to require/import; out of scope for M10 first cut.
+        return { path };
+    }
+
+    const content = await readTextFile(fs, path);
+
+    if (content === undefined) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(content) as { branches?: unknown; extends?: unknown; plugins?: unknown };
+
+        return {
+            branches: parsed.branches,
+            extends: typeof parsed.extends === "string" ? parsed.extends : undefined,
+            path,
+            plugins: Array.isArray(parsed.plugins) ? parsed.plugins : undefined,
+        };
+    } catch {
+        return undefined;
+    }
+};
+
+interface BranchEntry {
+    channel?: string;
+    name: string;
+    prerelease?: boolean | string;
+}
+
+const normaliseBranches = (raw: unknown): BranchEntry[] => {
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+
+    return raw
+        .map((entry): BranchEntry | undefined => {
+            if (typeof entry === "string") {
+                return { name: entry };
+            }
+
+            if (typeof entry === "object" && entry !== null && typeof (entry as { name?: unknown }).name === "string") {
+                const e = entry as { channel?: string; name: string; prerelease?: boolean | string };
+
+                return { channel: e.channel, name: e.name, prerelease: e.prerelease };
+            }
+
+            return undefined;
+        })
+        .filter((b): b is BranchEntry => b !== undefined);
+};
+
+const renderChannelsFromBranches = (branches: BranchEntry[]): Record<string, { mode?: string; prerelease?: string; tag: string }> => {
+    const channels: Record<string, { mode?: string; prerelease?: string; tag: string }> = {};
+
+    for (const branch of branches) {
+        const cfg: { mode?: string; prerelease?: string; tag: string } = { tag: "latest" };
+
+        if (typeof branch.prerelease === "string") {
+            cfg.prerelease = branch.prerelease;
+            cfg.tag = branch.prerelease;
+            cfg.mode = "auto-publish";
+        } else if (branch.prerelease === true) {
+            cfg.prerelease = branch.name;
+            cfg.tag = branch.name;
+            cfg.mode = "auto-publish";
+        } else {
+            cfg.tag = branch.channel ?? (branch.name === "main" || branch.name === "master" ? "latest" : branch.name);
+            cfg.mode = "version-pr";
+        }
+
+        channels[branch.name] = cfg;
+    }
+
+    return channels;
+};
+
+/** Render the `release: { … }` block suggested for `vis.config.ts`. */
+const renderReleaseBlock = (channels: Record<string, { mode?: string; prerelease?: string; tag: string }>, cutover: boolean): string => {
+    const channelsRendered = Object.entries(channels)
+        .map(([name, cfg]) => `        ${JSON.stringify(name)}: ${JSON.stringify(cfg)},`)
+        .join("\n");
+
+    // A cutover switches every package over in one step, so the config that
+    // ships with it must already say `defaultManaged: true` — anything else
+    // would contradict the writes it just made.
+    const defaultManagedLine = cutover ? "        defaultManaged: true," : "        defaultManaged: false, // per-package opt-in; --cutover flips this to true";
+
+    return `    release: {
+        baseBranch: "main",
+${defaultManagedLine}
+        channels: {
+${channelsRendered}
+        },
+        publish: {
+            packManager: "auto",
+            publishStrategy: "npm-publish-tarball",
+            publishArgs: ["--provenance"],
+            protocolResolution: "pack",
+            catalogResolution: "auto",
+            cleanPackageJson: true,
+        },
+        gitUser: { name: "release-bot", email: "release-bot@example.com" },
+    },`;
+};
+
+/** A file the migration will write, resolved down to its final bytes. */
+interface PlannedWrite {
+    /** `create` when the file does not exist yet, `update` when it does. */
+    action: "create" | "update";
+    /** Exactly what lands on disk. Print and apply both read this — neither re-derives it. */
+    content: string;
+    /** Parenthetical shown after the path, e.g. `release block`. */
+    detail: string;
+    path: string;
+}
+
+/** A file the migration deliberately leaves alone, and why. */
+interface SkippedWrite {
+    /**
+     * `true` when the skip means the repo would be left with no vis release
+     * config. The cutover deletions depend on that config existing, so a
+     * blocking skip aborts them instead of merely warning (issue #862).
+     */
+    blocking: boolean;
+    path: string;
+    reason: string;
+}
+
+/**
+ * Everything a semantic-release migration run touches. Built once, then
+ * either printed (`--dry-run`) or executed (`--apply`).
+ */
+export interface SemanticReleaseMigrationPlan {
+    /** `.releaserc.*` files `--cutover` removes. Only ever runs after every write landed. */
+    deletions: string[];
+    /** `package.json` files gaining `vis-release.managed = true`. */
+    manifests: PlannedWrite[];
+    skipped: SkippedWrite[];
+    /** The `vis.config.ts` write, when one is planned. */
+    visConfig: PlannedWrite | undefined;
+    /** Ready-to-log notes gathered while planning; the caller decides when to surface them. */
+    warnings: string[];
+}
+
+/**
+ * The plan's writes in apply order: the release config first, so a repo is
+ * never left with managed manifests and no config that reads them.
+ */
+const plannedWrites = (plan: SemanticReleaseMigrationPlan): PlannedWrite[] => (plan.visConfig ? [plan.visConfig, ...plan.manifests] : plan.manifests);
+
+type VisConfigOutcome = { kind: "skip"; skipped: SkippedWrite } | { kind: "write"; write: PlannedWrite };
+
+/**
+ * Resolve what the run does to the root `vis.config.ts`: create it, inject the
+ * release block as the first property of its `defineConfig({ … })` /
+ * `export default { … }` object, or skip it.
+ *
+ * The skips are not equally safe, and telling them apart is why the existing
+ * `release` key is found structurally ({@link scanVisConfigSource}) rather
+ * than by matching text. A config that genuinely declares a root `release`
+ * property is fine to leave alone: the repo still ends up with a release
+ * config, which is what a cutover depends on, so that skip is non-blocking. A
+ * config nothing can be written into is not — a cutover proceeding on that
+ * basis would strip every `.releaserc.*` and leave no configuration at all,
+ * so those skips block. A textual match cannot distinguish the two: it fires
+ * on a comment or a nested key and hands the destructive path a non-blocking
+ * skip it has not earned (issue #862).
+ */
+const planVisConfigWrite = async (fs: CerebroFs, cwd: string, releaseBlock: string): Promise<VisConfigOutcome> => {
+    const path = join(cwd, "vis.config.ts");
+    const existing = await readTextFile(fs, path);
+
+    if (existing === undefined) {
+        return {
+            kind: "write",
+            write: {
+                action: "create",
+                content: `import { defineConfig } from "@visulima/vis/config";\n\nexport default defineConfig({\n${releaseBlock}\n});\n`,
+                detail: "release block",
+                path,
+            },
+        };
+    }
+
+    const scan = scanVisConfigSource(existing);
+
+    if (scan.kind === "no-anchor") {
+        return {
+            kind: "skip",
+            skipped: {
+                blocking: true,
+                path,
+                reason: "could not locate `defineConfig({` or `export default {` to inject into; merge the suggested block manually",
+            },
+        };
+    }
+
+    if (scan.kind === "unterminated") {
+        return {
+            kind: "skip",
+            skipped: {
+                blocking: true,
+                path,
+                reason: "its config object is never closed (unbalanced braces); fix the file, or merge the suggested block manually",
+            },
+        };
+    }
+
+    if (scan.hasReleaseKey) {
+        // Already tuned by the operator — leave it alone rather than clobber
+        // it. The suggested block is printed above for a manual merge.
+        return { kind: "skip", skipped: { blocking: false, path, reason: "already has a `release` key; merge the suggested block manually" } };
+    }
+
+    return {
+        kind: "write",
+        write: {
+            action: "update",
+            content: `${existing.slice(0, scan.bodyStart)}\n${releaseBlock}\n${existing.slice(scan.bodyStart)}`,
+            detail: "release block",
+            path,
+        },
+    };
+};
+
+/**
+ * Plan the `"vis-release": { "managed": true }` opt-in for every `package.json`
+ * with a sibling `.releaserc.*`. `selection` (from `--packages`) narrows that
+ * down by manifest name or workspace-relative directory; `undefined` means
+ * "every candidate" and is only ever passed for `--cutover`.
+ *
+ * Manifests are re-serialised in their own style, so a 2-space `package.json`
+ * comes back 2-space indented instead of reformatted wholesale.
+ */
+const planManagedManifests = async (
+    fs: CerebroFs,
+    cwd: string,
+    rcFiles: string[],
+    selection: string[] | undefined,
+): Promise<{ warnings: string[]; writes: PlannedWrite[] }> => {
+    const warnings: string[] = [];
+    const writes: PlannedWrite[] = [];
+    const matched = new Set<string>();
+
+    for (const rcPath of rcFiles) {
+        const pkgDir = dirname(rcPath);
+        const pkgJsonPath = join(pkgDir, "package.json");
+        const raw = await readTextFile(fs, pkgJsonPath);
+
+        if (raw === undefined) {
+            // A `.releaserc.*` with no sibling package.json is uncommon but
+            // possible — skip silently rather than fabricate one.
+            continue;
+        }
+
+        let parsed: Record<string, unknown>;
+
+        try {
+            parsed = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+            warnings.push(`  skipped ${relative(cwd, pkgJsonPath)} — invalid JSON.`);
+
+            continue;
+        }
+
+        // `relative()` yields backslashes on Windows; --packages is typed by
+        // hand with forward slashes, so normalise both sides before matching.
+        const dir = relative(cwd, pkgDir).replaceAll("\\", "/");
+        const name = typeof parsed["name"] === "string" ? parsed["name"] : dir;
+
+        if (selection !== undefined) {
+            const hit = selection.find((entry) => entry === name || entry.replaceAll("\\", "/").replace(/\/+$/, "") === dir);
+
+            if (hit === undefined) {
+                continue;
+            }
+
+            matched.add(hit);
+        }
+
+        if (parsed["private"] === true) {
+            // A private manifest is never published, so `vis-release.managed`
+            // on it means nothing — and a repo root that carries a
+            // `.releaserc.*` would otherwise be opted in as if it were a
+            // publishable package.
+            warnings.push(`  skipped ${relative(cwd, pkgJsonPath)} — \`private: true\` packages are not published, so they are not opted in.`);
+
+            continue;
+        }
+
+        const existing = parsed["vis-release"];
+
+        if (existing !== null && typeof existing === "object" && (existing as { managed?: unknown }).managed === true) {
+            // Already opted in — leave it alone.
+            continue;
+        }
+
+        const merged = existing !== null && typeof existing === "object" ? { ...(existing as Record<string, unknown>), managed: true } : { managed: true };
+
+        writes.push({
+            action: "update",
+            content: serialiseJsonLike({ ...parsed, "vis-release": merged }, raw),
+            detail: "add vis-release.managed = true",
+            path: pkgJsonPath,
+        });
+    }
+
+    if (selection !== undefined) {
+        for (const entry of selection) {
+            if (!matched.has(entry)) {
+                warnings.push(`--packages: no package with a sibling .releaserc.* matched "${entry}".`);
+            }
+        }
+    }
+
+    return { warnings, writes };
+};
+
+/**
+ * Resolve the flags into the single structure both `--dry-run` and `--apply`
+ * walk. Manifests are only ever in it when the operator asked for them —
+ * `--cutover` (all of them) or `--packages` (the listed ones).
+ */
+const buildMigrationPlan = async (
+    fs: CerebroFs,
+    cwd: string,
+    rcFiles: string[],
+    releaseBlock: string,
+    { cutover, selection }: { cutover: boolean; selection: string[] | undefined },
+): Promise<SemanticReleaseMigrationPlan> => {
+    const managed
+        = cutover || selection !== undefined
+            ? await planManagedManifests(fs, cwd, rcFiles, cutover ? undefined : selection)
+            : { warnings: [] as string[], writes: [] as PlannedWrite[] };
+
+    const visConfig = await planVisConfigWrite(fs, cwd, releaseBlock);
+
+    return {
+        deletions: cutover ? rcFiles : [],
+        manifests: managed.writes,
+        skipped: visConfig.kind === "skip" ? [visConfig.skipped] : [],
+        visConfig: visConfig.kind === "write" ? visConfig.write : undefined,
+        warnings: managed.warnings,
+    };
+};
+
+/** `--dry-run` preview of a {@link SemanticReleaseMigrationPlan}. */
+const printMigrationPlan = (cwd: string, plan: SemanticReleaseMigrationPlan, logger: InitLogger): void => {
+    for (const skipped of plan.skipped) {
+        logger.info(`[dry-run] would skip ${relative(cwd, skipped.path)} — ${skipped.reason}`);
+    }
+
+    for (const write of plannedWrites(plan)) {
+        logger.info(`[dry-run] would ${write.action} ${relative(cwd, write.path)} (${write.detail})`);
+    }
+
+    for (const rcPath of plan.deletions) {
+        logger.info(`[dry-run] would delete ${relative(cwd, rcPath)}`);
+    }
+
+    if (plan.manifests.length === 0 && plan.deletions.length === 0) {
+        logger.info("[dry-run] no package.json or .releaserc.* is touched — pass `--packages <a,b>` to opt packages in, or `--cutover` for all of them.");
+    }
+};
+
+/** One undo step of an in-flight apply: the bytes `path` held before we touched it. */
+interface JournalEntry {
+    path: string;
+    previous: string | undefined;
+}
+
+/**
+ * Restore every file the failed apply had already changed, newest first.
+ *
+ * `CerebroFs` exposes no `rename`, so a temp-file swap is not available
+ * through the injected adapter (and reaching past it for a real `rename`
+ * would break in-memory adapters). Rolling the journal back instead buys the
+ * guarantee that actually matters here: a run that fails part-way leaves the
+ * repo as it found it rather than half-migrated.
+ */
+const rollback = async (fs: CerebroFs, journal: JournalEntry[]): Promise<void> => {
+    for (const entry of journal.toReversed()) {
+        try {
+            await (entry.previous === undefined ? fs.rm(entry.path, { force: true }) : fs.writeFile(entry.path, entry.previous));
+        } catch {
+            // Best effort — the original failure is the one worth reporting.
+        }
+    }
+};
+
+/**
+ * Execute a {@link SemanticReleaseMigrationPlan}.
+ *
+ * Writes run before deletions and every step is journalled, so the
+ * irreversible half of a cutover only happens once everything it depends on
+ * has succeeded.
+ */
+const applyMigrationPlan = async (fs: CerebroFs, cwd: string, plan: SemanticReleaseMigrationPlan, logger: InitLogger): Promise<void> => {
+    for (const skipped of plan.skipped) {
+        logger.warn(`  skipped ${relative(cwd, skipped.path)} — ${skipped.reason}.`);
+    }
+
+    const journal: JournalEntry[] = [];
+
+    try {
+        for (const write of plannedWrites(plan)) {
+            journal.push({ path: write.path, previous: await readTextFile(fs, write.path) });
+
+            await writeFileNoFollow(fs, write.path, write.content);
+            logger.info(`  ${write.action === "create" ? "wrote" : "updated"} ${relative(cwd, write.path)} (${write.detail})`);
+        }
+
+        for (const rcPath of plan.deletions) {
+            journal.push({ path: rcPath, previous: await readTextFile(fs, rcPath) });
+
+            await fs.rm(rcPath, { force: true });
+            logger.info(`  deleted ${relative(cwd, rcPath)}`);
+        }
+    } catch (error) {
+        logger.error(`Migration write failed — rolling back ${journal.length} change(s).`);
+
+        await rollback(fs, journal);
+
+        throw error;
+    }
+};
+
+/**
+ * `CerebroProcess` carries no TTY flag, so interactivity is probed on the
+ * global `process` — the same test the husky / workflow prompts use.
+ */
+const isInteractive = (): boolean => process.stdout.isTTY && process.env["CI"] !== "true";
+
+type CutoverConsent = "confirmed" | "declined" | "refused";
+
+/**
+ * Consent gate for the destructive half of a cutover (issue #862).
+ *
+ * `--yes` is the CI bypass. An interactive shell gets a confirm prompt that
+ * defaults to no. A non-interactive shell without `--yes` is refused outright:
+ * deleting 50-odd release configs is not something to infer from a missing
+ * TTY.
+ */
+const confirmCutover = async (plan: SemanticReleaseMigrationPlan, autoYes: boolean, logger: InitLogger): Promise<CutoverConsent> => {
+    if (plan.deletions.length === 0 || autoYes) {
+        return "confirmed";
+    }
+
+    if (!isInteractive()) {
+        logger.error(`Refusing to delete ${plan.deletions.length} .releaserc.* file(s) without confirmation.`);
+        logger.error("Re-run with `--yes` to confirm in a non-interactive shell, or with `--dry-run` to preview the run first.");
+
+        return "refused";
+    }
+
+    const question = `Delete ${plan.deletions.length} .releaserc.* file(s) and mark ${plan.manifests.length} package.json file(s) managed?`;
+
+    try {
+        const { confirmPrompt } = await import("../../../release/core/prompts");
+
+        return (await confirmPrompt(question, false)) ? "confirmed" : "declined";
+    } catch {
+        return "declined";
+    }
+};
+
+/** The blocking skips that make a cutover unsafe, if any. */
+const cutoverBlockers = (plan: SemanticReleaseMigrationPlan): SkippedWrite[] =>
+    (plan.deletions.length === 0 ? [] : plan.skipped.filter((entry) => entry.blocking));
+
+/**
+ * Refuse a cutover whose release config could not be written.
+ *
+ * Without this the deletion loop still runs after a skipped config write and
+ * the repo ends up with neither a semantic-release config nor a vis one —
+ * exactly the destruction issue #862 was filed about.
+ */
+const reportCutoverBlockers = (cwd: string, blockers: SkippedWrite[], logger: InitLogger): void => {
+    logger.error("Refusing to run the cutover — the vis release config could not be written:");
+
+    for (const blocker of blockers) {
+        logger.error(`  ${relative(cwd, blocker.path)} — ${blocker.reason}`);
+    }
+
+    logger.error("Deleting every .releaserc.* now would leave this repo with no release configuration at all.");
+    logger.error("Paste the release block above into your config (or remove the file so init can create it), then re-run with `--apply --cutover`.");
+};
+
+/** The follow-up prose printed after the migration writes — or after the preview of them. */
+const printMigrationFollowUp = (applied: boolean, cutover: boolean, logger: InitLogger): void => {
+    logger.info("");
+
+    if (cutover) {
+        logger.info("Full cutover (--cutover): every detected package is marked `vis-release.managed` and its `.releaserc.*` removed.");
+        logger.info("Backfill any missing git tags so already-published detection works.");
+    } else {
+        logger.info("Migration is per-package opt-in (RFC §17.1). For each package you want to migrate:");
+        logger.info("  1. Add to its package.json:  \"vis-release\": { \"managed\": true }  (or re-run with `--packages <a,b>`)");
+        logger.info("  2. Backfill any missing git tags so already-published detection works.");
+        logger.info("  3. Add to multi-semantic-release's --ignore-packages list in your release workflow.");
+        logger.info("");
+        logger.info("Existing .releaserc.json files are kept in place during transition.");
+        logger.info("Once every package is migrated, re-run with `--apply --cutover` to delete them (Phase 6).");
+    }
+
+    if (!applied) {
+        logger.info(`Re-run with \`--apply${cutover ? " --cutover --yes" : ""}\` to perform the writes automatically.`);
+
+        return;
+    }
+
+    logger.info("");
+    logger.info("Migration writes complete. Follow-up steps you still need to do manually:");
+    logger.info(
+        "  - Update your CI workflow: remove `multi-semantic-release` step, add `vis release ci/release` step (see `.github/workflows/vis-release.yml` example in the vis package)",
+    );
+    logger.info("  - Run `pnpm install` to drop semantic-release deps once you remove them from root package.json");
+    logger.info("  - Run `vis release doctor` to verify the migration");
+};
+
+/**
+ * Fold every `.releaserc.*` into what vis needs from them: the channel map
+ * their merged `branches` translate to, and how many of them drive a NAPI
+ * native-addons plugin.
+ */
+const readSemanticReleaseSources = async (
+    fs: CerebroFs,
+    rcFiles: string[],
+): Promise<{ channels: Record<string, { mode?: string; prerelease?: string; tag: string }>; nativeAddonCount: number }> => {
+    let mergedBranches: BranchEntry[] = [];
+    let nativeAddonCount = 0;
+
+    for (const path of rcFiles) {
+        const rc = await readReleaseRc(fs, path);
+
+        if (!rc) {
+            continue;
+        }
+
+        if (rc.branches) {
+            mergedBranches = [...mergedBranches, ...normaliseBranches(rc.branches)];
+        }
+
+        if (rc.plugins?.some((p) => typeof p === "string" && p.includes("native-addons"))) {
+            nativeAddonCount += 1;
+        }
+
+        if (rc.plugins?.some((p) => Array.isArray(p) && typeof p[0] === "string" && p[0].includes("native-addons"))) {
+            nativeAddonCount += 1;
+        }
+    }
+
+    // Deduplicate branches by name (keep first-seen)
+    const seen = new Set<string>();
+    const dedupedBranches = mergedBranches.filter((b) => {
+        if (seen.has(b.name)) {
+            return false;
+        }
+
+        seen.add(b.name);
+
+        return true;
+    });
+
+    return {
+        channels:
+            dedupedBranches.length > 0
+                ? renderChannelsFromBranches(dedupedBranches)
+                : { alpha: { mode: "auto-publish", prerelease: "alpha", tag: "alpha" }, main: { mode: "version-pr", tag: "latest" } },
+        nativeAddonCount,
+    };
+};
+
+export interface SemanticReleaseMigrationFlags {
+    apply: boolean;
+    autoYes: boolean;
+    cutover: boolean;
+    dryRun: boolean;
+    selection: string[] | undefined;
+}
+
+/**
+ * Read every `.releaserc.*`, print the `vis.config.ts` block they translate
+ * to, then plan — and, with `--apply`, perform — the migration writes.
+ */
+export const migrateFromSemanticRelease = async (
+    fs: CerebroFs,
+    cwd: string,
+    { apply, autoYes, cutover, dryRun, selection }: SemanticReleaseMigrationFlags,
+    logger: InitLogger,
+): Promise<void> => {
+    const rcFiles = await findReleaseRcFiles(fs, cwd);
+
+    logger.info(`Found ${rcFiles.length} .releaserc file(s).`);
+
+    if (rcFiles.length === 0) {
+        return;
+    }
+
+    const { channels, nativeAddonCount } = await readSemanticReleaseSources(fs, rcFiles);
+    const block = renderReleaseBlock(channels, cutover);
+
+    logger.info("");
+    logger.info("Suggested vis.config.ts release block (paste into your existing config):");
+    logger.info("");
+    logger.info(block);
+    logger.info("");
+
+    if (nativeAddonCount > 0) {
+        logger.info(`Found ${nativeAddonCount} package(s) using a NAPI native-addons plugin.`);
+        logger.info("These will auto-detect via the `napi` field in package.json — no config needed.");
+        logger.info("");
+    }
+
+    // Nothing past this point re-derives a write: both branches walk the plan,
+    // so the preview and the run always describe the same thing.
+    const plan = await buildMigrationPlan(fs, cwd, rcFiles, block, { cutover, selection });
+
+    for (const warning of plan.warnings) {
+        logger.warn(warning);
+    }
+
+    const blockers = cutoverBlockers(plan);
+
+    if (dryRun || !apply) {
+        if (dryRun) {
+            logger.info("Planned writes:");
+            printMigrationPlan(cwd, plan, logger);
+        }
+
+        if (blockers.length > 0) {
+            logger.warn("This cutover would be refused: the vis release config cannot be written, so the .releaserc.* deletions would strip the repo bare.");
+
+            for (const blocker of blockers) {
+                logger.warn(`  ${relative(cwd, blocker.path)} — ${blocker.reason}`);
+            }
+        }
+
+        printMigrationFollowUp(false, cutover, logger);
+
+        return;
+    }
+
+    if (blockers.length > 0) {
+        reportCutoverBlockers(cwd, blockers, logger);
+        process.exitCode = 1;
+
+        return;
+    }
+
+    const consent = await confirmCutover(plan, autoYes, logger);
+
+    if (consent !== "confirmed") {
+        logger.info("");
+        logger.info("Cutover cancelled — no migration writes were made.");
+
+        if (consent === "refused") {
+            process.exitCode = 1;
+        }
+
+        return;
+    }
+
+    logger.info("Applying migration writes (--apply set)…");
+    await applyMigrationPlan(fs, cwd, plan, logger);
+    printMigrationFollowUp(true, cutover, logger);
+};

--- a/packages/tooling/vis/src/commands/release/init/vis-config-source.ts
+++ b/packages/tooling/vis/src/commands/release/init/vis-config-source.ts
@@ -1,0 +1,370 @@
+/**
+ * Structural reader for the root `vis.config.ts` object literal.
+ *
+ * `vis release init` needs two facts about an existing config: where the
+ * config object's body starts — so the generated `release` block can be
+ * injected as its first property — and whether that object *already* declares
+ * a root-level `release` property, which the run must then leave alone.
+ *
+ * A textual `/\brelease\s*:/` answers neither question. It fires on a comment
+ * (`// release: TODO`), on a string (`"release: prod"`), and on a `release:`
+ * nested inside some other object — and a false hit there is not cosmetic.
+ * It makes the migration record a *non-blocking* skip, which tells `--cutover`
+ * the repo already has a usable release config, and every `.releaserc.*` is
+ * deleted on that basis. That is the destruction issue #862 was filed about,
+ * one level down.
+ *
+ * So the source is tokenised instead: comments and literal bodies are blanked
+ * out (offsets preserved, so every index maps straight back onto the original
+ * text), brace depth is tracked from the config object's opening `{`, and only
+ * a `release` key sitting directly in that body counts.
+ *
+ * This is a lexer, not a parser — enough to tell code from not-code, which is
+ * all the two questions need. Anything it cannot make sense of (an
+ * unterminated object) is reported rather than guessed at, and the caller
+ * treats that as blocking.
+ */
+
+/** The anchors `vis release init` knows how to inject into. Matched against masked source. */
+const CONFIG_ANCHORS: ReadonlyArray<RegExp> = [/defineConfig\s*\(\s*\{/, /export\s+default\s+\{/];
+
+/**
+ * Characters after which a `/` opens a regular expression rather than a
+ * division. Anything else (an identifier, a digit, a closing paren/bracket)
+ * means the `/` divides, so the rest of the line is ordinary code.
+ */
+const REGEX_ALLOWED_AFTER: ReadonlySet<string> = new Set([
+    "",
+    "!",
+    "%",
+    "&",
+    "(",
+    "*",
+    "+",
+    ",",
+    "-",
+    ":",
+    ";",
+    "<",
+    "=",
+    ">",
+    "?",
+    "[",
+    "^",
+    "{",
+    "|",
+    "}",
+    "~",
+]);
+
+type ScanMode = "block-comment" | "code" | "line-comment" | "regex-class" | "regex" | "string" | "template";
+
+/**
+ * Blank out every comment body and literal body in `source`, one character in
+ * for one character out so offsets keep pointing at the original text.
+ *
+ * String delimiters are *kept* — a quoted key (`"release":`) has to stay
+ * recognisable as a key, and its name is read back out of the original source
+ * at the recorded offsets. Everything between them goes, so a value like
+ * `"release: prod"` cannot be mistaken for one.
+ *
+ * Newlines survive masking so a masked offset still lands on the same line as
+ * the original, which keeps any future line-based reporting honest.
+ */
+const maskLiteralsAndComments = (source: string): string => {
+    const out: string[] = Array.from<string>({ length: source.length });
+    /** Brace depth inside each `${ … }` currently open, innermost last. */
+    const interpolations: number[] = [];
+    let mode: ScanMode = "code";
+    let quote = "";
+    /** Last significant *code* character emitted — decides `/` regex vs division. */
+    let previous = "";
+    let index = 0;
+
+    const emit = (at: number, keep: boolean): void => {
+        const char = source[at] as string;
+
+        out[at] = keep || char === "\n" ? char : " ";
+
+        if (keep && char.trim() !== "") {
+            previous = char;
+        }
+    };
+
+    /** Blank an escape pair (`\x`) in one step so the escaped char cannot close the literal. */
+    const emitEscape = (): void => {
+        emit(index, false);
+
+        if (index + 1 < source.length) {
+            emit(index + 1, false);
+        }
+
+        index += 2;
+    };
+
+    while (index < source.length) {
+        const char = source[index] as string;
+        const next = source[index + 1];
+
+        if (mode === "code") {
+            if (char === "/" && next === "/") {
+                emit(index, false);
+                emit(index + 1, false);
+                index += 2;
+                mode = "line-comment";
+            } else if (char === "/" && next === "*") {
+                emit(index, false);
+                emit(index + 1, false);
+                index += 2;
+                mode = "block-comment";
+            } else if (char === "\"" || char === "'") {
+                quote = char;
+                // The delimiter stays visible so a quoted key is still a key.
+                emit(index, true);
+                index += 1;
+                mode = "string";
+            } else if (char === "`") {
+                emit(index, false);
+                index += 1;
+                mode = "template";
+            } else if (char === "/" && REGEX_ALLOWED_AFTER.has(previous)) {
+                emit(index, false);
+                index += 1;
+                mode = "regex";
+            } else if (interpolations.length > 0 && char === "}" && (interpolations.at(-1) as number) === 0) {
+                // Closes the `${` this frame opened. Both braces are blanked,
+                // so the interpolation contributes nothing to brace depth.
+                interpolations.pop();
+                emit(index, false);
+                index += 1;
+                mode = "template";
+            } else {
+                if (interpolations.length > 0 && (char === "{" || char === "}")) {
+                    interpolations[interpolations.length - 1] = (interpolations.at(-1) as number) + (char === "{" ? 1 : -1);
+                }
+
+                emit(index, true);
+                index += 1;
+            }
+
+            continue;
+        }
+
+        if (mode === "line-comment") {
+            emit(index, false);
+            index += 1;
+
+            if (char === "\n") {
+                mode = "code";
+            }
+
+            continue;
+        }
+
+        if (mode === "block-comment") {
+            emit(index, false);
+
+            if (char === "*" && next === "/") {
+                emit(index + 1, false);
+                index += 2;
+                mode = "code";
+            } else {
+                index += 1;
+            }
+
+            continue;
+        }
+
+        if (mode === "string") {
+            if (char === "\\") {
+                emitEscape();
+
+                continue;
+            }
+
+            // An unterminated string ends at the newline, the way a JS lexer
+            // would stop rather than swallowing the rest of the file.
+            if (char === quote || char === "\n") {
+                emit(index, char === quote);
+                index += 1;
+                mode = "code";
+
+                continue;
+            }
+
+            emit(index, false);
+            index += 1;
+
+            continue;
+        }
+
+        if (mode === "template") {
+            if (char === "\\") {
+                emitEscape();
+
+                continue;
+            }
+
+            emit(index, false);
+
+            if (char === "`") {
+                index += 1;
+                mode = "code";
+            } else if (char === "$" && next === "{") {
+                // `${` opens real code again; blank both braces so the frame
+                // is depth-neutral, then scan its body as code.
+                emit(index + 1, false);
+                interpolations.push(0);
+                index += 2;
+                mode = "code";
+            } else {
+                index += 1;
+            }
+
+            continue;
+        }
+
+        if (char === "\\") {
+            emitEscape();
+
+            continue;
+        }
+
+        emit(index, false);
+        index += 1;
+
+        if (char === "\n") {
+            // An unterminated regex literal: bail rather than mask the rest of the file.
+            mode = "code";
+        } else if (mode === "regex" && char === "[") {
+            mode = "regex-class";
+        } else if (mode === "regex" && char === "/") {
+            mode = "code";
+        } else if (mode === "regex-class" && char === "]") {
+            mode = "regex";
+        }
+    }
+
+    return out.join("");
+};
+
+/** Sticky matchers for the depth-1 key scan. */
+const IDENTIFIER = /[A-Z_$][\w$]*/iy;
+const KEY_TERMINATOR = /\s*[:(,}]/y;
+
+/**
+ * `true` when the token that starts at `at` is followed by something that
+ * makes it a property key: `:` (a normal property), `(` (a method), or `,`/`}`
+ * (an ES2015 shorthand property).
+ */
+const isKeyPosition = (masked: string, at: number): boolean => {
+    KEY_TERMINATOR.lastIndex = at;
+
+    return KEY_TERMINATOR.test(masked);
+};
+
+export type VisConfigScan
+    /** The config object was located. */
+    = | { bodyStart: number; hasReleaseKey: boolean; kind: "found" }
+    /** No `defineConfig({` / `export default {` to inject into. */
+        | { kind: "no-anchor" }
+    /** An anchor was found but its object literal never closes. */
+        | { kind: "unterminated" };
+
+/**
+ * Locate the config object in a `vis.config.ts` source and report whether it
+ * already declares a root-level `release` property.
+ *
+ * `bodyStart` is the offset immediately after the object's opening `{`, in the
+ * original* source — masking preserves offsets — so injecting the generated
+ * block is a plain slice-and-splice at that index.
+ */
+export const scanVisConfigSource = (source: string): VisConfigScan => {
+    const masked = maskLiteralsAndComments(source);
+
+    let bodyStart: number | undefined;
+
+    // First anchor wins, in declaration order: a `defineConfig({` is the
+    // canonical form, and `export default {` is the fallback the generated
+    // configs never use but hand-written ones sometimes do.
+    for (const anchor of CONFIG_ANCHORS) {
+        const match = anchor.exec(masked);
+
+        if (match !== null) {
+            bodyStart = match.index + match[0].length;
+
+            break;
+        }
+    }
+
+    if (bodyStart === undefined) {
+        return { kind: "no-anchor" };
+    }
+
+    let depth = 1;
+    let hasReleaseKey = false;
+    let index = bodyStart;
+
+    while (index < masked.length) {
+        const char = masked[index] as string;
+
+        if (char === "{") {
+            depth += 1;
+            index += 1;
+
+            continue;
+        }
+
+        if (char === "}") {
+            depth -= 1;
+
+            if (depth === 0) {
+                return { bodyStart, hasReleaseKey, kind: "found" };
+            }
+
+            index += 1;
+
+            continue;
+        }
+
+        if (char === "\"" || char === "'") {
+            // Literal bodies are blanked, so the matching delimiter is the
+            // next one of the same kind. Read the key name back out of the
+            // original source, where it survived intact.
+            const close = masked.indexOf(char, index + 1);
+
+            if (close === -1) {
+                return { kind: "unterminated" };
+            }
+
+            if (depth === 1 && source.slice(index + 1, close) === "release" && isKeyPosition(masked, close + 1)) {
+                hasReleaseKey = true;
+            }
+
+            index = close + 1;
+
+            continue;
+        }
+
+        IDENTIFIER.lastIndex = index;
+
+        const identifier = IDENTIFIER.exec(masked);
+
+        if (identifier !== null) {
+            const end = index + identifier[0].length;
+
+            // `...release` is a spread of a variable, not a property named `release`.
+            if (depth === 1 && identifier[0] === "release" && masked[index - 1] !== "." && isKeyPosition(masked, end)) {
+                hasReleaseKey = true;
+            }
+
+            index = end;
+
+            continue;
+        }
+
+        index += 1;
+    }
+
+    return { kind: "unterminated" };
+};


### PR DESCRIPTION
Fixes #862.

`vis release init --from-semantic-release --apply` performed a full cutover — deleting every `.releaserc.json` and marking every manifest managed — while its own dry-run text promised an incremental, per-package migration. On a 52-package monorepo still releasing through multi-semantic-release, one `--apply` removed every package's semantic-release config before the vis side was wired up.

## What changed

- **`--apply` alone is now non-destructive** and does exactly what the dry-run describes: scaffold `.vis/release`, write the ignore-file entries, and create/inject the `vis.config.ts` release block. No `.releaserc.*` is deleted, no manifest is touched.
- **`--packages <a,b>`** (new) opts specific packages in, matching on manifest name or workspace-relative dir.
- **`--cutover`** (new) is the explicit Phase-6 path and the only thing that deletes `.releaserc.*`. It emits `defaultManaged: true` rather than the old contradictory `false // flip to true after Phase 6`.
- **Dry-run and apply now share one plan object**, so the preview and the run cannot describe different things. The "per-package opt-in / re-run with `--apply`" tail no longer prints after a cutover.

## Hardening from review

The first cut of `--cutover` reintroduced the original bug through the new flag: it deleted every `.releaserc.*` even when the `vis.config.ts` write was **skipped** (no `defineConfig({` anchor), leaving a repo with neither a semantic-release config nor a vis one. Now:

- Skips are typed. `SkippedWrite.blocking` distinguishes *"config already has a `release` key"* (non-blocking — the documented Phase-6 re-run depends on it) from *"no anchor to inject into"* (blocking). Blocking skips abort the whole apply **before any write**, with exit 1.
- `--cutover` requires confirmation: `--yes` in CI, otherwise an interactive prompt defaulting to **no**. Non-TTY without `--yes` is refused with no writes at all.
- `private: true` manifests are skipped (a private root package is not publishable).
- Manifest writes preserve the file's own indentation, CRLF and trailing-newline style instead of reformatting 2-space `package.json` files wholesale.
- Writes precede deletions and the apply is journalled, so a mid-run failure rolls back.

The ~450-line semantic-release lane moved out of `init/handler.ts` into `init/semantic-release.ts`, leaving the handler smaller than it started.

## Known limitation

Per-file crash safety against SIGINT mid-`writeFile` is **not** achieved — a temp-file swap needs `rename` on cerebro's `Fs` interface, a breaking change to a published API. Mitigated by plan-time byte computation, writes-before-deletions and journalled rollback.

## Testing

1299 passing / 0 failing across `__tests__/release` + `__tests__/commands/init`. Regression tests cover: `--apply` leaving `.releaserc.json` and manifests byte-identical; the blocked cutover; the confirmation gate; and the private/indentation handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AykNAXvDtCJyX6aymEBWQw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `vis release init` now supports incremental semantic-release migration.
  - Use `--packages` to migrate selected packages or `--cutover` to migrate all packages.
  - Cutover requires confirmation unless `--yes` is provided and removes migrated `.releaserc.*` files.
  - Dry-run previews, validation safeguards, and rollback protection help prevent partial migrations.
  - Existing formatting and manifest styles are preserved during updates.

- **Documentation**
  - Added comprehensive guidance, examples, option details, migration phases, and safety conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->