### PR TITLE
fix(vis): canonicalise paths in toRepoRelativePath

### DIFF
--- a/packages/tooling/vis/__tests__/release/core/git.test.ts
+++ b/packages/tooling/vis/__tests__/release/core/git.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { defaultTagFor, getCurrentBranch, getCurrentSha, getShortSha, tagExists, tagExistsRemote } from "../../../src/release/core/git";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { defaultTagFor, getCurrentBranch, getCurrentSha, getShortSha, tagExists, tagExistsRemote, toRepoRelativePath } from "../../../src/release/core/git";
 import { MockRunner } from "../../../src/release/core/shell-runner";
 
 describe("git: defaultTagFor", () => {
@@ -150,5 +154,86 @@ describe("git: tagExistsRemote", () => {
         });
 
         await expect(tagExistsRemote({ cwd: "/r", runner }, "missing")).resolves.toBe(false);
+    });
+});
+
+describe("git: toRepoRelativePath", () => {
+    const created: string[] = [];
+
+    afterAll(() => {
+        for (const dir of created) {
+            rmSync(dir, { force: true, recursive: true });
+        }
+    });
+
+    const mkRoot = (): string => {
+        const dir = realpathSync(mkdtempSync(join(tmpdir(), "vis-reporel-")));
+
+        created.push(dir);
+
+        return dir;
+    };
+
+    it("returns a plain repo-relative POSIX path", async () => {
+        expect.hasAssertions();
+
+        const root = mkRoot();
+        const runner = new MockRunner();
+
+        runner.on("git", ["rev-parse", "--show-toplevel"], () => {
+            return { exitCode: 0, stderr: "", stdout: `${root}\n` };
+        });
+
+        await expect(toRepoRelativePath({ cwd: root, runner }, join(root, ".vis", "release", "ci-abc.md"))).resolves.toBe(".vis/release/ci-abc.md");
+    });
+
+    it("does not escape the tree when git spells the toplevel differently", async () => {
+        expect.hasAssertions();
+
+        // Reproduces the shape of two real platform bugs with one mechanism:
+        // on Windows `git rev-parse --show-toplevel` reports the long name
+        // while `os.tmpdir()` yields the 8.3 short form (`RUNNER~1`), and on
+        // macOS `/var` is a symlink to `/private/var`. Both make git's
+        // toplevel and the caller's absolute path different spellings of the
+        // same directory. A symlinked alias reproduces that portably.
+        const root = mkRoot();
+        const alias = join(root, "alias");
+        const real = join(root, "real");
+
+        mkdirSync(join(real, ".vis", "release"), { recursive: true });
+        writeFileSync(join(real, ".vis", "release", "ci-abc.md"), "x");
+        symlinkSync(real, alias, "dir");
+
+        const runner = new MockRunner();
+
+        // git reports the REAL path; the caller holds the ALIAS path.
+        runner.on("git", ["rev-parse", "--show-toplevel"], () => {
+            return { exitCode: 0, stderr: "", stdout: `${real}\n` };
+        });
+
+        const result = await toRepoRelativePath({ cwd: real, runner }, join(alias, ".vis", "release", "ci-abc.md"));
+
+        expect(result).toBe(".vis/release/ci-abc.md");
+        expect(result.startsWith("..")).toBe(false);
+    });
+
+    it("still resolves a path whose file does not exist yet", async () => {
+        expect.hasAssertions();
+
+        // `--generate` builds the change-file path before writing it.
+        const root = mkRoot();
+        const alias = join(root, "alias");
+        const real = join(root, "real");
+
+        mkdirSync(real, { recursive: true });
+        symlinkSync(real, alias, "dir");
+
+        const runner = new MockRunner();
+
+        runner.on("git", ["rev-parse", "--show-toplevel"], () => {
+            return { exitCode: 0, stderr: "", stdout: `${real}\n` };
+        });
+
+        await expect(toRepoRelativePath({ cwd: real, runner }, join(alias, ".vis", "release", "ci-notyet.md"))).resolves.toBe(".vis/release/ci-notyet.md");
     });
 });

--- a/packages/tooling/vis/src/release/core/git.ts
+++ b/packages/tooling/vis/src/release/core/git.ts
@@ -6,7 +6,8 @@
  * `VisReleaseError` with `TAG_PUSH_FAILED` / `TAG_COLLISION` codes.
  */
 
-import { relative } from "node:path";
+import { realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { VisReleaseError } from "../errors";
 import type { CommandRunner } from "./package-managers/interface";
@@ -127,7 +128,50 @@ export const toRepoRelativePath = async (ctx: GitContext, absolutePath: string):
     const toplevel = await run(ctx, ["rev-parse", "--show-toplevel"]);
     const root = toplevel.exitCode === 0 && toplevel.stdout.trim() ? toplevel.stdout.trim() : ctx.cwd;
 
-    return relative(root, absolutePath).replaceAll("\\", "/");
+    const direct = relative(root, absolutePath);
+
+    // `git rev-parse --show-toplevel` and the caller's absolute path can spell
+    // the SAME directory differently: on Windows git reports the long name
+    // while `os.tmpdir()` yields the 8.3 short form (`RUNNER~1`), and on macOS
+    // `/var` is a symlink to `/private/var`. `relative()` then walks up out of
+    // the tree and returns something like `../../../../../RUNNER~1/AppData/…`,
+    // which no longer matches `git status --porcelain` output.
+    //
+    // Only pay for the syscalls when the cheap answer already escaped.
+    if (!direct.startsWith("..")) {
+        return direct.replaceAll("\\", "/");
+    }
+
+    return relative(canonicalisePath(root), canonicalisePath(absolutePath)).replaceAll("\\", "/");
+};
+
+/**
+ * Resolve a path to its canonical on-disk spelling, tolerating a target that
+ * does not exist yet: walk up to the deepest ancestor that does, canonicalise
+ * that, and re-append the rest. Returns the input resolved when nothing can be
+ * canonicalised (in-memory adapters, permission errors).
+ */
+const canonicalisePath = (target: string): string => {
+    const absolute = isAbsolute(target) ? target : resolve(target);
+    const missing: string[] = [];
+    let current = absolute;
+
+    for (;;) {
+        try {
+            const real = realpathSync.native(current);
+
+            return missing.length === 0 ? real : join(real, ...missing.toReversed());
+        } catch {
+            const parent = dirname(current);
+
+            if (parent === current) {
+                return absolute;
+            }
+
+            missing.push(basename(current));
+            current = parent;
+        }
+    }
 };
 
 // ── Mutating ───────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes the Windows and macOS `Test` jobs that #869 broke on `main`.

## The bug

`toRepoRelativePath` (`src/release/core/git.ts`) computed a repo-relative path as:

```ts
const root = (await run(ctx, ["rev-parse", "--show-toplevel"])).stdout.trim();
return relative(root, absolutePath).replaceAll("\\", "/");
```

Those two operands can be **different spellings of the same directory**:

- **Windows** — git reports the long name, while `os.tmpdir()` yields the 8.3 short form, so the runner's temp dir is `C:\Users\RUNNER~1\AppData\…` on one side and `C:/Users/runneradmin/AppData/…` on the other.
- **macOS** — `/var` is a symlink to `/private/var`, so a fixture under `os.tmpdir()` has the same split.

`relative()` between two spellings walks *up out of the tree*, producing e.g. `../../../../../RUNNER~1/AppData/…`. The result no longer matches `git status --porcelain` output, which is exactly what the value is compared against — so `ci release --generate` printed a bogus path and its clean-tree guard stopped recognising the change file it had just written.

Observed on CI:

```
AssertionError: expected 'Generated ../../../../../RUNNER~1/App…'
                to contain 'Generated .vis/release/ci-'
AssertionError: expected 1 to be +0
```

3 failures in `release-ci-release-generate.test.ts` on `windows-latest`, plus the macOS job. Because #869 is merged, this is red on `main` and therefore on **every** open PR, not just release ones.

## The fix

Canonicalise both operands and retry — but only when the cheap `relative()` has already escaped, so the common path costs no extra syscalls:

```ts
if (!direct.startsWith("..")) return direct.replaceAll("\\", "/");
return relative(canonicalisePath(root), canonicalisePath(absolutePath)).replaceAll("\\", "/");
```

`canonicalisePath` walks up to the deepest ancestor that exists, calls `realpathSync.native` on it, and re-appends the remainder — because `--generate` builds the change-file path *before* writing the file, so the target frequently does not exist yet. It falls back to the resolved input when nothing can be canonicalised (in-memory adapters, permission errors).

One fix covers both platforms: `realpathSync.native` resolves 8.3 short names on Windows and symlinks on macOS.

## Testing

Three tests in `__tests__/release/core/git.test.ts`. The mismatch is reproduced **portably** with a symlinked root, which has the same structural shape as the 8.3 and `/var` cases — I can't run Windows in this environment, so the tests fail for the right structural reason rather than claiming platform verification:

- `does not escape the tree when git spells the toplevel differently`
- `still resolves a path whose file does not exist yet`

Both **fail without the fix** (`expected '../alias/.vis/release/ci-abc.md' to be '.vis/release/ci-abc.md'`) and pass with it.

Full `__tests__/release` + `__tests__/schemas`: **1292 passed, 0 failed**. The previously-failing `release-ci-release-generate.test.ts` and `release-ci-release.test.ts` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AykNAXvDtCJyX6aymEBWQw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling for repository-relative file paths.
  * Fixed path resolution in environments involving symbolic links, Windows short names, or paths that do not yet exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->