### PR TITLE
feat(vis): support commit-driven release ci flows

### DIFF
--- a/packages/tooling/vis/__tests__/release/commands/release-ci-release-generate.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-ci-release-generate.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Regression tests for issue #864 §1 — `vis release ci release --generate`.
+ *
+ * Collapses the three-step commit-driven CI dance (`generate` → throwaway
+ * `git commit` → `ci release`) into one command:
+ *
+ *   - the change file is derived in-process before the pending-file check,
+ *   - the clean-tree guard tolerates exactly that file,
+ *   - an unrelated dirty tree still fails.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testFs = { access, mkdir, readdir, readFile, rm, stat, writeFile } as never;
+
+const publishOptionsCaptured: { resume?: boolean; tag?: string }[] = [];
+const applyCallCount = { value: 0 };
+
+vi.mock(import("../../../src/release/core/orchestrator"), async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../../src/release/core/orchestrator")>();
+
+    return {
+        ...actual,
+        applyContext: vi.fn(async () => {
+            applyCallCount.value += 1;
+
+            return { changedFiles: [], deletedFiles: [], plan: { consumedChangeFiles: [], releases: [], warnings: [] } };
+        }),
+        publishContext: vi.fn(async (_ctx: unknown, options: { resume?: boolean; tag?: string } = {}) => {
+            publishOptionsCaptured.push({ ...options });
+
+            return { failed: [], published: [], skipped: [], tags: [], tagsPushed: false };
+        }),
+    };
+});
+
+// Only the push is stubbed — `listUncommittedPaths` / `getShortSha` must
+// run for real, they are what this suite exercises.
+vi.mock(import("../../../src/release/core/git"), async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../../src/release/core/git")>();
+
+    return { ...actual, pushBranch: vi.fn(async () => undefined) };
+});
+
+const git = (cwd: string, ...args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+};
+
+const setupFixture = (): { cwd: string; rootSha: string } => {
+    const cwd = mkdtempSync(join(tmpdir(), "vis-ci-generate-"));
+
+    writeFileSync(
+        join(cwd, "package.json"),
+        `${JSON.stringify({ name: "fixture-root", packageManager: "pnpm@10.32.1", private: true, version: "0.0.0", workspaces: ["packages/*"] }, null, 4)}\n`,
+    );
+    writeFileSync(join(cwd, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    // `loadVisConfig` writes `node_modules/.cache/vis/vis-config-cache.json`;
+    // in a real repo that path is gitignored, so the fixture must be too or
+    // the clean-tree guard would fire on the tool's own cache.
+    writeFileSync(join(cwd, ".gitignore"), "node_modules\n");
+    mkdirSync(join(cwd, "packages", "a", "src"), { recursive: true });
+    writeFileSync(join(cwd, "packages", "a", "package.json"), `${JSON.stringify({ name: "@scope/a", version: "1.0.0" }, null, 4)}\n`);
+    writeFileSync(join(cwd, "packages", "a", "src", "index.ts"), "export const a = 0;\n");
+    mkdirSync(join(cwd, ".vis", "release"), { recursive: true });
+    writeFileSync(join(cwd, ".vis", "release", ".gitkeep"), "");
+    writeFileSync(
+        join(cwd, "vis.config.cjs"),
+        `module.exports = ${JSON.stringify({ release: { acknowledgeUnstable: true, channels: { alpha: { mode: "auto-publish", prerelease: "alpha", tag: "alpha" } }, defaultManaged: true } }, null, 4)};\n`,
+    );
+
+    git(cwd, "init", "-q", "--initial-branch", "alpha");
+    git(cwd, "config", "user.email", "test@test");
+    git(cwd, "config", "user.name", "Test");
+    git(cwd, "config", "commit.gpgsign", "false");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", "chore: initial");
+
+    const rootSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+
+    return { cwd, rootSha };
+};
+
+const commitFeature = (cwd: string, subject: string, marker: string): void => {
+    writeFileSync(join(cwd, "packages", "a", "src", "index.ts"), `export const a = "${marker}";\n`);
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", subject);
+};
+
+describe("vis release ci release --generate (#864)", () => {
+    let cwd: string | undefined;
+
+    beforeEach(() => {
+        cwd = undefined;
+        publishOptionsCaptured.length = 0;
+        applyCallCount.value = 0;
+        process.exitCode = undefined;
+    });
+
+    afterEach(async () => {
+        if (cwd) {
+            await rm(cwd, { force: true, recursive: true });
+        }
+
+        process.exitCode = undefined;
+        vi.clearAllMocks();
+    });
+
+    it("without --generate an empty change dir is still 'nothing to release'", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): add a thing", "one");
+
+        const info: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: (message: string) => info.push(message), warn: () => {} },
+            options: { autoPublish: true, channel: "alpha" },
+            workspaceRoot: cwd,
+        });
+
+        expect(info.join("\n")).toContain("No pending change files");
+        expect(publishOptionsCaptured).toHaveLength(0);
+    });
+
+    it("derives the change file, tolerates it in the clean-tree guard, and publishes", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): add a thing", "one");
+
+        const info: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: (message: string) => info.push(message), warn: () => {} },
+            options: { autoPublish: true, channel: "alpha", generate: true, generateFrom: fixture.rootSha },
+            workspaceRoot: cwd,
+        });
+
+        expect(info.join("\n")).toContain("Generated .vis/release/ci-");
+        expect(process.exitCode ?? 0).toBe(0);
+        expect(applyCallCount.value).toBe(1);
+        expect(publishOptionsCaptured).toHaveLength(1);
+
+        // The file is staged (never committed on its own) so `applyContext`
+        // can later stage its deletion — `git add` refuses a path that was
+        // never in the index.
+        const staged = execFileSync("git", ["diff", "--cached", "--name-only"], { cwd, encoding: "utf8" });
+
+        expect(staged).toContain(".vis/release/ci-");
+    });
+
+    it("still refuses an unrelated dirty tree when --generate is used", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): add a thing", "one");
+        writeFileSync(join(cwd, "unrelated-junk.txt"), "left over from a previous step\n");
+
+        const warnings: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: () => {}, warn: (message: string) => warnings.push(message), workspaceRoot: cwd } as never,
+            options: { autoPublish: true, channel: "alpha", generate: true, generateFrom: fixture.rootSha },
+            workspaceRoot: cwd,
+        });
+
+        expect(process.exitCode).toBe(1);
+        expect(warnings.join("\n")).toContain("unrelated-junk.txt");
+        expect(publishOptionsCaptured).toHaveLength(0);
+    });
+
+    /**
+     * F1: with no `--generate-from`, `--generate` defaults to
+     * `--since-last-release`. When no tag matches the configured
+     * `releaseTagPattern` the old code fell back to the repository root
+     * commit and published everything it found there. It must refuse.
+     */
+    it("refuses to publish off the whole history when no release tag matches", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        // Tagged, but not with the `{name}@{version}` pattern vis expects
+        // — so `git describe --match` finds nothing reachable from HEAD.
+        commitFeature(cwd, "feat(a)!: a breaking change from the distant past", "old");
+        git(cwd, "tag", "v1.2.3");
+        commitFeature(cwd, "fix(a): the one genuinely unreleased commit", "new");
+
+        const errors: string[] = [];
+        const info: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: (message: string) => errors.push(message), info: (message: string) => info.push(message), warn: () => {} },
+            options: { autoPublish: true, channel: "alpha", generate: true },
+            workspaceRoot: cwd,
+        });
+
+        expect(process.exitCode).toBe(1);
+        expect(errors.join("\n")).toContain("--allow-full-history");
+        expect(publishOptionsCaptured).toHaveLength(0);
+        expect(applyCallCount.value).toBe(0);
+        expect(info.join("\n")).not.toContain("Generated .vis/release/ci-");
+    });
+
+    it("walks the whole history when --allow-full-history is passed", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): the very first feature", "one");
+
+        const info: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: (message: string) => info.push(message), warn: () => {} },
+            options: { allowFullHistory: true, autoPublish: true, channel: "alpha", generate: true },
+            workspaceRoot: cwd,
+        });
+
+        expect(process.exitCode ?? 0).toBe(0);
+        expect(info.join("\n")).toContain("Generated .vis/release/ci-");
+        expect(publishOptionsCaptured).toHaveLength(1);
+    });
+
+    /**
+     * F2: a change file left behind by an interrupted `--generate` run
+     * used to wedge every later run — the next run generates
+     * `ci-&lt;new sha>.md`, so the leftover `ci-&lt;old sha>.md` counted as
+     * unexpected dirt and the clean-tree guard failed forever.
+     */
+    it("is not wedged by a change file left behind by an interrupted --generate run", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): add a thing", "one");
+
+        // Exactly what an aborted run leaves: written + staged, at a sha
+        // that is no longer HEAD.
+        await writeFile(join(cwd, ".vis", "release", "ci-deadbee.md"), "---\n\"@scope/a\": patch\n---\n\n- fix(a): from the interrupted run\n");
+        git(cwd, "add", "--", ".vis/release/ci-deadbee.md");
+
+        const info: string[] = [];
+        const warnings: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: (message: string) => info.push(message), warn: (message: string) => warnings.push(message) },
+            options: { autoPublish: true, channel: "alpha", generate: true, generateFrom: fixture.rootSha },
+            workspaceRoot: cwd,
+        });
+
+        expect(process.exitCode ?? 0).toBe(0);
+        expect(warnings.join("\n")).toContain("ci-deadbee.md");
+        expect(warnings.join("\n")).not.toContain("CI mode requires a clean tree");
+        expect(publishOptionsCaptured).toHaveLength(1);
+    });
+
+    it("still refuses unrelated dirt that merely lives in the change dir", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, "feat(a): add a thing", "one");
+        // A hand-written change file is NOT the generated shape, so the
+        // tolerance must not swallow it.
+        await writeFile(join(cwd, ".vis", "release", "brave-otter.md"), "---\n\"@scope/a\": patch\n---\n\n- a human wrote this\n");
+
+        const warnings: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: () => {}, warn: (message: string) => warnings.push(message) },
+            options: { autoPublish: true, channel: "alpha", generate: true, generateFrom: fixture.rootSha },
+            workspaceRoot: cwd,
+        });
+
+        expect(process.exitCode).toBe(1);
+        expect(warnings.join("\n")).toContain("brave-otter.md");
+        expect(publishOptionsCaptured).toHaveLength(0);
+    });
+
+    it("derives nothing when the range holds only release commits", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+        commitFeature(cwd, String.raw`chore(release): @scope/a@1.0.0 [skip ci]\n\n## @scope/a [1.0.0](https://x) (2026-09-07)`, "rel");
+
+        const info: string[] = [];
+        const { default: execute } = await import("../../../src/commands/release/ci/release/handler");
+
+        await execute({
+            fs: testFs,
+            logger: { error: () => {}, info: (message: string) => info.push(message), warn: () => {} },
+            options: { autoPublish: true, channel: "alpha", generate: true, generateFrom: fixture.rootSha },
+            workspaceRoot: cwd,
+        });
+
+        const joined = info.join("\n");
+
+        expect(joined).toContain("derived no bumps");
+        expect(joined).toContain("No pending change files");
+        expect(publishOptionsCaptured).toHaveLength(0);
+    });
+});

--- a/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/commands/release-ci-release.test.ts
@@ -96,7 +96,9 @@ vi.mock(import("../../../src/release/core/git"), async (importOriginal) => {
     return {
         ...actual,
         getCurrentBranch: vi.fn(async () => "main"),
-        hasUncommittedChanges: vi.fn(async () => false),
+        // The fixture writes `vis.config.cjs` after the initial commit, so the
+        // real probe would report a dirty tree and short-circuit the handler.
+        listUncommittedPaths: vi.fn(async () => [] as string[]),
         pushBranch: vi.fn(async () => undefined),
     };
 });

--- a/packages/tooling/vis/__tests__/release/core/generate-ignore-commits.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/generate-ignore-commits.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Regression tests for issue #864 §2 — `vis release generate` must not
+ * transcribe machine release commits into the change file.
+ *
+ * Covers:
+ *   - the built-in `chore(release):` / `[skip ci]` heuristic,
+ *   - `release.ignoreCommitPattern` extending (not replacing) it,
+ *   - `release.ignoreReleaseCommits: false` as the explicit opt-out,
+ *   - subject trimming for multi-semantic-release's literal `\n\n`
+ *     changelog-header suffix.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+    buildIgnoreCommitMatchers,
+    DEFAULT_RELEASE_COMMIT_PATTERNS,
+    isIgnoredCommit,
+    normalizeCommitSubject,
+} from "../../../src/release/core/generate/conventional-commits";
+import type { RunGenerateResult } from "../../../src/release/core/generate/run";
+import { runGenerate } from "../../../src/release/core/generate/run";
+import { createShellRunner } from "../../../src/release/core/shell-runner";
+import type { BumpLevel, VisReleaseConfig, WorkspacePackage } from "../../../src/release/types";
+
+const testFs = { access, mkdir, readdir, readFile, rm, stat, writeFile } as never;
+
+/**
+ * Assert the run actually walked a range and flatten the discriminated
+ * result for assertions. `content` is undefined for a `no-changes`
+ * outcome, which is exactly what the old shape reported.
+ */
+const walked = (
+    result: RunGenerateResult,
+): { bumps: ReadonlyMap<string, BumpLevel>; content: string | undefined; fromRef: string; ignoredCommits: number; status: RunGenerateResult["status"] } => {
+    if (result.status === "failed") {
+        throw new Error(`generate failed: ${result.error}`);
+    }
+
+    return { ...result, content: "content" in result ? result.content : undefined };
+};
+
+const git = (cwd: string, ...args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+};
+
+/**
+ * A one-package fixture repo. Every commit touches `packages/a/src/index.ts`
+ * so the path heuristic alone would attribute it to `@scope/a` — which is
+ * exactly the trap: a release commit that touches the package's
+ * `package.json` / `CHANGELOG.md` would otherwise bump it forever.
+ */
+const setupFixture = (): { cwd: string; packages: WorkspacePackage[]; rootSha: string } => {
+    const cwd = mkdtempSync(join(tmpdir(), "vis-generate-ignore-"));
+
+    mkdirSync(join(cwd, "packages", "a", "src"), { recursive: true });
+    writeFileSync(join(cwd, "package.json"), `${JSON.stringify({ name: "root", private: true, version: "0.0.0" }, null, 2)}\n`);
+    writeFileSync(join(cwd, "packages", "a", "package.json"), `${JSON.stringify({ name: "@scope/a", version: "1.0.0" }, null, 2)}\n`);
+    writeFileSync(join(cwd, "packages", "a", "src", "index.ts"), "export const a = 1;\n");
+
+    git(cwd, "init", "-q", "--initial-branch", "main");
+    git(cwd, "config", "user.email", "test@test");
+    git(cwd, "config", "user.name", "Test");
+    git(cwd, "config", "commit.gpgsign", "false");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", "chore: initial");
+
+    const packages: WorkspacePackage[] = [
+        {
+            dir: join(cwd, "packages", "a"),
+            manifest: { name: "@scope/a", version: "1.0.0" },
+            manifestPath: join(cwd, "packages", "a", "package.json"),
+            name: "@scope/a",
+            private: false,
+            version: "1.0.0",
+        },
+    ];
+
+    const rootSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+
+    return { cwd, packages, rootSha };
+};
+
+const commitTouchingPackage = (cwd: string, subject: string, marker: string): void => {
+    writeFileSync(join(cwd, "packages", "a", "src", "index.ts"), `export const a = "${marker}";\n`);
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", subject);
+};
+
+const generate = async (fixture: { cwd: string; packages: WorkspacePackage[]; rootSha: string }, config: VisReleaseConfig = {}) =>
+    runGenerate({
+        config,
+        cwd: fixture.cwd,
+        dryRun: true,
+        from: fixture.rootSha,
+        fs: testFs,
+        packages: fixture.packages,
+        runner: createShellRunner(),
+    });
+
+describe("generate — machine release-commit filtering (#864)", () => {
+    let cwd: string | undefined;
+
+    afterEach(async () => {
+        if (cwd) {
+            await rm(cwd, { force: true, recursive: true });
+            cwd = undefined;
+        }
+    });
+
+    describe(normalizeCommitSubject, () => {
+        it(String.raw`cuts the multi-semantic-release literal \n\n changelog header off the subject`, () => {
+            expect.hasAssertions();
+
+            const subject = String.raw`chore(release): @scope/a@1.0.0-alpha.44 [skip ci]\n\n## @scope/a [1.0.0-alpha.44](https://x/compare) (2026-09-07)`;
+
+            expect(normalizeCommitSubject(subject)).toBe("chore(release): @scope/a@1.0.0-alpha.44 [skip ci]");
+        });
+
+        it("cuts at a real newline too and leaves a plain subject untouched", () => {
+            expect.hasAssertions();
+
+            expect(normalizeCommitSubject("feat: a thing\n\nbody text")).toBe("feat: a thing");
+            expect(normalizeCommitSubject("feat: a thing")).toBe("feat: a thing");
+        });
+
+        it(String.raw`keeps a subject that merely mentions a literal \n escape`, () => {
+            expect.hasAssertions();
+
+            // Only a doubled escape introducing a markdown heading is the
+            // multi-semantic-release join; prose about escapes must survive.
+            expect(normalizeCommitSubject(String.raw`fix(parser): handle \n in template literals`)).toBe(
+                String.raw`fix(parser): handle \n in template literals`,
+            );
+            expect(normalizeCommitSubject(String.raw`docs: explain \n\n as a paragraph break`)).toBe(String.raw`docs: explain \n\n as a paragraph break`);
+        });
+    });
+
+    describe(buildIgnoreCommitMatchers, () => {
+        it("matches every machine release-commit shape by default", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers();
+
+            expect(isIgnoredCommit("chore(release): @scope/a@1.0.0-alpha.44 [skip ci]", matchers)).toBe(true);
+            expect(isIgnoredCommit("chore(release): version packages", matchers)).toBe(true);
+            expect(isIgnoredCommit("chore(main): release 1.2.3", matchers)).toBe(true);
+            expect(isIgnoredCommit("chore: release v1.2.3", matchers)).toBe(true);
+            expect(isIgnoredCommit("release(alpha): version packages [skip ci]", matchers)).toBe(true);
+        });
+
+        it("does not treat a bare [skip ci] marker as a release commit", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers();
+
+            // `[skip ci]` means "don't run CI", not "don't release" — swallowing
+            // these would silently drop a real patch bump.
+            expect(isIgnoredCommit("fix(api): correct the retry budget [skip ci]", matchers)).toBe(false);
+            expect(isIgnoredCommit("docs: tweak readme [ci skip]", matchers)).toBe(false);
+        });
+
+        it("lets a repo opt back into the blunt [skip ci] rule via config", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers({ ignoreCommitPattern: String.raw`\[skip ci\]` });
+
+            expect(isIgnoredCommit("fix(api): correct the retry budget [skip ci]", matchers)).toBe(true);
+            expect(isIgnoredCommit("fix(api): correct the retry budget", matchers)).toBe(false);
+        });
+
+        it("leaves human commits alone", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers();
+
+            expect(isIgnoredCommit("fix(client,react): encode SSR payloads", matchers)).toBe(false);
+            expect(isIgnoredCommit("feat: add a release dashboard", matchers)).toBe(false);
+            expect(isIgnoredCommit("chore(deps): bump vitest", matchers)).toBe(false);
+        });
+
+        it("extends the built-ins with user patterns rather than replacing them", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers({ ignoreCommitPattern: "^wip:" });
+
+            expect(matchers).toHaveLength(DEFAULT_RELEASE_COMMIT_PATTERNS.length + 1);
+            expect(isIgnoredCommit("wip: half a feature", matchers)).toBe(true);
+            expect(isIgnoredCommit("chore(release): version packages", matchers)).toBe(true);
+        });
+
+        it("drops the built-ins only on the explicit opt-out", () => {
+            expect.hasAssertions();
+
+            const matchers = buildIgnoreCommitMatchers({ ignoreCommitPattern: ["^wip:"], ignoreReleaseCommits: false });
+
+            expect(matchers).toHaveLength(1);
+            expect(isIgnoredCommit("chore(release): version packages", matchers)).toBe(false);
+            expect(isIgnoredCommit("wip: half a feature", matchers)).toBe(true);
+        });
+
+        it("skips an invalid user pattern with a warning instead of throwing", () => {
+            expect.hasAssertions();
+
+            const seen: string[] = [];
+            const matchers = buildIgnoreCommitMatchers({ ignoreCommitPattern: "([unclosed", onInvalidPattern: (source) => seen.push(source) });
+
+            expect(seen).toStrictEqual(["([unclosed"]);
+            expect(matchers).toHaveLength(DEFAULT_RELEASE_COMMIT_PATTERNS.length);
+        });
+    });
+
+    it("does not bump a package whose only commits in the range are its own release commits", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commitTouchingPackage(
+            cwd,
+            String.raw`chore(release): @scope/a@1.0.0-alpha.44 [skip ci]\n\n## @scope/a [1.0.0-alpha.44](https://x/compare) (2026-09-07)`,
+            "rel44",
+        );
+        commitTouchingPackage(
+            cwd,
+            String.raw`chore(release): @scope/a@1.0.0-alpha.43 [skip ci]\n\n## @scope/a [1.0.0-alpha.43](https://x/compare) (2026-09-06)`,
+            "rel43",
+        );
+
+        const result = walked(await generate(fixture));
+
+        expect(result.ignoredCommits).toBe(2);
+        expect([...result.bumps.keys()]).toStrictEqual([]);
+        expect(result.content).toBeUndefined();
+    });
+
+    it("keeps the human commit and drops the release commits that surround it", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commitTouchingPackage(cwd, "fix(a): encode SSR payloads", "human");
+        commitTouchingPackage(
+            cwd,
+            String.raw`chore(release): @scope/a@1.0.0-alpha.44 [skip ci]\n\n## @scope/a [1.0.0-alpha.44](https://x) (2026-09-07)`,
+            "rel44",
+        );
+
+        const result = walked(await generate(fixture));
+
+        expect(result.ignoredCommits).toBe(1);
+        expect(result.bumps.get("@scope/a")).toBe("patch");
+        expect(result.content).toContain("- fix(a): encode SSR payloads");
+        expect(result.content).not.toContain("chore(release)");
+        expect(result.content).not.toContain(String.raw`\n\n`);
+        expect(result.content).not.toContain("## @scope/a");
+    });
+
+    it("honours release.ignoreCommitPattern on top of the built-ins", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commitTouchingPackage(cwd, "fix(a): a real fix", "human");
+        commitTouchingPackage(cwd, "chore(deps): bump the lockfile", "deps");
+
+        const result = walked(await generate(fixture, { ignoreCommitPattern: String.raw`^chore\(deps\):` }));
+
+        expect(result.ignoredCommits).toBe(1);
+        expect(result.content).toContain("- fix(a): a real fix");
+        expect(result.content).not.toContain("chore(deps)");
+    });
+
+    it("reproduces the old verbatim behaviour when ignoreReleaseCommits is false", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commitTouchingPackage(
+            cwd,
+            String.raw`chore(release): @scope/a@1.0.0-alpha.44 [skip ci]\n\n## @scope/a [1.0.0-alpha.44](https://x) (2026-09-07)`,
+            "rel44",
+        );
+
+        const result = walked(await generate(fixture, { ignoreReleaseCommits: false }));
+
+        expect(result.ignoredCommits).toBe(0);
+        expect(result.bumps.get("@scope/a")).toBe("patch");
+        // Subject trimming is unconditional — the changelog header never
+        // lands in the change file even with the heuristic disabled.
+        expect(result.content).toContain("- chore(release): @scope/a@1.0.0-alpha.44 [skip ci]");
+        expect(result.content).not.toContain("## @scope/a [1.0.0-alpha.44]");
+    });
+});

--- a/packages/tooling/vis/__tests__/release/core/generate-since-last-release.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/generate-since-last-release.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Regression tests for issue #864 §1 — `vis release generate
+ * --since-last-release`.
+ *
+ * The range starts at the most recent `releaseTagPattern` tag reachable
+ * from HEAD (workspace-wide, because `generate` emits one change file
+ * for one range). When no such tag exists the run FAILS rather than
+ * silently walking the whole repository history — that fallback is only
+ * available behind `--allow-full-history`.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { RunGenerateResult } from "../../../src/release/core/generate/run";
+import { runGenerate } from "../../../src/release/core/generate/run";
+import { createShellRunner } from "../../../src/release/core/shell-runner";
+import { resolveLastReleaseRef } from "../../../src/release/core/version-resolver";
+import type { BumpLevel, VisReleaseConfig, WorkspacePackage } from "../../../src/release/types";
+
+const testFs = { access, mkdir, readdir, readFile, rm, stat, writeFile } as never;
+
+/**
+ * Assert the run actually walked a range and flatten the discriminated
+ * result for assertions.
+ */
+const walked = (result: RunGenerateResult): { bumps: ReadonlyMap<string, BumpLevel>; content: string | undefined; fromRef: string; ignoredCommits: number } => {
+    if (result.status === "failed") {
+        throw new Error(`generate failed: ${result.error}`);
+    }
+
+    return { ...result, content: "content" in result ? result.content : undefined };
+};
+
+const git = (cwd: string, ...args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+};
+
+const makePackage = (cwd: string, name: string, directory: string): WorkspacePackage => {
+    return {
+        dir: join(cwd, "packages", directory),
+        manifest: { name, version: "1.0.0" },
+        manifestPath: join(cwd, "packages", directory, "package.json"),
+        name,
+        private: false,
+        version: "1.0.0",
+    };
+};
+
+/** Two-package fixture, no tags yet. */
+const setupFixture = (): { cwd: string; packages: WorkspacePackage[]; rootSha: string } => {
+    const cwd = mkdtempSync(join(tmpdir(), "vis-generate-since-"));
+
+    for (const directory of ["a", "b"]) {
+        mkdirSync(join(cwd, "packages", directory, "src"), { recursive: true });
+        writeFileSync(join(cwd, "packages", directory, "package.json"), `${JSON.stringify({ name: `@scope/${directory}`, version: "1.0.0" }, null, 2)}\n`);
+        writeFileSync(join(cwd, "packages", directory, "src", "index.ts"), "export const x = 0;\n");
+    }
+
+    writeFileSync(join(cwd, "package.json"), `${JSON.stringify({ name: "root", private: true, version: "0.0.0" }, null, 2)}\n`);
+
+    git(cwd, "init", "-q", "--initial-branch", "main");
+    git(cwd, "config", "user.email", "test@test");
+    git(cwd, "config", "user.name", "Test");
+    git(cwd, "config", "commit.gpgsign", "false");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", "chore: initial");
+
+    const rootSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+
+    return { cwd, packages: [makePackage(cwd, "@scope/a", "a"), makePackage(cwd, "@scope/b", "b")], rootSha };
+};
+
+const commit = (cwd: string, directory: string, subject: string, marker: string): void => {
+    writeFileSync(join(cwd, "packages", directory, "src", "index.ts"), `export const x = "${marker}";\n`);
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-q", "-m", subject);
+};
+
+const generateSince = async (
+    fixture: { cwd: string; packages: WorkspacePackage[] },
+    config: VisReleaseConfig = {},
+    allowFullHistory = false,
+): Promise<RunGenerateResult> =>
+    runGenerate({
+        allowFullHistory,
+        config,
+        cwd: fixture.cwd,
+        dryRun: true,
+        fs: testFs,
+        packages: fixture.packages,
+        runner: createShellRunner(),
+        sinceLastRelease: true,
+    });
+
+describe("generate --since-last-release (#864)", () => {
+    let cwd: string | undefined;
+
+    afterEach(async () => {
+        if (cwd) {
+            await rm(cwd, { force: true, recursive: true });
+            cwd = undefined;
+        }
+    });
+
+    it("starts the range at the most recent release tag reachable from HEAD", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): shipped in the last wave", "one");
+        git(cwd, "tag", "@scope/a@1.1.0");
+        commit(cwd, "a", "fix(a): landed after the wave", "two");
+
+        const result = walked(await generateSince(fixture));
+
+        expect(result.fromRef).toBe("@scope/a@1.1.0");
+        expect(result.content).toContain("- fix(a): landed after the wave");
+        expect(result.content).not.toContain("shipped in the last wave");
+        expect(result.bumps.get("@scope/a")).toBe("patch");
+    });
+
+    it("picks the newest tag across the whole workspace, not per-package", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): a wave", "a1");
+        git(cwd, "tag", "@scope/a@1.1.0");
+        commit(cwd, "b", "feat(b): b wave", "b1");
+        git(cwd, "tag", "@scope/b@2.0.0");
+        commit(cwd, "a", "fix(a): after both waves", "a2");
+
+        const resolved = await resolveLastReleaseRef({ cwd, packages: fixture.packages, runner: createShellRunner() });
+
+        expect(resolved.tag).toBe("@scope/b@2.0.0");
+
+        const result = walked(await generateSince(fixture));
+
+        expect(result.fromRef).toBe("@scope/b@2.0.0");
+        expect([...result.bumps.keys()]).toStrictEqual(["@scope/a"]);
+    });
+
+    it("offers the repository root commit as a candidate, flagged as such, when no release tag exists", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): the very first feature", "one");
+
+        const resolved = await resolveLastReleaseRef({ cwd, packages: fixture.packages, runner: createShellRunner() });
+
+        expect(resolved.kind).toBe("root-commit");
+        expect(resolved.ref).toBe(fixture.rootSha);
+        expect(resolved.tag).toBeUndefined();
+        expect(resolved.reason).toContain("root commit");
+    });
+
+    it("refuses to walk the entire history when no release tag matches", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): the very first feature", "one");
+
+        const result = await generateSince(fixture);
+
+        expect(result.status).toBe("failed");
+        expect(result.status === "failed" && result.error).toContain("--allow-full-history");
+        // The destructive part is not "it warned", it is "it walked".
+        expect(result).not.toHaveProperty("bumps");
+    });
+
+    it("refuses when the repo's tags do not match the configured releaseTagPattern", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        // Real-world shape from the audit: the repo is tagged `v1.2.3`
+        // while `releaseTagPattern` is the default `{name}@{version}`.
+        // Nothing matches the glob, so the old code walked everything and
+        // `--auto-publish` shipped the lot.
+        commit(cwd, "a", "feat(a): released long ago", "one");
+        git(cwd, "tag", "v1.2.3");
+        commit(cwd, "b", "feat(b)!: breaking, released long ago", "b1");
+        commit(cwd, "a", "fix(a): the only unreleased commit", "two");
+
+        const result = await generateSince(fixture);
+
+        expect(result.status).toBe("failed");
+        expect(result).not.toHaveProperty("bumps");
+    });
+
+    it("walks the whole history only when --allow-full-history is passed", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): the very first feature", "one");
+
+        const result = await generateSince(fixture, {}, true);
+        const walkedResult = walked(result);
+
+        expect(walkedResult.fromRef).toBe(fixture.rootSha);
+        expect(walkedResult.content).toContain("- feat(a): the very first feature");
+        // Opting in is still worth a warning in the CI tail.
+        expect(result.warnings.join("\n")).toContain("--allow-full-history");
+    });
+
+    it("honours a custom releaseTagPattern", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): released", "one");
+        git(cwd, "tag", "v1.1.0");
+        commit(cwd, "a", "fix(a): unreleased", "two");
+
+        const result = walked(await generateSince(fixture, { releaseTagPattern: "v{version}" }));
+
+        expect(result.fromRef).toBe("v1.1.0");
+        expect(result.content).toContain("- fix(a): unreleased");
+        expect(result.content).not.toContain("feat(a): released");
+    });
+
+    it("ignores tags that match the glob but do not parse as a version", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): the very first feature", "one");
+        // The `--match` glob for `{name}@{version}` degrades to
+        // `@scope/a@*`, which this tag satisfies — the strict matcher
+        // must still reject it.
+        git(cwd, "tag", "@scope/a@nightly");
+
+        const resolved = await resolveLastReleaseRef({ cwd, packages: fixture.packages, runner: createShellRunner() });
+
+        expect(resolved.kind).toBe("root-commit");
+        expect(resolved.tag).toBeUndefined();
+        expect(resolved.ref).toBe(fixture.rootSha);
+    });
+
+    it("skips release commits inside the since-last-release range", async () => {
+        expect.hasAssertions();
+
+        const fixture = setupFixture();
+
+        cwd = fixture.cwd;
+
+        commit(cwd, "a", "feat(a): released", "one");
+        git(cwd, "tag", "@scope/a@1.1.0");
+        commit(cwd, "a", String.raw`chore(release): @scope/a@1.1.0 [skip ci]\n\n## @scope/a [1.1.0](https://x) (2026-09-07)`, "rel");
+
+        const result = walked(await generateSince(fixture));
+
+        expect(result.fromRef).toBe("@scope/a@1.1.0");
+        expect(result.ignoredCommits).toBe(1);
+        expect([...result.bumps.keys()]).toStrictEqual([]);
+    });
+});

--- a/packages/tooling/vis/__tests__/release/core/git.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { defaultTagFor, getCurrentBranch, getCurrentSha, getShortSha, hasUncommittedChanges, tagExists, tagExistsRemote } from "../../../src/release/core/git";
+import { defaultTagFor, getCurrentBranch, getCurrentSha, getShortSha, tagExists, tagExistsRemote } from "../../../src/release/core/git";
 import { MockRunner } from "../../../src/release/core/shell-runner";
 
 describe("git: defaultTagFor", () => {
@@ -94,32 +94,6 @@ describe("git: getCurrentSha + getShortSha", () => {
         });
 
         await expect(getCurrentSha({ cwd: "/r", runner })).resolves.toBeUndefined();
-    });
-});
-
-describe("git: hasUncommittedChanges", () => {
-    it("returns true when porcelain output is non-empty", async () => {
-        expect.hasAssertions();
-
-        const runner = new MockRunner();
-
-        runner.on("git", ["status", "--porcelain"], () => {
-            return { exitCode: 0, stderr: "", stdout: " M foo.ts\n" };
-        });
-
-        await expect(hasUncommittedChanges({ cwd: "/r", runner })).resolves.toBe(true);
-    });
-
-    it("returns false when working tree is clean", async () => {
-        expect.hasAssertions();
-
-        const runner = new MockRunner();
-
-        runner.on("git", ["status", "--porcelain"], () => {
-            return { exitCode: 0, stderr: "", stdout: "" };
-        });
-
-        await expect(hasUncommittedChanges({ cwd: "/r", runner })).resolves.toBe(false);
     });
 });
 

--- a/packages/tooling/vis/docs/commands/release.mdx
+++ b/packages/tooling/vis/docs/commands/release.mdx
@@ -127,17 +127,75 @@ Auto-derive a change file from branch commits.
 ```bash
 vis release generate
 vis release generate --from origin/main
+vis release generate --since-last-release
 vis release generate --dry-run
 ```
 
 **Options**
 
-| Option                   | Type    | Description                                                                |
-| ------------------------ | ------- | -------------------------------------------------------------------------- |
-| `--from <ref>`           | string  | Git ref to compare against (default: merge-base with `release.baseBranch`) |
-| `--name <slug>`          | string  | Filename slug (default: random animal name)                                |
-| `--dry-run`              | boolean | Print the would-be content without writing                                 |
-| `--print-config[=debug]` | string  | Print the resolved release config and exit                                 |
+| Option                   | Type    | Description                                                                           |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------- |
+| `--from <ref>`           | string  | Git ref to compare against (default: merge-base with `release.baseBranch`)            |
+| `--since-last-release`   | boolean | Start the range at the most recent release tag reachable from `HEAD` (see below)      |
+| `--allow-full-history`   | boolean | With `--since-last-release`: walk everything when no tag matches (first release only) |
+| `--name <slug>`          | string  | Filename slug (default: random animal name)                                           |
+| `--dry-run`              | boolean | Print the would-be content without writing                                            |
+| `--print-config[=debug]` | string  | Print the resolved release config and exit                                            |
+
+### Range resolution
+
+Precedence: `--from` → `--since-last-release` → merge-base with `release.baseBranch`.
+
+The merge-base default is right on a feature branch and useless on the release branch
+itself — there the merge-base with `baseBranch` _is_ `HEAD`, so the range is empty.
+`--since-last-release` is the flag for that case.
+
+**What "last release" means.** `generate` emits **one** change file for **one** commit
+range, so the boundary is workspace-wide, not per-package: the most recent tag matching
+`release.releaseTagPattern` that is reachable from `HEAD`, whichever package it belongs
+to. In the wave-based flow this flag exists for, every package that released did so at
+that wave's commit, so everything after it is genuinely unreleased. It resolves through
+the same tag machinery as `currentVersionResolver: "git-tag"` — the configured
+`releaseTagPattern` (per-package overrides included) drives both the tag glob and the
+strict matcher, so a tag like `@scope/a@nightly` is rejected.
+
+**No matching tag?** The command **fails**:
+
+```text
+--since-last-release: no git tag matching the configured releaseTagPattern is reachable from HEAD;
+the only remaining boundary is the repository root commit (a1b2c3d) — the whole history.
+Refusing to walk it: every package touched anywhere in that history would be bumped
+(major, for any breaking-change marker in it) and, on the auto-publish path, published.
+Pass --allow-full-history if this really is a first release, or pin the start of the
+range explicitly.
+```
+
+This is the common shape of the mistake: a repo tagged `v1.2.3` while `releaseTagPattern`
+is still the default `{name}@{version}` matches nothing, and the old fallback to the
+repository root commit turned that into "release every package in the workspace".
+
+`--allow-full-history` restores the root-commit range for the case it is actually right
+for — the very first release, before any tag exists. Pin the range with `--from <ref>`
+otherwise.
+
+### Machine release commits are skipped
+
+Commits written by release tooling never contribute a bump or a changelog line. The
+built-in heuristic covers `chore(release): …`, `chore(main): release …`,
+`chore: release v…` and vis's own `release(alpha): …` — so a package whose only commits
+in the range are its own release commits is **not** bumped.
+
+A bare `[skip ci]` / `[ci skip]` marker is **not** part of the heuristic: it means "don't
+run CI", not "don't release", and matching it would silently swallow a real
+`fix: … [skip ci]` along with its patch bump. Opt in with
+`ignoreCommitPattern: ["\\[skip ci\\]"]` if your repo wants the blunt rule.
+
+Subjects are also trimmed to their first line, which matters for multi-semantic-release:
+it writes a literal `\n\n`-joined changelog header into the commit subject, and without
+the trim that header would be transcribed verbatim into the new changelog entry.
+
+Extend the list with [`release.ignoreCommitPattern`](../guides/release.mdx#full-reference),
+or turn the built-ins off with `release.ignoreReleaseCommits: false`.
 
 ---
 
@@ -573,17 +631,53 @@ Force the auto-publish path with `--auto-publish` regardless of channel config.
 ```bash
 vis release ci release
 vis release ci release --auto-publish
+vis release ci release --auto-publish --generate
 ```
 
 **Options**
 
-| Option                   | Type    | Description                                                                    |
-| ------------------------ | ------- | ------------------------------------------------------------------------------ |
-| `--auto-publish`         | boolean | Skip the version-PR; version + publish inline                                  |
-| `--branch <name>`        | string  | Override the version-PR branch (default: `vis-release/version-packages`)       |
-| `--channel <name>`       | string  | Override branch-detected channel                                               |
-| `--first-release`        | boolean | Bootstrap mode: force `currentVersionResolver=disk` and skip remote tag checks |
-| `--print-config[=debug]` | string  | Print the resolved release config and exit                                     |
+| Option                   | Type    | Description                                                                          |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------ |
+| `--auto-publish`         | boolean | Skip the version-PR; version + publish inline                                        |
+| `--generate`             | boolean | Derive the change file from commits first (commit-driven repos)                      |
+| `--generate-from <ref>`  | string  | Start ref for `--generate` (e.g. `github.event.before`); default: since last release |
+| `--allow-full-history`   | boolean | With `--generate`: walk everything when no release tag matches (first release only)  |
+| `--branch <name>`        | string  | Override the version-PR branch (default: `vis-release/version-packages`)             |
+| `--channel <name>`       | string  | Override branch-detected channel                                                     |
+| `--first-release`        | boolean | Bootstrap mode: force `currentVersionResolver=disk` and skip remote tag checks       |
+| `--print-config[=debug]` | string  | Print the resolved release config and exit                                           |
+
+### Commit-driven repos: `--generate`
+
+If nobody on your team writes change files and conventional commits are the only source
+of truth, `--generate` turns the whole release into one step:
+
+```yaml
+- run: pnpm exec vis release ci release --auto-publish --generate
+```
+
+It runs [`generate`](#vis-release-generate) in-process before the pending-change-file
+check, using the [`--since-last-release`](#range-resolution) range by default (the
+merge-base default yields an empty range on the release branch itself). Pass
+`--generate-from "${{ github.event.before }}"` to pin the range to the previous CI run
+instead.
+
+If no tag matches `releaseTagPattern`, the command **fails** rather than walking the whole
+history and publishing everything in it — see [Range resolution](#range-resolution).
+`--allow-full-history` is the opt-in for a genuine first release.
+
+The generated file is **staged, never committed on its own** — no throwaway
+`chore(release): record pending vis change file` commit. Staging is what lets the version
+commit later record its deletion (`git add` refuses a path that was never in the index).
+
+The clean-tree guard runs **before** anything is generated, so an aborted run cannot leave
+a file behind that blocks the next one. Under `--generate` it forgives exactly one thing:
+a leftover `ci-<sha>.md` in the change dir from an interrupted earlier run, which is a
+real pending change file and gets released with the rest. Everything else — including a
+hand-written change file that was never committed — still fails, by name.
+
+When the range derives no bumps, the command reports it and falls through to the normal
+"nothing to release" path.
 
 **Tokens**
 

--- a/packages/tooling/vis/docs/guides/release.mdx
+++ b/packages/tooling/vis/docs/guides/release.mdx
@@ -665,6 +665,54 @@ Skips the GitHub / GitLab release-creation step while still pushing the git tag,
 
 Both forms parse identically. The gitmoji is stripped from the changelog entry; type/scope/subject parsing is unchanged.
 
+### Fully commit-driven repos
+
+If nobody authors change files and conventional commits alone decide the bumps, wire the
+whole release into one CI step:
+
+```yaml
+# push to the release branch
+- run: pnpm exec vis release ci release --auto-publish --generate
+```
+
+`--generate` derives the change file in-process (defaulting to the range since the last
+release tag), stages it without an extra commit, and publishes. Two behaviours make it
+safe to run over any range:
+
+- **`--since-last-release`** resolves the start ref to the most recent
+  `releaseTagPattern` tag reachable from `HEAD` — workspace-wide, because `generate`
+  produces one change file for one range. If **no** tag matches, the command fails
+  instead of quietly walking the entire history: "no release tag found" is not the same
+  statement as "nothing has ever been released", and treating it as such would bump every
+  package that has ever been touched — `major` for any historical `!` commit — and, on
+  this path, publish them. Pass `--allow-full-history` when that really is what you want
+  (a genuine first release), or pin the range with `--generate-from <ref>`.
+- **Machine release commits are skipped.** `chore(release): pkg@1.2.3 [skip ci]`,
+  `chore(main): release 1.2.3`, `chore: release v1.2.3` and vis's own `release(alpha): …`
+  contribute neither a bump nor a changelog line — so a package whose only commits in the
+  range are its own release commits is not bumped, and the previous changelog header those
+  commits carry is never pasted into the new entry. A bare `[skip ci]` marker is not part
+  of the heuristic (it would swallow a real `fix: … [skip ci]`); opt in with
+  `ignoreCommitPattern: ["\\[skip ci\\]"]`.
+
+Add your own patterns with `release.ignoreCommitPattern` (a regex source, or an array of
+them). They **extend** the built-ins:
+
+```ts
+release: {
+    ignoreCommitPattern: ["^chore\\(deps\\):", "^wip:"],
+}
+```
+
+Set `release.ignoreReleaseCommits: false` to drop the built-in heuristic entirely and
+match only your own patterns.
+
+> **`ignoreCommitPattern` vs `changelog.types[].hidden`.** Both hide commits, at different
+> layers: `ignoreCommitPattern` drops a commit from bump computation entirely (no version
+> bump, no changelog line), while a `hidden: true` entry in the changelog `types` table
+> only omits it from the rendered changelog — the commit still counts towards the bump.
+> Reach for `ignoreCommitPattern` when the commit should not cause a release at all.
+
 ### Bootstrapping the first release
 
 For brand-new packages with no published history, vis doesn't know what "previous" looks like. Use `--first-release` to bootstrap:
@@ -741,6 +789,8 @@ Run it locally before pushing release config changes, or wire it into your pre-m
 | Option                                                                                                            | Default                          | What it controls                                                                                                                                                                              |
 | ----------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `baseBranch`                                                                                                      | `"main"`                         | Baseline ref for `status` / `generate` / merge-base detection                                                                                                                                 |
+| `ignoreCommitPattern`                                                                                             | —                                | Extra regex source(s) whose matching commit subjects `generate` skips. Extends the built-in release-commit heuristic                                                                          |
+| `ignoreReleaseCommits`                                                                                            | `true`                           | Skip machine-authored release commits (`chore(release): …`, `chore(main): release …`, `release(…): …`) in `generate`. Set `false` to opt out                                                  |
 | `changesDir`                                                                                                      | `".vis/release"`                 | Where change files live                                                                                                                                                                       |
 | `access`                                                                                                          | `"public"`                       | Default npm `--access`                                                                                                                                                                        |
 | `defaultManaged`                                                                                                  | `false`                          | Whether unconfigured packages are released by default                                                                                                                                         |

--- a/packages/tooling/vis/schemas/vis-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-config.schema.json
@@ -4124,6 +4124,24 @@
                     },
                     "description": "Globs of packages to exclude from release entirely."
                 },
+                "ignoreCommitPattern": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Extra regex source(s) matched against each commit subject by `vis release generate`. A matching commit contributes neither a bump nor a changelog line.\n\nAccepts a single regex source or an array of them (plain strings, not `/…/` literals — the config file is also expressed as JSON in `schemas/vis-release-config.schema.json`). Invalid sources are skipped with a warning rather than failing the release.\n\nThese EXTEND the built-in machine-release-commit heuristic (`chore(release): …`, `chore(main): release …`, `chore: release v…`, `release(alpha): …`). Set `ignoreReleaseCommits: false` to drop the built-ins and match only your own patterns.\n\nA bare `[skip ci]` marker is deliberately not built in — it means \"don't run CI\", not \"don't release\", so matching it would swallow a real `fix: … [skip ci]` and its bump. Opt in with `ignoreCommitPattern: [\"\\\\[skip ci\\\\]\"]` if you want that."
+                },
+                "ignoreReleaseCommits": {
+                    "type": "boolean",
+                    "description": "Skip machine-authored release commits in `vis release generate`. Default `true`.\n\nWith the default, a package whose only commits in the range are its own `chore(release): pkg@1.2.3 [skip ci]` commits is not bumped, and the previous changelog header those commits carry is never transcribed into the new entry. Set to `false` for the historical (verbatim) behaviour — `ignoreCommitPattern` then becomes the only filter."
+                },
                 "include": {
                     "type": "array",
                     "items": {

--- a/packages/tooling/vis/schemas/vis-release-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-release-config.schema.json
@@ -198,6 +198,24 @@
             },
             "description": "Globs of packages to exclude from release entirely."
         },
+        "ignoreCommitPattern": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "description": "Extra regex source(s) matched against each commit subject by `vis release generate`. A matching commit contributes neither a bump nor a changelog line.\n\nAccepts a single regex source or an array of them (plain strings, not `/…/` literals — the config file is also expressed as JSON in `schemas/vis-release-config.schema.json`). Invalid sources are skipped with a warning rather than failing the release.\n\nThese EXTEND the built-in machine-release-commit heuristic (`chore(release): …`, `chore(main): release …`, `chore: release v…`, `release(alpha): …`). Set `ignoreReleaseCommits: false` to drop the built-ins and match only your own patterns.\n\nA bare `[skip ci]` marker is deliberately not built in — it means \"don't run CI\", not \"don't release\", so matching it would swallow a real `fix: … [skip ci]` and its bump. Opt in with `ignoreCommitPattern: [\"\\\\[skip ci\\\\]\"]` if you want that."
+        },
+        "ignoreReleaseCommits": {
+            "type": "boolean",
+            "description": "Skip machine-authored release commits in `vis release generate`. Default `true`.\n\nWith the default, a package whose only commits in the range are its own `chore(release): pkg@1.2.3 [skip ci]` commits is not bumped, and the previous changelog header those commits carry is never transcribed into the new entry. Set to `false` for the historical (verbatim) behaviour — `ignoreCommitPattern` then becomes the only filter."
+        },
         "include": {
             "type": "array",
             "items": {

--- a/packages/tooling/vis/src/commands/release/ci/release/handler.ts
+++ b/packages/tooling/vis/src/commands/release/ci/release/handler.ts
@@ -26,11 +26,14 @@
  *     downstream workflows on the version-PR)
  */
 
+import { join } from "node:path";
+
 import type { CerebroFs, CommandExecute, Toolbox } from "@visulima/cerebro";
 
 import { DEFAULT_CHANGES_DIR } from "../../../../release/config";
 import { readChangeFiles } from "../../../../release/core/change-file-reader";
-import { getCurrentBranch, hasUncommittedChanges, pushBranch, stageAndCommit } from "../../../../release/core/git";
+import { runGenerate } from "../../../../release/core/generate/run";
+import { getCurrentBranch, getShortSha, listUncommittedPaths, pushBranch, stageAndCommit, toRepoRelativePath } from "../../../../release/core/git";
 import { applyContext, buildContext, publishContext } from "../../../../release/core/orchestrator";
 import { createShellRunner } from "../../../../release/core/shell-runner";
 import { stateFilePath } from "../../../../release/core/state";
@@ -172,11 +175,26 @@ const applyPrMetadata = async (
     }
 };
 
+/**
+ * The exact filename shape `--generate` writes: `ci-&lt;short sha>.md`, or
+ * `ci-head.md` when the sha probe failed. Anchored and narrow on
+ * purpose — it is the only thing the clean-tree guard is allowed to
+ * forgive, so it must not match a hand-written change file.
+ */
+const GENERATED_CHANGE_FILE_NAME = /^ci-(?:head|[\da-f]{4,40})\.md$/;
+
+/** True for a repo-relative path that is this command's own generated change file. */
+const isGeneratedChangeFile = (path: string, changesDirRelative: string): boolean => {
+    const prefix = changesDirRelative === "" ? "" : `${changesDirRelative}/`;
+
+    return path.startsWith(prefix) && GENERATED_CHANGE_FILE_NAME.test(path.slice(prefix.length));
+};
+
 const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, ReleaseCiReleaseOptions>): Promise<void> => {
     const cwd = workspaceRoot ?? process.cwd();
     const runner = createShellRunner();
 
-    const ctx = await buildContext({ channel: options.channel, cwd });
+    let ctx = await buildContext({ channel: options.channel, cwd });
 
     const { printConfigIfRequested } = await import("../../../../release/core/print-config");
 
@@ -184,14 +202,112 @@ const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, 
         return;
     }
 
-    const mode: "version-pr" | "auto-publish" = options.autoPublish === true ? "auto-publish" : (ctx.channel?.mode ?? "auto-publish");
+    const changesDirectory = ctx.config.changesDir ?? DEFAULT_CHANGES_DIR;
+    const generating = options.generate === true;
 
-    if (await hasUncommittedChanges({ cwd, runner })) {
-        logger.warn("Working tree has uncommitted changes. CI mode requires a clean tree.");
+    // Clean-tree guard — runs BEFORE `--generate` writes anything.
+    //
+    // It used to run after, which made an aborted run poison every run
+    // that followed: the abort left `ci-<old sha>.md` behind, the next
+    // run at a new HEAD generated `ci-<new sha>.md`, and the leftover
+    // was then "unexpected dirt" forever (issue #864 F2).
+    //
+    // The only thing forgiven, and only under `--generate`, is a
+    // leftover matching the name this command itself writes, inside the
+    // change dir. That file is a genuine pending change file describing
+    // commits that were never released, so the wave consumes it like any
+    // other. With `--generate` off nothing is forgiven and this is
+    // exactly the old "is the tree clean?" boolean.
+    const changesDirRelative = generating ? await toRepoRelativePath({ cwd, runner }, join(cwd, changesDirectory)) : "";
+    const dirtyPaths = await listUncommittedPaths({ cwd, runner });
+    const leftoverGenerated = generating ? dirtyPaths.filter((path) => isGeneratedChangeFile(path, changesDirRelative)) : [];
+    const unexpectedPaths = dirtyPaths.filter((path) => !leftoverGenerated.includes(path));
+
+    if (unexpectedPaths.length > 0) {
+        const preview = unexpectedPaths.slice(0, 5).join(", ");
+        const more = unexpectedPaths.length > 5 ? ` (+${unexpectedPaths.length - 5} more)` : "";
+
+        logger.warn(`Working tree has uncommitted changes. CI mode requires a clean tree. Offending paths: ${preview}${more}`);
         process.exitCode = 1;
 
         return;
     }
+
+    if (leftoverGenerated.length > 0) {
+        logger.warn(`Keeping ${leftoverGenerated.length} change file(s) left behind by an interrupted --generate run: ${leftoverGenerated.join(", ")}.`);
+    }
+
+    // `--generate` (issue #864): derive the change file in-process so a
+    // commit-driven repo needs ONE CI step instead of
+    // `generate` → `git commit` → `ci release`. The generated file is
+    // staged (never committed on its own) so `applyContext`'s
+    // `git add -- <consumed change file>` can stage the deletion —
+    // `git add` refuses a path that was never in the index.
+    if (generating) {
+        const shortSha = await getShortSha({ cwd, runner });
+        const result = await runGenerate({
+            allowFullHistory: options.allowFullHistory === true,
+            config: ctx.config,
+            cwd,
+            from: options.generateFrom,
+            fs,
+            name: `ci-${shortSha ?? "head"}`,
+            packages: ctx.packages,
+            perPackageConfig: ctx.perPackageConfig,
+            runner,
+            // No explicit `--generate-from`? Walk from the last release
+            // tag — on the release branch itself the merge-base with
+            // baseBranch is HEAD, which would always yield nothing.
+            sinceLastRelease: options.generateFrom === undefined,
+        });
+
+        for (const note of result.notes) {
+            logger.info(note);
+        }
+
+        for (const warning of result.warnings) {
+            logger.warn(warning);
+        }
+
+        if (result.status === "failed") {
+            logger.error(result.error);
+            process.exitCode = 1;
+
+            return;
+        }
+
+        if (result.status === "written") {
+            const relativePath = await toRepoRelativePath({ cwd, runner }, result.createdFile);
+            const stage = await runner.run("git", ["add", "--", result.createdFile], { cwd, silent: true });
+
+            if (stage.exitCode !== 0) {
+                logger.error(`Could not stage the generated change file ${relativePath}: ${stage.stderr.trim() || `exit ${stage.exitCode}`}`);
+
+                // The guard above passed, so this file is the only thing
+                // this run added to the tree. Drop it again rather than
+                // leaving it for the next run to trip over.
+                try {
+                    await fs.rm(result.createdFile, { force: true });
+                } catch {
+                    logger.warn(`Could not clean up ${relativePath} after the staging failure — remove it before the next run.`);
+                }
+
+                process.exitCode = 1;
+
+                return;
+            }
+
+            logger.info(`Generated ${relativePath} from ${result.fromRef}..HEAD (${result.bumps.size} package(s)).`);
+
+            // The plan was assembled before the change file existed —
+            // rebuild so the release wave actually sees it.
+            ctx = await buildContext({ channel: options.channel, cwd });
+        } else {
+            logger.info(`--generate derived no bumps from ${result.fromRef}..HEAD.`);
+        }
+    }
+
+    const mode: "version-pr" | "auto-publish" = options.autoPublish === true ? "auto-publish" : (ctx.channel?.mode ?? "auto-publish");
 
     const { files: pendingFiles } = await readChangeFiles({ changesDir: ctx.config.changesDir, cwd });
 
@@ -241,8 +357,7 @@ const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, 
         // success). State-file present → pass `resume: true` so we
         // don't replay every package and either crash on already-
         // published versions or create parallel stages.
-        const changesDir = ctx.config.changesDir ?? DEFAULT_CHANGES_DIR;
-        const resumeWave = await hasPriorStateFile(fs, cwd, changesDir);
+        const resumeWave = await hasPriorStateFile(fs, cwd, changesDirectory);
 
         if (resumeWave) {
             logger.info("No pending change files but `.state.json` is present — resuming the prior wave's publish.");

--- a/packages/tooling/vis/src/commands/release/ci/release/index.ts
+++ b/packages/tooling/vis/src/commands/release/ci/release/index.ts
@@ -2,6 +2,10 @@ import type { InferOptions } from "@visulima/cerebro";
 import { defineCommand } from "@visulima/cerebro";
 
 const ciReleaseOptionDefinitions = {
+    "allow-full-history": {
+        description: "With --generate: walk the whole history when no release tag matches (first release only)",
+        type: Boolean,
+    },
     "auto-publish": {
         description: "Skip version-PR; version + publish inline",
         type: Boolean,
@@ -16,8 +20,16 @@ const ciReleaseOptionDefinitions = {
     },
     "first-release": {
         description:
-                "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
+            "Bootstrap mode for greenfield monorepos: force currentVersionResolver=disk and skip remote tag-collision checks. Use on the very first release before any git tags exist.",
         type: Boolean,
+    },
+    generate: {
+        description: "Derive the change file from commits first (commit-driven repos). Defaults to the range since the last release tag",
+        type: Boolean,
+    },
+    "generate-from": {
+        description: "Start ref for --generate (e.g. github.event.before). Overrides the since-last-release default",
+        type: String,
     },
     "print-config": {
         description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
@@ -31,6 +43,7 @@ const ciRelease = defineCommand({
     examples: [
         ["vis release ci release", "On push to main: open/update Versioned release PR; on PR merge: publish"],
         ["vis release ci release --auto-publish", "Skip version-PR; version + publish inline (alpha/beta workflow)"],
+        ["vis release ci release --auto-publish --generate", "Commit-driven: derive the change file from commits, then version + publish"],
     ],
     group: "Release",
     loader: () => import("./handler"),

--- a/packages/tooling/vis/src/commands/release/generate/handler.ts
+++ b/packages/tooling/vis/src/commands/release/generate/handler.ts
@@ -1,28 +1,26 @@
 /**
  * `vis release generate` — auto-derive a change file from branch commits.
  *
- * Two-tier resolution per commit (matches bumpy):
- *   1. Conventional-commits parse → `feat`→minor, `fix`/`perf`→patch,
- *      `BREAKING CHANGE`/`!`→major. Scope used to look up the package
- *      when present.
- *   2. File-path-based: detect changed packages from commit's file diff;
- *      default level `patch`.
+ * Thin cerebro wrapper around {@link runGenerate}; the derivation itself
+ * lives in `release/core/generate/run.ts` so `vis release ci release
+ * --generate` can reuse it in-process (issue #864).
  *
- * Multiple commits affecting the same package max-merge their levels.
+ * Range resolution, in precedence order:
+ *   1. `--from &lt;ref>`
+ *   2. `--since-last-release` — the most recent `releaseTagPattern` tag
+ *      reachable from HEAD (workspace-wide). No matching tag is an
+ *      error unless `--allow-full-history` says the whole history is
+ *      really what you want.
+ *   3. the merge-base with `baseBranch`.
  */
 
-import { join, relative } from "node:path";
+import { relative } from "node:path";
 
 import type { CommandExecute, Toolbox } from "@visulima/cerebro";
 
-import { DEFAULT_CHANGES_DIR } from "../../../release/config";
-import { formatChangeFile } from "../../../release/core/change-file";
-import { annotateAndResolveReverts, CC_TYPE_TO_BUMP } from "../../../release/core/generate/conventional-commits";
+import { runGenerate } from "../../../release/core/generate/run";
 import { buildContext } from "../../../release/core/orchestrator";
 import { createShellRunner } from "../../../release/core/shell-runner";
-import { randomAnimalSlug } from "../../../release/core/slug";
-import type { BumpLevel, ChangeFileSimple } from "../../../release/types";
-import { maxBump } from "../../../release/types";
 import type { ReleaseGenerateOptions } from "./index";
 
 const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, ReleaseGenerateOptions>): Promise<void> => {
@@ -35,192 +33,52 @@ const execute = async ({ fs, logger, options, workspaceRoot }: Toolbox<Console, 
         return;
     }
 
-    const runner = createShellRunner();
-
-    let fromRef = options.from;
-
-    if (!fromRef) {
-        // Find merge-base with baseBranch.
-        const baseBranch = ctx.config.baseBranch ?? "main";
-        const mergeBase = await runner.run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd, silent: true });
-
-        if (mergeBase.exitCode === 0 && mergeBase.stdout.trim()) {
-            fromRef = mergeBase.stdout.trim();
-        } else {
-            const fallback = await runner.run("git", ["merge-base", baseBranch, "HEAD"], { cwd, silent: true });
-
-            fromRef = fallback.exitCode === 0 ? fallback.stdout.trim() : "HEAD~10";
-        }
-    }
-
-    // Build a directory→package lookup. `git log --name-only` always emits
-    // forward slashes, so normalise pkg.dir to the same so Windows backslashes
-    // don't sabotage the prefix match below.
-    const dirToPkg = new Map<string, string>();
-
-    for (const pkg of ctx.packages) {
-        const rawRel = pkg.dir.startsWith(cwd) ? pkg.dir.slice(cwd.length) : pkg.dir;
-        const rel = rawRel.replaceAll("\\", "/").replace(/^\/+/, "");
-
-        dirToPkg.set(rel, pkg.name);
-    }
-
-    const findPackageForFile = (file: string): string | undefined => {
-        for (const [dir, name] of dirToPkg) {
-            if (file.startsWith(`${dir}/`) || file === `${dir}/package.json`) {
-                return name;
-            }
-        }
-
-        return undefined;
-    };
-
-    // Walk commits in fromRef..HEAD with a SINGLE git log invocation.
-    // Each commit's subject + body + changed files is delimited by a
-    // sentinel so we can parse without N+1 git calls. Was: 2 git calls
-    // per commit (50 commits → 100 git invocations); now: 1 total.
-    //
-    // Sentinels include random hex (per-process) so a commit body that
-    // legitimately contains the literal string "@@VIS_RELEASE_COMMIT@@"
-    // can't accidentally split a record. Belt + suspenders.
-    // eslint-disable-next-line sonarjs/pseudo-random -- non-cryptographic sentinel salt to avoid commit-body collisions
-    const sentinelSalt = Math.random().toString(16).slice(2, 10);
-    const SENTINEL_COMMIT = `@@VIS_RELEASE_COMMIT_${sentinelSalt}@@`;
-    const SENTINEL_FILES = `@@VIS_RELEASE_FILES_${sentinelSalt}@@`;
-    const log = await runner.run("git", ["log", `${fromRef}..HEAD`, `--pretty=format:${SENTINEL_COMMIT}%n%H%n%s%n%b%n${SENTINEL_FILES}`, "--name-only"], {
+    const result = await runGenerate({
+        allowFullHistory: options.allowFullHistory === true,
+        config: ctx.config,
         cwd,
-        silent: true,
+        dryRun: options.dryRun === true,
+        from: options.from,
+        fs,
+        name: options.name,
+        packages: ctx.packages,
+        perPackageConfig: ctx.perPackageConfig,
+        runner: createShellRunner(),
+        sinceLastRelease: options.sinceLastRelease === true,
     });
 
-    if (log.exitCode !== 0) {
-        logger.error(`git log failed: ${log.stderr}`);
+    // `runGenerate` is pure core — it returns what happened, this layer
+    // prints it. Notes/warnings first so they read as context for the
+    // outcome that follows.
+    for (const note of result.notes) {
+        logger.info(note);
+    }
+
+    for (const warning of result.warnings) {
+        logger.warn(warning);
+    }
+
+    if (result.status === "failed") {
+        logger.error(result.error);
         process.exitCode = 1;
 
         return;
     }
 
-    const bumps = new Map<string, BumpLevel>();
-    const subjects: string[] = [];
-
-    // Parse the sentinel-delimited stream into per-commit records.
-    interface CommitRecord {
-        body: string;
-        files: string[];
-        hash: string;
-        subject: string;
-    }
-
-    const commits: CommitRecord[] = [];
-    const sections = log.stdout
-        .split(SENTINEL_COMMIT)
-        .map((s) => s.trim())
-        .filter(Boolean);
-
-    for (const section of sections) {
-        const [filesPart, headerPart = ""] = section.split(SENTINEL_FILES).toReversed();
-        const headerLines = headerPart.split("\n");
-        const hash = headerLines[0]?.trim() ?? "";
-        const subject = headerLines[1]?.trim() ?? "";
-        const body = headerLines.slice(2).join("\n").trim();
-        const files = (filesPart ?? "")
-            .split("\n")
-            .map((s) => s.trim())
-            .filter(Boolean);
-
-        if (hash) {
-            commits.push({ body, files, hash, subject });
-        }
-    }
-
-    // Resolve revert pairs (release-please #296 parity). Commits whose
-    // revert lands inside the same fromRef..HEAD window get marked
-    // `cancelled` and contribute neither to the bump map nor the
-    // changelog subject list. Reverts of already-released commits are
-    // a no-op — `fromRef` is already the merge-base / last-release
-    // boundary, so anything older than that is implicitly shipped and
-    // wouldn't appear in the commit window in the first place.
-    const { commits: annotated, warnings: revertWarnings } = annotateAndResolveReverts(commits, undefined, `${fromRef}..HEAD`);
-
-    // F19: surface warnings produced during revert annotation (e.g. the
-    // no-type-ratio warning) via logger.warn so operators with no
-    // observability into "100 commits had no type" notice their team
-    // is shipping commits without conventional-commits prefixes.
-    for (const warning of revertWarnings) {
-        logger.warn(warning);
-    }
-
-    for (const { cancelled, files, parsed, subject } of annotated) {
-        if (cancelled) {
-            continue;
-        }
-
-        let level: BumpLevel = "patch";
-
-        if (parsed.breaking) {
-            level = "major";
-        } else if (parsed.type && CC_TYPE_TO_BUMP[parsed.type]) {
-            level = CC_TYPE_TO_BUMP[parsed.type] ?? "patch";
-        }
-
-        // Map by scope first, then by file paths from the same commit.
-        const targets = new Set<string>();
-
-        if (parsed.scope) {
-            for (const pkg of ctx.packages) {
-                if (pkg.name === parsed.scope || pkg.name.endsWith(`/${parsed.scope}`)) {
-                    targets.add(pkg.name);
-                }
-            }
-        }
-
-        if (targets.size === 0) {
-            for (const file of files) {
-                const owner = findPackageForFile(file);
-
-                if (owner) {
-                    targets.add(owner);
-                }
-            }
-        }
-
-        for (const target of targets) {
-            const existing = bumps.get(target);
-
-            bumps.set(target, existing ? maxBump(existing, level) : level);
-        }
-
-        if (targets.size > 0) {
-            subjects.push(`- ${subject}`);
-        }
-    }
-
-    if (bumps.size === 0) {
-        logger.info("No commits affected workspace packages — nothing to generate.");
-
+    if (result.status === "no-changes") {
         return;
     }
 
-    const payload: ChangeFileSimple = { bumps: Object.fromEntries(bumps) };
-    const body = subjects.length > 0 ? subjects.join("\n") : "Auto-generated change file.";
-    const content = formatChangeFile(payload, body);
-
-    if (options.dryRun) {
+    if (result.status === "dry-run") {
         logger.info("[dry-run] would write:");
-        logger.info(content);
+        logger.info(result.content);
 
         return;
     }
 
-    const changesDir = ctx.config.changesDir ?? DEFAULT_CHANGES_DIR;
-    const slug = (options.name ?? randomAnimalSlug()).replaceAll(/[^a-z0-9-]/gi, "-");
-    const filePath = join(cwd, changesDir, `${slug}.md`);
+    logger.info(`Created ${relative(cwd, result.createdFile)}`);
 
-    await fs.mkdir(join(cwd, changesDir), { recursive: true });
-    await fs.writeFile(filePath, content);
-
-    logger.info(`Created ${relative(cwd, filePath)}`);
-
-    for (const [name, level] of bumps) {
+    for (const [name, level] of result.bumps) {
         logger.info(`  ${name}: ${level}`);
     }
 };

--- a/packages/tooling/vis/src/commands/release/generate/index.ts
+++ b/packages/tooling/vis/src/commands/release/generate/index.ts
@@ -2,6 +2,10 @@ import type { InferOptions } from "@visulima/cerebro";
 import { defineCommand } from "@visulima/cerebro";
 
 const generateOptionDefinitions = {
+    "allow-full-history": {
+        description: "With --since-last-release: walk the whole history when no release tag matches (first release only)",
+        type: Boolean,
+    },
     "dry-run": {
         description: "Print would-be content without writing",
         type: Boolean,
@@ -18,6 +22,10 @@ const generateOptionDefinitions = {
         description: "Print the resolved release config and exit (--print-config=debug for runtime-resolved fields)",
         type: String,
     },
+    "since-last-release": {
+        description: "Start the range at the most recent releaseTagPattern tag reachable from HEAD (fails when no tag matches)",
+        type: Boolean,
+    },
 } as const;
 
 const generate = defineCommand({
@@ -26,6 +34,8 @@ const generate = defineCommand({
     examples: [
         ["vis release generate", "Walk commits since the merge-base with baseBranch"],
         ["vis release generate --from origin/main", "Walk commits since the given ref"],
+        ["vis release generate --since-last-release", "Walk commits since the most recent release tag reachable from HEAD"],
+        ["vis release generate --since-last-release --allow-full-history", "First release: no tag exists yet, so walk everything"],
         ["vis release generate --dry-run", "Print the would-be content without writing"],
     ],
     group: "Release",

--- a/packages/tooling/vis/src/release/core/generate/conventional-commits.ts
+++ b/packages/tooling/vis/src/release/core/generate/conventional-commits.ts
@@ -487,3 +487,190 @@ export const annotateAndResolveReverts = (
 
     return { commits: annotated, warnings };
 };
+
+// ── Machine release-commit filtering (issue #864) ──────────────────
+
+/**
+ * Built-in heuristic for "this commit was written by release tooling,
+ * not by a human". Release commits must never contribute a bump or a
+ * changelog line — a package whose only commits in the range are its
+ * own release commits would otherwise be bumped forever, and the
+ * previous changelog header would be transcribed verbatim into the new
+ * entry.
+ *
+ * Recognised shapes:
+ *
+ *   - `chore(release): \@scope/pkg\@1.0.0-alpha.44 [skip ci]` —
+ *     multi-semantic-release + changesets (`chore(release): version packages`).
+ *   - `chore(main): release 1.2.3` — release-please.
+ *   - `chore: release v1.2.3` — plain release-please / lerna style.
+ *   - `release(alpha): version packages [skip ci]` — vis's own
+ *     version-PR commit (see `ci release`).
+ *
+ * A `[skip ci]` / `[ci skip]` marker is deliberately NOT a pattern of
+ * its own. It means "don't run CI", not "don't release": humans put it
+ * on ordinary commits, so matching it alone would silently swallow a
+ * real `fix: … [skip ci]` and lose the patch bump with it. Every
+ * machine format above already carries its own subject prefix, so
+ * nothing is missed. Repos that do want the blunt rule can opt in with
+ * `ignoreCommitPattern: ["\\[skip ci\\]"]`.
+ *
+ * Every pattern BELOW is anchored and uses bounded quantifiers so a
+ * pathological subject cannot trigger catastrophic backtracking
+ * (CodeQL polynomial-ReDoS). That property is a claim about these
+ * literals only — user-supplied `ignoreCommitPattern` sources carry no
+ * such guarantee (see {@link buildIgnoreCommitMatchers}).
+ */
+export const DEFAULT_RELEASE_COMMIT_PATTERNS: ReadonlyArray<RegExp> = [
+    // `chore(release): …` / `chore(release)!: …`
+    /^chore\(release\)!?:/i,
+    // release-please: `chore(main): release 1.2.3`, `chore(@scope/pkg): release 1.2.3`
+    /^chore\([^\n)]{0,64}\)!?:[ \t]{0,8}release[ \t]/i,
+    // `chore: release v1.2.3`
+    /^chore!?:[ \t]{0,8}release[ \t]/i,
+    // vis: `release: version packages [skip ci]` / `release(alpha): …`
+    /^release(?:\([^\n)]{0,64}\))?!?:/i,
+];
+
+/** Options controlling {@link buildIgnoreCommitMatchers}. */
+export interface BuildIgnoreCommitMatchersOptions {
+    /** `release.ignoreCommitPattern` — regex source(s) from user config. */
+    ignoreCommitPattern?: string | string[];
+
+    /**
+     * `release.ignoreReleaseCommits` — explicit opt-out from the
+     * built-in heuristic. Default `true` (heuristic active). User
+     * patterns EXTEND the built-ins; setting this to `false` is the
+     * only way to drop them.
+     */
+    ignoreReleaseCommits?: boolean;
+
+    /**
+     * Invoked once per unparseable user pattern so the caller can
+     * surface it (`logger.warn`). An invalid pattern is skipped, never
+     * fatal — a typo in config must not brick a release.
+     */
+    onInvalidPattern?: (source: string, error: Error) => void;
+}
+
+/**
+ * Compile the effective ignore-matcher list: the built-in release-commit
+ * heuristic (unless explicitly opted out via `ignoreReleaseCommits:
+ * false`) plus every user-supplied `ignoreCommitPattern` source.
+ *
+ * User patterns are compiled with `new RegExp(source)` — case-sensitive
+ * unless the source itself opts otherwise — and run unsandboxed.
+ *
+ * **No ReDoS guarantee.** {@link isIgnoredCommit} truncates the tested
+ * subject, which bounds the *input*, not the backtracking: a pattern
+ * with nested quantifiers (`(a+)+$` and friends) is exponential in the
+ * input length and hangs long before 512 characters. There is no
+ * timeout around a JS regex, so a pathological source here stalls the
+ * release until the job is killed.
+ *
+ * That is accepted rather than mitigated because this is not a trust
+ * boundary: the sources come from the repo's own `vis.config.*`, which
+ * already executes arbitrary code at load time. A repo that can set
+ * `ignoreCommitPattern` can hang its release far more directly. Do NOT
+ * extend this to accept patterns from a commit, a PR body, or any other
+ * attacker-reachable input without a real mitigation first.
+ */
+export const buildIgnoreCommitMatchers = (options: BuildIgnoreCommitMatchersOptions = {}): RegExp[] => {
+    const matchers: RegExp[] = options.ignoreReleaseCommits === false ? [] : [...DEFAULT_RELEASE_COMMIT_PATTERNS];
+    const raw = options.ignoreCommitPattern;
+    const sources = raw === undefined ? [] : typeof raw === "string" ? [raw] : raw;
+
+    for (const source of sources) {
+        if (typeof source !== "string" || source.trim() === "") {
+            continue;
+        }
+
+        try {
+            matchers.push(new RegExp(source));
+        } catch (error) {
+            options.onInvalidPattern?.(source, error as Error);
+        }
+    }
+
+    return matchers;
+};
+
+/**
+ * Maximum subject length considered by {@link isIgnoredCommit}. Commit
+ * subjects are conventionally ≤ 100 chars, so this only ever truncates
+ * pathological ones and keeps the built-in matchers' linear scan cheap.
+ *
+ * It is NOT a ReDoS bound for user-supplied patterns — see
+ * {@link buildIgnoreCommitMatchers} for why that is accepted.
+ */
+const IGNORE_MATCH_MAX_SUBJECT_LENGTH = 512;
+
+/**
+ * True when the subject matches any ignore matcher — i.e. the commit is
+ * machine-authored release bookkeeping (or the operator asked for it to
+ * be dropped) and must contribute neither a bump nor a changelog line.
+ */
+export const isIgnoredCommit = (subject: string, matchers: ReadonlyArray<RegExp>): boolean => {
+    if (matchers.length === 0) {
+        return false;
+    }
+
+    const probe = subject.slice(0, IGNORE_MATCH_MAX_SUBJECT_LENGTH);
+
+    return matchers.some((matcher) => {
+        // `lastIndex` is shared state on /g and /y regexes; reset it
+        // defensively so a user pattern carrying those flags can't skip
+        // every other commit.
+
+        matcher.lastIndex = 0;
+
+        return matcher.test(probe);
+    });
+};
+
+/**
+ * Trim a commit subject down to its first line.
+ *
+ * `git log --pretty=%s` yields the real first line, but
+ * multi-semantic-release writes its release commits with a LITERAL
+ * `\n\n` escape sequence between the subject and the changelog header
+ * it appends:
+ *
+ * ```text
+ * chore(release): \@scope/pkg\@1.0.0 [skip ci]\n\n## \@scope/pkg [1.0.0](…) (2026-09-07)
+ * ```
+ *
+ * Git sees that as one physical line, so `%s` returns the whole thing
+ * and the old changelog header gets transcribed into the freshly
+ * generated change file.
+ *
+ * Cut at the first real newline, or at a literal `\n\n` escape that is
+ * followed by a markdown heading — the exact shape above. The heading
+ * check is what keeps an ordinary subject that merely *mentions* an
+ * escape intact: `fix(parser): handle \n in template literals` must
+ * survive whole, so a bare literal `\n` is never a cut point.
+ */
+export const normalizeCommitSubject = (subject: string): string => {
+    const candidates: number[] = [];
+    const realNewline = subject.indexOf("\n");
+
+    if (realNewline !== -1) {
+        candidates.push(realNewline);
+    }
+
+    // Only the doubled escape immediately preceding a `#` heading is the
+    // multi-semantic-release changelog-header join. Anything else is prose.
+    const escapedBreak = String.raw`\n\n`;
+    let index = subject.indexOf(escapedBreak);
+
+    while (index !== -1) {
+        if (/^\s{0,8}#/.test(subject.slice(index + escapedBreak.length))) {
+            candidates.push(index);
+            break;
+        }
+
+        index = subject.indexOf(escapedBreak, index + 1);
+    }
+
+    return (candidates.length > 0 ? subject.slice(0, Math.min(...candidates)) : subject).trim();
+};

--- a/packages/tooling/vis/src/release/core/generate/run.ts
+++ b/packages/tooling/vis/src/release/core/generate/run.ts
@@ -1,0 +1,396 @@
+/**
+ * Shared implementation behind `vis release generate` and
+ * `vis release ci release --generate`.
+ *
+ * Extracted from the command handler (issue #864) so the CI driver can
+ * derive its own change file in-process instead of the three-step
+ * "generate → commit → ci release" dance, and so both entry points can
+ * never drift on range resolution or release-commit filtering.
+ *
+ * Two-tier resolution per commit (matches bumpy):
+ *   1. Conventional-commits parse → `feat`→minor, `fix`/`perf`→patch,
+ *      `BREAKING CHANGE`/`!`→major. Scope used to look up the package
+ *      when present.
+ *   2. File-path-based: detect changed packages from the commit's file
+ *      diff; default level `patch`.
+ *
+ * Multiple commits affecting the same package max-merge their levels.
+ *
+ * Pure core: this module never logs. It returns a discriminated
+ * {@link RunGenerateResult} plus `notes` / `warnings`, and the command
+ * layer decides what to print — so the two entry points can't drift on
+ * wording or print the same fact twice.
+ */
+
+import { join } from "node:path";
+
+import type { CerebroFs } from "@visulima/cerebro";
+
+import { DEFAULT_CHANGES_DIR } from "../../config";
+import type { BumpLevel, ChangeFileSimple, PerPackageReleaseConfig, VisReleaseConfig, WorkspacePackage } from "../../types";
+import { maxBump } from "../../types";
+import { formatChangeFile } from "../change-file";
+import type { CommandRunner } from "../package-managers/interface";
+import { randomAnimalSlug } from "../slug";
+import { resolveLastReleaseRef } from "../version-resolver";
+import { annotateAndResolveReverts, buildIgnoreCommitMatchers, CC_TYPE_TO_BUMP, isIgnoredCommit, normalizeCommitSubject } from "./conventional-commits";
+
+export interface RunGenerateOptions {
+    /**
+     * Permit `--since-last-release` to walk the ENTIRE repository
+     * history when no release tag is reachable from HEAD.
+     *
+     * Off by default, and deliberately so: the tagless case is not rare
+     * (a repo tagged `v1.2.3` while `releaseTagPattern` is
+     * `{name}@{version}` never matches), and walking everything bumps
+     * every package that has ever been touched — `major` for any
+     * historical `!` commit — which `ci release --generate
+     * --auto-publish` would then publish unattended. Callers surface
+     * this as `--allow-full-history`; it is the right answer only for a
+     * genuine first release.
+     */
+    allowFullHistory?: boolean;
+    /** Resolved `release` config block. */
+    config: VisReleaseConfig;
+    /** Workspace root. */
+    cwd: string;
+    /** Compute the change file but do not write it. */
+    dryRun?: boolean;
+    /** Explicit start ref. Wins over `sinceLastRelease`. */
+    from?: string;
+    /** Injected fs (cerebro toolbox). */
+    fs: CerebroFs;
+    /** Slug for the generated filename. Default: a random animal name. */
+    name?: string;
+    /** Discovered workspace packages. */
+    packages: ReadonlyArray<WorkspacePackage>;
+    /** Per-package config map (for `releaseTagPattern` overrides). */
+    perPackageConfig?: ReadonlyMap<string, PerPackageReleaseConfig>;
+    runner: CommandRunner;
+
+    /**
+     * Resolve the start ref to the most recent `releaseTagPattern`
+     * tag reachable from HEAD instead of the merge-base with
+     * `baseBranch`. Ignored when `from` is set.
+     */
+    sinceLastRelease?: boolean;
+}
+
+/**
+ * Fields every outcome carries.
+ *
+ * `notes` / `warnings` exist because this module is `release/core`: it
+ * computes and returns, the command layer decides what to print (same
+ * contract as `resolveCurrentVersions` and `annotateAndResolveReverts`).
+ * Nothing here writes to a logger.
+ */
+interface RunGenerateOutcome {
+    /** Number of commits dropped by the release-commit / `ignoreCommitPattern` filter. */
+    ignoredCommits: number;
+    /** Info-level lines for the command layer to print, in order. */
+    notes: string[];
+    /** Warning-level lines for the command layer to print, in order. */
+    warnings: string[];
+}
+
+/** Outcomes that got far enough to walk a commit range. */
+interface RunGenerateWalked extends RunGenerateOutcome {
+    /** Derived bumps, keyed by package name. */
+    bumps: ReadonlyMap<string, BumpLevel>;
+    /** The resolved start ref of the walked range. */
+    fromRef: string;
+}
+
+/** `dryRun` — the content was rendered but nothing was written. */
+export interface RunGenerateDryRun extends RunGenerateWalked {
+    /** Rendered change-file content. */
+    content: string;
+    status: "dry-run";
+}
+
+/** The run could not produce a change file; the caller must exit non-zero. */
+export interface RunGenerateFailure extends RunGenerateOutcome {
+    /** Operator-facing explanation — print it via `logger.error`. */
+    error: string;
+    /** The start ref, when the failure happened after the range was resolved. */
+    fromRef?: string;
+    status: "failed";
+}
+
+/** The range held no commit that maps to a workspace package. */
+export interface RunGenerateNoChanges extends RunGenerateWalked {
+    status: "no-changes";
+}
+
+/** A change file was written to disk. */
+export interface RunGenerateWritten extends RunGenerateWalked {
+    /** Rendered change-file content. */
+    content: string;
+    /** Absolute path of the file written. */
+    createdFile: string;
+    status: "written";
+}
+
+export type RunGenerateResult = RunGenerateDryRun | RunGenerateFailure | RunGenerateNoChanges | RunGenerateWritten;
+
+interface CommitRecord {
+    body: string;
+    files: string[];
+    hash: string;
+    subject: string;
+}
+
+interface ResolveFromRefResult {
+    /** Set when no safe range could be derived; the run must fail. */
+    error?: string;
+    notes: string[];
+    /** The resolved start ref. Absent iff `error` is set. */
+    ref?: string;
+    warnings: string[];
+}
+
+/**
+ * Resolve the `&lt;from>` side of the walked range.
+ *
+ * Precedence: explicit `--from` → `--since-last-release` → merge-base
+ * with `baseBranch` → `HEAD~10`.
+ */
+const resolveFromRef = async (options: RunGenerateOptions): Promise<ResolveFromRefResult> => {
+    const { config, cwd, packages, perPackageConfig, runner } = options;
+    const notes: string[] = [];
+    const warnings: string[] = [];
+
+    if (options.from) {
+        return { notes, ref: options.from, warnings };
+    }
+
+    if (options.sinceLastRelease) {
+        const resolved = await resolveLastReleaseRef({ cwd, packages, perPackageConfig, runner, workspaceConfig: config });
+
+        if (resolved.kind === "tag" && resolved.ref) {
+            notes.push(`--since-last-release: ${resolved.reason}.`);
+
+            return { notes, ref: resolved.ref, warnings };
+        }
+
+        if (resolved.kind === "root-commit" && resolved.ref) {
+            // The destructive case. "No release tag matched" is NOT the
+            // same statement as "everything ever committed is
+            // unreleased", and silently treating it as such bumps every
+            // package in the workspace — `major` on any historical `!`
+            // commit — which `ci release --generate --auto-publish`
+            // then publishes with no human in the loop.
+            if (options.allowFullHistory !== true) {
+                return {
+                    error:
+                        `--since-last-release: ${resolved.reason}. Refusing to walk it: every package touched anywhere in that history `
+                        + `would be bumped (major, for any breaking-change marker in it) and, on the auto-publish path, published. `
+                        + `Pass --allow-full-history if this really is a first release, or pin the start of the range explicitly.`,
+                    notes,
+                    warnings,
+                };
+            }
+
+            warnings.push(`--since-last-release: ${resolved.reason}. Walking it because --allow-full-history was passed.`);
+
+            return { notes, ref: resolved.ref, warnings };
+        }
+
+        warnings.push(`--since-last-release: ${resolved.reason}. Falling back to the merge-base with baseBranch.`);
+    }
+
+    const baseBranch = config.baseBranch ?? "main";
+    const mergeBase = await runner.run("git", ["merge-base", `origin/${baseBranch}`, "HEAD"], { cwd, silent: true });
+
+    if (mergeBase.exitCode === 0 && mergeBase.stdout.trim()) {
+        return { notes, ref: mergeBase.stdout.trim(), warnings };
+    }
+
+    const fallback = await runner.run("git", ["merge-base", baseBranch, "HEAD"], { cwd, silent: true });
+
+    return { notes, ref: fallback.exitCode === 0 && fallback.stdout.trim() ? fallback.stdout.trim() : "HEAD~10", warnings };
+};
+
+export const runGenerate = async (options: RunGenerateOptions): Promise<RunGenerateResult> => {
+    const { config, cwd, fs, packages, runner } = options;
+
+    const range = await resolveFromRef(options);
+    const notes: string[] = [...range.notes];
+    const warnings: string[] = [...range.warnings];
+
+    if (range.error !== undefined || range.ref === undefined) {
+        return { error: range.error ?? "Could not resolve the start of the commit range.", ignoredCommits: 0, notes, status: "failed", warnings };
+    }
+
+    const fromRef = range.ref;
+
+    // Build a directory→package lookup. `git log --name-only` always emits
+    // forward slashes, so normalise pkg.dir to the same so Windows backslashes
+    // don't sabotage the prefix match below.
+    const dirToPkg = new Map<string, string>();
+
+    for (const pkg of packages) {
+        const rawRel = pkg.dir.startsWith(cwd) ? pkg.dir.slice(cwd.length) : pkg.dir;
+        const rel = rawRel.replaceAll("\\", "/").replace(/^\/+/, "");
+
+        dirToPkg.set(rel, pkg.name);
+    }
+
+    const findPackageForFile = (file: string): string | undefined => {
+        for (const [dir, name] of dirToPkg) {
+            if (file.startsWith(`${dir}/`) || file === `${dir}/package.json`) {
+                return name;
+            }
+        }
+
+        return undefined;
+    };
+
+    // Walk commits in fromRef..HEAD with a SINGLE git log invocation.
+    // Each commit's subject + body + changed files is delimited by a
+    // sentinel so we can parse without N+1 git calls. Was: 2 git calls
+    // per commit (50 commits → 100 git invocations); now: 1 total.
+    //
+    // Sentinels include random hex (per-process) so a commit body that
+    // legitimately contains the literal string "@@VIS_RELEASE_COMMIT@@"
+    // can't accidentally split a record. Belt + suspenders.
+    // eslint-disable-next-line sonarjs/pseudo-random -- non-cryptographic sentinel salt to avoid commit-body collisions
+    const sentinelSalt = Math.random().toString(16).slice(2, 10);
+    const SENTINEL_COMMIT = `@@VIS_RELEASE_COMMIT_${sentinelSalt}@@`;
+    const SENTINEL_FILES = `@@VIS_RELEASE_FILES_${sentinelSalt}@@`;
+    const log = await runner.run("git", ["log", `${fromRef}..HEAD`, `--pretty=format:${SENTINEL_COMMIT}%n%H%n%s%n%b%n${SENTINEL_FILES}`, "--name-only"], {
+        cwd,
+        silent: true,
+    });
+
+    if (log.exitCode !== 0) {
+        return { error: `git log failed: ${log.stderr}`, fromRef, ignoredCommits: 0, notes, status: "failed", warnings };
+    }
+
+    const bumps = new Map<string, BumpLevel>();
+    const subjects: string[] = [];
+
+    const commits: CommitRecord[] = [];
+    const sections = log.stdout
+        .split(SENTINEL_COMMIT)
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+    for (const section of sections) {
+        const [filesPart, headerPart = ""] = section.split(SENTINEL_FILES).toReversed();
+        const headerLines = headerPart.split("\n");
+        const hash = headerLines[0]?.trim() ?? "";
+        // Trim the subject to its first line — multi-semantic-release
+        // release commits carry a LITERAL `\n\n`-joined changelog header
+        // in the subject, which git reports as one physical line.
+        const subject = normalizeCommitSubject(headerLines[1] ?? "");
+        const body = headerLines.slice(2).join("\n").trim();
+        const files = (filesPart ?? "")
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean);
+
+        if (hash) {
+            commits.push({ body, files, hash, subject });
+        }
+    }
+
+    // Drop machine-authored release commits (and any operator-configured
+    // `ignoreCommitPattern`) BEFORE revert resolution and bump mapping —
+    // a package whose only commits in the range are its own release
+    // commits must not get a bump, and the previous changelog header
+    // must never be transcribed into the new entry.
+    const matchers = buildIgnoreCommitMatchers({
+        ignoreCommitPattern: config.ignoreCommitPattern,
+        ignoreReleaseCommits: config.ignoreReleaseCommits,
+        onInvalidPattern: (source, error) => {
+            warnings.push(`Ignoring invalid release.ignoreCommitPattern entry ${JSON.stringify(source)}: ${error.message}`);
+        },
+    });
+    const kept = commits.filter((commit) => !isIgnoredCommit(commit.subject, matchers));
+    const ignoredCommits = commits.length - kept.length;
+
+    if (ignoredCommits > 0) {
+        notes.push(`Skipped ${ignoredCommits} release/ignored commit(s) in ${fromRef}..HEAD.`);
+    }
+
+    // Resolve revert pairs (release-please #296 parity). Commits whose
+    // revert lands inside the same fromRef..HEAD window get marked
+    // `cancelled` and contribute neither to the bump map nor the
+    // changelog subject list.
+    const { commits: annotated, warnings: revertWarnings } = annotateAndResolveReverts(kept, undefined, `${fromRef}..HEAD`);
+
+    // F19: surface warnings produced during revert annotation (e.g. the
+    // no-type-ratio warning) so operators with no observability into
+    // "100 commits had no type" notice their team is shipping commits
+    // without conventional-commits prefixes.
+    warnings.push(...revertWarnings);
+
+    for (const { cancelled, files, parsed, subject } of annotated) {
+        if (cancelled) {
+            continue;
+        }
+
+        let level: BumpLevel = "patch";
+
+        if (parsed.breaking) {
+            level = "major";
+        } else if (parsed.type && CC_TYPE_TO_BUMP[parsed.type]) {
+            level = CC_TYPE_TO_BUMP[parsed.type] ?? "patch";
+        }
+
+        // Map by scope first, then by file paths from the same commit.
+        const targets = new Set<string>();
+
+        if (parsed.scope) {
+            for (const pkg of packages) {
+                if (pkg.name === parsed.scope || pkg.name.endsWith(`/${parsed.scope}`)) {
+                    targets.add(pkg.name);
+                }
+            }
+        }
+
+        if (targets.size === 0) {
+            for (const file of files) {
+                const owner = findPackageForFile(file);
+
+                if (owner) {
+                    targets.add(owner);
+                }
+            }
+        }
+
+        for (const target of targets) {
+            const existing = bumps.get(target);
+
+            bumps.set(target, existing ? maxBump(existing, level) : level);
+        }
+
+        if (targets.size > 0) {
+            subjects.push(`- ${subject}`);
+        }
+    }
+
+    if (bumps.size === 0) {
+        notes.push("No commits affected workspace packages — nothing to generate.");
+
+        return { bumps, fromRef, ignoredCommits, notes, status: "no-changes", warnings };
+    }
+
+    const payload: ChangeFileSimple = { bumps: Object.fromEntries(bumps) };
+    const body = subjects.length > 0 ? subjects.join("\n") : "Auto-generated change file.";
+    const content = formatChangeFile(payload, body);
+
+    if (options.dryRun) {
+        return { bumps, content, fromRef, ignoredCommits, notes, status: "dry-run", warnings };
+    }
+
+    const changesDir = config.changesDir ?? DEFAULT_CHANGES_DIR;
+    const slug = (options.name ?? randomAnimalSlug()).replaceAll(/[^a-z0-9-]/gi, "-");
+    const filePath = join(cwd, changesDir, `${slug}.md`);
+
+    await fs.mkdir(join(cwd, changesDir), { recursive: true });
+    await fs.writeFile(filePath, content);
+
+    return { bumps, content, createdFile: filePath, fromRef, ignoredCommits, notes, status: "written", warnings };
+};

--- a/packages/tooling/vis/src/release/core/git.ts
+++ b/packages/tooling/vis/src/release/core/git.ts
@@ -6,6 +6,8 @@
  * `VisReleaseError` with `TAG_PUSH_FAILED` / `TAG_COLLISION` codes.
  */
 
+import { relative } from "node:path";
+
 import { VisReleaseError } from "../errors";
 import type { CommandRunner } from "./package-managers/interface";
 
@@ -43,10 +45,59 @@ export const getShortSha = async (ctx: GitContext): Promise<string | undefined> 
     return result.exitCode === 0 ? result.stdout.trim() : undefined;
 };
 
-export const hasUncommittedChanges = async (ctx: GitContext): Promise<boolean> => {
-    const result = await run(ctx, ["status", "--porcelain"]);
+/**
+ * List every path git reports as dirty (modified, staged, untracked,
+ * renamed, deleted), as repo-relative POSIX paths.
+ *
+ * Superseded the old `hasUncommittedChanges` boolean: `ci release
+ * --generate` needs to name the offending paths, and to tell its own
+ * generated change file apart from unrelated dirt (issue #864). An
+ * empty array is the "clean tree" answer.
+ *
+ * Porcelain v1 line shapes handled:
+ *   `?? path`            — untracked
+ *   ` M path`            — worktree modification
+ *   `R  old -> new`      — rename (we report the destination)
+ *   `A  "quoted path"`   — paths with specials are C-quoted by git.
+ */
+export const listUncommittedPaths = async (ctx: GitContext): Promise<string[]> => {
+    // `--untracked-files=all` disables git's directory rollup (`?? .vis/`),
+    // which would otherwise hide sibling junk behind the same entry the
+    // generated change file lives in.
+    const result = await run(ctx, ["status", "--porcelain", "--untracked-files=all"]);
 
-    return result.exitCode === 0 && result.stdout.trim() !== "";
+    if (result.exitCode !== 0) {
+        return [];
+    }
+
+    const unquote = (value: string): string => {
+        if (!value.startsWith(String.raw`"`) || !value.endsWith(String.raw`"`) || value.length < 2) {
+            return value;
+        }
+
+        const inner = value.slice(1, -1);
+
+        try {
+            return JSON.parse(`"${inner}"`) as string;
+        } catch {
+            return inner;
+        }
+    };
+
+    return result.stdout
+        .split("\n")
+        .map((line) => line.replace(/\r$/, ""))
+        .filter((line) => line.trim() !== "")
+        .map((line) => {
+            // Status codes occupy the first two columns; the path starts at column 3.
+            const rest = line.length > 3 ? line.slice(3) : line.trim();
+            // Renames/copies are reported as `old -> new`; the destination is what's dirty.
+            const arrow = rest.lastIndexOf(" -> ");
+            const raw = arrow === -1 ? rest : rest.slice(arrow + 4);
+
+            return unquote(raw.trim());
+        })
+        .filter(Boolean);
 };
 
 export const tagExists = async (ctx: GitContext, tag: string): Promise<boolean> => {
@@ -59,6 +110,24 @@ export const tagExistsRemote = async (ctx: GitContext, tag: string, remote = "or
     const result = await run(ctx, ["ls-remote", "--tags", remote, tag]);
 
     return result.exitCode === 0 && result.stdout.trim() !== "";
+};
+
+/**
+ * Repo-relative POSIX path for an absolute file, as `git status
+ * --porcelain` would report it — so a path can be compared against
+ * {@link listUncommittedPaths} output.
+ *
+ * `ctx.cwd` is the workspace root, which is not necessarily the git
+ * toplevel (a workspace nested in a larger repo), hence the probe.
+ * Falls back to `ctx.cwd`-relative when the probe fails — that only
+ * happens outside a git repo, where the caller fails for other reasons
+ * anyway.
+ */
+export const toRepoRelativePath = async (ctx: GitContext, absolutePath: string): Promise<string> => {
+    const toplevel = await run(ctx, ["rev-parse", "--show-toplevel"]);
+    const root = toplevel.exitCode === 0 && toplevel.stdout.trim() ? toplevel.stdout.trim() : ctx.cwd;
+
+    return relative(root, absolutePath).replaceAll("\\", "/");
 };
 
 // ── Mutating ───────────────────────────────────────────────────────

--- a/packages/tooling/vis/src/release/core/version-resolver.ts
+++ b/packages/tooling/vis/src/release/core/version-resolver.ts
@@ -225,6 +225,29 @@ export const compileReleaseTagRegex = (pattern: string, pkg: { name: string }): 
     return new RegExp(reSource);
 };
 
+/** Fallback `releaseTagPattern` when neither per-package nor workspace config sets one. */
+export const DEFAULT_RELEASE_TAG_PATTERN = "{name}@{version}";
+
+/**
+ * Turn a `releaseTagPattern` into a `git tag --list` / `git describe
+ * --match` glob so we never have to pull every tag in the repo and
+ * post-filter in process. Tokens with a known literal value (`{name}`,
+ * `{unscopedName}`) are substituted; every other token becomes `*`
+ * because we don't yet know the value.
+ */
+export const releaseTagListGlob = (pattern: string, pkg: { name: string }): string =>
+    pattern.replaceAll(/\{(name|unscopedName|version|major|minor|patch|date|channel)\}/g, (_match, key: string) => {
+        if (key === "name") {
+            return pkg.name;
+        }
+
+        if (key === "unscopedName") {
+            return pkg.name.replace(/^@[^/]+\//, "");
+        }
+
+        return "*";
+    });
+
 /**
  * Resolve the "current" version of a single package via the requested mode.
  *
@@ -269,24 +292,8 @@ export const resolveCurrentVersion = async (
     }
 
     // git-tag mode
-    const pattern = options.perPackageConfig?.releaseTagPattern ?? options.workspaceConfig?.releaseTagPattern ?? "{name}@{version}";
-
-    // Compile the pattern to a globbed `--list` filter so we don't have to
-    // pull every tag in the repo and post-filter in process. The substitution
-    // replaces tokens with their literal counterparts where known (`{name}`,
-    // `{unscopedName}`) and a `*` glob for everything else — `{version}`,
-    // `{major}`, etc. all become wildcards because we don't yet know the value.
-    const listGlob = pattern.replaceAll(/\{(name|unscopedName|version|major|minor|patch|date|channel)\}/g, (_match, key: string) => {
-        if (key === "name") {
-            return pkg.name;
-        }
-
-        if (key === "unscopedName") {
-            return pkg.name.replace(/^@[^/]+\//, "");
-        }
-
-        return "*";
-    });
+    const pattern = options.perPackageConfig?.releaseTagPattern ?? options.workspaceConfig?.releaseTagPattern ?? DEFAULT_RELEASE_TAG_PATTERN;
+    const listGlob = releaseTagListGlob(pattern, pkg);
 
     const listResult = await options.runner.run("git", ["tag", "--list", listGlob, "--sort=-v:refname"], { cwd: options.cwd, silent: true });
 
@@ -450,4 +457,147 @@ export const resolveCurrentVersionsForWorkspace = async (
     }
 
     return { versions, warnings };
+};
+
+// ── "Since last release" range resolution (issue #864) ─────────────
+
+export interface ResolveLastReleaseRefOptions {
+    /** Workspace root. */
+    cwd: string;
+    /** Packages whose `releaseTagPattern`s form the candidate tag set. */
+    packages: ReadonlyArray<WorkspacePackage>;
+    /** Per-package config map (for `releaseTagPattern` overrides). */
+    perPackageConfig?: ReadonlyMap<string, PerPackageReleaseConfig>;
+    /** Runner used for the `git describe` / `git rev-list` probes. */
+    runner: CommandRunner;
+    /** Workspace-level config. Read for the `releaseTagPattern` default. */
+    workspaceConfig?: VisReleaseConfig;
+}
+
+export interface ResolveLastReleaseRefResult {
+    /**
+     * How the boundary was resolved. Callers MUST branch on this rather
+     * than on `ref` alone: `"root-commit"` carries a ref too, but it
+     * means "the entire repository history", which is a destructive
+     * range for anything that publishes unattended (issue #864).
+     *
+     *   - `"tag"`         — a real release tag was found.
+     *   - `"root-commit"` — no tag matched; `ref` is the repo's oldest
+     *                       root commit, i.e. the whole history.
+     *   - `"unresolved"`  — not even the root commit could be resolved;
+     *                       `ref` is absent.
+     */
+    kind: "root-commit" | "tag" | "unresolved";
+    /** Human-readable explanation of how the ref was picked (logged by callers). */
+    reason: string;
+    /** The resolved start ref, or `undefined` when even the root-commit fallback failed. */
+    ref?: string;
+    /** The matched tag, when the resolution came from one. */
+    tag?: string;
+}
+
+/**
+ * Resolve the git ref marking "the last release" so `vis release
+ * generate --since-last-release` can walk `&lt;ref>..HEAD` without the
+ * operator hand-picking a `--from`.
+ *
+ * Reuses the `currentVersionResolver: "git-tag"` machinery — the same
+ * `releaseTagPattern` → glob derivation ({@link releaseTagListGlob})
+ * and the same strict matcher ({@link compileReleaseTagRegex}) — rather
+ * than introducing a second tag scanner that could drift.
+ *
+ * **Workspace-wide, not per-package.** `generate` emits ONE change file
+ * covering ONE commit range, so it cannot express a different boundary
+ * per package. The boundary we want is therefore "the most recent
+ * release tag reachable from HEAD, whichever package it belongs to":
+ * in the wave-based CI flow this command exists for, every package that
+ * released did so at that wave's commit, so everything after it is
+ * genuinely unreleased. That is also exactly the boundary
+ * `github.event.before` approximates in the workaround from issue #864,
+ * only derived from the tag history instead of the CI event payload.
+ *
+ * When no matching tag exists (greenfield repo, first release, or a
+ * `releaseTagPattern` that has never been written), the result carries
+ * `kind: "root-commit"` and `ref` set to the repo's oldest root commit —
+ * i.e. effectively the whole history. That is offered as a *candidate*,
+ * not a default: walking it bumps every package that has ever been
+ * touched, so callers must gate it behind an explicit opt-in and treat
+ * `kind !== "tag"` as "no boundary found" otherwise. `reason` explains
+ * which case fired so the decision is visible in CI logs.
+ */
+export const resolveLastReleaseRef = async (options: ResolveLastReleaseRefOptions): Promise<ResolveLastReleaseRefResult> => {
+    const { cwd, packages, perPackageConfig, runner, workspaceConfig } = options;
+
+    // Build the candidate glob set — deduped, because a workspace-wide
+    // `v{version}` collapses 50 packages into a single `v*` glob while
+    // the default `{name}@{version}` yields one glob per package.
+    const globs = new Set<string>();
+    const patterns = new Map<string, string>();
+
+    for (const pkg of packages) {
+        const pattern = perPackageConfig?.get(pkg.name)?.releaseTagPattern ?? workspaceConfig?.releaseTagPattern ?? DEFAULT_RELEASE_TAG_PATTERN;
+
+        patterns.set(pkg.name, pattern);
+        globs.add(releaseTagListGlob(pattern, pkg));
+    }
+
+    const rootFallback = async (reason: string): Promise<ResolveLastReleaseRefResult> => {
+        const roots = await runner.run("git", ["rev-list", "--max-parents=0", "HEAD"], { cwd, silent: true });
+        const lines
+            = roots.exitCode === 0
+                ? roots.stdout
+                    .split("\n")
+                    .map((line) => line.trim())
+                    .filter(Boolean)
+                : [];
+        // `rev-list` is newest-first, so the LAST entry is the oldest
+        // root commit. Multi-root histories (grafted / subtree merges)
+        // are rare; picking the oldest keeps the range maximal.
+        const root = lines.at(-1);
+
+        if (!root) {
+            return { kind: "unresolved", reason: `${reason} and the repository root commit could not be resolved` };
+        }
+
+        return {
+            kind: "root-commit",
+            reason: `${reason}; the only remaining boundary is the repository root commit (${root.slice(0, 7)}) — the whole history`,
+            ref: root,
+        };
+    };
+
+    if (globs.size === 0) {
+        return rootFallback("no workspace packages to derive a release tag pattern from");
+    }
+
+    // `git describe --abbrev=0` returns the most recent tag *reachable
+    // from HEAD* by ancestry distance — precisely the boundary we want,
+    // and stronger than sorting by creatordate (which a rebase or an
+    // out-of-order tag push can scramble).
+    const describe = await runner.run("git", ["describe", "--tags", "--abbrev=0", ...[...globs].flatMap((glob) => ["--match", glob]), "HEAD"], {
+        cwd,
+        silent: true,
+    });
+
+    const tag = describe.exitCode === 0 ? describe.stdout.trim() : "";
+
+    if (!tag) {
+        return rootFallback(`no git tag matching the configured releaseTagPattern is reachable from HEAD`);
+    }
+
+    // Re-validate against the strict matcher. `--match` is an fnmatch
+    // glob, so `{version}` degraded to `*` can accept a tag the real
+    // pattern would reject (e.g. `@scope/a@nightly`). Only tags that
+    // parse into a real semver count as a release boundary.
+    const matched = packages.some((pkg) => {
+        const match = compileReleaseTagRegex(patterns.get(pkg.name) ?? DEFAULT_RELEASE_TAG_PATTERN, pkg).exec(tag);
+
+        return match?.[1] !== undefined && semver.valid(match[1]) !== null;
+    });
+
+    if (!matched) {
+        return rootFallback(`the nearest matching tag "${tag}" did not parse as a release tag`);
+    }
+
+    return { kind: "tag", reason: `resolved the last release boundary to tag "${tag}"`, ref: tag, tag };
 };

--- a/packages/tooling/vis/src/release/types.ts
+++ b/packages/tooling/vis/src/release/types.ts
@@ -1400,6 +1400,41 @@ export interface VisReleaseConfig {
 
     /** Globs of packages to exclude from release entirely. */
     ignore?: string[];
+
+    /**
+     * Extra regex source(s) matched against each commit subject by
+     * `vis release generate`. A matching commit contributes neither a
+     * bump nor a changelog line.
+     *
+     * Accepts a single regex source or an array of them (plain strings,
+     * not `/…/` literals — the config file is also expressed as JSON in
+     * `schemas/vis-release-config.schema.json`). Invalid sources are
+     * skipped with a warning rather than failing the release.
+     *
+     * These EXTEND the built-in machine-release-commit heuristic
+     * (`chore(release): …`, `chore(main): release …`, `chore: release v…`,
+     * `release(alpha): …`). Set `ignoreReleaseCommits: false` to drop the
+     * built-ins and match only your own patterns.
+     *
+     * A bare `[skip ci]` marker is deliberately not built in — it means
+     * "don't run CI", not "don't release", so matching it would swallow a
+     * real `fix: … [skip ci]` and its bump. Opt in with
+     * `ignoreCommitPattern: ["\\[skip ci\\]"]` if you want that.
+     */
+    ignoreCommitPattern?: string | string[];
+
+    /**
+     * Skip machine-authored release commits in `vis release generate`.
+     * Default `true`.
+     *
+     * With the default, a package whose only commits in the range are
+     * its own `chore(release): pkg@1.2.3 [skip ci]` commits is not
+     * bumped, and the previous changelog header those commits carry is
+     * never transcribed into the new entry. Set to `false` for the
+     * historical (verbatim) behaviour — `ignoreCommitPattern` then
+     * becomes the only filter.
+     */
+    ignoreReleaseCommits?: boolean;
     /** Globs that override `ignore` and `private` exclusion. */
     include?: string[];
 


### PR DESCRIPTION
Fixes #864.

Closes the two gaps that made a commit-driven CI flow awkward to assemble, for repos where conventional commits alone decide the bumps and nobody authors change files.

## What changed

**`generate --since-last-release`** — resolves the range start to the highest `releaseTagPattern`-matching tag reachable from HEAD, reusing the `git-tag` version-resolver machinery (`releaseTagListGlob()` is now shared) rather than adding a second tag scanner. Workspace-wide, not per-package: `generate` emits one change file for one range, so it cannot express a per-package boundary, and in the wave model every package that released did so at that wave's commit.

**`ci release --generate` / `--generate-from <ref>`** — collapses the three-step CI dance into one command. The generated change file is *staged, not committed* (load-bearing: `applyContext` later runs `git add` on the consumed file, which hard-fails on a path never in the index). The clean-tree guard tolerates only the exact path this run wrote; unrelated dirt still fails.

**Machine release commits are ignored.** `chore(release): …`, `chore(main): release …`, `chore: release v…` and vis's own `release(…): …` contribute neither a bump nor a changelog line, so a package whose only commits in the range are its own release commits is not bumped. Subjects are trimmed so multi-semantic-release's literal `\n\n`-joined changelog header stops being transcribed into new entries. Configurable via `ignoreCommitPattern` (extends the built-ins) and `ignoreReleaseCommits: false` (drops them).

## Fixes from review

- **`--since-last-release` could mass-publish.** It fell back to the repo root commit whenever no tag matched — so a repo tagged `v1.2.3` under `releaseTagPattern: "{name}@{version}"` walked the entire history, bumped every package, went `major` on any historical `!` commit, and on `--auto-publish` published the lot. Only signal was a `logger.info`. `resolveLastReleaseRef` now returns a discriminated `kind: "tag" | "root-commit" | "unresolved"`, and the root-commit case is **refused on both paths** unless `--allow-full-history` is passed.
- **A bare `[skip ci]` marker no longer counts as a release commit.** It means "don't run CI", not "don't release" — matching it swallowed a human `fix(api): … [skip ci]` and its patch bump. The four release-shaped patterns still catch every machine format; repos wanting the blunt rule opt in via `ignoreCommitPattern`.
- **Subject trimming no longer truncates prose.** It cut at the first literal `\n`, so `fix(parser): handle \n in template literals` became `fix(parser): handle`. Now only a literal `\n\n` introducing a markdown heading is a cut point.
- **An aborted `--generate` run no longer wedges the next one.** The clean-tree guard runs *before* generation, a leftover matching this command's own filename shape is forgiven (and consumed, not deleted — it may be a real pending change file), and the file is removed again if staging fails.
- **Schema drift fixed.** `vis-config.schema.json` inlines `VisReleaseConfig` under `$defs` and was missing both new keys, which would have failed `check:schemas-drift`.
- Corrected a comment that claimed a 512-char probe made user-config regexes ReDoS-safe; it doesn't (`(a+)+$` hangs well under 512).

## Testing

1291 passing / 0 failing across `__tests__/release` + `__tests__/schemas`. The full-history refusal and the wedged-guard scenarios have regression tests confirmed to fail without their fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AykNAXvDtCJyX6aymEBWQw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to generate release notes since the most recent release tag or from a specified reference.
  * Added full-history support for repositories without a matching release tag.
  * Added in-process generation for CI releases, including staged change-file creation and clean-tree safeguards.
  * Added configurable filtering for machine-generated release commits and custom commit patterns.

* **Documentation**
  * Expanded release command references and guides with new options, workflows, range resolution, and commit-filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->