### PR TITLE
feat(vis): group changelog entries by commit type

### DIFF
--- a/packages/tooling/vis/__tests__/release/core/changelog-conventional.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-conventional.test.ts
@@ -1,0 +1,763 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ChangelogContext } from "../../../src/release/core/changelog/api";
+import { createConventionalFormatter } from "../../../src/release/core/changelog/conventional";
+import { hasBulletMarker, isBreakingChange, parseConventionalHeader, stripBulletMarker } from "../../../src/release/core/changelog/conventional-header";
+import { createDefaultFormatter } from "../../../src/release/core/changelog/default";
+import { createGithubFormatter } from "../../../src/release/core/changelog/github";
+import { buildCompareUrl, renderReleaseHeading } from "../../../src/release/core/changelog/release-heading";
+import { detectRepo } from "../../../src/release/core/changelog/repo-slug";
+import { DEFAULT_CONVENTIONAL_TYPES, renderGroupedEntries, withBullet } from "../../../src/release/core/changelog/sections";
+import type { CommandRunner } from "../../../src/release/core/package-managers/interface";
+import { MockRunner } from "../../../src/release/core/shell-runner";
+import type { ChangeFile, PlannedRelease } from "../../../src/release/types";
+
+const mkRelease = (overrides: Partial<PlannedRelease> = {}): PlannedRelease => {
+    return {
+        changeFiles: [],
+        isCascadeBump: false,
+        isDependencyBump: false,
+        isGroupBump: false,
+        name: "@scope/pkg",
+        newVersion: "1.1.0",
+        oldVersion: "1.0.0",
+        reasons: ["EXPLICIT"],
+        sources: [],
+        type: "minor",
+        ...overrides,
+    };
+};
+
+const mkCtx = (overrides: Partial<ChangelogContext> = {}): ChangelogContext => {
+    return {
+        changeFiles: [],
+        date: "2026-05-02",
+        release: mkRelease(),
+        target: "changelog",
+        ...overrides,
+    };
+};
+
+const mkFile = (body: string): ChangeFile => {
+    return { body, id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } };
+};
+
+/** A runner that answers nothing — exercises the "no repo slug detected" path. */
+const noRemoteRunner = (): MockRunner => new MockRunner();
+
+describe(parseConventionalHeader, () => {
+    it("splits type, scope and subject", () => {
+        expect.hasAssertions();
+
+        expect(parseConventionalHeader("fix(client,react): encode SSR payloads")).toStrictEqual({
+            breakingMarker: false,
+            breakingNote: false,
+            scope: "client,react",
+            subject: "encode SSR payloads",
+            type: "fix",
+        });
+    });
+
+    it("returns a scope-less parse for a bare type prefix", () => {
+        expect.hasAssertions();
+
+        expect(parseConventionalHeader("feat: add pdf()")).toStrictEqual({
+            breakingMarker: false,
+            breakingNote: false,
+            scope: undefined,
+            subject: "add pdf()",
+            type: "feat",
+        });
+    });
+
+    it("reports the `!` marker and an inline BREAKING CHANGE note separately", () => {
+        expect.hasAssertions();
+
+        const bang = parseConventionalHeader("feat(api)!: drop v1")!;
+        const note = parseConventionalHeader("feat: drop v1 BREAKING CHANGE")!;
+
+        expect(bang.breakingMarker).toBe(true);
+        expect(bang.breakingNote).toBe(false);
+        expect(note.breakingMarker).toBe(false);
+        expect(note.breakingNote).toBe(true);
+        expect([bang, note].every((parsed) => isBreakingChange(parsed))).toBe(true);
+    });
+
+    it("tolerates a leading bullet marker and a gitmoji prefix", () => {
+        expect.hasAssertions();
+
+        expect(parseConventionalHeader("- 🚀 feat(cli): add tab completion")?.type).toBe("feat");
+        expect(parseConventionalHeader("* :rocket: feat(cli): add tab completion")?.scope).toBe("cli");
+    });
+
+    it("strips a gitmoji prefix that carries a variation selector, modifier or ZWJ", () => {
+        expect.hasAssertions();
+
+        // `🏗️` is U+1F3D7 + U+FE0F. Matching only the base code point left the
+        // selector where the separator was expected, so the whole line failed
+        // to parse and landed silently in the uncategorized bucket.
+        expect(parseConventionalHeader("🏗️ feat: add builder")).toStrictEqual({
+            breakingMarker: false,
+            breakingNote: false,
+            scope: undefined,
+            subject: "add builder",
+            type: "feat",
+        });
+        expect(parseConventionalHeader("- 🏗️ feat(cli): add builder")?.scope).toBe("cli");
+        // Skin-tone modifier (U+1F44D U+1F3FD) and a ZWJ sequence.
+        expect(parseConventionalHeader("👍🏽 fix: guard nulls")?.type).toBe("fix");
+        expect(parseConventionalHeader("👨‍💻 docs: rewrite the guide")?.type).toBe("docs");
+    });
+
+    it("returns undefined for a non-conventional subject", () => {
+        expect.hasAssertions();
+
+        expect(parseConventionalHeader("Untagged note here.")).toBeUndefined();
+        expect(parseConventionalHeader("not a type(scope) missing colon")).toBeUndefined();
+    });
+
+    it("stays linear on a long run of parens (no catastrophic backtracking)", () => {
+        expect.hasAssertions();
+
+        const started = Date.now();
+
+        expect(parseConventionalHeader(`feat${"(".repeat(20_000)}`)).toBeUndefined();
+        expect(Date.now() - started).toBeLessThan(1000);
+    });
+});
+
+describe(renderGroupedEntries, () => {
+    it("orders sections by the `types` array, not by input order", () => {
+        expect.hasAssertions();
+
+        const lines = renderGroupedEntries([{ line: "perf: reuse the session" }, { line: "fix: handle empty input" }, { line: "feat: add pdf()" }]);
+        const text = lines.join("\n");
+
+        expect(text.indexOf("### Features")).toBeLessThan(text.indexOf("### Bug Fixes"));
+        expect(text.indexOf("### Bug Fixes")).toBeLessThan(text.indexOf("### Performance Improvements"));
+    });
+
+    it("omits hidden types entirely", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "chore: bump linter" }, { line: "feat: real feature" }]).join("\n");
+
+        expect(text).not.toContain("bump linter");
+        expect(text).not.toContain("Miscellaneous Chores");
+        expect(text).toContain("* real feature");
+    });
+
+    it("keeps a hidden-type breaking change under the breaking section", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "chore!: drop node 20" }]).join("\n");
+
+        expect(text).toContain("### ⚠ BREAKING CHANGES");
+        expect(text).toContain("* drop node 20");
+    });
+
+    it("routes unparseable subjects to the uncategorized bucket verbatim", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "feat: typed thing" }, { line: "- Untagged note here." }]).join("\n");
+
+        expect(text).toContain("### Other Changes");
+        expect(text).toContain("* Untagged note here.");
+    });
+
+    it("keeps a parsed-but-unmapped type verbatim rather than dropping its prefix", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "banana: peel it" }]).join("\n");
+
+        expect(text).toContain("### Other Changes");
+        expect(text).toContain("* banana: peel it");
+    });
+
+    it("bolds the lifted scope and drops the `type(scope):` prefix", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "fix(client,react): encode SSR payloads" }]).join("\n");
+
+        expect(text).toContain("* **client,react:** encode SSR payloads");
+        expect(text).not.toContain("fix(client,react):");
+    });
+
+    it("renders a scope-less commit as the bare subject", () => {
+        expect.hasAssertions();
+
+        expect(renderGroupedEntries([{ line: "feat: add pdf() to the rendering surface" }]).join("\n")).toContain("* add pdf() to the rendering surface");
+    });
+
+    it("merges types that share a section heading", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "feature: one" }, { line: "feat: two" }]).join("\n");
+
+        expect(text.match(/### Features/g)).toHaveLength(1);
+    });
+
+    it("honours a custom `types` table and a custom bullet", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "feat: shown" }, { line: "fix: hidden" }], {
+            bullet: "-",
+            types: [
+                { section: "Headlines", type: "feat" },
+                { hidden: true, section: "Internal", type: "fix" },
+            ],
+        }).join("\n");
+
+        expect(text).toContain("### Headlines");
+        expect(text).toContain("- shown");
+        expect(text).not.toContain("hidden");
+    });
+
+    it("appends the per-entry suffix after the rendered text", () => {
+        expect.hasAssertions();
+
+        expect(renderGroupedEntries([{ line: "fix(cli): thing", suffix: " (#42)" }]).join("\n")).toContain("* **cli:** thing (#42)");
+    });
+
+    it("hides `docs` by default and shows `deps` as Dependencies", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "docs: tweak readme" }, { line: "deps(@visulima/fs): upgraded to 6.0.8" }]).join("\n");
+
+        expect(text).not.toContain("tweak readme");
+        expect(text).toContain("### Dependencies");
+        expect(text).toContain("* **@visulima/fs:** upgraded to 6.0.8");
+    });
+
+    it("renders a repeated type once instead of appending its bucket twice", () => {
+        expect.hasAssertions();
+
+        // Both rendering loops used to walk the raw `types` array, so a table
+        // that names the same type twice emitted the bucket once per rule.
+        expect(
+            renderGroupedEntries([{ line: "feat: add pdf()" }], {
+                types: [
+                    { section: "Features", type: "feat" },
+                    { section: "Features", type: "feat" },
+                ],
+            }),
+        ).toStrictEqual(["### Features", "", "* add pdf()", ""]);
+    });
+
+    it("lets the first rule win, so a later visible rule can't unhide a type", () => {
+        expect.hasAssertions();
+
+        // `ruleByType` already kept the first rule, but the render loops did
+        // not — a trailing visible duplicate resurrected a type the author had
+        // explicitly hidden.
+        expect(
+            renderGroupedEntries([{ line: "feat: add pdf()" }], {
+                types: [
+                    { hidden: true, section: "Features", type: "feat" },
+                    { section: "Features", type: "feat" },
+                ],
+            }),
+        ).toStrictEqual([]);
+    });
+
+    it("treats a `+` list marker as an existing bullet", () => {
+        expect.hasAssertions();
+
+        // `stripBulletMarker` accepts `*`, `+` and `-`; `withBullet` used to
+        // accept only `*` and `-`, so a `+` entry rendered as `* + fix: …`.
+        expect(withBullet("+ fix: guard nulls", "*")).toBe("+ fix: guard nulls");
+        expect(
+            renderGroupedEntries([{ line: "+ fix: guard nulls" }], { entryStyle: "verbatim", types: [{ section: "Bug Fixes", type: "fix" }] }),
+        ).toStrictEqual(["### Bug Fixes", "", "+ fix: guard nulls", ""]);
+
+        for (const marker of ["*", "+", "-"]) {
+            expect(hasBulletMarker(`${marker} fix: guard nulls`)).toBe(true);
+            expect(stripBulletMarker(`${marker} fix: guard nulls`)).toBe("fix: guard nulls");
+        }
+
+        // A marker glued to the text is not a list item in Markdown either.
+        expect(hasBulletMarker("-v is now the short flag")).toBe(false);
+        expect(withBullet("-v is now the short flag", "*")).toBe("* -v is now the short flag");
+    });
+
+    it("ships hidden defaults for the repo-specific extra commit types", () => {
+        expect.hasAssertions();
+
+        for (const type of ["dx", "types", "wip", "release", "workflow"]) {
+            expect(DEFAULT_CONVENTIONAL_TYPES.find((rule) => rule.type === type)?.hidden).toBe(true);
+        }
+
+        expect(DEFAULT_CONVENTIONAL_TYPES.find((rule) => rule.type === "deps")?.hidden).toBeUndefined();
+    });
+});
+
+describe(renderReleaseHeading, () => {
+    it("substitutes every token", () => {
+        expect.hasAssertions();
+
+        expect(
+            renderReleaseHeading("## {name} [{version}]({compareUrl}) ({date})", {
+                compareUrl: "https://github.com/o/r/compare/a...b",
+                date: "2026-05-02",
+                name: "@scope/pkg",
+                version: "1.1.0",
+            }),
+        ).toBe("## @scope/pkg [1.1.0](https://github.com/o/r/compare/a...b) (2026-05-02)");
+    });
+
+    it("unwraps the link syntax when there is no compare URL", () => {
+        expect.hasAssertions();
+
+        expect(
+            renderReleaseHeading("## {name} [{version}]({compareUrl}) ({date})", {
+                date: "2026-05-02",
+                name: "@scope/pkg",
+                version: "1.1.0",
+            }),
+        ).toBe("## @scope/pkg 1.1.0 (2026-05-02)");
+    });
+
+    it("leaves unknown tokens intact so a typo is visible", () => {
+        expect.hasAssertions();
+
+        expect(renderReleaseHeading("## {versionn}", { date: "d", name: "n", version: "1.0.0" })).toBe("## {versionn}");
+    });
+
+    it("builds a compare URL from repo + tag pattern, and nothing without a previous version", () => {
+        expect.hasAssertions();
+
+        expect(buildCompareUrl({ name: "@scope/pkg", newVersion: "1.1.0", oldVersion: "1.0.0", repo: "o/r" })).toBe(
+            "https://github.com/o/r/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0",
+        );
+        expect(buildCompareUrl({ name: "@scope/pkg", newVersion: "1.1.0", oldVersion: "1.0.0", repo: "o/r", tagPattern: "v{version}" })).toBe(
+            "https://github.com/o/r/compare/v1.0.0...v1.1.0",
+        );
+        expect(buildCompareUrl({ name: "@scope/pkg", newVersion: "1.1.0", oldVersion: "1.0.0" })).toBeUndefined();
+        expect(buildCompareUrl({ name: "@scope/pkg", newVersion: "1.0.0", oldVersion: "", repo: "o/r" })).toBeUndefined();
+    });
+
+    it("uses the provider's compare path, not github.com, for a GitLab slug", () => {
+        expect.hasAssertions();
+
+        expect(buildCompareUrl({ name: "@scope/pkg", newVersion: "1.1.0", oldVersion: "1.0.0", provider: "gitlab", repo: "group/proj" })).toBe(
+            "https://gitlab.com/group/proj/-/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0",
+        );
+    });
+});
+
+describe("conventional formatter", () => {
+    it("renders the semantic-release heading + grouped, scope-bolded body", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "visulima/visulima", runner: noRemoteRunner() });
+        const result = await formatter(
+            mkCtx({
+                changeFiles: [
+                    mkFile("fix(client,react): encode SSR payloads\nfeat(browser): add pdf() to the rendering surface\nperf(browser): reuse the session"),
+                ],
+            }),
+        );
+
+        expect(result).toBe(
+            [
+                "## @scope/pkg [1.1.0](https://github.com/visulima/visulima/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0) (2026-05-02)",
+                "",
+                "### Features",
+                "",
+                "* **browser:** add pdf() to the rendering surface",
+                "",
+                "### Bug Fixes",
+                "",
+                "* **client,react:** encode SSR payloads",
+                "",
+                "### Performance Improvements",
+                "",
+                "* **browser:** reuse the session",
+            ].join("\n"),
+        );
+    });
+
+    it("degrades the heading link when no remote can be detected", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")] }));
+
+        expect(result).toContain("## @scope/pkg 1.1.0 (2026-05-02)");
+        expect(result).not.toContain("]()");
+    });
+
+    it("degrades the heading link on a first release (no previous version)", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "o/r", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")], release: mkRelease({ newVersion: "1.0.0", oldVersion: "" }) }));
+
+        expect(result).toContain("## @scope/pkg 1.0.0 (2026-05-02)");
+        expect(result).not.toContain("compare");
+    });
+
+    it("honours a custom heading template", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ heading: "## v{version} — {date}", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")] }));
+
+        expect(result).toContain("## v1.1.0 — 2026-05-02");
+    });
+
+    it("drops the heading for the github-release target", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "o/r", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")], target: "github-release" }));
+
+        expect(result).not.toContain("1.1.0");
+        expect(result.startsWith("### Features")).toBe(true);
+    });
+
+    it("renders dependency bumps under Dependencies with the package bolded", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "o/r", runner: noRemoteRunner() });
+        const result = await formatter(
+            mkCtx({
+                release: mkRelease({
+                    isDependencyBump: true,
+                    sources: [
+                        { bumpType: "patch", name: "@visulima/fs", newVersion: "6.0.8" },
+                        { bumpType: "patch", name: "@visulima/dropped", newVersion: "" },
+                    ],
+                }),
+            }),
+        );
+
+        expect(result).toContain("### Dependencies");
+        expect(result).toContain("* **@visulima/fs:** upgraded to 6.0.8");
+        expect(result).toContain("* **@visulima/dropped:** removed");
+        expect(result).not.toContain("@\n");
+    });
+
+    it("linkifies bare issue refs when a repo slug is known", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "visulima/visulima", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("fix(cli): stop the hang #607")] }));
+
+        expect(result).toContain("[#607](https://github.com/visulima/visulima/issues/607)");
+    });
+});
+
+describe("opt-in options on the existing formatters", () => {
+    it("github: `types` groups + bolds while keeping the PR/commit refs", async () => {
+        expect.hasAssertions();
+
+        const formatter = createGithubFormatter({ repo: "o/r", runner: noRemoteRunner(), types: [] });
+        const result = await formatter(
+            mkCtx({
+                changeFiles: [
+                    {
+                        body: "fix(client,react): encode SSR payloads",
+                        id: "x",
+                        meta: { author: "@someone", pr: 607 },
+                        path: "x.md",
+                        payload: { bumps: { "@scope/pkg": "patch" } },
+                    },
+                ],
+            }),
+        );
+
+        expect(result).toContain("### Bug Fixes");
+        expect(result).toContain("* **client,react:** encode SSR payloads ([#607](https://github.com/o/r/pull/607))");
+        expect(result).toContain("Thanks @someone!");
+    });
+
+    it("github: `heading` templates the release heading", async () => {
+        expect.hasAssertions();
+
+        const formatter = createGithubFormatter({ heading: "## {name} [{version}]({compareUrl}) ({date})", repo: "o/r", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")] }));
+
+        expect(result).toContain("## @scope/pkg [1.1.0](https://github.com/o/r/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0) (2026-05-02)");
+        expect(result).not.toContain("<sub>");
+    });
+
+    it("github: unconfigured output is unchanged", async () => {
+        expect.hasAssertions();
+
+        const formatter = createGithubFormatter({ repo: "o/r", runner: noRemoteRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("fix(client,react): encode SSR payloads")] }));
+
+        expect(result).toBe(["## 1.1.0", "<sub>2026-05-02</sub>", "", "- fix(client,react): encode SSR payloads"].join("\n"));
+    });
+
+    it("default: `heading` templates the release heading", async () => {
+        expect.hasAssertions();
+
+        const formatter = createDefaultFormatter({ heading: "## {name} [{version}]({compareUrl}) ({date})", repo: "o/r" });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat: a thing")] }));
+
+        expect(result).toContain("## @scope/pkg [1.1.0](https://github.com/o/r/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0) (2026-05-02)");
+    });
+
+    it("default: unconfigured output is unchanged", async () => {
+        expect.hasAssertions();
+
+        const formatter = createDefaultFormatter();
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("fix(client,react): encode SSR payloads")] }));
+
+        expect(result).toBe(["## 1.1.0", "<sub>2026-05-02</sub>", "", "- fix(client,react): encode SSR payloads"].join("\n"));
+    });
+});
+
+describe("custom `types` tables never swallow entries (the documented Other-Changes guarantee)", () => {
+    /** The exact table the `release` guide prints as its `types` example. */
+    const DOCS_TYPES = [
+        { section: "Features", type: "feat" },
+        { section: "Bug Fixes", type: "fix" },
+        { hidden: true, section: "Internal", type: "refactor" },
+    ];
+
+    it("keeps unparseable lines, unmapped types and dependency bumps when the table has no `other` rule", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries(
+            [
+                { line: "feat(cli): add flag" },
+                { line: "chore: bump ci image" },
+                { line: "Fix a typo in the docs" },
+                { line: "deps(@visulima/fs): upgraded to 6.0.8" },
+            ],
+            { types: DOCS_TYPES },
+        ).join("\n");
+
+        expect(text).toContain("### Features");
+        expect(text).toContain("* **cli:** add flag");
+        expect(text).toContain("### Other Changes");
+        expect(text).toContain("* chore: bump ci image");
+        expect(text).toContain("* Fix a typo in the docs");
+        expect(text).toContain("* deps(@visulima/fs): upgraded to 6.0.8");
+    });
+
+    it("still drops the catch-all when the caller opts out with `{ type: \"other\", hidden: true }`", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "feat: shown" }, { line: "Untagged note here." }], {
+            types: [...DOCS_TYPES, { hidden: true, section: "Other Changes", type: "other" }],
+        }).join("\n");
+
+        expect(text).toContain("### Features");
+        expect(text).not.toContain("Other Changes");
+        expect(text).not.toContain("Untagged note here.");
+    });
+
+    it("renders the catch-all at the `other` rule's position when the table places one", () => {
+        expect.hasAssertions();
+
+        const text = renderGroupedEntries([{ line: "feat: shown" }, { line: "Untagged note here." }], {
+            types: [
+                { section: "Loose Ends", type: "other" },
+                { section: "Features", type: "feat" },
+            ],
+        }).join("\n");
+
+        expect(text.indexOf("### Loose Ends")).toBeLessThan(text.indexOf("### Features"));
+        expect(text).toContain("* Untagged note here.");
+    });
+
+    it("keeps non-conventional change-file lines through the conventional formatter with the docs' table", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "o/r", runner: noRemoteRunner(), types: DOCS_TYPES });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat(cli): add flag\nFix a typo in the docs")] }));
+
+        expect(result).toContain("### Features");
+        expect(result).toContain("### Other Changes");
+        expect(result).toContain("* Fix a typo in the docs");
+    });
+
+    it("keeps a dependency-only release visible even though the docs' table has no `deps` rule", async () => {
+        expect.hasAssertions();
+
+        const formatter = createConventionalFormatter({ repo: "o/r", runner: noRemoteRunner(), types: DOCS_TYPES });
+        const result = await formatter(
+            mkCtx({
+                release: mkRelease({
+                    isDependencyBump: true,
+                    sources: [{ bumpType: "patch", name: "@visulima/fs", newVersion: "6.0.8" }],
+                }),
+            }),
+        );
+
+        expect(result).toContain("### Other Changes");
+        expect(result).toContain("* deps(@visulima/fs): upgraded to 6.0.8");
+    });
+});
+
+describe("remote-provider-aware links", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    /** A runner whose every call rejects — no `git`/`gh` on PATH, or a broken repo. */
+    const rejectingRunner = (): CommandRunner => {
+        return {
+            run: async (): Promise<never> => {
+                throw new Error("spawn git ENOENT");
+            },
+        };
+    };
+
+    /** A runner that reports a GitLab origin, so provider detection picks `gitlab`. */
+    const gitlabRunner = (): MockRunner => {
+        const runner = new MockRunner();
+
+        runner.on("git", ["config", "--get", "remote.origin.url"], () => {
+            return { exitCode: 0, stderr: "", stdout: "git@gitlab.com:group/proj.git\n" };
+        });
+
+        return runner;
+    };
+
+    /**
+     * `detectRemoteProvider` short-circuits on CI env vars, and
+     * `GitlabRemoteClient` prefers `CI_PROJECT_PATH`. Clear all four so the
+     * git remote decides — on a workstation and on GitHub Actions alike.
+     */
+    const forceGitRemoteDetection = (): void => {
+        vi.stubEnv("GITHUB_ACTIONS", "");
+        vi.stubEnv("GITHUB_REPOSITORY", "");
+        vi.stubEnv("GITLAB_CI", "");
+        vi.stubEnv("CI_PROJECT_PATH", "");
+    };
+
+    it("degrades to no slug when the detection runner rejects", async () => {
+        expect.hasAssertions();
+
+        await expect(detectRepo(undefined, rejectingRunner(), "/cwd")).resolves.toStrictEqual({ provider: "github", slug: undefined });
+    });
+
+    it("still renders a changelog when the detection runner rejects", async () => {
+        expect.hasAssertions();
+
+        // Both built-in formatters await this shared promise before rendering
+        // a line, so a rejection used to fail the whole workspace run instead
+        // of degrading to the documented link-free plain text.
+        const formatter = createConventionalFormatter({ runner: rejectingRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("feat(cli): add tab completion #607")] }));
+
+        expect(result).toContain("### Features");
+        expect(result).toContain("* **cli:** add tab completion #607");
+        expect(result).not.toContain("http");
+    });
+
+    it("points the conventional formatter's issue and compare links at a GitLab remote", async () => {
+        expect.hasAssertions();
+
+        forceGitRemoteDetection();
+
+        const formatter = createConventionalFormatter({ runner: gitlabRunner() });
+        const result = await formatter(mkCtx({ changeFiles: [mkFile("fix(cli): stop the hang #607")] }));
+
+        expect(result).toContain("[#607](https://gitlab.com/group/proj/-/issues/607)");
+        expect(result).toContain("(https://gitlab.com/group/proj/-/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0)");
+        expect(result).not.toContain("github.com");
+    });
+
+    it("points the github formatter's refs at a GitLab remote as merge requests", async () => {
+        expect.hasAssertions();
+
+        forceGitRemoteDetection();
+
+        const formatter = createGithubFormatter({ runner: gitlabRunner(), types: [] });
+        const result = await formatter(
+            mkCtx({
+                changeFiles: [
+                    {
+                        body: "fix(cli): stop the hang #607",
+                        id: "x",
+                        meta: { commit: "abc1234def", pr: 42 },
+                        path: "x.md",
+                        payload: { bumps: { "@scope/pkg": "patch" } },
+                    },
+                ],
+            }),
+        );
+
+        expect(result).toContain("[#42](https://gitlab.com/group/proj/-/merge_requests/42)");
+        expect(result).toContain("[`abc1234`](https://gitlab.com/group/proj/-/commit/abc1234def)");
+        expect(result).toContain("[#607](https://gitlab.com/group/proj/-/issues/607)");
+        expect(result).not.toContain("github.com");
+    });
+});
+
+describe("regex complexity (CodeQL polynomial-redos)", () => {
+    it("parses a pathological whitespace subject in linear time", () => {
+        expect.hasAssertions();
+
+        // CodeQL alert 582. `[ \t]+(.+)$` let both groups match whitespace, so
+        // every split had to be tried before the match could be rejected — and
+        // it is only rejected when a newline blocks `.`, since `.` matches a
+        // tab but not `\n`. Measured on the old regex: 1350 ms at 50k tabs,
+        // quadratic from there. The current regex consumes exactly one
+        // separator, so there is no split to search.
+        const pathological = `fix:${"\t".repeat(50_000)}\nencode SSR payloads`;
+        const started = performance.now();
+        const parsed = parseConventionalHeader(pathological);
+        const elapsed = performance.now() - started;
+
+        expect(elapsed).toBeLessThan(250);
+        // A body line containing a newline is not a conventional header.
+        expect(parsed).toBeUndefined();
+    });
+
+    it("keeps the parse result identical for ordinary multi-space headers", () => {
+        expect.hasAssertions();
+
+        // The separator is now a single char, so extra whitespace lands in the
+        // subject and is trimmed — the observable result must not change.
+        expect(parseConventionalHeader("fix(a,b):   encode SSR payloads")).toStrictEqual({
+            breakingMarker: false,
+            breakingNote: false,
+            scope: "a,b",
+            subject: "encode SSR payloads",
+            type: "fix",
+        });
+        expect(parseConventionalHeader("feat!:\t\tadd pdf()")?.subject).toBe("add pdf()");
+        expect(parseConventionalHeader("feat!:\t\tadd pdf()")?.breakingMarker).toBe(true);
+        // Still requires a separator after the colon.
+        expect(parseConventionalHeader("fix:no-space")).toBeUndefined();
+    });
+
+    it("bails out of a long emoji ZWJ run in linear time", () => {
+        expect.hasAssertions();
+
+        // The gitmoji prefix accepts a ZWJ sequence. Each optional part is one
+        // code point from a class disjoint from what may follow it, so a
+        // failing match unwinds instead of exploring combinations.
+        const started = performance.now();
+        const zwjRun = "👨\u200D".repeat(20_000);
+
+        expect(parseConventionalHeader(`${zwjRun}nope`)).toBeUndefined();
+        expect(performance.now() - started).toBeLessThan(1000);
+    });
+
+    it("strips trailing slashes from a compare-url base in linear time", () => {
+        expect.hasAssertions();
+
+        // CodeQL alert 583. `replace(/\/+$/, "")` has an unanchored start, so
+        // the engine retries the `+` at every offset when the run is NOT at the
+        // end. Measured on the old expression: 1924 ms for 60k interior slashes.
+        const started = performance.now();
+        const url = buildCompareUrl({
+            compareUrlPrefix: `https://git.example.com/${"/".repeat(60_000)}a`,
+            name: "@scope/pkg",
+            newVersion: "1.1.0",
+            oldVersion: "1.0.0",
+        });
+        const elapsed = performance.now() - started;
+
+        expect(elapsed).toBeLessThan(250);
+        expect(url).toBe(`https://git.example.com/${"/".repeat(60_000)}a/compare/@scope/pkg@1.0.0...@scope/pkg@1.1.0`);
+    });
+});

--- a/packages/tooling/vis/__tests__/release/core/changelog-default.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-default.test.ts
@@ -319,3 +319,114 @@ describe("default formatter: sections option (release-please parity)", () => {
         expect(result).toContain("- Untagged note here.");
     });
 });
+
+describe("default formatter: byte-for-byte output (guards the shared-renderer refactor)", () => {
+    /** One body covering every branch: breaking, visible, hidden, unmapped and unparseable. */
+    const MIXED_BODY = [
+        "feat: add tab completion",
+        "feat!: drop legacy API",
+        "fix(cli): handle empty input",
+        "chore: bump linter",
+        "docs: tweak readme",
+        "banana: peel it",
+        "Untagged note here.",
+    ].join("\n");
+
+    const mkMixedCtx = (release: PlannedRelease = mkRelease()): ChangelogContext =>
+        mkCtx({ changeFiles: [{ body: MIXED_BODY, id: "x", path: "x.md", payload: { bumps: { "@scope/pkg": "minor" } } }], release });
+
+    it("`sections: []` renders the release-please default table unchanged", async () => {
+        expect.hasAssertions();
+
+        const result = await createDefaultFormatter({ sections: [] })(mkMixedCtx());
+
+        expect(result).toBe(
+            [
+                "## 1.1.0",
+                "<sub>2026-05-02</sub>",
+                "",
+                "### Breaking Changes",
+                "",
+                "- feat!: drop legacy API",
+                "",
+                "### Features",
+                "",
+                "- feat: add tab completion",
+                "",
+                "### Bug Fixes",
+                "",
+                "- fix(cli): handle empty input",
+                "",
+                "### Documentation",
+                "",
+                "- docs: tweak readme",
+                "",
+                "### Miscellaneous",
+                "",
+                "- banana: peel it",
+                "- Untagged note here.",
+            ].join("\n"),
+        );
+    });
+
+    it("a custom table renders unchanged, catch-all included", async () => {
+        expect.hasAssertions();
+
+        const result = await createDefaultFormatter({
+            sections: [
+                { section: "Headlines", type: "feat" },
+                { hidden: true, section: "Internal", type: "chore" },
+            ],
+        })(mkMixedCtx());
+
+        expect(result).toBe(
+            [
+                "## 1.1.0",
+                "<sub>2026-05-02</sub>",
+                "",
+                "### Headlines",
+                "",
+                "- feat: add tab completion",
+                "",
+                "### Miscellaneous",
+                "",
+                "- feat!: drop legacy API",
+                "- fix(cli): handle empty input",
+                "- docs: tweak readme",
+                "- banana: peel it",
+                "- Untagged note here.",
+            ].join("\n"),
+        );
+    });
+
+    it("appends cascade notes straight after the catch-all, as it always has", async () => {
+        expect.hasAssertions();
+
+        const result = await createDefaultFormatter({ sections: [] })(
+            mkMixedCtx(mkRelease({ isCascadeBump: true, sources: [{ bumpType: "minor", name: "@scope/core", newVersion: "2.0.0" }] })),
+        );
+
+        expect(result.endsWith(["- banana: peel it", "- Untagged note here.", "- Cascade from @scope/core@2.0.0"].join("\n"))).toBe(true);
+    });
+
+    it("`sections` omitted stays a flat list", async () => {
+        expect.hasAssertions();
+
+        const result = await createDefaultFormatter()(mkMixedCtx());
+
+        expect(result).toBe(
+            [
+                "## 1.1.0",
+                "<sub>2026-05-02</sub>",
+                "",
+                "- feat: add tab completion",
+                "- feat!: drop legacy API",
+                "- fix(cli): handle empty input",
+                "- chore: bump linter",
+                "- docs: tweak readme",
+                "- banana: peel it",
+                "- Untagged note here.",
+            ].join("\n"),
+        );
+    });
+});

--- a/packages/tooling/vis/__tests__/release/core/changelog-resolve.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/changelog-resolve.test.ts
@@ -101,6 +101,27 @@ describe("resolveFormatter — built-ins", () => {
 
         expect(out).toBeTypeOf("string");
     });
+
+    it("returns the conventional formatter for setting=\"conventional\"", async () => {
+        expect.hasAssertions();
+
+        const formatter = await resolveFormatter("conventional", "/tmp");
+        const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
+
+        // `{compareUrl}` resolves against whatever remote the sandbox has (or
+        // none), so assert on the tokens the template always fills.
+        expect(out).toContain("## a ");
+        expect(out).toContain("(2026-01-01)");
+    }, 15_000);
+
+    it("aliases \"conventionalcommits\" to the same formatter", async () => {
+        expect.hasAssertions();
+
+        const formatter = await resolveFormatter("conventionalcommits", "/tmp");
+        const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
+
+        expect(out).toBeTypeOf("string");
+    }, 15_000);
 });
 
 describe("resolveFormatter — tuple form for built-ins", () => {
@@ -129,6 +150,20 @@ describe("resolveFormatter — tuple form for built-ins", () => {
         const out = await formatter({ changeFiles: [], date: "2026-01-01", release: mkRelease("a"), target: "changelog" });
 
         expect(out).toBeTypeOf("string");
+    });
+
+    it("forwards `types` + `heading` options to the conventional factory", async () => {
+        expect.hasAssertions();
+
+        const formatter = await resolveFormatter(["conventional", { heading: "## {version} ({date})", repo: "owner/name" }], "/tmp");
+        const out = await formatter({
+            changeFiles: [{ body: "feat(cli): add pdf()", id: "x", path: "x.md", payload: { bumps: { a: "minor" } } }],
+            date: "2026-01-01",
+            release: mkRelease("a"),
+            target: "changelog",
+        });
+
+        expect(out).toBe(["## 1.1.0 (2026-01-01)", "", "### Features", "", "* **cli:** add pdf()"].join("\n"));
     });
 });
 

--- a/packages/tooling/vis/docs/commands/release.mdx
+++ b/packages/tooling/vis/docs/commands/release.mdx
@@ -242,6 +242,8 @@ vis release changelog --json
 vis release changelog --filter '@scope/*'
 ```
 
+The rendering comes from `release.changelog` — `"default"`, `"github"`, `"keep-a-changelog"` or `"conventional"` (grouped by commit type, scope bolded, templated heading). See [Changelog formatters](../guides/release.mdx#changelog-formatters).
+
 **Options**
 
 | Option                   | Type    | Description                                |

--- a/packages/tooling/vis/docs/guides/release-plugin-authoring.mdx
+++ b/packages/tooling/vis/docs/guides/release-plugin-authoring.mdx
@@ -441,7 +441,7 @@ For the **full publish path** with catalog rewriting, clean-package-json, proven
 
 ## Custom `ChangelogFormatter`
 
-Use this when neither the `default` formatter (plain Markdown), the `github` formatter (PR / commit / author links), nor the `keep-a-changelog` formatter (the [keepachangelog.com](https://keepachangelog.com) 1.1.0 layout) match your house style. Common reasons:
+Use this when none of the built-ins — `default` (plain Markdown), `github` (PR / commit / author links), `keep-a-changelog` (the [keepachangelog.com](https://keepachangelog.com) 1.1.0 layout), or `conventional` (grouped by commit type, scope bolded, templated heading) — match your house style. Common reasons:
 
 - You want emoji prefixes per change type (`✨ Features`, `🐛 Bug Fixes`).
 - You ship to docs (Mintlify, Docusaurus) and need MDX-compatible output.
@@ -483,7 +483,7 @@ The convention: for `"github-release"`, **omit the version heading** (`## 1.2.3`
 // vis.config.ts
 export default {
     release: {
-        // Built-in id — `"default"`, `"github"`, or `"keep-a-changelog"`:
+        // Built-in id — `"default"`, `"github"`, `"keep-a-changelog"`, or `"conventional"`:
         changelog: "github",
         // Or false — no-op formatter (writes nothing):
         // changelog: false,
@@ -682,7 +682,7 @@ A few observations:
 
 ### Re-using built-in formatters
 
-To layer a small tweak on top of a built-in — e.g. the github formatter with a footer — set `release.changelog` to the built-in id in your config and wrap the rendered output with a post-process step in your CI. For deeper composition (calling `createGithubFormatter` directly), copy the formatter logic into your own module: the built-in factories live at `packages/tooling/vis/src/release/core/changelog/{default,github,keep-a-changelog}.ts` and are not re-exported from the plugin SDK.
+To layer a small tweak on top of a built-in — e.g. the github formatter with a footer — set `release.changelog` to the built-in id in your config and wrap the rendered output with a post-process step in your CI. For deeper composition (calling `createGithubFormatter` directly), copy the formatter logic into your own module: the built-in factories live at `packages/tooling/vis/src/release/core/changelog/{default,github,keep-a-changelog,conventional}.ts` and are not re-exported from the plugin SDK. The primitives they share sit next to them, one module per concern: the commit-header grammar (`parseConventionalHeader`, `isBreakingChange`) in `changelog/conventional-header.ts`, the grouped-section renderer (`renderGroupedEntries`) in `changelog/sections.ts`, and the heading template (`renderReleaseHeading`, `buildCompareUrl`) in `changelog/release-heading.ts`.
 
 ## Cross-references
 

--- a/packages/tooling/vis/docs/guides/release.mdx
+++ b/packages/tooling/vis/docs/guides/release.mdx
@@ -753,7 +753,7 @@ Run it locally before pushing release config changes, or wire it into your pre-m
 | `fixed` / `linked`                                                                                                | `[]`                             | Group rules (locked versions / locked bump levels). Object form opts into a shared changelog                                                                                                  |
 | `ignore` / `include`                                                                                              | `[]`                             | Globs that opt-out / force-include packages                                                                                                                                                   |
 | `privatePackages`                                                                                                 | `{ version: false, tag: false }` | Whether to version / tag `private: true` packages                                                                                                                                             |
-| `changelog`                                                                                                       | `"default"`                      | `false` / `"default"` / `"github"` / `"keep-a-changelog"` / `[path, options]` / `[builtin, options]`                                                                                          |
+| `changelog`                                                                                                       | `"default"`                      | `false` / `"default"` / `"github"` / `"keep-a-changelog"` / `"conventional"` / `[path, options]` / `[builtin, options]` — see [Changelog formatters](#changelog-formatters)                   |
 | `publish.cleanPackageJson`                                                                                        | `true`                           | Strip `scripts`, `devDependencies`, etc. from the published manifest                                                                                                                          |
 | `publish.guards`                                                                                                  | conservative defaults            | Pre-publish gates — see [security audit](./security-audit.mdx)                                                                                                                                |
 | `publish.releaseAssets`                                                                                           | `{}`                             | Post-publish: stamp tarball hashes into the release body and/or upload the tarball                                                                                                            |
@@ -787,6 +787,116 @@ Run it locally before pushing release config changes, or wire it into your pre-m
 | `acknowledgeUnstable`                                                                                             | `false`                          | Suppress the unstable-subsystem warning                                                                                                                                                       |
 
 </details>
+
+### Changelog formatters
+
+`release.changelog` picks how each entry is rendered. Four built-ins ship in the box; every one also takes an options object through the tuple form (`["github", { … }]`).
+
+| Value                | Shape                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| `false`              | No changelog output at all                                                                     |
+| `"default"`          | Plain Markdown — `## <version>` + `<sub><date></sub>`, then a flat bullet list                 |
+| `"github"`           | The same, plus PR / commit / author links and a `Thanks @user!` footer                         |
+| `"keep-a-changelog"` | The [keepachangelog.com](https://keepachangelog.com) 1.1.0 `Added` / `Changed` / … layout      |
+| `"conventional"`     | The `conventional-changelog` / `semantic-release` shape — grouped by commit type, scope bolded |
+
+#### `conventional` — grouping, scopes, and a templated heading
+
+Pick this one when you are migrating a package off `multi-semantic-release` and want the existing `CHANGELOG.md` to keep its shape instead of visibly changing hands mid-file.
+
+```typescript
+export default {
+    release: {
+        changelog: [
+            "conventional",
+            {
+                // owner/name — auto-detected from the git remote when omitted.
+                repo: "acme/monorepo",
+                // Should match `releaseTagPattern` so `{compareUrl}` points at real tags.
+                tagPattern: "{name}@{version}",
+            },
+        ],
+    },
+};
+```
+
+Given `fix(client,react): encode SSR payloads`, `feat(browser): add pdf()` and `chore: bump linter`, it writes:
+
+```text
+## @acme/browser [1.1.0](https://github.com/acme/monorepo/compare/@acme/browser@1.0.0...@acme/browser@1.1.0) (2026-09-08)
+
+### Features
+
+* **browser:** add pdf()
+
+### Bug Fixes
+
+* **client,react:** encode SSR payloads
+```
+
+Note what happened to each part:
+
+- **Grouping.** Entries are bucketed by conventional-commit type and emitted in the order of the `types` table (below). `chore:` is hidden by default, so it is gone.
+- **Scope lifting.** `fix(client,react):` became `**client,react:**`; the type prefix is dropped. A scope-less commit renders as the bare subject.
+- **Heading.** `heading` defaults to `"## {name} [{version}]({compareUrl}) ({date})"`.
+
+#### `types` — section headings per commit type
+
+Same shape as `conventional-changelog-conventionalcommits`' `presetConfig.types`, so a table lifted out of a `.versionrc` works unchanged:
+
+```typescript
+changelog: [
+    "conventional",
+    {
+        types: [
+            { section: "Features", type: "feat" },
+            { section: "Bug Fixes", type: "fix" },
+            { hidden: true, section: "Internal", type: "refactor" },
+        ],
+    },
+];
+```
+
+The default table is the conventional preset plus this repo's extra commit types:
+
+| Type                                        | Section                  | Hidden |
+| ------------------------------------------- | ------------------------ | ------ |
+| `feat`, `feature`                           | Features                 | no     |
+| `fix`                                       | Bug Fixes                | no     |
+| `perf`                                      | Performance Improvements | no     |
+| `revert`                                    | Reverts                  | no     |
+| `deps`                                      | Dependencies             | no     |
+| `docs`                                      | Documentation            | yes    |
+| `style`                                     | Styles                   | yes    |
+| `refactor`                                  | Code Refactoring         | yes    |
+| `test`                                      | Tests                    | yes    |
+| `build`                                     | Build System             | yes    |
+| `ci`                                        | Continuous Integration   | yes    |
+| `chore`                                     | Miscellaneous Chores     | yes    |
+| `dx`, `types`, `wip`, `release`, `workflow` | (per-type)               | yes    |
+| `other`                                     | Other Changes            | no     |
+
+`deps` is the one non-Angular type left **visible**: `multi-semantic-release` already writes a `### Dependencies` section, and hiding it would lose the upgrade trail an adopter reads to answer "which version of X did this release pull in?". Dependency, cascade and group bumps are synthesized as `deps(<pkg>):` entries, so they land there as `* **@acme/fs:** upgraded to 6.0.8`.
+
+**Nothing is silently dropped.** A line that does not parse as conventional — and a line whose type has no rule in the table — lands verbatim under `### Other Changes`. That holds for a table of your own too: leave `feat` and `fix` as the only rules and a `chore:` commit, a plain prose line and a dependency bump still all show up under `### Other Changes` rather than vanishing. Place or rename the bucket with a `{ type: "other", section: "…" }` rule of your own, or hide it explicitly with `{ type: "other", section: "Other Changes", hidden: true }` if you would rather lose them. Breaking changes (`feat!:`, or an inline `BREAKING CHANGE`) are additionally listed under `### ⚠ BREAKING CHANGES`, **even when their own type is hidden** — hiding `chore` never hides a `chore!:`. Set `breakingSection: false` to fold them back into their type section.
+
+#### `heading` — a template for the release heading
+
+Tokens: `{name}`, `{version}`, `{date}`, `{compareUrl}` — the same substitution style as `releaseTagPattern`, and unknown `{tokens}` are left intact so a typo is visible rather than silently empty.
+
+`{compareUrl}` is built from `repo` (or `compareUrlPrefix`, for self-hosted GitLab / Gitea) plus `tagPattern`. When there is nothing to compare against — no remote detected, or a first release with no previous version — the surrounding `[…]({compareUrl})` link syntax is **unwrapped**, so the heading degrades to `## @acme/browser 1.0.0 (2026-09-08)` rather than emitting a dangling `[1.0.0]()`.
+
+Every link — the compare URL, `#123` issue refs, and the `github` formatter's PR / commit refs — is shaped by the **detected remote provider**, not by the formatter's name. On a GitLab remote the same config emits `https://gitlab.com/<group>/<project>/-/compare/…`, `/-/issues/123` and `/-/merge_requests/42`. When the remote can't be detected at all (no `git`, no remote, a failing `gh`), the changelog is rendered as plain text without links rather than guessing.
+
+`heading` also works on `"default"` and `"github"`, and `types` also works on `"github"` — so you can keep the PR / commit / author links and still get grouped, scope-bolded sections:
+
+```typescript
+changelog: ["github", { heading: "## {name} [{version}]({compareUrl}) ({date})", types: [] }];
+```
+
+`types: []` means "use the default table". Both options default to **off** on `default` and `github`: leave them out and those formatters emit exactly what they always did.
+
+`default` spells the same idea `sections` rather than `types`. The rule shape is identical (`{ type, section, hidden? }`) and both run through the same renderer; only the presentation differs, because `sections` predates `types` and its output is pinned: entries keep their `type:` prefix instead of lifting the scope, `feat!:` gets its own `Breaking Changes` section instead of being listed twice, and the catch-all is called `Miscellaneous`. Use `types` on `conventional` / `github` for the conventional-changelog look; keep `sections` if a changelog already written by `default` should carry on unchanged.
 
 ## What's next
 

--- a/packages/tooling/vis/schemas/vis-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-config.schema.json
@@ -4041,7 +4041,7 @@
                             ]
                         }
                     ],
-                    "description": "Changelog formatter selection. Pass `false` to disable changelog output, one of the built-in names (`\"default\"`, `\"github\"`, `\"keep-a-changelog\"`), a path to a custom module, or a `[path, options]` tuple."
+                    "description": "Changelog formatter selection. Pass `false` to disable changelog output, one of the built-in names (`\"default\"`, `\"github\"`, `\"keep-a-changelog\"`, `\"conventional\"`), a path to a custom module, or a `[path, options]` tuple.\n\n`\"conventional\"` renders the `conventional-changelog` / `semantic-release` shape: entries grouped by commit type under configurable `types: [{ type, section, hidden? }]` headings, the scope lifted out and bolded (`* **client,react:** …`), and a templated release heading (`heading`, tokens `{name}`, `{version}`, `{date}`, `{compareUrl}`). The same `types` / `heading` options are available opt-in on `\"github\"`, and `heading` on `\"default\"`."
                 },
                 "changesDir": {
                     "type": "string",

--- a/packages/tooling/vis/schemas/vis-release-config.schema.json
+++ b/packages/tooling/vis/schemas/vis-release-config.schema.json
@@ -115,7 +115,7 @@
                     ]
                 }
             ],
-            "description": "Changelog formatter selection. Pass `false` to disable changelog output, one of the built-in names (`\"default\"`, `\"github\"`, `\"keep-a-changelog\"`), a path to a custom module, or a `[path, options]` tuple."
+            "description": "Changelog formatter selection. Pass `false` to disable changelog output, one of the built-in names (`\"default\"`, `\"github\"`, `\"keep-a-changelog\"`, `\"conventional\"`), a path to a custom module, or a `[path, options]` tuple.\n\n`\"conventional\"` renders the `conventional-changelog` / `semantic-release` shape: entries grouped by commit type under configurable `types: [{ type, section, hidden? }]` headings, the scope lifted out and bolded (`* **client,react:** …`), and a templated release heading (`heading`, tokens `{name}`, `{version}`, `{date}`, `{compareUrl}`). The same `types` / `heading` options are available opt-in on `\"github\"`, and `heading` on `\"default\"`."
         },
         "changesDir": {
             "type": "string",

--- a/packages/tooling/vis/src/release/core/changelog/conventional-header.ts
+++ b/packages/tooling/vis/src/release/core/changelog/conventional-header.ts
@@ -1,0 +1,119 @@
+/**
+ * The conventional-commit header grammar — one parser for every changelog
+ * formatter under this directory.
+ *
+ * A changelog entry is a single authored line (`fix(client,react): encode SSR
+ * payloads`), optionally carrying a list marker and/or a gitmoji prefix. This
+ * module owns every regex needed to take that line apart; formatters decide
+ * what to *do* with the result (see `sections.ts`) but never re-derive it.
+ *
+ * The two breaking-change signals are reported separately rather than folded
+ * into one flag, because the shipped formatters weigh them differently: the
+ * `!` marker is part of the header and can therefore re-type an entry, while
+ * an inline `BREAKING CHANGE` note is prose that only earns a mention in the
+ * breaking section. {@link isBreakingChange} is the "either signal" predicate.
+ */
+
+/** Leading list marker (`- `, `* `, `+ `) authored in a change-file body. */
+const BULLET_PREFIX_RE = /^[*+-]\s+/;
+
+/**
+ * Optional gitmoji / `:shortcode:` prefix preceding the conventional type
+ * (`🚀 feat: …`, `:rocket: feat: …`) — release-please #2385 parity. Stripped
+ * before parsing so the header regex doesn't bail on the leading non-ASCII
+ * glyph.
+ *
+ * A pictographic base is not enough: half the gitmoji set is written with a
+ * trailing U+FE0F VARIATION SELECTOR-16 (`🏗️` is U+1F3D7 U+FE0F), and an
+ * emoji picker will hand the author a skin-tone modifier (`👍🏽`) or a
+ * ZWJ sequence (`👨‍💻`). Matching only the base code point left the selector
+ * sitting where the separator was expected, so the whole line failed to parse
+ * as a conventional header and silently landed in the uncategorized bucket.
+ *
+ * Every optional part is a single code point drawn from a class that is
+ * disjoint from what may follow it (a variation selector is not a modifier,
+ * not a ZWJ and not whitespace), and each `*` iteration must start with a
+ * ZWJ — so a failed match backtracks straight out instead of exploring
+ * combinations. Together with the `^` anchor that keeps matching linear.
+ * Keycap sequences (`1️⃣`) are deliberately not covered: they start with an
+ * ASCII digit, and stripping those would swallow legitimate prose.
+ */
+const GITMOJI_PREFIX_RE
+    = /^(?:[\p{Emoji_Presentation}\p{Extended_Pictographic}][\uFE0E\uFE0F]?\p{Emoji_Modifier}?(?:\u200D[\p{Emoji_Presentation}\p{Extended_Pictographic}][\uFE0E\uFE0F]?\p{Emoji_Modifier}?)*|:\w+:)\s+/u;
+
+/**
+ * Conventional-commit header. Fully anchored (`^`…`$`) and free of nested
+ * quantifiers: the scope body is `[^()]*` so it can never overlap with the
+ * closing paren, and the type charset excludes `(`, `!` and `:`. Matching is
+ * therefore linear in the length of the line — this repo has been bitten by
+ * CodeQL polynomial-ReDoS findings on unanchored commit scanners.
+ */
+// `[ \t]` is deliberately a SINGLE character rather than `[ \t]+`, and the
+// subject is `(.*)` rather than `(.+)`. With `[ \t]+(.+)$` the two groups can
+// both match whitespace, so a subject of many tabs makes the engine try every
+// split between them — O(n²) (CodeQL polynomial-redos, alert 582). Consuming
+// exactly one separator makes the split deterministic; any further leading
+// whitespace lands in the subject and is removed by the `.trim()` below, so
+// the parsed result is unchanged.
+const CONVENTIONAL_HEADER_RE = /^([a-z][\w-]*)(?:\(([^()]*)\))?(!)?:[ \t](.*)$/i;
+
+/** `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer written inline in a change-file body. */
+const BREAKING_NOTE = "BREAKING CHANGE";
+
+const BREAKING_NOTE_ALT = "BREAKING-CHANGE";
+
+/** Result of parsing a conventional-commit header line. */
+export interface ParsedConventionalHeader {
+    /** `true` for the `!` marker — `feat!:`, `fix(scope)!:`. */
+    breakingMarker: boolean;
+    /** `true` when the line carries an inline `BREAKING CHANGE` / `BREAKING-CHANGE` note. */
+    breakingNote: boolean;
+    /** Scope between the parentheses, `undefined` when the header has none. */
+    scope: string | undefined;
+    /** Everything after `: `. */
+    subject: string;
+    /** Lower-cased conventional type. */
+    type: string;
+}
+
+/**
+ * `true` when the line already opens with a Markdown list marker.
+ *
+ * Renderers use this to decide whether to prefix a bullet of their own; it is
+ * the same test {@link stripBulletMarker} strips with, so the two can never
+ * disagree about what a marker is (a `+ ` bullet used to be stripped here but
+ * re-bulleted there, emitting `* + fix: …`).
+ */
+export const hasBulletMarker = (line: string): boolean => BULLET_PREFIX_RE.test(line);
+
+/** Strip the leading list marker (if any) from an authored body line. */
+export const stripBulletMarker = (line: string): string => line.replace(BULLET_PREFIX_RE, "").trim();
+
+/**
+ * Parse a single body line as a conventional-commit header.
+ *
+ * Returns `undefined` when the line does not follow the convention — the
+ * caller is responsible for routing those to the uncategorized bucket rather
+ * than dropping them.
+ */
+export const parseConventionalHeader = (line: string): ParsedConventionalHeader | undefined => {
+    const text = stripBulletMarker(line).replace(GITMOJI_PREFIX_RE, "");
+    const match = CONVENTIONAL_HEADER_RE.exec(text);
+
+    if (!match) {
+        return undefined;
+    }
+
+    const [, type, scope, bang, subject] = match;
+
+    return {
+        breakingMarker: bang === "!",
+        breakingNote: text.includes(BREAKING_NOTE) || text.includes(BREAKING_NOTE_ALT),
+        scope: scope === undefined || scope.trim() === "" ? undefined : scope.trim(),
+        subject: subject!.trim(),
+        type: type!.toLowerCase(),
+    };
+};
+
+/** `true` when the header announces a breaking change by either signal. */
+export const isBreakingChange = (parsed: ParsedConventionalHeader): boolean => parsed.breakingMarker || parsed.breakingNote;

--- a/packages/tooling/vis/src/release/core/changelog/conventional.ts
+++ b/packages/tooling/vis/src/release/core/changelog/conventional.ts
@@ -1,0 +1,146 @@
+/**
+ * Conventional-commit changelog formatter — the shape
+ * `conventional-changelog` / `semantic-release` produce, so a package
+ * migrating off `multi-semantic-release` keeps writing into the same
+ * CHANGELOG.md without the heading and section style visibly changing hands.
+ *
+ * Three differences from the `default` formatter:
+ *
+ *   1. Entries are grouped by conventional-commit type under configurable
+ *      section headings (`presetConfig.types` parity — see
+ *      {@link DEFAULT_CONVENTIONAL_TYPES}).
+ *   2. The scope is lifted out and bolded: `fix(client,react): encode …`
+ *      renders as `* **client,react:** encode …`.
+ *   3. The release heading is a template (`{name}`, `{version}`, `{date}`,
+ *      `{compareUrl}`), defaulting to the semantic-release-monorepo shape
+ *      `## &lt;pkg> [&lt;version>](&lt;compare-url>) (&lt;date>)`.
+ *
+ * Use:
+ *   release.changelog: "conventional"
+ *   release.changelog: ["conventional", { repo: "owner/name", types: [...] }]
+ */
+
+import type { CommandRunner } from "../package-managers/interface";
+import { createShellRunner } from "../shell-runner";
+import type { ChangelogContext, ChangelogFormatter } from "./api";
+import { buildCompareUrl, renderReleaseHeading } from "./release-heading";
+import type { DetectedRepo } from "./repo-slug";
+import { detectRepo, linkifyHashRefs } from "./repo-slug";
+import type { ConventionalTypeRule, GroupableEntry } from "./sections";
+import { DEFAULT_CONVENTIONAL_TYPES, renderGroupedEntries } from "./sections";
+import { sourceBumpEntries } from "./source-bumps";
+
+export interface ConventionalFormatterOptions {
+    /**
+     * Heading for breaking changes, rendered above every type section.
+     * `false` folds them into their type section instead.
+     * Default: `"⚠ BREAKING CHANGES"`.
+     */
+    breakingSection?: false | string;
+
+    /** List marker. Default `"*"` — what conventional-changelog emits. */
+    bullet?: string;
+
+    /**
+     * Base URL for `{compareUrl}` (self-hosted GitLab / Gitea). Wins over
+     * `repo`. The formatter appends `/compare/&lt;fromTag>...&lt;toTag>`.
+     */
+    compareUrlPrefix?: string;
+
+    /**
+     * Release-heading template. Tokens: `{name}`, `{version}`, `{date}`,
+     * `{compareUrl}`. `[...]({compareUrl})` link syntax is unwrapped when
+     * there is no compare URL (no remote, or a first release), so the
+     * heading never degrades into a dangling `[1.0.0]()`.
+     *
+     * Default: `"## {name} [{version}]({compareUrl}) ({date})"`.
+     */
+    heading?: string;
+
+    /**
+     * `owner/name` slug for `{compareUrl}` and `#123` issue links.
+     * Auto-detected from the active remote provider when omitted; when
+     * detection fails the links are simply not emitted. The provider itself
+     * is always detected, so a GitLab remote gets GitLab link shapes.
+     */
+    repo?: string;
+
+    /** Override the runner — used by tests. */
+    runner?: CommandRunner;
+
+    /**
+     * Tag template naming both ends of `{compareUrl}`. Should match the
+     * workspace `releaseTagPattern`. Default `"{name}@{version}"`.
+     */
+    tagPattern?: string;
+
+    /**
+     * Ordered `type → section` table, `presetConfig.types` shaped.
+     * Default: {@link DEFAULT_CONVENTIONAL_TYPES}.
+     */
+    types?: ReadonlyArray<ConventionalTypeRule>;
+}
+
+export const DEFAULT_CONVENTIONAL_HEADING = "## {name} [{version}]({compareUrl}) ({date})";
+
+export const createConventionalFormatter = (options: ConventionalFormatterOptions = {}): ChangelogFormatter => {
+    const runner = options.runner ?? createShellRunner();
+    const heading = options.heading ?? DEFAULT_CONVENTIONAL_HEADING;
+    const types = options.types ?? DEFAULT_CONVENTIONAL_TYPES;
+    let repoCachePromise: Promise<DetectedRepo> | undefined;
+
+    const formatter: ChangelogFormatter = async (context: ChangelogContext): Promise<string> => {
+        const { changeFiles, date, release, target } = context;
+
+        // Detected once per formatter instance — the slug feeds both
+        // `{compareUrl}` and the `#123` issue links.
+        repoCachePromise ??= detectRepo(options.repo, runner, process.cwd());
+
+        const repo = await repoCachePromise;
+
+        const entries: GroupableEntry[] = [];
+
+        for (const file of changeFiles) {
+            const body = file.body.trim();
+
+            if (!body) {
+                continue;
+            }
+
+            for (const rawLine of body.split(/\r?\n/)) {
+                const line = rawLine.trim();
+
+                if (line) {
+                    entries.push({ line: linkifyHashRefs(line, repo) });
+                }
+            }
+        }
+
+        entries.push(...sourceBumpEntries(context));
+
+        const lines: string[] = [];
+
+        if (target !== "github-release") {
+            const compareUrl = buildCompareUrl({
+                compareUrlPrefix: options.compareUrlPrefix,
+                name: release.name,
+                newVersion: release.newVersion,
+                oldVersion: release.oldVersion,
+                provider: repo.provider,
+                repo: repo.slug,
+                tagPattern: options.tagPattern,
+            });
+
+            lines.push(renderReleaseHeading(heading, { compareUrl, date, name: release.name, version: release.newVersion }), "");
+        }
+
+        lines.push(...renderGroupedEntries(entries, { breakingSection: options.breakingSection, bullet: options.bullet, types }));
+
+        return lines
+            .join("\n")
+            .replaceAll(/\n{3,}/g, "\n\n")
+            .trim();
+    };
+
+    return formatter;
+};

--- a/packages/tooling/vis/src/release/core/changelog/default.ts
+++ b/packages/tooling/vis/src/release/core/changelog/default.ts
@@ -10,9 +10,18 @@
  * produced from that file. Set this on a workspace via
  * `release.changelog: ["default", { authorCredit: true }]` — defaults
  * to off so legacy changelogs don't gain unsolicited credit lines.
+ *
+ * `sections` opts into grouped output. It uses the shared renderer in
+ * `sections.ts`, configured to this formatter's long-standing shape: entries
+ * stay verbatim (no scope lifting), `-` bullets, `!`-marked headers re-typed
+ * to a `breaking` pseudo-type rather than listed in a separate section, and a
+ * `Miscellaneous` catch-all.
  */
 
 import type { ChangelogContext, ChangelogFormatter } from "./api";
+import { buildCompareUrl, renderReleaseHeading } from "./release-heading";
+import type { ConventionalTypeRule, GroupableEntry } from "./sections";
+import { renderGroupedEntries, withBullet } from "./sections";
 
 /**
  * Section heading config — release-please parity. Each rule maps a
@@ -22,18 +31,12 @@ import type { ChangelogContext, ChangelogFormatter } from "./api";
  *
  * Default mapping (when `sections` is omitted) preserves the legacy
  * flat-list output.
+ *
+ * Structurally identical to — and an alias of — the `types` table the
+ * `conventional` and `github` formatters take; the two option names are kept
+ * apart only because `sections` shipped first.
  */
-export interface ChangelogSection {
-    /**
-     * Drop entries of this type entirely. Useful for `chore`, `style`,
-     * `refactor` — the "internal" changes consumers don't care about.
-     */
-    hidden?: boolean;
-    /** Markdown heading (without leading `###`). */
-    section: string;
-    /** Conventional-commit type — `feat`, `fix`, `perf`, `chore`, … */
-    type: string;
-}
+export type ChangelogSection = ConventionalTypeRule;
 
 export interface DefaultFormatterOptions {
     /**
@@ -42,6 +45,23 @@ export interface DefaultFormatterOptions {
      */
     authorCredit?: boolean;
 
+    /** Override the URL prefix used by `{compareUrl}` (self-hosted GitLab, Gitea, …). */
+    compareUrlPrefix?: string;
+
+    /**
+     * Release-heading template. Tokens: `{name}`, `{version}`, `{date}`,
+     * `{compareUrl}` — the `[…]({compareUrl})` link syntax is unwrapped when
+     * there is nothing to compare against (no `repo`/`compareUrlPrefix`, or a
+     * first release), so the heading never degrades to `[1.0.0]()`.
+     *
+     * Omitted (the default) keeps the legacy two-line
+     * `## &lt;version>` + `&lt;sub>&lt;date>&lt;/sub>` heading byte-for-byte.
+     */
+    heading?: string;
+
+    /** `owner/name` slug used to build `{compareUrl}`. Not auto-detected — pass it explicitly. */
+    repo?: string;
+
     /**
      * Group entries under section headings inferred from
      * conventional-commit type prefixes. When omitted, the formatter
@@ -49,10 +69,34 @@ export interface DefaultFormatterOptions {
      * grouping uses the release-please default mapping.
      */
     sections?: ChangelogSection[];
+
+    /**
+     * Tag template naming both ends of `{compareUrl}`. Should match the
+     * workspace `releaseTagPattern`. Default `"{name}@{version}"`.
+     */
+    tagPattern?: string;
 }
 
+/**
+ * Pseudo-type `feat!:` / `fix(scope)!:` entries are re-bucketed under, so the
+ * table below can give them a section without the operator having to invent a
+ * `breaking:` commit type.
+ */
+const BREAKING_PSEUDO_TYPE = "breaking";
+
+/** Catch-all heading for entries no rule in `sections` claims. */
+const MISCELLANEOUS_SECTION = "Miscellaneous";
+
+/** List marker this formatter has always used. */
+const BULLET = "-";
+
+/**
+ * Release-please's default mapping, used when `sections: []`. Deliberately not
+ * the `conventional` formatter's table: this one shows `docs`, carries the
+ * `breaking` pseudo-type, and leans on the `Miscellaneous` catch-all.
+ */
 const DEFAULT_SECTIONS: ChangelogSection[] = [
-    { section: "Breaking Changes", type: "breaking" },
+    { section: "Breaking Changes", type: BREAKING_PSEUDO_TYPE },
     { section: "Features", type: "feat" },
     { section: "Bug Fixes", type: "fix" },
     { section: "Performance Improvements", type: "perf" },
@@ -66,119 +110,11 @@ const DEFAULT_SECTIONS: ChangelogSection[] = [
     { hidden: true, section: "Miscellaneous Chores", type: "chore" },
 ];
 
-const COMMIT_TYPE_REGEX = /^(?<type>[a-z]+)(?:\([^)]+\))?!?:\s+/;
-
-/**
- * Optional gitmoji / `:shortcode:` prefix preceding the conventional
- * commit type (release-please #2385 parity).
- *
- * Some teams use ":rocket: feat: add tab completion" or "🚀 feat: …".
- * Strip a leading single emoji codepoint OR a `:word:` shortcode (plus
- * trailing whitespace) before applying COMMIT_TYPE_REGEX so the parser
- * doesn't bail on the leading non-ASCII glyph.
- */
-const GITMOJI_PREFIX_REGEX = /^(?:[\p{Emoji_Presentation}\p{Extended_Pictographic}]|:\w+:)\s+/u;
-
-/**
- * Extract a conventional-commit type from a body line. Returns
- * `undefined` for lines that don't match the convention; the caller
- * is responsible for the "no type" bucket.
- *
- * `feat!:`/`fix!:`/etc. → `"breaking"` so type-level breaking
- * conventions get the `Breaking Changes` section without requiring
- * the operator to use a custom `breaking:` prefix.
- *
- * A leading gitmoji (Unicode emoji codepoint) or `:shortcode:` is
- * stripped before parsing (release-please #2385). Lines like
- * `:rocket: feat: add tab completion` and `🚀 feat: add tab completion`
- * both yield `"feat"`.
- */
-const extractCommitType = (line: string): string | undefined => {
-    // Strip a leading gitmoji / shortcode before applying the conventional-
-    // commits regex. Keeps the rest of the parser unchanged.
-    const stripped = line.replace(GITMOJI_PREFIX_REGEX, "");
-    const match = COMMIT_TYPE_REGEX.exec(stripped);
-
-    if (!match?.groups?.["type"]) {
-        return undefined;
-    }
-
-    // Breaking-change shorthand: `feat!:` / `fix!:` / etc.
-    if (stripped.includes("!:") && stripped.split("!:")[0]?.match(/^[a-z]+(?:\([^)]+\))?$/)) {
-        return "breaking";
-    }
-
-    return match.groups["type"];
-};
-
 const formatAuthor = (author: string): string => `(${author.startsWith("@") ? author : `@${author}`})`;
 
-const renderFlat = (lines: string[], entries: { line: string; suffix: string }[]): void => {
+const renderFlat = (lines: string[], entries: ReadonlyArray<GroupableEntry>): void => {
     for (const entry of entries) {
-        const normalised = entry.line.startsWith("-") || entry.line.startsWith("*") ? entry.line : `- ${entry.line}`;
-
-        lines.push(`${normalised}${entry.suffix}`);
-    }
-};
-
-const renderSectioned = (lines: string[], entries: { line: string; suffix: string; type: string | undefined }[], sections: ChangelogSection[]): void => {
-    // Bucket entries by type. Lines without a recognised type go to a
-    // "Miscellaneous" catch-all rendered after every configured
-    // section, unless that catch-all type is itself hidden.
-    const byType = new Map<string, { line: string; suffix: string }[]>();
-
-    for (const entry of entries) {
-        const type = entry.type ?? "other";
-        const bucket = byType.get(type) ?? [];
-
-        bucket.push({ line: entry.line, suffix: entry.suffix });
-        byType.set(type, bucket);
-    }
-
-    for (const rule of sections) {
-        const bucket = byType.get(rule.type);
-
-        if (rule.hidden) {
-            // Hidden types are dropped entirely — remove the bucket so it
-            // doesn't leak into the Miscellaneous catch-all rendered below.
-            byType.delete(rule.type);
-
-            continue;
-        }
-
-        if (!bucket || bucket.length === 0) {
-            continue;
-        }
-
-        lines.push(`### ${rule.section}`);
-        lines.push("");
-
-        for (const entry of bucket) {
-            const normalised = entry.line.startsWith("-") || entry.line.startsWith("*") ? entry.line : `- ${entry.line}`;
-
-            lines.push(`${normalised}${entry.suffix}`);
-        }
-
-        lines.push("");
-
-        byType.delete(rule.type);
-    }
-
-    // Leftover types not covered by `sections` → catch-all section.
-    // Skip if `other` is configured + hidden.
-    const otherHidden = sections.some((s) => s.type === "other" && s.hidden);
-
-    if (!otherHidden && byType.size > 0) {
-        lines.push("### Miscellaneous");
-        lines.push("");
-
-        for (const bucket of byType.values()) {
-            for (const entry of bucket) {
-                const normalised = entry.line.startsWith("-") || entry.line.startsWith("*") ? entry.line : `- ${entry.line}`;
-
-                lines.push(`${normalised}${entry.suffix}`);
-            }
-        }
+        lines.push(`${withBullet(entry.line, BULLET)}${entry.suffix ?? ""}`);
     }
 };
 
@@ -189,14 +125,25 @@ export const createDefaultFormatter
             const lines: string[] = [];
 
             if (target !== "github-release") {
-                lines.push(`## ${release.newVersion}`);
-                lines.push(`<sub>${date}</sub>`);
-                lines.push("");
+                if (options.heading === undefined) {
+                    lines.push(`## ${release.newVersion}`);
+                    lines.push(`<sub>${date}</sub>`);
+                    lines.push("");
+                } else {
+                    const compareUrl = buildCompareUrl({
+                        compareUrlPrefix: options.compareUrlPrefix,
+                        name: release.name,
+                        newVersion: release.newVersion,
+                        oldVersion: release.oldVersion,
+                        repo: options.repo,
+                        tagPattern: options.tagPattern,
+                    });
+
+                    lines.push(renderReleaseHeading(options.heading, { compareUrl, date, name: release.name, version: release.newVersion }), "");
+                }
             }
 
-            // Collect entries with their inferred conventional-commit type
-            // so the renderer can decide flat-list vs sectioned output.
-            const entries: { line: string; suffix: string; type: string | undefined }[] = [];
+            const entries: GroupableEntry[] = [];
 
             for (const file of changeFiles) {
                 const body = file.body.trim();
@@ -211,18 +158,25 @@ export const createDefaultFormatter
                 for (const rawLine of body.split(/\r?\n/)) {
                     const line = rawLine.trim();
 
-                    if (!line) {
-                        continue;
+                    if (line) {
+                        entries.push({ line, suffix });
                     }
-
-                    entries.push({ line, suffix, type: extractCommitType(line) });
                 }
             }
 
             const sections = options.sections === undefined ? undefined : options.sections.length === 0 ? DEFAULT_SECTIONS : options.sections;
 
             if (sections) {
-                renderSectioned(lines, entries, sections);
+                lines.push(
+                    ...renderGroupedEntries(entries, {
+                        breakingSection: false,
+                        breakingType: BREAKING_PSEUDO_TYPE,
+                        bullet: BULLET,
+                        entryStyle: "verbatim",
+                        types: sections,
+                        uncategorizedSection: MISCELLANEOUS_SECTION,
+                    }),
+                );
             } else {
                 renderFlat(lines, entries);
             }

--- a/packages/tooling/vis/src/release/core/changelog/github.ts
+++ b/packages/tooling/vis/src/release/core/changelog/github.ts
@@ -8,48 +8,88 @@
  *
  * Repo slug auto-detected via the active provider's `detectRepoSlug` when
  * not passed in options. Falls back to plain text when no provider is
- * available.
+ * available. The link *shapes* follow that detected provider rather than this
+ * formatter's name, so pointing it at a GitLab remote emits
+ * `/-/merge_requests/…` instead of a github.com URL addressing a different
+ * repository.
  *
  * Honours `internalAuthors: string[]` to suppress "Thanks \@user!" lines for
  * team members (RFC §22 still-open question — defaults to empty list).
  *
  * Uses an injectable runner via `createShellRunner()` by default so the
  * formatter is provider-agnostic and testable.
+ *
+ * Opt-in conventional-commit rendering (both default to off, so existing
+ * changelogs keep their exact shape):
+ *   - `types: [...]`  — group entries by commit type under section
+ *                       headings, bolding the lifted scope.
+ *   - `heading: "..."`— template the release heading (`{name}`,
+ *                       `{version}`, `{date}`, `{compareUrl}`).
  */
 
 import type { CommandRunner } from "../package-managers/interface";
+import type { RemoteWebUrls } from "../remote/web-urls";
+import { remoteWebUrls } from "../remote/web-urls";
 import { createShellRunner } from "../shell-runner";
 import type { ChangelogContext, ChangelogFormatter } from "./api";
+import { buildCompareUrl, renderReleaseHeading } from "./release-heading";
+import type { DetectedRepo } from "./repo-slug";
+import { detectRepo, linkifyHashRefs } from "./repo-slug";
+import type { ConventionalTypeRule, GroupableEntry } from "./sections";
+import { DEFAULT_CONVENTIONAL_TYPES, renderGroupedEntries, withBullet } from "./sections";
+import { sourceBumpEntries } from "./source-bumps";
 
 export interface GithubFormatterOptions {
+    /**
+     * Heading for breaking changes when `types` grouping is on. `false`
+     * folds them into their type section. Default `"⚠ BREAKING CHANGES"`.
+     * Ignored unless `types` is set.
+     */
+    breakingSection?: false | string;
+
+    /**
+     * Release-heading template. Tokens: `{name}`, `{version}`, `{date}`,
+     * `{compareUrl}` — `[…]({compareUrl})` is unwrapped when there is no
+     * compare URL (no remote, or a first release).
+     *
+     * Omitted (the default) keeps the legacy two-line
+     * `## &lt;version>` + `&lt;sub>&lt;date>&lt;/sub>` heading byte-for-byte.
+     */
+    heading?: string;
+
     includeCommitLink?: boolean;
     internalAuthors?: ReadonlyArray<string>;
     repo?: string;
     /** Override the runner — used by tests. */
     runner?: CommandRunner;
+
+    /**
+     * Tag template naming both ends of `{compareUrl}`. Should match the
+     * workspace `releaseTagPattern`. Default `"{name}@{version}"`.
+     */
+    tagPattern?: string;
+
     thankContributors?: boolean;
+
+    /**
+     * Group entries by conventional-commit type under these section
+     * headings (`presetConfig.types` shape), lifting the scope out as a
+     * bolded `**scope:**` prefix. Pass `[]` to use
+     * {@link DEFAULT_CONVENTIONAL_TYPES}.
+     *
+     * Omitted (the default) keeps the legacy flat bullet list.
+     */
+    types?: ReadonlyArray<ConventionalTypeRule>;
 }
 
-const DEFAULT_OPTIONS: Required<Omit<GithubFormatterOptions, "repo" | "internalAuthors" | "runner">> & { internalAuthors: ReadonlyArray<string> } = {
+const DEFAULT_OPTIONS: Required<
+    Omit<GithubFormatterOptions, "breakingSection" | "heading" | "internalAuthors" | "repo" | "runner" | "tagPattern" | "types">
+> & {
+    internalAuthors: ReadonlyArray<string>;
+} = {
     includeCommitLink: true,
     internalAuthors: [],
     thankContributors: true,
-};
-
-/**
- * Try to find the repo slug (owner/name) — used for inline links.
- * Order: option → active provider's `detectRepoSlug` → undefined.
- */
-const detectRepoSlugSync = async (option: string | undefined, runner: CommandRunner, cwd: string): Promise<string | undefined> => {
-    if (option) {
-        return option;
-    }
-
-    const { createRemoteClient, detectRemoteProvider } = await import("../remote/detect");
-    const provider = await detectRemoteProvider(cwd, runner, undefined);
-    const client = createRemoteClient(provider);
-
-    return client.detectRepoSlug(cwd, runner);
 };
 
 const resolveAuthorFromGit = async (runner: CommandRunner, cwd: string, changeFilePath: string): Promise<string | undefined> => {
@@ -64,35 +104,45 @@ const resolveAuthorFromGit = async (runner: CommandRunner, cwd: string, changeFi
     return lines[0]?.trim() || undefined;
 };
 
-const linkifyHashRefs = (text: string, repo: string | undefined): string => {
-    if (!repo) {
-        return text;
-    }
-
-    return text.replaceAll(/(?<!\[)#(\d+)/g, (_match, num: string) => `[#${num}](https://github.com/${repo}/issues/${num})`);
-};
-
 export const createGithubFormatter = (options: GithubFormatterOptions = {}): ChangelogFormatter => {
     const cfg = { ...DEFAULT_OPTIONS, ...options };
     const runner = options.runner ?? createShellRunner();
-    let repoCachePromise: Promise<string | undefined> | undefined;
+    let repoCachePromise: Promise<DetectedRepo> | undefined;
 
     const formatter: ChangelogFormatter = async (context: ChangelogContext): Promise<string> => {
         const { changeFiles, date, release, target } = context;
         const lines: string[] = [];
+        const entries: GroupableEntry[] = [];
         const authors = new Set<string>();
         const cwd = process.cwd();
 
         if (!repoCachePromise) {
-            repoCachePromise = detectRepoSlugSync(options.repo, runner, cwd);
+            repoCachePromise = detectRepo(options.repo, runner, cwd);
         }
 
         const repoCache = await repoCachePromise;
+        // PR / commit links follow the detected forge, not this formatter's
+        // name: a slug read off a GitLab remote must not be pasted into a
+        // github.com URL, where it addresses somebody else's repository.
+        const urls: RemoteWebUrls | undefined = repoCache.slug === undefined ? undefined : remoteWebUrls(repoCache.provider, repoCache.slug);
 
         if (target !== "github-release") {
-            lines.push(`## ${release.newVersion}`);
-            lines.push(`<sub>${date}</sub>`);
-            lines.push("");
+            if (options.heading === undefined) {
+                lines.push(`## ${release.newVersion}`);
+                lines.push(`<sub>${date}</sub>`);
+                lines.push("");
+            } else {
+                const compareUrl = buildCompareUrl({
+                    name: release.name,
+                    newVersion: release.newVersion,
+                    oldVersion: release.oldVersion,
+                    provider: repoCache.provider,
+                    repo: repoCache.slug,
+                    tagPattern: options.tagPattern,
+                });
+
+                lines.push(renderReleaseHeading(options.heading, { compareUrl, date, name: release.name, version: release.newVersion }), "");
+            }
         }
 
         for (const file of changeFiles) {
@@ -108,16 +158,16 @@ export const createGithubFormatter = (options: GithubFormatterOptions = {}): Cha
 
             const refs: string[] = [];
 
-            if (meta.pr && repoCache) {
-                refs.push(`[#${meta.pr}](https://github.com/${repoCache}/pull/${meta.pr})`);
+            if (meta.pr && urls) {
+                refs.push(`[#${meta.pr}](${urls.pullRequest(String(meta.pr))})`);
             } else if (meta.pr) {
                 refs.push(`#${meta.pr}`);
             }
 
-            if (meta.commit && cfg.includeCommitLink && repoCache) {
+            if (meta.commit && cfg.includeCommitLink && urls) {
                 const short = meta.commit.slice(0, 7);
 
-                refs.push(`[\`${short}\`](https://github.com/${repoCache}/commit/${meta.commit})`);
+                refs.push(`[\`${short}\`](${urls.commit(meta.commit)})`);
             }
 
             const refSuffix = refs.length > 0 ? ` (${refs.join(", ")})` : "";
@@ -130,35 +180,44 @@ export const createGithubFormatter = (options: GithubFormatterOptions = {}): Cha
                         continue;
                     }
 
-                    const linkified = linkifyHashRefs(line, repoCache);
-
-                    if (line.startsWith("-") || line.startsWith("*")) {
-                        lines.push(`${linkified}${refSuffix}`);
-                    } else {
-                        lines.push(`- ${linkified}${refSuffix}`);
-                    }
+                    entries.push({ line: linkifyHashRefs(line, repoCache), suffix: refSuffix });
                 }
             }
         }
 
-        if (release.isCascadeBump || release.isGroupBump) {
-            for (const source of release.sources) {
-                const verb = release.isCascadeBump ? "Cascade from" : "Group bump with";
-
-                lines.push(`- ${verb} ${source.name}@${source.newVersion}`);
+        if (options.types === undefined) {
+            for (const entry of entries) {
+                lines.push(`${withBullet(entry.line, "-")}${entry.suffix ?? ""}`);
             }
-        } else if (release.isDependencyBump && changeFiles.length === 0) {
-            for (const source of release.sources) {
-                // F13: catalog REMOVALs surface as `newVersion === ""`
-                // (the release-plan stores `entry.newVersion ?? ""` for
-                // the synthetic catalog source). Render as a removal
-                // line so we don't emit a malformed trailing `@`.
-                if (source.newVersion === "") {
-                    lines.push(`- Removed dependency ${source.name}`);
-                } else {
-                    lines.push(`- Updated dependency ${source.name}@${source.newVersion}`);
+
+            if (release.isCascadeBump || release.isGroupBump) {
+                for (const source of release.sources) {
+                    const verb = release.isCascadeBump ? "Cascade from" : "Group bump with";
+
+                    lines.push(`- ${verb} ${source.name}@${source.newVersion}`);
+                }
+            } else if (release.isDependencyBump && changeFiles.length === 0) {
+                for (const source of release.sources) {
+                    // F13: catalog REMOVALs surface as `newVersion === ""`
+                    // (the release-plan stores `entry.newVersion ?? ""` for
+                    // the synthetic catalog source). Render as a removal
+                    // line so we don't emit a malformed trailing `@`.
+                    if (source.newVersion === "") {
+                        lines.push(`- Removed dependency ${source.name}`);
+                    } else {
+                        lines.push(`- Updated dependency ${source.name}@${source.newVersion}`);
+                    }
                 }
             }
+        } else {
+            entries.push(...sourceBumpEntries(context));
+
+            lines.push(
+                ...renderGroupedEntries(entries, {
+                    breakingSection: options.breakingSection,
+                    types: options.types.length === 0 ? DEFAULT_CONVENTIONAL_TYPES : options.types,
+                }),
+            );
         }
 
         if (cfg.thankContributors && authors.size > 0) {
@@ -166,7 +225,11 @@ export const createGithubFormatter = (options: GithubFormatterOptions = {}): Cha
             lines.push(`Thanks ${[...authors].join(", ")}!`);
         }
 
-        return lines.join("\n");
+        const output = lines.join("\n");
+
+        // Legacy flat mode is byte-identical to what it always emitted;
+        // grouped mode ends on a section separator that needs collapsing.
+        return options.types === undefined ? output : output.replaceAll(/\n{3,}/g, "\n\n").trimEnd();
     };
 
     return formatter;

--- a/packages/tooling/vis/src/release/core/changelog/index.ts
+++ b/packages/tooling/vis/src/release/core/changelog/index.ts
@@ -2,10 +2,12 @@
  * Public entry point for `@visulima/vis/release/changelog`.
  *
  * Exposes the changelog formatter contract (`ChangelogFormatter` /
- * `ChangelogContext`), the `defineFormatter` authoring helper, and
- * `resolveFormatter` which maps a `release.changelog` config value
- * (`"default"`, `"github"`, `"keep-a-changelog"`, a path, a `[path, opts]`
- * tuple, or `false`) to a concrete formatter function.
+ * `ChangelogContext`), the `defineFormatter` authoring helper, the
+ * conventional-commit primitives the built-in formatters share
+ * (`parseConventionalHeader`, `renderGroupedEntries`, `renderReleaseHeading`),
+ * and `resolveFormatter` which maps a `release.changelog` config value
+ * (`"default"`, `"github"`, `"keep-a-changelog"`, `"conventional"`, a path, a
+ * `[path, opts]` tuple, or `false`) to a concrete formatter function.
  */
 export {
     type ChangeFileMeta,
@@ -15,4 +17,18 @@ export {
     type ChangelogTarget,
     defineFormatter,
 } from "./api";
+export { type ConventionalFormatterOptions, createConventionalFormatter, DEFAULT_CONVENTIONAL_HEADING } from "./conventional";
+export { hasBulletMarker, isBreakingChange, parseConventionalHeader, type ParsedConventionalHeader, stripBulletMarker } from "./conventional-header";
+export { buildCompareUrl, type CompareUrlInput, type ReleaseHeadingTokens, renderReleaseHeading } from "./release-heading";
 export { resolveFormatter } from "./resolve";
+export {
+    type ConventionalTypeRule,
+    DEFAULT_BREAKING_SECTION,
+    DEFAULT_CONVENTIONAL_TYPES,
+    DEFAULT_UNCATEGORIZED_SECTION,
+    type EntryStyle,
+    type GroupableEntry,
+    renderGroupedEntries,
+    type RenderGroupedOptions,
+    UNCATEGORIZED_TYPE,
+} from "./sections";

--- a/packages/tooling/vis/src/release/core/changelog/release-heading.ts
+++ b/packages/tooling/vis/src/release/core/changelog/release-heading.ts
@@ -1,0 +1,148 @@
+/**
+ * The release heading a formatter writes above each entry block: a
+ * `releaseTagPattern`-style template (tokens `{name}`, `{version}`, `{date}`,
+ * `{compareUrl}`) plus the compare-URL builder that fills its one non-trivial
+ * token.
+ *
+ * Both live here because the URL exists only to be substituted into the
+ * template, and the template has to know how to degrade when there isn't one.
+ */
+
+import { renderTagPattern } from "../git";
+import type { RemoteProvider } from "../remote/interface";
+import { remoteWebUrls } from "../remote/web-urls";
+
+/** Values substituted into a `heading` template. */
+export interface ReleaseHeadingTokens {
+    /** Version-comparison URL. Omit / leave empty when there is nothing to compare against. */
+    compareUrl?: string;
+    /** ISO date `YYYY-MM-DD`. */
+    date: string;
+    /** Package name. */
+    name: string;
+    /** The version being released. */
+    version: string;
+}
+
+const HEADING_TOKEN_RE = /\{(name|version|date|compareUrl)\}/g;
+
+const COMPARE_LINK_TAIL = "]({compareUrl})";
+
+/**
+ * Unwrap `[…]({compareUrl})` link syntax when there is no compare URL, so
+ * `## {name} [{version}]({compareUrl}) ({date})` degrades to
+ * `## \@scope/pkg 1.0.0 (2026-09-08)` instead of emitting a dangling `[1.0.0]()`.
+ *
+ * Implemented with `indexOf`/`slice` rather than a regex: the equivalent
+ * `\[[^\]]*\]\(\)` pattern is exactly the unanchored shape CodeQL flags as
+ * polynomial ReDoS.
+ */
+const stripEmptyCompareLink = (template: string): string => {
+    let out = template;
+    let index = out.indexOf(COMPARE_LINK_TAIL);
+
+    while (index !== -1) {
+        const open = out.lastIndexOf("[", index);
+
+        out
+            = open === -1
+                ? out.slice(0, index) + out.slice(index + COMPARE_LINK_TAIL.length)
+                : out.slice(0, open) + out.slice(open + 1, index) + out.slice(index + COMPARE_LINK_TAIL.length);
+
+        index = out.indexOf(COMPARE_LINK_TAIL);
+    }
+
+    return out;
+};
+
+/**
+ * Render a release heading from a template. Recognised tokens:
+ *
+ *   `{name}`       — package name (`@scope/pkg`)
+ *   `{version}`    — the version being released
+ *   `{date}`       — ISO date `YYYY-MM-DD`
+ *   `{compareUrl}` — version-comparison URL, or nothing
+ *
+ * Mirrors `renderTagPattern`: unknown `{x}` tokens are left intact so a typo
+ * shows up in the output rather than silently vanishing.
+ */
+export const renderReleaseHeading = (template: string, tokens: ReleaseHeadingTokens): string => {
+    const compareUrl = tokens.compareUrl ?? "";
+    const resolved = compareUrl === "" ? stripEmptyCompareLink(template) : template;
+    const values: Record<string, string> = {
+        compareUrl,
+        date: tokens.date,
+        name: tokens.name,
+        version: tokens.version,
+    };
+
+    return resolved.replaceAll(HEADING_TOKEN_RE, (_match, key: string) => values[key] ?? "");
+};
+
+export interface CompareUrlInput {
+    /** Override the URL prefix (self-hosted GitLab, Gitea, …). Wins over `repo`. */
+    compareUrlPrefix?: string;
+    name: string;
+    newVersion: string;
+    /** Previous version. Absent / empty on a first release → no compare URL. */
+    oldVersion?: string;
+
+    /**
+     * Forge the `repo` slug lives on — it decides the URL shape (GitLab nests
+     * the comparison under `/-/`). Default `"github"`.
+     */
+    provider?: RemoteProvider;
+    /** `owner/name` slug, resolved against the provider's public web host. */
+    repo?: string;
+    /** Tag template used to name both ends of the comparison. Default `"{name}@{version}"`. */
+    tagPattern?: string;
+}
+
+/**
+ * Build a `…/compare/&lt;fromTag>...&lt;toTag>` URL, or `undefined` when there's
+ * nothing to point at — no remote configured, or no previous version (first
+ * release). Callers pass the result straight to {@link renderReleaseHeading},
+ * which degrades the link syntax when it's `undefined`.
+ */
+
+/**
+ * Drop trailing `/` characters.
+ *
+ * A linear scan rather than `replace(/\/+$/, "")`: the regex form has an
+ * unanchored start, so the engine retries the `+` at every offset and a base
+ * URL of many slashes costs O(n²) (CodeQL polynomial-redos, alert 583).
+ */
+const stripTrailingSlashes = (value: string): string => {
+    let end = value.length;
+
+    // 47 === "/"
+    while (end > 0 && value.codePointAt(end - 1) === 47) {
+        end -= 1;
+    }
+
+    return end === value.length ? value : value.slice(0, end);
+};
+
+export const buildCompareUrl = (input: CompareUrlInput): string | undefined => {
+    const { compareUrlPrefix, name, newVersion, oldVersion, repo } = input;
+
+    if (!oldVersion) {
+        return undefined;
+    }
+
+    const pattern = input.tagPattern ?? "{name}@{version}";
+    const fromTag = renderTagPattern(pattern, { name, version: oldVersion });
+    const toTag = renderTagPattern(pattern, { name, version: newVersion });
+
+    // An explicit prefix is already a repo URL — append the path GitHub/Gitea
+    // use, which is also what this option has always meant.
+    if (compareUrlPrefix) {
+        return `${stripTrailingSlashes(compareUrlPrefix)}/compare/${fromTag}...${toTag}`;
+    }
+
+    if (!repo) {
+        return undefined;
+    }
+
+    return remoteWebUrls(input.provider ?? "github", repo).compare(fromTag, toTag);
+};

--- a/packages/tooling/vis/src/release/core/changelog/repo-slug.ts
+++ b/packages/tooling/vis/src/release/core/changelog/repo-slug.ts
@@ -1,0 +1,69 @@
+/**
+ * Repository detection shared by the link-emitting changelog formatters
+ * (`github`, `conventional`): which forge the working copy points at, and the
+ * `owner/name` slug on it.
+ *
+ * Resolution order for the slug: explicit option → the active remote
+ * provider's `detectRepoSlug` → `undefined`. The *provider* is resolved even
+ * when the slug is configured, because it decides the shape of every link the
+ * formatters emit — rendering a GitLab slug into a `github.com` URL points the
+ * reader at an unrelated repository that happens to share the path.
+ *
+ * Two deliberate defences:
+ *
+ *   - The remote module is imported lazily so a formatter that never needs a
+ *     slug doesn't drag the provider clients (and their shell calls) into the
+ *     module graph.
+ *   - The whole detection path runs under one `try`/`catch`. It shells out
+ *     (`git config --get remote.origin.url`, `gh repo view`), and both
+ *     built-in formatters await this before rendering a single line — so a
+ *     rejecting runner has to degrade to the documented link-free plain text
+ *     rather than fail the entire workspace changelog run.
+ */
+
+import type { CommandRunner } from "../package-managers/interface";
+import type { RemoteProvider } from "../remote/interface";
+import { remoteWebUrls } from "../remote/web-urls";
+
+/** Everything the formatters need to build links: the forge, and the repo on it. */
+export interface DetectedRepo {
+    /** Forge the links point at. Falls back to `github` when detection fails. */
+    provider: RemoteProvider;
+
+    /** `owner/name`, or `undefined` when there is no remote worth linking to. */
+    slug: string | undefined;
+}
+
+export const detectRepo = async (option: string | undefined, runner: CommandRunner, cwd: string): Promise<DetectedRepo> => {
+    try {
+        const { createRemoteClient, detectRemoteProvider } = await import("../remote/detect");
+        const provider = await detectRemoteProvider(cwd, runner, undefined);
+
+        if (option) {
+            return { provider, slug: option };
+        }
+
+        return { provider, slug: await createRemoteClient(provider).detectRepoSlug(cwd, runner) };
+    } catch {
+        // No remote, no `gh` on PATH, a runner that rejects: every formatter
+        // renders correctly without links, so this is never fatal.
+        return { provider: "github", slug: option };
+    }
+};
+
+/**
+ * Turn bare `#123` references into issue links on the detected provider.
+ * Left untouched when no repository was detected, and when the reference is
+ * already the label of a Markdown link (`[#123](…)`).
+ */
+export const linkifyHashRefs = (text: string, repo: DetectedRepo): string => {
+    const { slug } = repo;
+
+    if (!slug) {
+        return text;
+    }
+
+    const urls = remoteWebUrls(repo.provider, slug);
+
+    return text.replaceAll(/(?<!\[)#(\d+)/g, (_match, issueNumber: string) => `[#${issueNumber}](${urls.issue(issueNumber)})`);
+};

--- a/packages/tooling/vis/src/release/core/changelog/resolve.ts
+++ b/packages/tooling/vis/src/release/core/changelog/resolve.ts
@@ -5,6 +5,7 @@
  *   - `false`      → no-op formatter (returns empty string)
  *   - `"default"`  → built-in default
  *   - `"github"`   → built-in github (with default options)
+ *   - `"conventional"` → built-in conventional-commits (grouped by type)
  *   - `string`     → path to a custom module
  *   - `[string, options]` → path + options for the custom module
  */
@@ -13,6 +14,7 @@ import { pathToFileURL } from "node:url";
 
 import type { VisReleaseConfig } from "../../types";
 import type { ChangelogFormatter, ChangelogFormatterModule } from "./api";
+import { createConventionalFormatter } from "./conventional";
 import { createDefaultFormatter, defaultFormatter } from "./default";
 import { createGithubFormatter } from "./github";
 import { createKeepAChangelogFormatter } from "./keep-a-changelog";
@@ -34,6 +36,10 @@ export const resolveFormatter = async (setting: VisReleaseConfig["changelog"], c
         return createKeepAChangelogFormatter();
     }
 
+    if (setting === "conventional" || setting === "conventionalcommits") {
+        return createConventionalFormatter();
+    }
+
     let path: string;
     let options: Record<string, unknown> = {};
 
@@ -53,6 +59,10 @@ export const resolveFormatter = async (setting: VisReleaseConfig["changelog"], c
 
     if (path === "keep-a-changelog" || path === "keepachangelog") {
         return createKeepAChangelogFormatter(options);
+    }
+
+    if (path === "conventional" || path === "conventionalcommits") {
+        return createConventionalFormatter(options);
     }
 
     // Path to user module. The import is deferred through a helper file that

--- a/packages/tooling/vis/src/release/core/changelog/sections.ts
+++ b/packages/tooling/vis/src/release/core/changelog/sections.ts
@@ -1,0 +1,319 @@
+/**
+ * Grouped-section rendering — the one renderer behind every built-in
+ * formatter that buckets changelog entries by conventional-commit type.
+ *
+ * The shape is `conventional-changelog-conventionalcommits`'
+ * `presetConfig.types`: an ordered `{ type, section, hidden? }` table drives
+ * both which sections exist and what order they appear in. Formatters supply
+ * their own table plus a handful of format decisions ({@link RenderGroupedOptions});
+ * they do not re-implement the bucketing.
+ *
+ * The invariant this module exists to guarantee: **nothing is silently
+ * dropped**. Every entry lands in exactly one bucket, and every bucket is
+ * emitted — a type with no rule, and a line that does not parse as a
+ * conventional header at all, both fall through to the catch-all section.
+ * The only way to lose an entry is to hide its type explicitly.
+ */
+
+import type { ParsedConventionalHeader } from "./conventional-header";
+import { hasBulletMarker, isBreakingChange, parseConventionalHeader, stripBulletMarker } from "./conventional-header";
+
+/**
+ * One `type → section` mapping. Same shape as
+ * `conventional-changelog-conventionalcommits`' `presetConfig.types`, so a
+ * config lifted straight out of a `.versionrc` / release-please config works
+ * unchanged.
+ */
+export interface ConventionalTypeRule {
+    /**
+     * Drop entries of this type from the rendered output. Breaking changes
+     * are still surfaced under the breaking section — hiding a type never
+     * hides an incompatible change.
+     */
+    hidden?: boolean;
+    /** Markdown heading text, rendered as `### &lt;section>`. */
+    section: string;
+    /** Conventional-commit type — `feat`, `fix`, `perf`, … Matched case-insensitively. */
+    type: string;
+}
+
+/**
+ * Bucket key for entries that no rule claims: a line that does not parse as a
+ * conventional header, and a header whose type has no rule in the table.
+ * A table may name it explicitly (`{ type: "other", … }`) to place the
+ * catch-all section or to hide it.
+ */
+export const UNCATEGORIZED_TYPE = "other";
+
+/** Heading used for breaking changes, matching this monorepo's existing history. */
+export const DEFAULT_BREAKING_SECTION = "⚠ BREAKING CHANGES";
+
+/** Heading used for the catch-all bucket when the table doesn't name one. */
+export const DEFAULT_UNCATEGORIZED_SECTION = "Other Changes";
+
+/**
+ * Default `type → section` table.
+ *
+ * The first block is `conventional-changelog-conventionalcommits`' preset
+ * verbatim (`feat`/`fix`/`perf`/`revert` visible; `docs`/`style`/`chore`/
+ * `refactor`/`test`/`build`/`ci` hidden), so a package migrating off
+ * semantic-release keeps the exact section set its history already uses.
+ *
+ * The second block covers the extra types this repo's commit convention adds
+ * on top of the Angular set. They are hidden by default — they describe work
+ * on the repo rather than a change a consumer of the published package can
+ * observe — with one exception: `deps` is visible as `Dependencies`, because
+ * `multi-semantic-release` already writes a visible `### Dependencies` section
+ * and dropping it would lose the upgrade trail an adopter reads to answer
+ * "which version of X did this release pull in?".
+ *
+ * `other` is the home for commits that do not parse as conventional; it is
+ * visible so nothing is ever silently dropped. Hide it explicitly with
+ * `{ type: "other", section: "…", hidden: true }` if you would rather lose them.
+ */
+export const DEFAULT_CONVENTIONAL_TYPES: ReadonlyArray<ConventionalTypeRule> = [
+    { section: "Features", type: "feat" },
+    { section: "Features", type: "feature" },
+    { section: "Bug Fixes", type: "fix" },
+    { section: "Performance Improvements", type: "perf" },
+    { section: "Reverts", type: "revert" },
+    { hidden: true, section: "Documentation", type: "docs" },
+    { hidden: true, section: "Styles", type: "style" },
+    { hidden: true, section: "Code Refactoring", type: "refactor" },
+    { hidden: true, section: "Tests", type: "test" },
+    { hidden: true, section: "Build System", type: "build" },
+    { hidden: true, section: "Continuous Integration", type: "ci" },
+    { hidden: true, section: "Miscellaneous Chores", type: "chore" },
+
+    // visulima-specific types (see CLAUDE.md "Commit Convention").
+    { section: "Dependencies", type: "deps" },
+    { hidden: true, section: "Developer Experience", type: "dx" },
+    { hidden: true, section: "Types", type: "types" },
+    { hidden: true, section: "Work In Progress", type: "wip" },
+    { hidden: true, section: "Releases", type: "release" },
+    { hidden: true, section: "Workflow", type: "workflow" },
+
+    { section: DEFAULT_UNCATEGORIZED_SECTION, type: UNCATEGORIZED_TYPE },
+];
+
+/** A single changelog line handed to the grouped renderer. */
+export interface GroupableEntry {
+    /** The authored line — with or without a leading bullet marker. */
+    line: string;
+    /** Appended verbatim after the rendered entry (PR / commit refs, author credit). */
+    suffix?: string;
+}
+
+/**
+ * How an entry's text is derived from its authored line.
+ *
+ *   - `"scope"`    — conventional-changelog rendering: drop the `type(scope):`
+ *                    prefix and re-emit the scope as a bold `**scope:**`
+ *                    lead-in. Lines no rule claims stay verbatim so their
+ *                    prefix isn't lost.
+ *   - `"verbatim"` — keep the authored line exactly as written, including any
+ *                    leading list marker (what the `default` formatter emits).
+ */
+export type EntryStyle = "scope" | "verbatim";
+
+export interface RenderGroupedOptions {
+    /**
+     * Heading listing every breaking change ahead of the type sections, so an
+     * incompatible change stays visible even when its own type is hidden.
+     * Pass `false` to fold breaking changes into their type section only.
+     * Default: {@link DEFAULT_BREAKING_SECTION}.
+     */
+    breakingSection?: false | string;
+
+    /**
+     * Re-bucket entries whose header carries the `!` marker under this
+     * pseudo-type instead of their own, so a table can give them a section of
+     * their own (`{ section: "Breaking Changes", type: "breaking" }`). An
+     * inline `BREAKING CHANGE` note does *not* re-type an entry — only the
+     * header marker does. Off by default.
+     */
+    breakingType?: string;
+
+    /** List marker. Default `"*"`, matching conventional-changelog output. */
+    bullet?: string;
+
+    /** How each entry's text is rendered. Default `"scope"`. */
+    entryStyle?: EntryStyle;
+
+    /** Ordered `type → section` table. Default: {@link DEFAULT_CONVENTIONAL_TYPES}. */
+    types?: ReadonlyArray<ConventionalTypeRule>;
+
+    /**
+     * Heading for the catch-all section, used when `types` has no
+     * `{ type: "other" }` rule to place and name it.
+     * Default: {@link DEFAULT_UNCATEGORIZED_SECTION}.
+     */
+    uncategorizedSection?: string;
+}
+
+/**
+ * Prefix `line` with `bullet` unless the author already wrote a list marker.
+ *
+ * "Already a marker" is {@link hasBulletMarker}'s definition, shared with the
+ * parser's `stripBulletMarker`, so a `+ ` bullet isn't stripped in one place
+ * and re-bulleted in the other.
+ */
+export const withBullet = (line: string, bullet: string): string => (hasBulletMarker(line) ? line : `${bullet} ${line}`);
+
+/**
+ * Render one entry as a finished Markdown list item: `* **scope:** subject`
+ * when the header carries a scope and the style lifts it, the bare subject
+ * when it doesn't, and the authored line verbatim when no rule claims it.
+ */
+const renderEntry = (entry: GroupableEntry, parsed: ParsedConventionalHeader | undefined, bullet: string, style: EntryStyle): string => {
+    const suffix = entry.suffix ?? "";
+
+    if (style === "verbatim") {
+        return `${withBullet(entry.line, bullet)}${suffix}`;
+    }
+
+    if (!parsed) {
+        return `${bullet} ${stripBulletMarker(entry.line)}${suffix}`;
+    }
+
+    return parsed.scope ? `${bullet} **${parsed.scope}:** ${parsed.subject}${suffix}` : `${bullet} ${parsed.subject}${suffix}`;
+};
+
+/** Push `### &lt;section>` plus its items, skipping the section when it has none. */
+const pushSection = (lines: string[], section: string, items: ReadonlyArray<string>, trailingBlank: boolean): void => {
+    if (items.length === 0) {
+        return;
+    }
+
+    lines.push(`### ${section}`, "");
+    lines.push(...items);
+
+    if (trailingBlank) {
+        lines.push("");
+    }
+};
+
+/**
+ * Bucket `entries` by conventional-commit type and render them as Markdown
+ * lines (`### &lt;section>` followed by a bullet list, blank-line separated).
+ *
+ * Ordering follows the `types` array; types sharing a section heading are
+ * merged under it, emitted at the position of the first rule that names it.
+ * Hidden types are omitted. Everything no rule claims — unparseable lines and
+ * unmapped types alike — is emitted under the catch-all section, which sits
+ * where the table's `{ type: "other" }` rule places it or, when the table has
+ * none, after every other section.
+ */
+export const renderGroupedEntries = (entries: ReadonlyArray<GroupableEntry>, options: RenderGroupedOptions = {}): string[] => {
+    const bullet = options.bullet ?? "*";
+    const entryStyle = options.entryStyle ?? "scope";
+    const rules = options.types ?? DEFAULT_CONVENTIONAL_TYPES;
+    const breakingSection = options.breakingSection === undefined ? DEFAULT_BREAKING_SECTION : options.breakingSection;
+    const uncategorizedSection = options.uncategorizedSection ?? DEFAULT_UNCATEGORIZED_SECTION;
+    const breakingType = options.breakingType?.toLowerCase();
+
+    /**
+     * First rule per type — a table may repeat a type, and only the first one
+     * speaks for it. Rendering walks `canonicalRules` rather than the raw
+     * table so a repeat can neither append the same bucket twice nor override
+     * an earlier `hidden: true` (which would render a type the author had
+     * explicitly hidden).
+     */
+    const ruleByType = new Map<string, ConventionalTypeRule>();
+    const canonicalRules: ConventionalTypeRule[] = [];
+
+    for (const rule of rules) {
+        const type = rule.type.toLowerCase();
+
+        if (!ruleByType.has(type)) {
+            ruleByType.set(type, rule);
+            canonicalRules.push(rule);
+        }
+    }
+
+    const byType = new Map<string, string[]>();
+    const breaking: string[] = [];
+
+    for (const entry of entries) {
+        const parsed = parseConventionalHeader(entry.line);
+        const type = parsed === undefined ? UNCATEGORIZED_TYPE : breakingType !== undefined && parsed.breakingMarker ? breakingType : parsed.type;
+        // A type with no rule is rendered like an unparsed line: kept verbatim,
+        // so `foo: …` reaches the catch-all with its prefix intact.
+        const text = renderEntry(entry, ruleByType.has(type) ? parsed : undefined, bullet, entryStyle);
+
+        if (breakingSection !== false && parsed !== undefined && isBreakingChange(parsed)) {
+            breaking.push(text);
+        }
+
+        const bucket = byType.get(type) ?? [];
+
+        bucket.push(text);
+        byType.set(type, bucket);
+    }
+
+    /** The catch-all: the unparsed bucket plus every bucket no rule claims, in first-seen order. */
+    const uncategorized = (): string[] => {
+        const items: string[] = [];
+
+        for (const [type, bucket] of byType) {
+            if (type !== UNCATEGORIZED_TYPE && ruleByType.has(type)) {
+                continue;
+            }
+
+            items.push(...bucket);
+        }
+
+        return items;
+    };
+
+    const lines: string[] = [];
+
+    if (breakingSection !== false) {
+        pushSection(lines, breakingSection, breaking, true);
+    }
+
+    const rendered = new Set<string>();
+
+    for (const rule of canonicalRules) {
+        const type = rule.type.toLowerCase();
+
+        if (rule.hidden || rendered.has(type)) {
+            continue;
+        }
+
+        rendered.add(type);
+
+        if (type === UNCATEGORIZED_TYPE) {
+            pushSection(lines, rule.section, uncategorized(), true);
+
+            continue;
+        }
+
+        // Several types may share a section (`feat` + `feature` → `Features`);
+        // emit the heading once, in the position of its first rule.
+        const items: string[] = [];
+
+        for (const other of canonicalRules) {
+            const otherType = other.type.toLowerCase();
+
+            if (other.hidden || otherType === UNCATEGORIZED_TYPE || other.section !== rule.section) {
+                continue;
+            }
+
+            rendered.add(otherType);
+            items.push(...(byType.get(otherType) ?? []));
+        }
+
+        pushSection(lines, rule.section, items, true);
+    }
+
+    // No `other` rule to place the catch-all: append it last, unless the table
+    // opted out with `{ type: "other", hidden: true }`. No trailing blank —
+    // callers append their own trailing content (dependency notes, credits)
+    // straight after.
+    if (!rendered.has(UNCATEGORIZED_TYPE) && ruleByType.get(UNCATEGORIZED_TYPE)?.hidden !== true) {
+        pushSection(lines, uncategorizedSection, uncategorized(), false);
+    }
+
+    return lines;
+};

--- a/packages/tooling/vis/src/release/core/changelog/source-bumps.ts
+++ b/packages/tooling/vis/src/release/core/changelog/source-bumps.ts
@@ -1,0 +1,40 @@
+/**
+ * Dependency / cascade / group bumps, expressed as changelog entries.
+ *
+ * A release can be planned with no change file of its own — it moved only
+ * because something it depends on moved. The grouped formatters render those
+ * releases by synthesizing `deps(&lt;pkg>): …` lines, so they flow through the
+ * same parse + scope-lifting path as authored entries and land under
+ * `### Dependencies` as `* **@scope/pkg:** upgraded to 1.2.3` — the shape
+ * `multi-semantic-release` already writes into these files.
+ *
+ * The flat formatters spell the same facts out in prose
+ * (`- Updated dependency \@scope/pkg@1.2.3`) and don't use this.
+ */
+
+import type { ChangelogContext } from "./api";
+import type { GroupableEntry } from "./sections";
+
+export const sourceBumpEntries = (context: ChangelogContext): GroupableEntry[] => {
+    const { changeFiles, release } = context;
+
+    if (release.isCascadeBump || release.isGroupBump) {
+        const verb = release.isCascadeBump ? "cascade bump to" : "group bump to";
+
+        return release.sources.map((source) => {
+            return { line: `deps(${source.name}): ${verb} ${source.newVersion}` };
+        });
+    }
+
+    if (release.isDependencyBump && changeFiles.length === 0) {
+        return release.sources.map((source) => {
+            // F13: catalog REMOVALs surface as `newVersion === ""` (the
+            // release-plan stores `entry.newVersion ?? ""` for the synthetic
+            // catalog source). Render a removal line rather than a malformed
+            // trailing `@`.
+            return { line: source.newVersion === "" ? `deps(${source.name}): removed` : `deps(${source.name}): upgraded to ${source.newVersion}` };
+        });
+    }
+
+    return [];
+};

--- a/packages/tooling/vis/src/release/core/remote/web-urls.ts
+++ b/packages/tooling/vis/src/release/core/remote/web-urls.ts
@@ -1,0 +1,61 @@
+/**
+ * Browser URL shapes per remote provider — the `…/issues/123`, `…/pull/42`,
+ * `…/commit/&lt;sha>` and `…/compare/a...b` links the changelog formatters embed.
+ *
+ * These live next to the provider clients rather than in `changelog/` because
+ * the shapes are a property of the forge, not of a formatter: GitLab nests
+ * every repo-scoped page under `/-/` and calls a pull request a merge request.
+ * A changelog rendered for a GitLab remote must never link into github.com —
+ * a link pointing at a *different* repository that happens to share the slug
+ * is worse than no link at all.
+ *
+ * Everything that talks to a forge over the network lives on the
+ * `RemoteReleaseClient` interface; these are pure string builders with no I/O,
+ * so they stay a plain lookup keyed by the same {@link RemoteProvider} union
+ * rather than another member on that interface.
+ */
+
+import type { RemoteProvider } from "./interface";
+
+/** Public web host per provider, used when no self-hosted base is configured. */
+const DEFAULT_WEB_ORIGIN: Record<RemoteProvider, string> = {
+    github: "https://github.com",
+    gitlab: "https://gitlab.com",
+};
+
+/** Browser URL builders for one repository on one provider. */
+export interface RemoteWebUrls {
+    /** Commit page for `sha`. */
+    commit: (sha: string) => string;
+
+    /** Two-dot comparison page between two refs (used with release tags). */
+    compare: (fromReference: string, toReference: string) => string;
+
+    /** Issue page. */
+    issue: (issueNumber: string) => string;
+
+    /** Pull request page — a *merge* request on GitLab. */
+    pullRequest: (pullNumber: string) => string;
+}
+
+/**
+ * Build the web URLs for `repo` (an `owner/name` slug, or a nested
+ * `group/sub/project` path on GitLab) on `provider`.
+ *
+ * Self-hosted instances are not modelled here: the changelog path never learns
+ * the configured `githubHost` / `gitlabHost`, and the `compareUrlPrefix`
+ * formatter option is the documented escape hatch for one.
+ */
+export const remoteWebUrls = (provider: RemoteProvider, repo: string): RemoteWebUrls => {
+    const root = `${DEFAULT_WEB_ORIGIN[provider]}/${repo}`;
+    // GitLab namespaces every repo-scoped page under `/-/` so a nested group
+    // path can never collide with a route name.
+    const scope = provider === "gitlab" ? `${root}/-` : root;
+
+    return {
+        commit: (sha: string): string => `${scope}/commit/${sha}`,
+        compare: (fromReference: string, toReference: string): string => `${scope}/compare/${fromReference}...${toReference}`,
+        issue: (issueNumber: string): string => `${scope}/issues/${issueNumber}`,
+        pullRequest: (pullNumber: string): string => `${scope}/${provider === "gitlab" ? "merge_requests" : "pull"}/${pullNumber}`,
+    };
+};

--- a/packages/tooling/vis/src/release/types.ts
+++ b/packages/tooling/vis/src/release/types.ts
@@ -1208,8 +1208,17 @@ export interface VisReleaseConfig {
 
     /**
      * Changelog formatter selection. Pass `false` to disable changelog output,
-     * one of the built-in names (`"default"`, `"github"`, `"keep-a-changelog"`),
-     * a path to a custom module, or a `[path, options]` tuple.
+     * one of the built-in names (`"default"`, `"github"`, `"keep-a-changelog"`,
+     * `"conventional"`), a path to a custom module, or a `[path, options]`
+     * tuple.
+     *
+     * `"conventional"` renders the `conventional-changelog` /
+     * `semantic-release` shape: entries grouped by commit type under
+     * configurable `types: [{ type, section, hidden? }]` headings, the scope
+     * lifted out and bolded (`* **client,react:** …`), and a templated
+     * release heading (`heading`, tokens `{name}`, `{version}`, `{date}`,
+     * `{compareUrl}`). The same `types` / `heading` options are available
+     * opt-in on `"github"`, and `heading` on `"default"`.
      */
     changelog?: false | string | [string, Record<string, unknown>];
     /** Directory holding change files. Default: `".vis/release"`. */


### PR DESCRIPTION
Fixes #865.

Both built-in formatters rendered a release as a flat bullet list of raw commit subjects, so a package migrating from semantic-release ended up with two heading styles stacked in one `CHANGELOG.md`.

## What changed

**A `conventional` formatter** (alias `conventionalcommits`) rendering the `conventional-changelog` shape: entries grouped by commit type under configurable `types: [{ type, section, hidden? }]` headings, the scope lifted out and bolded (`* **client,react:** …`), and a templated release heading with `{name}` / `{version}` / `{date}` / `{compareUrl}`.

The same `types` / `heading` options are also available **opt-in** on `github`, and `heading` on `default`. Unconfigured output of both existing formatters is byte-for-byte unchanged, pinned by exact-string tests.

Defaults follow the conventional preset, with this repo's extra types mapped: `deps → Dependencies` stays **visible** (multi-semantic-release already writes that section, and hiding it loses the upgrade trail); `dx`, `types`, `wip`, `release`, `workflow` are hidden. Breaking changes surface under their own section **even when their own type is hidden**, so `chore!:` can't vanish. `{compareUrl}` unwraps the `[…](…)` link syntax when there's nothing to compare against, so a first release renders `## @acme/browser 1.0.0 (2026-09-08)` rather than `[1.0.0]()`.

Dependency bumps are synthesized as `deps(<pkg>):` entries so they flow through the same scope-lifting path, landing as `* **@visulima/fs:** upgraded to 6.0.8`.

## Fixes from review

- **Silent changelog data loss.** `renderGroupedEntries` filled an uncategorized bucket but the render loop only iterated `rules`, so any custom `types` table without an explicit `{ type: "other" }` rule **discarded every non-conventional line and every dependency-bump line**. Reproduced with the example table from this PR's own docs, which claim "Nothing is silently dropped." The catch-all is now first-class: it collects unparsed entries plus every type with no rule, renders at the `other` rule's position when the table has one and is appended otherwise, and is dropped only on explicit `{ type: "other", hidden: true }`.
- **One grammar, three parsers.** The branch initially added a third hand-rolled conventional-header parser, leaving the gitmoji regex character-for-character identical in three files with three different breaking-change rules. The two changelog parsers are now one; `ChangelogSection` is an alias of the shared rule type, and `default.ts` routes through the shared renderer (deleting `extractCommitType`, `renderSectioned`, `COMMIT_TYPE_REGEX` and its duplicate gitmoji regex). Breaking-change policy is now explicit: the parse reports `breakingMarker` and `breakingNote` separately and each formatter picks.
- **`grouping.ts` (409 lines, five jobs) is gone**, replaced by `conventional-header.ts` (86) / `sections.ts` (305) / `release-heading.ts` (111) / `source-bumps.ts` (40) — the last isolating the only piece that needs `ChangelogContext`.

`default`'s existing output was verified unchanged with a parity harness over a matrix of bodies × section tables × targets × release shapes, not just by assertion.

## Follow-up (not in this PR)

`src/release/core/generate/conventional-commits.ts` still carries its own copy of the gitmoji regex and its own breaking rule. It belongs to #864's branch, so unifying that third parser is a deliberate post-merge follow-up.

## Testing

All changelog suites green; the data-loss regression tests were confirmed to fail against the pre-fix code, reproducing the reported output verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AykNAXvDtCJyX6aymEBWQw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in Conventional Commits changelog formatter.
  * Added configurable grouping by commit type, breaking-change sections, scopes, bullets, and release-heading templates.
  * Added support for comparison URLs in generated release headings.
  * Extended the default and GitHub changelog formatters with optional grouping and heading customization.

* **Documentation**
  * Expanded release configuration and plugin-authoring guides with formatter options, examples, and rendering behavior.
  * Updated configuration references to include the conventional formatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->