### PR TITLE
fix(vis): surface release in help and fix doctor cause

### DIFF
--- a/packages/terminal/cerebro/__tests__/unit/commands/help.test.ts
+++ b/packages/terminal/cerebro/__tests__/unit/commands/help.test.ts
@@ -366,6 +366,37 @@ describe("command/help", () => {
             expect(content.some((row) => row[0].includes("ai test") && row[1] === "Test the selected provider")).toBe(true);
         });
 
+        it("should list grandchildren, not only direct children, under a parent", () => {
+            expect.assertions(3);
+
+            commandsMap.set("release status", {
+                commandPath: ["release"],
+                description: "Show pending releases",
+                execute: () => {},
+                name: "status",
+            });
+
+            commandsMap.set("release ci plan", {
+                commandPath: ["release", "ci"],
+                description: "Plan a CI release",
+                execute: () => {},
+                name: "plan",
+            });
+
+            const helpCommand = new HelpCommand(commandsMap);
+
+            helpCommand.execute({ commandName: "release", logger: loggerMock, runtime: runtimeMock } as unknown as IToolbox);
+
+            const usageCalls = vi.mocked(commandLineUsage).mock.calls[0][0];
+            const subcommandsSection = usageCalls.find((section) => section.header?.includes("Subcommands"));
+            const content = subcommandsSection?.content as [string, string][];
+
+            expect(content).toHaveLength(2);
+            expect(content.some((row) => row[0].includes("release status"))).toBe(true);
+            // Equal-depth matching used to drop the whole `ci` group here.
+            expect(content.some((row) => row[0].includes("release ci plan"))).toBe(true);
+        });
+
         it("should support multi-segment parent paths", () => {
             expect.assertions(2);
 

--- a/packages/terminal/cerebro/src/commands/help-command.ts
+++ b/packages/terminal/cerebro/src/commands/help-command.ts
@@ -107,7 +107,14 @@ const findChildren = <OD extends OptionDefinition<any>>(commands: Map<string, IC
 
         const commandPath = cmd.commandPath ?? [];
 
-        if (commandPath.length !== parentPath.length) {
+        // Prefix match, not equal depth. Requiring equality hid every
+        // grandchild from a parent listing: `help release` skipped all six
+        // `release ci *` commands (commandPath `["release", "ci"]`) because
+        // their path is one segment longer than `["release"]`, so the whole
+        // `ci` group was undiscoverable from the only place a user would look
+        // (visulima/visulima#863). A listing for `X` should show everything
+        // under `X`.
+        if (commandPath.length < parentPath.length) {
             continue;
         }
 

--- a/packages/tooling/vis/__tests__/commands/release-discoverability.test.ts
+++ b/packages/tooling/vis/__tests__/commands/release-discoverability.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `vis release` discoverability + dispatch (visulima/visulima#863).
+ *
+ * Every release subcommand is registered as a nested `commandPath: ["release"]`
+ * command. Two things fell out of that before the flat `release` umbrella
+ * command existed:
+ *
+ *  1. `vis --help` never carried a `release` entry — only ~23 `release &lt;sub>`
+ *     rows, in the last group of a long listing.
+ *  2. `release ci release` has the leaf name `release`, so cerebro's
+ *     name-keyed lookup resolved a bare `vis release` (and `vis release
+ *     --help` / `vis help release`) onto the CI version-PR / publish flow.
+ *
+ * These tests pin both: the top-level listing names `release`, and the three
+ * bare-path spellings render the subcommand tree instead of running CI.
+ */
+
+import { createCerebro } from "@visulima/cerebro";
+import { describe, expect, it, vi } from "vitest";
+
+import registerCommands from "../../src/register-commands";
+
+const createLoggerMock = () => {
+    return {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        log: vi.fn(),
+        raw: vi.fn(),
+        warn: vi.fn(),
+    };
+};
+
+const runCli = async (argv: string[]): Promise<{ logger: ReturnType<typeof createLoggerMock>; output: string }> => {
+    const logger = createLoggerMock();
+    const cli = createCerebro("vis", { argv, logger: logger as unknown as Console, packageName: "vis", packageVersion: "0.0.0-test" });
+
+    registerCommands(cli);
+
+    await cli.run({ shouldExitProcess: false });
+
+    const output = [...logger.raw.mock.calls, ...logger.log.mock.calls].flat().join("\n");
+
+    return { logger, output };
+};
+
+// Strip ANSI so assertions match regardless of the ambient color support.
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\u001B\[[\d;]*m/g;
+
+const decolor = (value: string): string => value.replaceAll(ANSI_PATTERN, "");
+
+describe("vis release discoverability", () => {
+    it("lists `release` as its own entry in the top-level help", async () => {
+        expect.assertions(3);
+
+        const { logger, output } = await runCli(["--help"]);
+        const plain = decolor(output);
+
+        expect(logger.error).not.toHaveBeenCalled();
+        // A dedicated group header, not just the nested `release <sub>` rows.
+        expect(plain).toMatch(/\bRelease\b/);
+        // The one-line umbrella entry: `release` followed by its description,
+        // with no subcommand segment in between.
+        expect(plain).toMatch(/^\s*release\s{2,}Version, changelog and publish workspace packages/m);
+    });
+
+    it.each([["release"], ["release", "--help"], ["help", "release"]])("renders the subcommand tree for `vis %s`", async (...argv: string[]) => {
+        expect.assertions(4);
+
+        const { logger, output } = await runCli(argv);
+        const plain = decolor(output);
+
+        expect(logger.error).not.toHaveBeenCalled();
+        expect(plain).toContain("Subcommands");
+        expect(plain).toContain("release doctor");
+        // Regression guard: this used to render `vis release ci release`'s own
+        // help (and, for the bare form, *run* it).
+        expect(plain).not.toMatch(/Usage[\s\S]*vis release ci release/);
+    });
+
+    it("still resolves the nested `release ci release` by its full path", async () => {
+        expect.assertions(2);
+
+        const { logger, output } = await runCli(["release", "ci", "release", "--help"]);
+        const plain = decolor(output);
+
+        expect(logger.error).not.toHaveBeenCalled();
+        expect(plain).toContain("vis release ci release");
+    });
+});

--- a/packages/tooling/vis/__tests__/release/commands/release-doctor-managed-packages.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-doctor-managed-packages.test.ts
@@ -1,0 +1,284 @@
+/**
+ * `vis release doctor` — workspace-discovered vs. release-managed
+ * (visulima/visulima#863).
+ *
+ * `ctx.packages` is the *release-managed* set, so an empty list used to be
+ * reported as `workspace-discovered: No packages discovered. Ensure your
+ * package manager's workspace block resolves.` — an error pointing at
+ * `pnpm-workspace.yaml` even when the workspace resolved perfectly and the
+ * only thing missing was `defaultManaged` / a per-package `"vis-release":
+ * { "managed": true }`.
+ *
+ * The two states are now separate checks:
+ *   - `workspace-discovered`      — does the package manager see any project?
+ *   - `release-managed-packages`  — has any of them opted in?
+ *
+ * Only the first can be an error; "workspace resolves, nothing opted in yet"
+ * is a legitimate mid-migration state, so it warns and the doctor exits 0.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import doctorHandler from "../../../src/commands/release/doctor/handler";
+import { buildContext } from "../../../src/release/core/orchestrator";
+import { fixturePackageManager, RELEASE_SUITE_TIMEOUT, removeTemporaryDirectoryWithRetry, restorePristineStdout } from "../../test-helpers";
+
+// These tests shell out to real git/pnpm and transpile the release/core graph;
+// the 30s global default is too tight on Windows CI. See RELEASE_SUITE_TIMEOUT.
+vi.setConfig({ hookTimeout: RELEASE_SUITE_TIMEOUT, testTimeout: RELEASE_SUITE_TIMEOUT });
+
+interface DoctorCheck {
+    message: string;
+    name: string;
+    severity: string;
+    status: string;
+}
+
+const writeJson = (path: string, value: unknown): void => {
+    writeFileSync(path, `${JSON.stringify(value, null, 4)}\n`);
+};
+
+/**
+ * Create a throwaway pnpm workspace + git repo for one doctor run.
+ * @param options Fixture knobs.
+ * @param options.defaultManaged Value for `release.defaultManaged`; the key is omitted entirely when undefined.
+ * @param options.extraPackages How many additional, deliberately unmanaged `packages/extra-N` members to
+ * create — used to prove the workspace count and the release-managed count are reported separately.
+ * @param options.namedRoot Whether the root manifest carries a `name` — `pnpm -r ls` only reports
+ * manifests that have one, so an unnamed root plus no members is how a workspace that genuinely
+ * resolves to zero projects is simulated.
+ * @param options.privatePackage Whether `packages/a` is `private: true` — `isPackageManaged` drops
+ * private packages unless `release.privatePackages.version` is set, independently of `defaultManaged`.
+ * @param options.withPackage Whether to create `packages/a` (a nameable workspace member).
+ */
+const setupRepo = (
+    options: { defaultManaged?: boolean; extraPackages?: number; namedRoot?: boolean; privatePackage?: boolean; withPackage?: boolean } = {},
+): string => {
+    const { defaultManaged, extraPackages = 0, namedRoot = true, privatePackage = false, withPackage = true } = options;
+    const cwd = mkdtempSync(join(tmpdir(), "vis-doctor-managed-"));
+
+    writeJson(join(cwd, "package.json"), {
+        ...(namedRoot ? { name: "fixture-root" } : {}),
+        packageManager: fixturePackageManager(),
+        private: true,
+        version: "0.0.0",
+        workspaces: ["packages/*"],
+    });
+
+    writeFileSync(join(cwd, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+
+    if (withPackage) {
+        mkdirSync(join(cwd, "packages", "a"), { recursive: true });
+        writeJson(join(cwd, "packages", "a", "package.json"), { name: "@scope/a", private: privatePackage, version: "0.0.1" });
+    }
+
+    for (let index = 0; index < extraPackages; index += 1) {
+        const dir = join(cwd, "packages", `extra-${index}`);
+
+        mkdirSync(dir, { recursive: true });
+        writeJson(join(dir, "package.json"), { name: `@scope/extra-${index}`, private: false, version: "0.0.1" });
+    }
+
+    mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
+
+    const block = { release: { acknowledgeUnstable: true, ...(defaultManaged === undefined ? {} : { defaultManaged }) } };
+
+    writeFileSync(join(cwd, "vis.config.cjs"), `module.exports = ${JSON.stringify(block, null, 4)};\n`);
+
+    execFileSync("git", ["init", "-q", "--initial-branch", "main"], { cwd });
+    execFileSync("git", ["config", "user.email", "test@test"], { cwd });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd });
+    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+    execFileSync("git", ["config", "tag.gpgSign", "false"], { cwd });
+    execFileSync("git", ["add", "."], { cwd });
+    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd });
+
+    return cwd;
+};
+
+const makeToolbox = (cwd: string) =>
+    ({
+        argument: {},
+        logger: {
+            error: () => undefined,
+            info: () => undefined,
+            warn: () => undefined,
+        } as never,
+        options: { json: true } as never,
+        workspaceRoot: cwd,
+    }) as never;
+
+const runDoctor = async (cwd: string): Promise<DoctorCheck[]> => {
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+
+    (process.stdout as { write: unknown }).write = (chunk: string | Uint8Array): boolean => {
+        chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+
+        return true;
+    };
+
+    try {
+        await doctorHandler(makeToolbox(cwd));
+    } finally {
+        (process.stdout as { write: typeof originalWrite }).write = originalWrite;
+    }
+
+    return (JSON.parse(chunks.join("")) as { checks: DoctorCheck[] }).checks;
+};
+
+const find = (checks: DoctorCheck[], name: string): DoctorCheck | undefined => checks.find((check) => check.name === name);
+
+describe("vis release doctor — workspace-discovered vs release-managed (#863)", () => {
+    let cwd: string;
+    const originalExitCode = process.exitCode;
+    const originalEnvironment = { ...process.env };
+
+    // Warm the `release/core` lazy-`import()` graph once so the first real test
+    // isn't charged the cold transpile cost on top of its own subprocess spawns.
+    beforeAll(async () => {
+        const scratch = setupRepo({ defaultManaged: true });
+
+        try {
+            await buildContext({ cwd: scratch });
+        } catch {
+            // Warm-up only — failures here are not test failures.
+        } finally {
+            await removeTemporaryDirectoryWithRetry(scratch);
+        }
+    });
+
+    beforeEach(() => {
+        process.exitCode = 0;
+        // The doctor's `oidc-available` check fires error-severity when CI=true
+        // and no NPM_TOKEN; unrelated noise for these tests.
+        delete process.env.CI;
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.NPM_TOKEN;
+        delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+    });
+
+    afterEach(async () => {
+        restorePristineStdout();
+        process.exitCode = originalExitCode;
+        process.env = originalEnvironment;
+
+        if (cwd) {
+            await removeTemporaryDirectoryWithRetry(cwd);
+        }
+    });
+
+    it("passes both checks when packages are release-managed", async () => {
+        expect.assertions(5);
+
+        cwd = setupRepo({ defaultManaged: true });
+
+        const checks = await runDoctor(cwd);
+        const discovered = find(checks, "workspace-discovered");
+        const managed = find(checks, "release-managed-packages");
+
+        expect(discovered).toMatchObject({ severity: "info", status: "pass" });
+        expect(discovered?.message).toMatch(/^Discovered \d+ workspace package\(s\)\.$/);
+        expect(managed).toMatchObject({ severity: "info", status: "pass" });
+        expect(managed?.message).toMatch(/^\d+ of \d+ package\(s\) are release-managed\.$/);
+        expect(process.exitCode).toBe(0);
+    });
+
+    it("blames opt-in, not the workspace block, when packages exist but none is managed", async () => {
+        expect.assertions(6);
+
+        // No `defaultManaged`, no per-package `vis-release.managed` — the exact
+        // shape reported in #863.
+        cwd = setupRepo();
+
+        const checks = await runDoctor(cwd);
+        const discovered = find(checks, "workspace-discovered");
+        const managed = find(checks, "release-managed-packages");
+
+        // The workspace itself resolved — that check must NOT be the error.
+        expect(discovered).toMatchObject({ severity: "info", status: "pass" });
+        expect(discovered?.message).not.toContain("workspace block");
+
+        expect(managed).toMatchObject({ severity: "warn", status: "fail" });
+        expect(managed?.message).toContain("No release-managed packages");
+        expect(managed?.message).toContain("Set release.defaultManaged: true in vis.config.ts, or add \"vis-release\": { \"managed\": true } to a package.json.");
+
+        // A warn, not an error: mid-migration is a legitimate state.
+        expect(process.exitCode).toBe(0);
+    });
+
+    it("keeps the workspace-block error when discovery genuinely finds nothing", async () => {
+        expect.assertions(4);
+
+        cwd = setupRepo({ namedRoot: false, withPackage: false });
+
+        const checks = await runDoctor(cwd);
+        const discovered = find(checks, "workspace-discovered");
+        const managed = find(checks, "release-managed-packages");
+
+        expect(discovered).toMatchObject({ severity: "error", status: "fail" });
+        expect(discovered?.message).toBe("No packages discovered. Ensure your package manager's workspace block resolves.");
+        expect(managed).toMatchObject({ status: "skip" });
+        expect(process.exitCode).toBe(1);
+    });
+
+    it("reports the workspace count, not the managed count, when only some packages are managed", async () => {
+        expect.hasAssertions();
+
+        // 4 workspace packages, exactly 1 opted in. `ctx.packages` is the
+        // managed subset, so reporting its length here would print
+        // "Discovered 1 workspace package(s)." — re-conflating the two numbers
+        // this check exists to separate (visulima/visulima#863).
+        // `listWorkspacePackages` counts the workspace root as a project, so
+        // this fixture is: root + packages/a + 3 extras == 5 discovered, 1 managed.
+        cwd = setupRepo({ extraPackages: 3 });
+        writeJson(join(cwd, "packages", "a", "package.json"), {
+            name: "@scope/a",
+            private: false,
+            version: "0.0.1",
+            "vis-release": { managed: true },
+        });
+
+        const checks = await runDoctor(cwd);
+        const discovered = checks.find((check) => check.name === "workspace-discovered");
+        const managed = checks.find((check) => check.name === "release-managed-packages");
+
+        expect(discovered?.status).toBe("pass");
+        expect(discovered?.message).toBe("Discovered 5 workspace package(s).");
+        expect(managed?.status).toBe("pass");
+        expect(managed?.message).toBe("1 of 5 package(s) are release-managed.");
+    });
+
+    it("names the private-package rule when defaultManaged is on but every package is private", async () => {
+        expect.assertions(3);
+
+        // `isPackageManaged` drops private packages regardless of
+        // `defaultManaged`, so pointing only at the two opt-in knobs would be
+        // its own dead end.
+        cwd = setupRepo({ defaultManaged: true, privatePackage: true });
+
+        const checks = await runDoctor(cwd);
+        const managed = find(checks, "release-managed-packages");
+
+        expect(managed).toMatchObject({ severity: "warn", status: "fail" });
+        expect(managed?.message).toContain("Every discovered package is private");
+        expect(managed?.message).toContain("release.privatePackages.version");
+    });
+
+    it("says why the plan is empty instead of reporting a clean 'No pending releases.'", async () => {
+        expect.assertions(2);
+
+        cwd = setupRepo();
+
+        const checks = await runDoctor(cwd);
+        const plan = find(checks, "plan-readable");
+
+        expect(plan?.status).toBe("pass");
+        expect(plan?.message).toBe("No pending releases — no package is release-managed, so the plan is always empty.");
+    });
+});

--- a/packages/tooling/vis/docs/commands/release.mdx
+++ b/packages/tooling/vis/docs/commands/release.mdx
@@ -21,6 +21,7 @@ The release subsystem ships package versions, changelogs, git tags, and registry
 | Override individual bumps before shipping              | [`vis release plan -i`](#vis-release-plan)                |
 | Preview changelog entries without writing              | [`vis release changelog`](#vis-release-changelog)         |
 | Gate that every changed package has a change file      | [`vis release check`](#vis-release-check)                 |
+| See the whole subcommand tree                          | `vis release`                                             |
 | Diagnose a broken setup                                | [`vis release doctor`](#vis-release-doctor)               |
 | Apply pending bumps to disk (run locally — rare)       | [`vis release version`](#vis-release-version)             |
 | Publish to npm (run locally — rare)                    | [`vis release publish`](#vis-release-publish)             |
@@ -287,7 +288,16 @@ vis release check --no-fail            # Warnings only, exit 0
 vis release doctor [flags]
 ```
 
-Run read-only preflight diagnostics: `config-loads`, `workspace-discovered`, `pm-version`, `branch-channel`, `gh-cli-available`, `oidc-available`, and per-package `napi-*` checks (sidecar platforms + version alignment + optionalDependencies wiring).
+Run read-only preflight diagnostics: `config-loads`, `workspace-discovered`, `release-managed-packages`, `pm-version`, `branch-channel`, `gh-cli-available`, `oidc-available`, and per-package `napi-*` checks (sidecar platforms + version alignment + optionalDependencies wiring).
+
+`workspace-discovered` and `release-managed-packages` answer two different questions, and the fix differs:
+
+| Finding                                                       | Severity | What it means                                                                                                                                                                                                              |
+| ------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workspace-discovered: No packages discovered.`               | error    | The package manager's workspace block resolves to nothing — check `pnpm-workspace.yaml` / `package.json#workspaces`.                                                                                                       |
+| `release-managed-packages: No release-managed packages (N …)` | warn     | The workspace resolves fine, but nothing has opted in. Set `release.defaultManaged: true`, or add `"vis-release": { "managed": true }` to a package. Private packages additionally need `release.privatePackages.version`. |
+
+The second is a warning, not an error: adopting `vis release` one package at a time is a supported path, so `doctor` still exits 0 while the workspace is mid-migration.
 
 **When to use.** First port of call when something looks broken. Each check is tagged `error` / `warn` / `info`; exits non-zero on any error.
 

--- a/packages/tooling/vis/src/commands/release/doctor/handler.ts
+++ b/packages/tooling/vis/src/commands/release/doctor/handler.ts
@@ -53,20 +53,86 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
         return;
     }
 
-    // Workspace integrity
-    if (ctx.packages.length === 0) {
+    // Workspace integrity.
+    //
+    // `ctx.packages` is the *release-managed* set — what discovery found, minus
+    // everything `isPackageManaged` filtered out. An empty list therefore has
+    // two very different causes, and collapsing them into one "check your
+    // workspace block" error sent visulima/visulima#863 to `pnpm-workspace.yaml`,
+    // the one file that was not the problem. `defaultManaged` defaults to
+    // `false`, so "workspace resolves, nothing has opted in yet" is the normal
+    // state of every mid-migration repo.
+    //
+    // Split into two checks: `workspace-discovered` answers "does the package
+    // manager see any projects?", `release-managed-packages` answers "has any
+    // of them opted in?". Only the first can be an error — the second is a
+    // legitimate waypoint during an incremental adoption, so it warns.
+    // Probe the package manager unconditionally. `ctx.packages` is the MANAGED
+    // subset, so reporting its length as the workspace count would print
+    // "Discovered 3 workspace package(s)" on a 50-package repo with 3 opted in —
+    // re-conflating the two numbers this very check exists to separate.
+    let workspaceEntries: { private: boolean }[] | undefined;
+
+    try {
+        workspaceEntries = await ctx.pm.listWorkspacePackages(cwd);
+    } catch {
+        // Probe failed (PM missing / workspace unreadable) — indistinguishable
+        // from "resolves to nothing" from here.
+        workspaceEntries = undefined;
+    }
+
+    if (ctx.packages.length > 0) {
+        // A managed package can only come from a discovered one, so the probe
+        // failing here is a probe problem, not a workspace problem — fall back
+        // to the managed count rather than claiming the workspace is empty.
+        const discovered = workspaceEntries === undefined ? ctx.packages.length : Math.max(workspaceEntries.length, ctx.packages.length);
+
+        checks.push({
+            message: `Discovered ${discovered} workspace package(s).`,
+            name: "workspace-discovered",
+            severity: "info",
+            status: "pass",
+        });
+        checks.push({
+            message: `${ctx.packages.length} of ${discovered} package(s) are release-managed.`,
+            name: "release-managed-packages",
+            severity: "info",
+            status: "pass",
+        });
+    } else if (workspaceEntries === undefined || workspaceEntries.length === 0) {
         checks.push({
             message: "No packages discovered. Ensure your package manager's workspace block resolves.",
             name: "workspace-discovered",
             severity: "error",
             status: "fail",
         });
-    } else {
         checks.push({
-            message: `Discovered ${ctx.packages.length} workspace package(s).`,
+            message: "Skipped — no workspace packages to opt in.",
+            name: "release-managed-packages",
+            severity: "info",
+            status: "skip",
+        });
+    } else {
+        const workspaceProjectCount = workspaceEntries.length;
+        // `isPackageManaged` rule 5 drops every `private: true` package
+        // unless `privatePackages.version` is set — so on an all-private
+        // workspace even `defaultManaged: true` yields an empty managed set.
+        // Naming only the two opt-in knobs there would be its own dead end.
+        const privateHint = workspaceEntries.every((entry) => entry.private)
+            ? " Every discovered package is private — private packages additionally need release.privatePackages.version."
+            : "";
+
+        checks.push({
+            message: `Discovered ${workspaceProjectCount} workspace package(s).`,
             name: "workspace-discovered",
             severity: "info",
             status: "pass",
+        });
+        checks.push({
+            message: `No release-managed packages (${workspaceProjectCount} workspace package(s) discovered). Set release.defaultManaged: true in vis.config.ts, or add "vis-release": { "managed": true } to a package.json.${privateHint}`,
+            name: "release-managed-packages",
+            severity: "warn",
+            status: "fail",
         });
     }
 
@@ -406,8 +472,21 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
             checks.push({ message: w, name: "plan-warning", severity: "warn", status: "fail" });
         }
     } else {
+        // "No pending releases." reads like a clean bill of health, but with an
+        // empty managed set it is vacuous — nothing *can* release. Say which of
+        // the two it is (see the workspace-integrity block above).
+        let planMessage: string;
+
+        if (ctx.plan.releases.length > 0) {
+            planMessage = `Plan resolves ${ctx.plan.releases.length} release(s).`;
+        } else if (ctx.packages.length === 0) {
+            planMessage = "No pending releases — no package is release-managed, so the plan is always empty.";
+        } else {
+            planMessage = "No pending releases.";
+        }
+
         checks.push({
-            message: ctx.plan.releases.length === 0 ? "No pending releases." : `Plan resolves ${ctx.plan.releases.length} release(s).`,
+            message: planMessage,
             name: "plan-readable",
             severity: "info",
             status: "pass",
@@ -1355,15 +1434,26 @@ const execute = async ({ logger, options, workspaceRoot }: Toolbox<Console, Rele
                 }
             }
 
-            checks.push({
-                message:
-                    missing.length === 0
-                        ? "All catalog: references resolve against pnpm-workspace.yaml."
-                        : `${missing.length} catalog: reference(s) don't resolve: ${missing.slice(0, 3).join("; ")}${missing.length > 3 ? "…" : ""}`,
-                name: "catalog-consistency",
-                severity: "warn",
-                status: missing.length === 0 ? "pass" : "fail",
-            });
+            // With no release-managed packages the loop above inspected nothing,
+            // so "all references resolve" would be a pass nobody earned.
+            if (ctx.packages.length === 0) {
+                checks.push({
+                    message: "Skipped — no release-managed packages to inspect.",
+                    name: "catalog-consistency",
+                    severity: "info",
+                    status: "skip",
+                });
+            } else {
+                checks.push({
+                    message:
+                        missing.length === 0
+                            ? "All catalog: references resolve against pnpm-workspace.yaml."
+                            : `${missing.length} catalog: reference(s) don't resolve: ${missing.slice(0, 3).join("; ")}${missing.length > 3 ? "…" : ""}`,
+                    name: "catalog-consistency",
+                    severity: "warn",
+                    status: missing.length === 0 ? "pass" : "fail",
+                });
+            }
         }
     } catch {
         // No catalog support / parse failure — not fatal for the doctor.

--- a/packages/tooling/vis/src/commands/release/root-command.ts
+++ b/packages/tooling/vis/src/commands/release/root-command.ts
@@ -1,0 +1,38 @@
+import { defineCommand } from "@visulima/cerebro";
+
+/**
+ * `vis release` — umbrella entry for the release subsystem.
+ *
+ * Every real subcommand is registered as a nested `commandPath: ["release"]`
+ * command, which left the parent path unclaimed. That had two consequences
+ * (visulima/visulima#863):
+ *
+ *  1. **Undiscoverable.** `vis --help` groups by `command.group`, so the
+ *     subsystem only ever showed up as ~23 `release &lt;sub>` rows in the very
+ *     last group of a long listing, with no one-line entry naming it.
+ *  2. **Mis-dispatched.** `vis release ci release` has the leaf name
+ *     `release`, so cerebro's name-keyed lookup mapped a bare `vis release`
+ *     (and `vis release --help`, `vis help release`) onto the CI
+ *     version-PR/publish command. Declaring a flat `release` command is what
+ *     fixes that: `Cli.addCommand` re-keys the nested namesake under its full
+ *     path so the flat one owns the bare name (`cerebro/src/cli.ts:865-878`
+ *     handles this in EITHER registration order — the order below is about
+ *     help-group placement only, not correctness).
+ *
+ * Registered ahead of the nested subcommands in `register-commands.ts` so the
+ * "Release" group lands with the other top-level groups instead of at the
+ * bottom of `vis --help`, which is grouped by first registration.
+ */
+const releaseRoot = defineCommand({
+    description: "Version, changelog and publish workspace packages (unstable)",
+    examples: [
+        ["vis release", "List the release subcommands"],
+        ["vis release status", "Show what is about to release"],
+        ["vis release doctor", "Diagnose the release setup"],
+    ],
+    group: "Release",
+    loader: () => import("./root-handler"),
+    name: "release",
+});
+
+export default releaseRoot;

--- a/packages/tooling/vis/src/commands/release/root-handler.ts
+++ b/packages/tooling/vis/src/commands/release/root-handler.ts
@@ -1,0 +1,28 @@
+import type { CommandExecute, Toolbox } from "@visulima/cerebro";
+
+/**
+ * `vis release` with no subcommand — prints the subcommand listing.
+ *
+ * Rendering goes through cerebro's own help command so the output is
+ * identical to `vis release --help`. It is invoked as a *method call*
+ * (`helpCommand.execute(...)`, the same form `executeCommand` uses) because
+ * `HelpCommand` is class-based and reads `this.commands`; and directly
+ * rather than via `runtime.runCommand("help", …)` so the plugin lifecycle
+ * — upgrade check, tips, sponsor notice — doesn't fire a second time.
+ */
+const execute = async (toolbox: Toolbox): Promise<void> => {
+    const helpCommand = toolbox.runtime.getCommands().get("help");
+
+    if (typeof helpCommand?.execute !== "function") {
+        toolbox.logger.info("Run \"vis release <subcommand> --help\" — for example \"vis release status --help\".");
+
+        return;
+    }
+
+    // `commandName: "help"` + the positional `["release"]` is exactly what
+    // `vis help release` produces, which resolves to this command and renders
+    // its Subcommands section.
+    await helpCommand.execute({ ...toolbox, argument: ["release"], commandName: "help" });
+};
+
+export default execute as CommandExecute<Toolbox>;

--- a/packages/tooling/vis/src/register-commands.ts
+++ b/packages/tooling/vis/src/register-commands.ts
@@ -46,6 +46,7 @@ import migrateCommands from "./commands/migrate";
 import optimizeCommand from "./commands/optimize";
 import pmCommand from "./commands/pm";
 import releaseCommands from "./commands/release";
+import releaseRootCommand from "./commands/release/root-command";
 import removeCommand from "./commands/remove";
 import replayCommand from "./commands/replay";
 import runCommand from "./commands/run";
@@ -99,6 +100,15 @@ const registerCommands = (cli: Cli<Console>): void => {
     cli.addCommand(listCommand);
     cli.addCommand(completionCommand);
     cli.addCommand(versionCommand);
+
+    // Release umbrella. Declaring it at all is what stops `release ci release`
+    // (leaf name `release`) from owning the bare `release` slot and making
+    // `vis release` run the CI publish flow — `Cli.addCommand` re-keys the
+    // nested namesake under its full path in either order. Registering it
+    // HERE, ahead of the nested `release <sub>` commands at the bottom of this
+    // function, only decides where the "Release" group lands in `vis --help`,
+    // which is grouped by first registration.
+    cli.addCommand(releaseRootCommand);
 
     // Lint & format commands
     cli.addCommand(lintCommand);


### PR DESCRIPTION
Fixes #863.

Two adoption papercuts in the release subsystem — plus a dispatch bug found while verifying them.

## 1. A bare `vis release` ran the CI publish flow

Every release subcommand is registered as `commandPath: ["release"]`, so nothing owned the flat `release` name. `vis release ci release` has the **leaf name `release`**, and cerebro's name-keyed map handed it that slot — so `vis release`, `vis release --help` and `vis help release` all resolved to the CI version-PR/publish command.

Declaring a flat `release` umbrella command fixes it: `Cli.addCommand` re-keys the nested namesake under its full path. `vis release` now prints usage + subcommands.

> Note on the issue's first point: `group: "Release"` already existed, so `vis --help` *did* render a Release group — but as the 12th and last of twelve, which is why it read as missing. The umbrella entry gives it a one-line description and moves the group 7th.

## 2. `release doctor` blamed workspace discovery when nothing was opted in

`ctx.packages` is the *release-managed* set, so an empty list had three causes collapsed into one "check your `pnpm-workspace.yaml`" error — pointing at the one file that was not the problem.

Split into two checks:

| managed | workspace | `workspace-discovered` | `release-managed-packages` |
|---|---|---|---|
| N>0 | — | pass | pass |
| 0 | N>0 | pass | **warn** — names `defaultManaged` / `vis-release.managed` |
| 0 | 0 | **error** — original message | skip |

`warn`, not `error`, because incremental adoption is a supported state and the doctor should still exit 0 mid-migration. A third cause gets its own hint: an all-private workspace yields zero managed packages even with `defaultManaged: true`, because private packages additionally need `release.privatePackages.version`.

Two neighbouring vacuous passes fixed the same way: `plan-readable` no longer reports a clean "No pending releases." when nothing *can* release, and `catalog-consistency` reports `skip` instead of claiming all references resolve after inspecting zero packages.

## Fixes from review

- **`workspace-discovered` re-created the very conflation it set out to split** — it reported `ctx.packages.length` (the managed subset) in its pass branch, so 50 packages with 3 opted in printed "Discovered 3 workspace package(s)". It now probes the package manager unconditionally and reports `"3 of 50 package(s) are release-managed."`
- **`cerebro`: `findChildren` required equal path depth**, so `vis release` listed 16 children and silently hid all six `release ci *` commands — the whole `ci` group was undiscoverable from the only place a user would look. Changed to prefix matching. Also completes `vis advisories` and `vis ai`, the other two depth-2 groups.
- Corrected two comments that claimed registration order is what stops the nested namesake winning the flat slot. It isn't — `cli.ts:865-878` re-keys either way; order only sets help-group placement.

## Testing

vis: 2982 passing. cerebro: 679/680. The new cerebro test was verified to fail without the `findChildren` fix. Remaining failures are pre-existing on `main` (10 `cache-scope-cli` git-commit failures; one `cross-env` binary missing from a fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AykNAXvDtCJyX6aymEBWQw
